### PR TITLE
cluster host-claude-md-fixed-points: Phase 0 不动点注入(#2 共识)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,4 +36,4 @@
 
 ## 当前状态
 
-- `skills/codex-refactor-loop/` 为 host 项目移植,**verbatim**,仍带"重构"外壳与少量 host 主张。泛化路线见 `README.md` 的「泛化路线」。脱壳 / 重命名前不要改它的正文逻辑。
+- `skills/codex-refactor-loop/` 为 host 项目移植,**verbatim**,仍带"重构"外壳与少量 host 主张。泛化路线见 `README.md` 的「泛化路线」。脱壳 / 重命名前不要改它的正文逻辑；例外：经 Phase 9 deep consensus 明确授权的 host-agnostic bootstrap / policy 注入修正可先落地，但不得引入具体 host 事实，且必须配套行为测试。

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -14,7 +14,7 @@ description: Unattended three-phase refactor loop (analyze → implement → ver
 | `$REPO_ROOT` | host 仓库根 | host.env 必填 |
 | `$INTEGRATION_BRANCH` | 集成分支 | `auto-refact-dev` |
 | `$REVIEW_BASE_BRANCH` | review 基线分支 | `dev` |
-| `$PROJECT_RULES` | 审计/review 读的规则文档 | `CLAUDE.md` |
+| `$PROJECT_RULES` | 审计/review 读的规则文档,也是 Phase 0 managed fixed-point 写入目标 | `CLAUDE.md` |
 | `$BUILD_CMD` | 构建命令 | 示例 `dotnet build` / `cargo build` / `npm run build` |
 | `$TEST_CMD` | 测试命令 | host 专属 |
 | `$CI_GUARDS` | CI 守卫脚本(可选) | host 专属 |
@@ -579,6 +579,15 @@ Controller turn 间 / session 间 / `/clear` 后,**后台 codex 继续跑不中�
 0. **host.env 自检(缺失即停,绝不臆造)**:`source .refactor-loop/host.env` 取 `$REPO_ROOT/$GH_REPO_SLUG/$BUILD_CMD/$TEST_CMD/...`。
    - 不存在 → 从 `skills/codex-refactor-loop/host.env.example` 复制到 `.refactor-loop/host.env` 并填必填项;无法确定必填值(REPO_ROOT/GH_REPO_SLUG/BUILD_CMD/TEST_CMD)→ **PushNotification 请 maintainer 填,end turn,不 spawn 任何东西**。
    - ❌ 严禁用 `git rev-parse` / `gh repo view` 猜值后带空 BUILD_CMD/TEST_CMD 硬跑。
+0b. **ProjectRulesFixedPointEnsurer(强制,先于任何 actor 派发)**:在 `host.env` 注入后立即运行:
+   ```bash
+   python3 skills/codex-refactor-loop/scripts/ensure_project_rules_fixed_points.py
+   ```
+   - 该 helper 只维护解析后的 `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 内一个 `consensus-rnd:foundational-invariants` sentinel managed 区块;区块外 host 内容保持不变。
+   - helper 退出非 0 → bootstrap fail closed:不得初始化 state、不得建 labels、不得起 daemon、不得派 audit / solver / reviewer / implement actor。
+   - # Refactor (iter1/host-claude-md-fixed-points):
+     #   Old pattern: host 的 PROJECT_RULES/CLAUDE.md 不保证基础不动点(泛化理论)在场,跑 loop 时基础理论未被可靠加载
+     #   New principle: Phase 0 ProjectRulesFixedPointEnsurer 幂等向 $PROJECT_RULES 写入带 sentinel 的 managed 不动点区块(consensus:minimal,不覆盖 host 已有内容)
 1. **state + integration 分支**:`mkdir -p .refactor-loop/{...}` + 写 `state.json` + idempotent 建/推 `$INTEGRATION_BRANCH`(下方细节)。
 2. **建全套 labels**:跑「Label 系统」节的 Bootstrap —— 9 个 phase label + 3 个 human label 创建循环。**漏建 = 后续 phase transition 无 label 可挂、comment-monitor 查 `--label auto-loop` 漏掉 PR**。
 3. **起并挂载全部 5 个 daemon**:按「Host 运行编排 → Daemon 启动」节的 `bash -c 'source host.env && exec'` pattern 起齐 `concurrency_monitor.py` / `codex-progress-reporter.sh` / `comment-monitor.sh` / `dev_sync_daemon.py` / `triage-monitor.sh`,逐个 `pgrep -f <daemon>` 验 = 1。**首轮就必须把 5 个全起起来——它不是「以后某次 wakeup 才做的 liveness 检查」**。

--- a/skills/codex-refactor-loop/host.env.example
+++ b/skills/codex-refactor-loop/host.env.example
@@ -40,6 +40,7 @@ export INTEGRATION_BRANCH="auto-refact-dev"
 export REVIEW_BASE_BRANCH="dev"
 
 # audit / review codex 读的规则文档(违反它的地方就是工作单元的种子)。
+# Phase 0 会在此文件中维护 consensus-rnd foundational invariant managed block;无 opt-out。
 export PROJECT_RULES="CLAUDE.md"
 
 # ─── 可选 ─────────────────────────────────────────────────────────

--- a/skills/codex-refactor-loop/prompts/audit.md
+++ b/skills/codex-refactor-loop/prompts/audit.md
@@ -4,8 +4,8 @@
 
 ## 必读
 
-1. `CLAUDE.md` 顶级架构约束；所有"违反"必须对应到一条强制条款（引原文）。
-2. `AGENTS.md` 协作规范（如有）。
+1. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 顶级架构约束；所有"违反"必须对应到一条强制条款（引原文）。
+2. `$REPO_ROOT/AGENTS.md` 协作规范（如有,辅助规则）。
 3. `$REPO_ROOT 的架构/词汇文档(若有)` 权威参考。
 4. `docs/audit-scorecard/` 历史审计仅作起点参考，**不**作为唯一线索源。
 5. 当前 git 分支：`git branch --show-current`。
@@ -14,7 +14,7 @@
 
 ### Step 1 — Coverage manifest（必出）
 
-为每条 CLAUDE/AGENTS 强制条款分配一个 `rule_id`。对每个 `rule_id`：
+为每条 PROJECT_RULES/AGENTS 强制条款分配一个 `rule_id`。对每个 `rule_id`：
 
 - 至少执行 1 个 grep/analyzer 命令（**记录命令字符串 + 命中数**）
 - 至少**打开** 3 个非测试生产文件**通读**（不是只看前 50 行）；写明 file path + summary
@@ -46,7 +46,7 @@ rg -n "<stringly typed identity / routing / subscription patterns>" $SOURCE_GLOB
 写入 `$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}-candidates.ndjson`：每行一个 candidate。
 
 ```json
-{"rule_id": "<CLAUDE clause id>", "path": "<file>", "line": <int>, "evidence": "<one-line code snippet>", "verdict": "accept|reject", "reject_reason": "<if reject>", "prior_cluster_overlap": "<cluster-id|none>"}
+{"rule_id": "<PROJECT_RULES clause id>", "path": "<file>", "line": <int>, "evidence": "<one-line code snippet>", "verdict": "accept|reject", "reject_reason": "<if reject>", "prior_cluster_overlap": "<cluster-id|none>"}
 ```
 
 **`candidate_count >= 25`**（除非所有 6 个 analyzer 命令都 0 命中——这时也要写 0-count 证据）。

--- a/skills/codex-refactor-loop/prompts/audit.md
+++ b/skills/codex-refactor-loop/prompts/audit.md
@@ -129,7 +129,7 @@ human_brief:
 
 `verdict: reject` 的 candidate 必须有：
 
-- CLAUDE clause 引用 + 该 clause 对该候选**不适用**的具体理由（不是泛泛 "covered by guard"）
+- PROJECT_RULES clause 引用 + 该 clause 对该候选**不适用**的具体理由（不是泛泛 "covered by guard"）
 - 如 reject reason 是 "covered by existing CI guard"：必须给 guard 文件路径 + 行号 + 证明候选路径在 guard scan include set + 临时 probe 描述确认 reintroduction 会 fail
 - 如 reject reason 是 "same family as prior cluster"：必须证明候选 anti-pattern 100% 等同已修过的，不是字面相似但语义不同
 

--- a/skills/codex-refactor-loop/prompts/design-issue-reply.md
+++ b/skills/codex-refactor-loop/prompts/design-issue-reply.md
@@ -36,7 +36,7 @@ NyxId API keys / secrets / 内部 URL 之类敏感信息绝对禁止出现在 re
 
 ## 必读
 
-1. `$REPO_ROOT/CLAUDE.md` 全部条款（特别 cluster 引用的 rule_ids）。
+1. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 全部条款（特别 cluster 引用的 rule_ids）。
 2. issue body（含 cluster YAML / evidence / fix boundary / human_brief）—— 用 `gh issue view ${ISSUE_NUMBER}` 拉。
 3. cluster 在 `.refactor-loop/runs/audit-iter-${ITERATION}.md` 的原文。
 4. 评论中引用的具体文件 + 行号（**必须打开通读**，不只看 line refs）。

--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -4,7 +4,7 @@
 
 ## 必读上下文
 
-1. 主仓库 `$REPO_ROOT/CLAUDE.md` 全部强制条款。
+1. 主仓库 `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 全部强制条款。
 2. 完整审计：`$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md` 中 "${CLUSTER_ID}" 一节。
 3. `$REPO_ROOT 的架构/词汇文档(若有)` 下相关权威文档。
 

--- a/skills/codex-refactor-loop/prompts/remote-ci-fix.md
+++ b/skills/codex-refactor-loop/prompts/remote-ci-fix.md
@@ -5,7 +5,7 @@ PR: `${PR_NUMBER}`，失败 check: `${CHECK_NAME}`，run url: `${RUN_URL}`。
 
 ## 必读
 
-1. `$REPO_ROOT/CLAUDE.md`
+1. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}`
 2. 失败日志：`${FAILURE_LOG_PATH}` —— 完整 stderr/stdout 的最后 200-1000 行
 3. 最近 commits（可能引入失败的）：通过 `git log --oneline -10 origin/${BASE_BRANCH}..HEAD` 查看
 4. 失败 check 对应的本地 job 脚本（如有，位于 `.github/workflows/`）
@@ -25,7 +25,7 @@ PR: `${PR_NUMBER}`，失败 check: `${CHECK_NAME}`，run url: `${RUN_URL}`。
    - **如本地复现** → 继续
 
 3. **修复**：
-   - 按 CLAUDE.md 原则修复，**不破坏已合并 cluster 的成果**
+   - 按 PROJECT_RULES 原则修复，**不破坏已合并 cluster 的成果**
    - 改动**最小化**：只动失败 test 直接相关的代码 + test
    - 如失败是 test 写错（不是产线 bug），改 test；如失败是产线 bug，改产线
    - 加 `// Fix (remote-ci/${CHECK_NAME}):` 注释说明根因

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -15,7 +15,7 @@ Your job: read every reviewer's reject/comment evidence and apply concrete fixes
    - `${REVIEW_TESTS_PATH}`
    - `${REVIEW_QUALITY_PATH}`
 4. Cluster source: audit `${AUDIT_PATH}` and implement summary `${IMPLEMENT_SUMMARY_PATH}`.
-5. `$REPO_ROOT/CLAUDE.md` — every fix must comply with these clauses.
+5. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` — every fix must comply with these clauses.
 
 ## Procedure
 
@@ -24,7 +24,7 @@ Your job: read every reviewer's reject/comment evidence and apply concrete fixes
 Open the 3 reviewer files. For each `reject` AND each `comment`, extract:
 - file:line citations
 - the exact "What would change your verdict" / suggestion text
-- which CLAUDE/AGENTS clause is cited (if any)
+- which PROJECT_RULES/AGENTS clause is cited (if any)
 
 Categorize each demand into one of:
 

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -30,7 +30,7 @@ Categorize each demand into one of:
 
 - **(A) Fixable in-scope** — concrete code change within `scope_paths` of this cluster. Apply it.
 - **(B) Fixable but scope-extend** — concrete code change outside scope_paths. Print `SCOPE_EXTEND: <file> <reason>` and apply it ONLY if rejecting this demand would block consensus AND the file is in the same logical refactor (e.g. add missing test file for the new public method).
-- **(C) False positive** — the reviewer mis-read (e.g. cited a file not in the PR, cited a deletion that never happened, demand contradicts CLAUDE.md). Do NOT apply. Record in `FIX_REPORT.md` with evidence proving it's a false positive.
+- **(C) False positive** — the reviewer mis-read (e.g. cited a file not in the PR, cited a deletion that never happened, demand contradicts `$PROJECT_RULES`). Do NOT apply. Record in `FIX_REPORT.md` with evidence proving it's a false positive.
 - **(D) Conflicting demands** — Architect demands X, Quality demands ¬X. Do NOT apply either side without resolution. Record both sides in `FIX_REPORT.md` and emit `FIX_BLOCKED:conflict:<short>` at the end.
 - **(E) Outside fix-codex authority** — demand requires a design decision (e.g. "delete this feature entirely" / "split this into 3 PRs" / "rename core type that other clusters depend on"). Record in `FIX_REPORT.md` and emit `FIX_BLOCKED:human-decision:<short>`.
 
@@ -66,7 +66,7 @@ Write `${FIX_OUTPUT_PATH}` with this structure:
 - (B) <file:line>: <SCOPE_EXTEND reason> ; <what was added>
 
 ## Rejected as false positive
-- <file:line cited by reviewer:<role>>: <evidence that this is wrong — e.g. "file not in PR's three-dot diff", "cited test still exists at line N", "CLAUDE clause M actually requires this">
+- <file:line cited by reviewer:<role>>: <evidence that this is wrong — e.g. "file not in PR's three-dot diff", "cited test still exists at line N", "PROJECT_RULES clause M actually requires this">
 
 ## Blocked (cannot fix this round)
 - <reviewer:<role>'s demand>: <reason — conflict|human-decision|build-broken>
@@ -97,7 +97,7 @@ End your output with EXACTLY one of:
 - **You do NOT modify other cluster's PRs** (only this PR's HEAD branch).
 - **False-positive demands must have proof** in FIX_REPORT — don't dismiss without evidence.
 - **FIX_REPORT 写入路径强制 `${FIX_OUTPUT_PATH}`**(典型 `.refactor-loop/runs/fix-pr<N>-r<N>.md`)— **禁止**写到 repo root `FIX_REPORT.md`(会污染 worktree + rebase conflict)。若 `${FIX_OUTPUT_PATH}` 空(env var 漏传),emit `FIX_BLOCKED:env-missing:FIX_OUTPUT_PATH` 不要瞎写默认路径。
-- **A demand citing CLAUDE.md verbatim is presumed valid** — burden of proof is on you to show it's a misreading.
+- **A demand citing `$PROJECT_RULES` verbatim is presumed valid** — burden of proof is on you to show it's a misreading.
 
 ## Anti-patterns (forbidden — emit FIX_BLOCKED instead of doing these)
 

--- a/skills/codex-refactor-loop/prompts/reviewer-architect.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-architect.md
@@ -6,8 +6,8 @@ You are **one of N independent reviewers**; you do not see the other reviewers' 
 
 ## Inputs (read in order)
 
-1. `$REPO_ROOT/CLAUDE.md` — full text. The PR must not regress any clause.
-2. `$REPO_ROOT/AGENTS.md` — supporting rules.
+1. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` — full text. The PR must not regress any clause.
+2. `$REPO_ROOT/AGENTS.md` — supporting rules when present.
 3. PR diff: `cd $REPO_ROOT && git diff origin/${BASE_BRANCH}...origin/${HEAD_BRANCH} -- $SOURCE_GLOBS '$REPO_ROOT 的架构/词汇文档(若有)'` **(three dots — symmetric-from-merge-base; two dots would mis-flag dev's new commits as PR deletions)**
 4. Cluster source (audit + implement summary): `${AUDIT_PATH}` and `${IMPLEMENT_SUMMARY_PATH}` if they exist (skip if not — some PRs are out-of-loop).
 
@@ -59,14 +59,14 @@ verdict: approve | comment | reject
 Verdict semantics:
 - **approve**: no architectural concerns; merge OK from architect angle.
 - **comment**: minor observations or improvements; not blocking but worth surfacing in the PR comment.
-- **reject**: real CLAUDE/AGENTS clause violation introduced or worsened; merge would degrade architecture compliance.
+- **reject**: real PROJECT_RULES/AGENTS clause violation introduced or worsened; merge would degrade architecture compliance.
 
 End with marker line: `REVIEW_DONE:${PR_NUMBER}:architect:<verdict>`
 
 ## Hard rules
 
 - Read **the actual diff and the actual referenced files**. Don't trust the implement summary alone.
-- Cite a CLAUDE/AGENTS clause **verbatim** for every reject. "Architectural smell" without a clause = comment, not reject.
+- Cite a PROJECT_RULES/AGENTS clause **verbatim** for every reject. "Architectural smell" without a clause = comment, not reject.
 - You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays).
 - Don't edit any file outside `${REVIEW_OUTPUT_PATH}`.
 - No bilingual requirement here (this is an internal artifact consumed by controller).

--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -15,8 +15,8 @@ You explicitly resist adding code. If after honest evaluation the feature must s
 
 1. `gh issue view ${ISSUE_NUMBER}` — full body + comments.
 2. `$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md`.
-3. `$REPO_ROOT/CLAUDE.md` "## 架构哲学" → "删除优先" clause; "Deletion-first" principle.
-4. If deletion requires changing CLAUDE.md/AGENTS.md, L0/L1/L2 clauses, Tier boundaries, SPEC/conformance/trusted_base wording, or architecture vocabulary, treat that change as part of the deletion plan rather than a reason to escalate.
+3. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` "删除优先" clause; "Deletion-first" principle. `$REPO_ROOT/AGENTS.md` is supporting input when present.
+4. If deletion requires changing PROJECT_RULES/AGENTS.md, L0/L1/L2 clauses, Tier boundaries, SPEC/conformance/trusted_base wording, or architecture vocabulary, treat that change as part of the deletion plan rather than a reason to escalate.
 5. Call sites of the violating code:
    ```bash
    # Find all callers

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -8,7 +8,7 @@ Your bias: **smallest viable change** that resolves the audit's flagged violatio
 
 1. `gh issue view ${ISSUE_NUMBER}` — full body + comments (skip controller `## 🤖` markers).
 2. `$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md` — cluster spec.
-3. `$REPO_ROOT/CLAUDE.md` + `$REPO_ROOT/AGENTS.md` — clauses that frame the violation.
+3. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` — primary rules that frame the violation; `$REPO_ROOT/AGENTS.md` — supporting rules when present.
 4. The actual source files cited in the audit `evidence:` block (open them; do NOT trust line numbers without verifying).
 
 ## Procedure

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -21,7 +21,7 @@ Your bias: **smallest viable change** that resolves the audit's flagged violatio
    - LOC delta estimate (new + removed)
    - Files touched (count + paths)
    - Whether tests need adding (count + which test files)
-   - Any rule exception required, with exact CLAUDE.md text change proposed.
+   - Any rule exception required, with exact `$PROJECT_RULES` text change proposed.
 4. **Treat philosophy/Tier changes as plan material, not escape hatches**:
    - If the minimum viable solution changes CLAUDE.md/AGENTS.md, L0/L1/L2 clauses, Tier I/Tier II boundaries, core abstractions, or architecture vocabulary, include that edit directly in the concrete plan.
    - Spell out: exact file/clause, current rule being changed, proposed text, why it is worth the trusted-base cost, and why deep consensus should be reachable.
@@ -49,7 +49,7 @@ verdict: propose | abstain | escalate
 - Files: <list with intended action per file>
 - LOC delta: ~+N / -M
 - Tests to add/modify: <list>
-- Philosophy/CLAUDE.md/SPEC/Tier change (if any): <exact file/clause + from X to Y + why worth it + why consensus can hold, OR "none">
+- Philosophy/PROJECT_RULES/SPEC/Tier change (if any): <exact file/clause + from X to Y + why worth it + why consensus can hold, OR "none">
 - Migration path: <single-step; "no migration needed" is also valid>
 
 ## Concrete plan (中文)

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -8,7 +8,7 @@ Your bias: **CLAUDE-philosophy-aligned, structurally clean**. You accept higher 
 
 1. `gh issue view ${ISSUE_NUMBER}` — full body + comments (skip controller `## 🤖` markers).
 2. `$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md` — cluster spec.
-3. `$REPO_ROOT/CLAUDE.md` + `$REPO_ROOT/AGENTS.md` — clauses that frame the violation.
+3. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` — primary rules that frame the violation; `$REPO_ROOT/AGENTS.md` — supporting rules when present.
 4. `$REPO_ROOT/$REPO_ROOT 的架构/词汇文档(若有)` — repo vocabulary (Module / Interface / Depth / Seam / Adapter / Leverage / Locality).
 5. The actual source files cited in the audit `evidence:` block (open them; verify line numbers).
 

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -14,7 +14,7 @@ Your bias: **CLAUDE-philosophy-aligned, structurally clean**. You accept higher 
 
 ## Procedure
 
-1. **Restate the violation** in CLAUDE-clause-precise terms. Which clause is it, exactly? Quote it.
+1. **Restate the violation** in PROJECT_RULES-clause-precise terms. Which clause is it, exactly? Quote it.
 2. **Map the clean structural solution**:
    - Which existing repo primitives apply (`IAsyncEnumerable`, `Channel`, actor inbox, projection pipeline, event envelope, etc.)?
    - What new abstraction is required, IF any (named precisely)?
@@ -44,8 +44,8 @@ cluster: ${CLUSTER_ID}
 verdict: propose | abstain | escalate
 ---
 
-## CLAUDE clause violated (quoted verbatim)
-> <exact CLAUDE.md text>
+## PROJECT_RULES clause violated (quoted verbatim)
+> <exact PROJECT_RULES text>
 
 ## Recommended framing (English)
 <one paragraph: what new structure, where, why it eliminates the violation by construction (not by exception)>
@@ -59,7 +59,7 @@ verdict: propose | abstain | escalate
 - LOC delta: ~+N / -M
 - Tests to add: <list with what behavior each asserts>
 - proto changes (if any): <field name + number + .proto file>
-- Philosophy/CLAUDE.md/SPEC/Tier changes (if any): <exact file/clause + from X to Y + why worth it + why consensus can hold, OR "none">
+- Philosophy/PROJECT_RULES/SPEC/Tier changes (if any): <exact file/clause + from X to Y + why worth it + why consensus can hold, OR "none">
 - Runtime cost: <latency estimate, allocation estimate>
 
 ## Risks

--- a/skills/codex-refactor-loop/prompts/test-add.md
+++ b/skills/codex-refactor-loop/prompts/test-add.md
@@ -4,7 +4,7 @@ worktree: `${WORKTREE_PATH}`，分支 `${BRANCH}`。
 
 ## 必读
 
-1. `$REPO_ROOT/CLAUDE.md` 全部强制条款（含 "Codex CLI 调用规范"、"测试与质量门禁"）。
+1. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 全部强制条款（含 "Codex CLI 调用规范"、"测试与质量门禁"）。
 2. `$REPO_ROOT/.refactor-loop/runs/audit-iter-N.md` 中 `${CLUSTER_ID}` 一节
 3. `$REPO_ROOT/.refactor-loop/runs/implement-${CLUSTER_ID}.md`
 4. **未覆盖行报告**：以下文件:行号 是 codecov 标记为 patch miss/partial 的位置：

--- a/skills/codex-refactor-loop/prompts/triage-external-issue.md
+++ b/skills/codex-refactor-loop/prompts/triage-external-issue.md
@@ -1,7 +1,7 @@
 # Triage codex — 外部 issue 评估 + 接入(or 拒绝)
 
 你是 triage codex,任务:把 maintainer 加了 `auto-loop-triage` label 的**外部 issue** 评估为:
-- **accept** — 属于本 refactor loop 范畴(违反 CLAUDE/AGENTS 条款),reshape body + 切换 label 进入 Phase 9 三 solver 流程
+- **accept** — 属于本 refactor loop 范畴(违反 PROJECT_RULES/AGENTS 条款),reshape body + 切换 label 进入 Phase 9 三 solver 流程
 - **reject** — 不属于(产品需求 / bug 报告 / feature request / 文档问题 / 第三方工具问题),评论解释 + 移除 triage label
 
 ## Context
@@ -18,7 +18,7 @@
 
 **Accept 标准(全部满足)**:
 - 描述的问题对应到具体 source file:line(在本 repo 内,不是外部依赖)
-- 违反某条 CLAUDE.md 或 AGENTS.md 强制条款(查证条款,引原文)
+- 违反某条 PROJECT_RULES 或 AGENTS.md 强制条款(查证条款,引原文)
 - 不是产品 feature request("加 X 功能")或 bug report("Y 不工作")
 - 不是 docs-only 或 tooling-only(本 loop 处理 production code 违反)
 - 范围合理(≤ 50 files;过大需 maintainer split,reject + 解释)
@@ -52,8 +52,8 @@
 
 ## 必读
 
-1. `$REPO_ROOT/CLAUDE.md` 强制条款全文(判 accept 必须引证某条)
-2. `$REPO_ROOT/AGENTS.md`(若存在)
+1. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 强制条款全文(判 accept 必须引证某条)
+2. `$REPO_ROOT/AGENTS.md`(若存在,辅助规则)
 3. 现有 open auto-loop issues:`gh issue list --label "auto-loop" --state open --json number,title`(查重)
 4. 现有 open auto-loop PRs:`gh pr list --label "auto-loop" --state open --json number,title`(查重)
 

--- a/skills/codex-refactor-loop/prompts/verify.md
+++ b/skills/codex-refactor-loop/prompts/verify.md
@@ -4,7 +4,7 @@
 
 ## 必读
 
-1. `$REPO_ROOT/CLAUDE.md` 全部强制条款。
+1. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 全部强制条款。
 2. `$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md` 的 "${CLUSTER_ID}" 一节。
 3. `$REPO_ROOT/.refactor-loop/runs/implement-${CLUSTER_ID}.md` 实施摘要。
 4. `git diff HEAD` —— 完整改动 diff。

--- a/skills/codex-refactor-loop/scripts/ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/ensure_project_rules_fixed_points.py
@@ -54,8 +54,7 @@ class ProjectRulesFixedPointEnsurer:
     #   New principle: Phase 0 ProjectRulesFixedPointEnsurer 幂等向 $PROJECT_RULES 写入带 sentinel 的 managed 不动点区块(consensus:minimal,不覆盖 host 已有内容)
     def __init__(self, repo_root: str, project_rules: str | None = None) -> None:
         self.repo_root = self._resolve_repo_root(repo_root)
-        self.project_rules = project_rules if project_rules else "CLAUDE.md"
-        self.target = self._resolve_target(self.project_rules)
+        self.target = self._resolve_target(project_rules if project_rules else "CLAUDE.md")
 
     @classmethod
     def from_env(cls) -> "ProjectRulesFixedPointEnsurer":
@@ -130,11 +129,10 @@ class ProjectRulesFixedPointEnsurer:
 
         return text[: start.start()] + self._managed_block() + text[end_index + len(END_MARKER):]
 
-    def _managed_block(self, body: str = CANONICAL_BODY) -> str:
-        body_hash = sha256_text(body)
+    def _managed_block(self) -> str:
         return (
-            f"<!-- consensus-rnd:foundational-invariants:start version=1 sha256={body_hash} -->\n"
-            f"{body}"
+            f"<!-- consensus-rnd:foundational-invariants:start version=1 sha256={CANONICAL_HASH} -->\n"
+            f"{CANONICAL_BODY}"
             f"{END_MARKER}"
         )
 

--- a/skills/codex-refactor-loop/scripts/ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/ensure_project_rules_fixed_points.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Ensure the host project rules file carries consensus-rnd fixed points."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+
+CANONICAL_BODY = """## 共识研发不动点（由 consensus-rnd 管理）
+
+- FI-001 AI 产物默认不可信；进入主线前必须经过独立检查，至少包含共识、review 或自动验证中的适用组合。
+- FI-002 Host 事实必须由 host 配置或 host 规则注入；通用 skill / engine 不硬编码具体项目、组织、路径、分支或人员事实。
+- FI-003 稳定核心保持小而可审计；高频变化留在 host 规则、prompt、脚本或扩展层，不下沉为核心不变量。
+- FI-004 跨进程、跨 turn 或跨节点的事实必须有权威记录；进程内记忆、cache、临时变量不能冒充事实源。
+- FI-005 边界优先于便利；职责、层级、协议和状态所有权必须清楚，禁止用中间层快捷方式绕过主链路。
+- FI-006 变更必须可验证且基于 evidence；失败、缺口和越界承诺要显式暴露，禁止用静默假设或禁用测试换取通过。
+- FI-007 删除优先；废弃路径直接移除，除非 host 规则明确要求迁移期兼容。
+"""
+
+OLD_CANONICAL_BODY = """## 共识研发不动点（由 consensus-rnd 管理）
+
+- FI-001 AI 产物默认不可信；进入主线前必须经过独立检查。
+- FI-002 Host 事实必须由 host 配置或 host 规则注入。
+- FI-003 稳定核心保持小而可审计。
+"""
+
+START_RE = re.compile(
+    r"<!-- consensus-rnd:foundational-invariants:start version=1 "
+    r"sha256=([0-9a-f]{64}) -->"
+)
+END_MARKER = "<!-- consensus-rnd:foundational-invariants:end -->"
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+CANONICAL_HASH = sha256_text(CANONICAL_BODY)
+KNOWN_CANONICAL_HASHES = frozenset({sha256_text(OLD_CANONICAL_BODY)})
+
+
+class FixedPointError(Exception):
+    """Raised when the managed block cannot be safely ensured."""
+
+
+class ProjectRulesFixedPointEnsurer:
+    # Refactor (iter1/host-claude-md-fixed-points):
+    #   Old pattern: host 的 PROJECT_RULES/CLAUDE.md 不保证基础不动点(泛化理论)在场,跑 loop 时基础理论未被可靠加载
+    #   New principle: Phase 0 ProjectRulesFixedPointEnsurer 幂等向 $PROJECT_RULES 写入带 sentinel 的 managed 不动点区块(consensus:minimal,不覆盖 host 已有内容)
+    def __init__(self, repo_root: str, project_rules: str | None = None) -> None:
+        self.repo_root = self._resolve_repo_root(repo_root)
+        self.project_rules = project_rules if project_rules else "CLAUDE.md"
+        self.target = self._resolve_target(self.project_rules)
+
+    @classmethod
+    def from_env(cls) -> "ProjectRulesFixedPointEnsurer":
+        return cls(os.environ.get("REPO_ROOT", ""), os.environ.get("PROJECT_RULES"))
+
+    def ensure(self) -> str:
+        # Refactor (iter1/host-claude-md-fixed-points):
+        #   Old pattern: host 的 PROJECT_RULES/CLAUDE.md 不保证基础不动点(泛化理论)在场,跑 loop 时基础理论未被可靠加载
+        #   New principle: Phase 0 ProjectRulesFixedPointEnsurer 幂等向 $PROJECT_RULES 写入带 sentinel 的 managed 不动点区块(consensus:minimal,不覆盖 host 已有内容)
+        original = self._read_target()
+        updated = self._updated_text(original)
+        if updated == original:
+            return "already-current"
+        self._atomic_write(updated)
+        return "updated"
+
+    def _resolve_repo_root(self, repo_root: str) -> Path:
+        if not repo_root:
+            raise FixedPointError("REPO_ROOT is required")
+        root = Path(repo_root).expanduser().resolve()
+        if not root.is_dir():
+            raise FixedPointError(f"REPO_ROOT is not a directory: {root}")
+        return root
+
+    def _resolve_target(self, project_rules: str) -> Path:
+        raw = Path(project_rules)
+        if any(part == ".." for part in raw.parts):
+            raise FixedPointError(f"PROJECT_RULES must not contain '..': {project_rules}")
+        target = (raw if raw.is_absolute() else self.repo_root / raw).expanduser().resolve()
+        if not target.is_relative_to(self.repo_root):
+            raise FixedPointError(f"PROJECT_RULES escapes REPO_ROOT: {project_rules}")
+        return target
+
+    def _read_target(self) -> str:
+        try:
+            text = self.target.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise FixedPointError(f"PROJECT_RULES file does not exist: {self.target}") from exc
+        except OSError as exc:
+            raise FixedPointError(f"PROJECT_RULES file is unreadable: {self.target}: {exc}") from exc
+        if text == "":
+            raise FixedPointError(f"PROJECT_RULES file is empty: {self.target}")
+        return text
+
+    def _updated_text(self, text: str) -> str:
+        # Refactor (iter1/host-claude-md-fixed-points):
+        #   Old pattern: host 的 PROJECT_RULES/CLAUDE.md 不保证基础不动点(泛化理论)在场,跑 loop 时基础理论未被可靠加载
+        #   New principle: Phase 0 ProjectRulesFixedPointEnsurer 幂等向 $PROJECT_RULES 写入带 sentinel 的 managed 不动点区块(consensus:minimal,不覆盖 host 已有内容)
+        starts = list(START_RE.finditer(text))
+        end_count = text.count(END_MARKER)
+        if len(starts) != end_count:
+            raise FixedPointError("managed marker pair is missing or unbalanced")
+        if len(starts) > 1:
+            raise FixedPointError("duplicate managed marker blocks are not allowed")
+        if not starts:
+            return text + "\n\n" + self._managed_block()
+
+        start = starts[0]
+        end_index = text.find(END_MARKER, start.end())
+        if end_index < 0:
+            raise FixedPointError("managed end marker is missing")
+
+        enclosed = text[start.end() + 1:end_index]
+        enclosed_hash = sha256_text(enclosed)
+        marker_hash = start.group(1)
+        if marker_hash != enclosed_hash:
+            raise FixedPointError("managed block hash mismatch; refusing to overwrite manual edits")
+        if enclosed_hash == CANONICAL_HASH:
+            return text
+        if enclosed_hash not in KNOWN_CANONICAL_HASHES:
+            raise FixedPointError("unknown managed block version; refusing to overwrite")
+
+        return text[: start.start()] + self._managed_block() + text[end_index + len(END_MARKER):]
+
+    def _managed_block(self, body: str = CANONICAL_BODY) -> str:
+        body_hash = sha256_text(body)
+        return (
+            f"<!-- consensus-rnd:foundational-invariants:start version=1 sha256={body_hash} -->\n"
+            f"{body}"
+            f"{END_MARKER}"
+        )
+
+    def _atomic_write(self, text: str) -> None:
+        self.target.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{self.target.name}.", dir=self.target.parent)
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(text)
+            os.replace(tmp_path, self.target)
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+
+def main() -> int:
+    try:
+        status = ProjectRulesFixedPointEnsurer.from_env().ensure()
+    except FixedPointError as exc:
+        sys.stderr.write(f"PROJECT_RULES_FIXED_POINT_ERROR: {exc}\n")
+        return 1
+    sys.stdout.write(f"PROJECT_RULES_FIXED_POINT:{status}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -21,6 +21,23 @@ from ensure_project_rules_fixed_points import (
 )
 
 SCRIPT_PATH = Path(__file__).with_name("ensure_project_rules_fixed_points.py")
+SKILL_ROOT = SCRIPT_PATH.parents[1]
+REPO_ROOT = SCRIPT_PATH.parents[3]
+
+PROMPTS_WITH_MANDATORY_PROJECT_RULES_INPUT = (
+    "audit.md",
+    "design-issue-reply.md",
+    "implement.md",
+    "remote-ci-fix.md",
+    "review-fix.md",
+    "reviewer-architect.md",
+    "solver-delete.md",
+    "solver-minimal.md",
+    "solver-structural.md",
+    "test-add.md",
+    "triage-external-issue.md",
+    "verify.md",
+)
 
 
 class ProjectRulesFixedPointEnsurerTests(unittest.TestCase):
@@ -224,6 +241,32 @@ class ProjectRulesFixedPointEnsurerTests(unittest.TestCase):
         self.assertTrue(text.endswith("\n\n## Host extension\n"))
         self.assertIn(CANONICAL_BODY, text)
         self.assertEqual(START_RE.search(text).group(1), CANONICAL_HASH)
+
+
+class ProjectRulesPromptContractTests(unittest.TestCase):
+    # Refactor (iter1/host-claude-md-fixed-points):
+    #   Old pattern: actor prompts could regress to hardcoded $REPO_ROOT/CLAUDE.md as the mandatory rules input while helper tests still passed
+    #   New principle: source-regression coverage keeps actor prompts wired to $REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}
+    def test_actor_prompts_keep_project_rules_as_mandatory_rules_input(self) -> None:
+        prompts_root = SKILL_ROOT / "prompts"
+
+        for prompt_name in PROMPTS_WITH_MANDATORY_PROJECT_RULES_INPUT:
+            prompt = prompts_root / prompt_name
+            text = prompt.read_text(encoding="utf-8")
+            with self.subTest(prompt=prompt_name):
+                self.assertIn("$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}", text)
+
+        for prompt in sorted(prompts_root.glob("*.md")):
+            text = prompt.read_text(encoding="utf-8")
+            with self.subTest(no_hardcoded_rules_input=prompt.name):
+                self.assertNotIn("$REPO_ROOT/CLAUDE.md", text)
+
+    def test_phase0_runtime_contract_names_resolved_project_rules_target(self) -> None:
+        skill_text = (REPO_ROOT / "skills" / "codex-refactor-loop" / "SKILL.md").read_text(encoding="utf-8")
+
+        self.assertIn("ProjectRulesFixedPointEnsurer(强制,先于任何 actor 派发)", skill_text)
+        self.assertIn("$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}", skill_text)
+        self.assertIn("helper 退出非 0 → bootstrap fail closed", skill_text)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -16,6 +19,8 @@ from ensure_project_rules_fixed_points import (
     START_RE,
     sha256_text,
 )
+
+SCRIPT_PATH = Path(__file__).with_name("ensure_project_rules_fixed_points.py")
 
 
 class ProjectRulesFixedPointEnsurerTests(unittest.TestCase):
@@ -32,6 +37,61 @@ class ProjectRulesFixedPointEnsurerTests(unittest.TestCase):
 
     def ensure(self, project_rules: str = "CLAUDE.md") -> str:
         return ProjectRulesFixedPointEnsurer(str(self.repo), project_rules).ensure()
+
+    def run_cli(self, env_updates: dict[str, str] | None = None, *, clear_rules_env: bool = True) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        if clear_rules_env:
+            env.pop("REPO_ROOT", None)
+            env.pop("PROJECT_RULES", None)
+        if env_updates:
+            env.update(env_updates)
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_cli_default_project_rules_writes_and_reports_status(self) -> None:
+        self.rules.write_text("# Host rules\nExisting text.\n", encoding="utf-8")
+
+        first = self.run_cli({"REPO_ROOT": str(self.repo)})
+
+        self.assertEqual(first.returncode, 0)
+        self.assertEqual(first.stdout, "PROJECT_RULES_FIXED_POINT:updated\n")
+        self.assertEqual(first.stderr, "")
+        self.assertIn(CANONICAL_BODY, self.rules.read_text(encoding="utf-8"))
+
+        second = self.run_cli({"REPO_ROOT": str(self.repo)})
+
+        self.assertEqual(second.returncode, 0)
+        self.assertEqual(second.stdout, "PROJECT_RULES_FIXED_POINT:already-current\n")
+        self.assertEqual(second.stderr, "")
+
+    def test_cli_explicit_project_rules_targets_nested_file(self) -> None:
+        nested_rules = self.repo / "docs" / "RULES.md"
+        nested_rules.parent.mkdir()
+        nested_rules.write_text("# Nested host rules\n", encoding="utf-8")
+
+        result = self.run_cli({"REPO_ROOT": str(self.repo), "PROJECT_RULES": "docs/RULES.md"})
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "PROJECT_RULES_FIXED_POINT:updated\n")
+        self.assertEqual(result.stderr, "")
+        self.assertIn(CANONICAL_BODY, nested_rules.read_text(encoding="utf-8"))
+        self.assertFalse(self.rules.exists())
+
+    def test_cli_missing_repo_root_fails_closed_without_modifying_files(self) -> None:
+        original = "# Host rules\n"
+        self.rules.write_text(original, encoding="utf-8")
+
+        result = self.run_cli()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("PROJECT_RULES_FIXED_POINT_ERROR: REPO_ROOT is required", result.stderr)
+        self.assertEqual(self.rules.read_text(encoding="utf-8"), original)
 
     def test_first_append_adds_one_managed_block(self) -> None:
         self.rules.write_text("# Host rules\nExisting text.\n", encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -93,6 +93,14 @@ class ProjectRulesFixedPointEnsurerTests(unittest.TestCase):
         with self.assertRaisesRegex(Exception, "must not contain|escapes"):
             ProjectRulesFixedPointEnsurer(str(self.repo), "../CLAUDE.md")
 
+    def test_absolute_path_outside_repo_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as outside_tmp:
+            outside_rules = Path(outside_tmp) / "CLAUDE.md"
+            outside_rules.write_text("# Outside host rules\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(Exception, "escapes REPO_ROOT"):
+                ProjectRulesFixedPointEnsurer(str(self.repo), str(outside_rules))
+
     def test_duplicate_marker_is_refused_without_changes(self) -> None:
         block = ProjectRulesFixedPointEnsurer(str(self.repo))._managed_block()
         original = "# Host rules\n\n" + block + "\n\n" + block
@@ -118,6 +126,22 @@ class ProjectRulesFixedPointEnsurerTests(unittest.TestCase):
         self.rules.write_text(original, encoding="utf-8")
 
         with self.assertRaisesRegex(Exception, "hash mismatch"):
+            self.ensure()
+
+        self.assertEqual(self.rules.read_text(encoding="utf-8"), original)
+
+    def test_hash_valid_unknown_block_version_fails_closed(self) -> None:
+        unknown_body = "## 共识研发不动点（由 consensus-rnd 管理）\n\n- FI-999 未知版本。\n"
+        unknown_hash = sha256_text(unknown_body)
+        unknown_block = (
+            f"<!-- consensus-rnd:foundational-invariants:start version=1 sha256={unknown_hash} -->\n"
+            f"{unknown_body}"
+            f"{END_MARKER}"
+        )
+        original = "# Host rules\n\n" + unknown_block
+        self.rules.write_text(original, encoding="utf-8")
+
+        with self.assertRaisesRegex(Exception, "unknown managed block version"):
             self.ensure()
 
         self.assertEqual(self.rules.read_text(encoding="utf-8"), original)

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Behavior tests for ensure_project_rules_fixed_points.py."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from ensure_project_rules_fixed_points import (
+    CANONICAL_BODY,
+    CANONICAL_HASH,
+    END_MARKER,
+    OLD_CANONICAL_BODY,
+    ProjectRulesFixedPointEnsurer,
+    START_RE,
+    sha256_text,
+)
+
+
+class ProjectRulesFixedPointEnsurerTests(unittest.TestCase):
+    # Refactor (iter1/host-claude-md-fixed-points):
+    #   Old pattern: host 的 PROJECT_RULES/CLAUDE.md 不保证基础不动点(泛化理论)在场,跑 loop 时基础理论未被可靠加载
+    #   New principle: Phase 0 ProjectRulesFixedPointEnsurer 幂等向 $PROJECT_RULES 写入带 sentinel 的 managed 不动点区块(consensus:minimal,不覆盖 host 已有内容)
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.rules = self.repo / "CLAUDE.md"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def ensure(self, project_rules: str = "CLAUDE.md") -> str:
+        return ProjectRulesFixedPointEnsurer(str(self.repo), project_rules).ensure()
+
+    def test_first_append_adds_one_managed_block(self) -> None:
+        self.rules.write_text("# Host rules\nExisting text.\n", encoding="utf-8")
+
+        status = self.ensure()
+
+        text = self.rules.read_text(encoding="utf-8")
+        self.assertEqual(status, "updated")
+        self.assertTrue(text.startswith("# Host rules\nExisting text.\n\n\n"))
+        self.assertEqual(text.count("consensus-rnd:foundational-invariants:start"), 1)
+        self.assertEqual(text.count(END_MARKER), 1)
+        self.assertIn(f"sha256={CANONICAL_HASH}", text)
+        self.assertIn(CANONICAL_BODY, text)
+
+    def test_repeated_ensure_is_byte_stable(self) -> None:
+        self.rules.write_text("# Host rules\n", encoding="utf-8")
+        self.ensure()
+        once = self.rules.read_bytes()
+
+        status = self.ensure()
+
+        self.assertEqual(status, "already-current")
+        self.assertEqual(self.rules.read_bytes(), once)
+
+    def test_preserves_content_outside_managed_block(self) -> None:
+        prefix = "# Host rules\nKeep this.\n"
+        suffix = "\n## Host extension\nKeep that.\n"
+        block = ProjectRulesFixedPointEnsurer(str(self.repo))._managed_block()
+        self.rules.write_text(prefix + "\n\n" + block + suffix, encoding="utf-8")
+
+        self.ensure()
+
+        text = self.rules.read_text(encoding="utf-8")
+        self.assertTrue(text.startswith(prefix))
+        self.assertTrue(text.endswith(suffix))
+
+    def test_missing_rules_file_is_refused(self) -> None:
+        with self.assertRaisesRegex(Exception, "does not exist"):
+            self.ensure()
+
+    def test_empty_rules_file_is_refused(self) -> None:
+        self.rules.write_text("", encoding="utf-8")
+
+        with self.assertRaisesRegex(Exception, "empty"):
+            self.ensure()
+
+    def test_unreadable_rules_file_is_refused(self) -> None:
+        self.rules.write_text("# Host rules\n", encoding="utf-8")
+        self.rules.chmod(0)
+        try:
+            with self.assertRaisesRegex(Exception, "unreadable"):
+                self.ensure()
+        finally:
+            self.rules.chmod(0o600)
+
+    def test_path_escape_is_refused(self) -> None:
+        self.rules.write_text("# Host rules\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(Exception, "must not contain|escapes"):
+            ProjectRulesFixedPointEnsurer(str(self.repo), "../CLAUDE.md")
+
+    def test_duplicate_marker_is_refused_without_changes(self) -> None:
+        block = ProjectRulesFixedPointEnsurer(str(self.repo))._managed_block()
+        original = "# Host rules\n\n" + block + "\n\n" + block
+        self.rules.write_text(original, encoding="utf-8")
+
+        with self.assertRaisesRegex(Exception, "duplicate"):
+            self.ensure()
+
+        self.assertEqual(self.rules.read_text(encoding="utf-8"), original)
+
+    def test_unpaired_marker_is_refused_without_changes(self) -> None:
+        original = "# Host rules\n\n<!-- consensus-rnd:foundational-invariants:start version=1 sha256=" + ("0" * 64) + " -->\n"
+        self.rules.write_text(original, encoding="utf-8")
+
+        with self.assertRaisesRegex(Exception, "missing or unbalanced"):
+            self.ensure()
+
+        self.assertEqual(self.rules.read_text(encoding="utf-8"), original)
+
+    def test_manual_edit_inside_block_fails_closed(self) -> None:
+        block = ProjectRulesFixedPointEnsurer(str(self.repo))._managed_block()
+        original = "# Host rules\n\n" + block.replace("FI-007 删除优先", "FI-007 手工改动")
+        self.rules.write_text(original, encoding="utf-8")
+
+        with self.assertRaisesRegex(Exception, "hash mismatch"):
+            self.ensure()
+
+        self.assertEqual(self.rules.read_text(encoding="utf-8"), original)
+
+    def test_known_old_hash_upgrades_only_managed_block(self) -> None:
+        old_hash = sha256_text(OLD_CANONICAL_BODY)
+        old_block = (
+            f"<!-- consensus-rnd:foundational-invariants:start version=1 sha256={old_hash} -->\n"
+            f"{OLD_CANONICAL_BODY}"
+            f"{END_MARKER}"
+        )
+        original = "# Host rules\n\n" + old_block + "\n\n## Host extension\n"
+        self.rules.write_text(original, encoding="utf-8")
+
+        status = self.ensure()
+
+        text = self.rules.read_text(encoding="utf-8")
+        self.assertEqual(status, "updated")
+        self.assertTrue(text.startswith("# Host rules\n\n"))
+        self.assertTrue(text.endswith("\n\n## Host extension\n"))
+        self.assertIn(CANONICAL_BODY, text)
+        self.assertEqual(START_RE.search(text).group(1), CANONICAL_HASH)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

实现 issue #2 的 Phase 9 r4 共识(minimal framing):**Phase 0 ProjectRulesFixedPointEnsurer** —— 让 skill 在 host bootstrap 时幂等地向 `$PROJECT_RULES` 写入一个带 sentinel 的 managed 不动点区块。

- **新增** `scripts/ensure_project_rules_fixed_points.py`(+ `test_*.py`):幂等、不覆盖 host 已有内容、可重复 bootstrap 不重复写、host 可在区块外扩展。不动点取自 fkst/aevatar CLAUDE.md 提炼的泛化理论。
- **SKILL.md** Phase 0 首次唤醒强制序列增 ensurer 步骤。
- **prompt PROJECT_RULES 接线**(7 处,implement 已声明 `SCOPE_EXTEND`,理由:共识方案需统一 PROJECT_RULES 语义)。
- **CLAUDE.md**:dogfood 运行 ensurer,注入本仓库不动点区块。

## 范围 / reviewer 注意

15 文件改 + 2 新增。**请 reviewer 重点审**:(a) 7 处 prompt SCOPE_EXTEND 是否都为共识所必需(还是夹带);(b) ensurer 幂等性 + 不覆盖 host 内容的保证;(c) 对本仓库 CLAUDE.md 的注入是否恰当。

共识链路:#2 r1→r4(converge×3 → 3/3 consensus)。完整 solver/judge 记录见 issue #2。

🤖 Auto-loop / codex-refactor-loop · 共识 implement(issue #2)

⟦AI:AUTO-LOOP⟧