### PR TITLE
cluster-007: v1 work-unit 契约(#3 共识)

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -2,11 +2,48 @@
 
 Detailed specifications, edge cases, and recovery playbook. The main workflow is in [SKILL.md](SKILL.md).
 
+## WorkUnitV1 contract
+
+`WorkUnitV1` is the v1 queue item contract stored inside the existing `clusters_planned`,
+`clusters_active`, `clusters_done`, and `clusters_failed` containers. The container names are
+historical but authoritative for state schema v1; do not add migrated queue containers, envelope
+wrappers, a normalizer helper, or a state-v2 migration for this contract.
+
+Required identity/provenance fields:
+
+- `work_unit_id`: canonical work-unit identity.
+- `kind`: work-unit type, for example `audit-cluster`; future producers may use non-audit kinds.
+- `producer`: source producer, for example `audit`; future producers must not pretend to be audit.
+- `source_ref`: stable pointer to the source material, for example `audit-iter-N.md#cluster-001`.
+
+Required audit-work fields when present in planned units:
+
+- `scope_paths`
+- `old_pattern`
+- `new_principle`
+- `verification_hints`
+- `dependencies`
+- `risk`
+- `leverage`
+
+Audit compatibility:
+
+- For current audit-backed units, `work_unit_id == id == cluster_id == legacy_cluster_id`.
+- For non-audit units, `work_unit_id` is not required to start with `cluster-`; omit
+  `legacy_cluster_id` and do not fabricate `cluster_id`.
+- Old state without `work_unit_schema_version` is read as v1 legacy state. Derive
+  `work_unit_id` from each queue item's `id`, treat `kind=producer=audit`, and use the audit
+  section as `source_ref` when known.
+- Prompt dispatch for current audit-backed units exports `WORK_UNIT_ID=$CLUSTER_ID`. Existing
+  markers, artifact names, branch names, and audit section lookups may continue to use
+  `CLUSTER_ID` during v1 compatibility.
+
 ## State schema (`.refactor-loop/state.json`)
 
 ```json
 {
   "schema_version": 1,
+  "work_unit_schema_version": 1,
   "loop_started_at": "<ISO8601>",
   "trunk_branch": "<branch the loop integrates into; same as integration_branch>",
   "integration_branch": "<branch all clusters land on>",
@@ -22,12 +59,33 @@ Detailed specifications, edge cases, and recovery playbook. The main workflow is
     "total_clusters": <int>
   },
   "clusters_planned": [
-    {"id": "cluster-001", "batch": "A", "risk": "low|medium|high", "leverage": "low|medium|high",
-     "dependencies": ["cluster-XXX"]}
+    {
+      "work_unit_id": "cluster-001",
+      "id": "cluster-001",
+      "cluster_id": "cluster-001",
+      "legacy_cluster_id": "cluster-001",
+      "kind": "audit-cluster",
+      "producer": "audit",
+      "source_ref": "audit-iter-1.md#cluster-001",
+      "batch": "A",
+      "scope_paths": ["<path>"],
+      "old_pattern": "<problem>",
+      "new_principle": "<target principle>",
+      "verification_hints": "<checks>",
+      "risk": "low|medium|high",
+      "leverage": "low|medium|high",
+      "dependencies": ["cluster-XXX"]
+    }
   ],
   "clusters_active": [
     {
+      "work_unit_id": "cluster-001",
       "id": "cluster-001",
+      "cluster_id": "cluster-001",
+      "legacy_cluster_id": "cluster-001",
+      "kind": "audit-cluster",
+      "producer": "audit",
+      "source_ref": "audit-iter-1.md#cluster-001",
       "phase": "implement | verify",
       "worktree": "<relative path>",
       "branch": "<refactor/iterN-cluster-id>",
@@ -38,11 +96,32 @@ Detailed specifications, edge cases, and recovery playbook. The main workflow is
     }
   ],
   "clusters_done": [
-    {"id": "cluster-001", "merged_at": "<ISO8601>", "commit": "<sha>",
-     "pr_number": <int|null>, "merged_into": "<integration_branch | upstream-cluster-branch>"}
+    {
+      "work_unit_id": "cluster-001",
+      "id": "cluster-001",
+      "cluster_id": "cluster-001",
+      "legacy_cluster_id": "cluster-001",
+      "kind": "audit-cluster",
+      "producer": "audit",
+      "source_ref": "audit-iter-1.md#cluster-001",
+      "merged_at": "<ISO8601>",
+      "commit": "<sha>",
+      "pr_number": <int|null>,
+      "merged_into": "<integration_branch | upstream-cluster-branch>"
+    }
   ],
   "clusters_failed": [
-    {"id": "cluster-001", "phase": "implement|verify|merge|remote-ci|stack-rebase", "reason": "<short>"}
+    {
+      "work_unit_id": "cluster-001",
+      "id": "cluster-001",
+      "cluster_id": "cluster-001",
+      "legacy_cluster_id": "cluster-001",
+      "kind": "audit-cluster",
+      "producer": "audit",
+      "source_ref": "audit-iter-1.md#cluster-001",
+      "phase": "implement|verify|merge|remote-ci|stack-rebase",
+      "reason": "<short>"
+    }
   ],
   "rollup_pr": {
     "pr_number": <int|null>,
@@ -57,6 +136,7 @@ Detailed specifications, edge cases, and recovery playbook. The main workflow is
   },
   "design_pending": [
     {
+      "work_unit_id": "cluster-NNN",
       "cluster_id": "cluster-NNN",
       "issue_number": <int>,
       "opened_at": "<ISO8601>",

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -32,8 +32,8 @@ Audit compatibility:
 - For non-audit units, `work_unit_id` is not required to start with `cluster-`; omit
   `legacy_cluster_id` and do not fabricate `cluster_id`.
 - Old state without `work_unit_schema_version` is read as v1 legacy state. Derive
-  `work_unit_id` from each queue item's `id`, treat `kind=producer=audit`, and use the audit
-  section as `source_ref` when known.
+  `work_unit_id` from each queue item's `id`, treat items as `kind="audit-cluster"` and
+  `producer="audit"`, and use the audit section as `source_ref` when known.
 - Prompt dispatch for current audit-backed units exports `WORK_UNIT_ID=$CLUSTER_ID`. Existing
   markers, artifact names, branch names, and audit section lookups may continue to use
   `CLUSTER_ID` during v1 compatibility.

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -614,6 +614,7 @@ Write initial `state.json`:
 ```json
 {
   "schema_version": 1,
+  "work_unit_schema_version": 1,
   "trunk_branch": "auto-refact-dev",
   "integration_branch": "auto-refact-dev",
   "review_base_branch": "dev",
@@ -627,6 +628,12 @@ Write initial `state.json`:
   "clusters_failed": []
 }
 ```
+
+`work_unit_schema_version: 1` means `clusters_planned`, `clusters_active`, `clusters_done`, and
+`clusters_failed` are the authoritative v1 queue containers, but each item is a WorkUnitV1 record
+as specified in [REFERENCE.md](REFERENCE.md). If an existing state file lacks
+`work_unit_schema_version`, read it as v1 legacy state: derive `work_unit_id` from each item's
+`id`, treat audit clusters as `kind=producer=audit`, and continue without migration.
 
 **Default integration branch**: `auto-refact-dev`. This is the long-lived branch where all auto-refactor cluster PRs land before rolling up to `dev`. On a fresh loop:
 
@@ -682,7 +689,17 @@ When task notification fires → **controller validation** before accepting the 
 
 Anti-anchoring: **do not** include phrases like "prefer 0", "loop saturated", "healthy signal" in the audit prompt body. These bias codex toward terminating instead of digging. Use the mechanical thresholds in `prompts/audit.md` as the only stop criteria.
 
-After validation: read `audit-iter-N.md`, populate `clusters_planned`, split into batches (max `max_parallel_clusters` per batch) by **file/project disjointness**:
+After validation: read `audit-iter-N.md`, normalize each accepted audit cluster into a WorkUnitV1
+record, populate `clusters_planned`, split into batches (max `max_parallel_clusters` per batch) by
+**file/project disjointness**:
+
+- Current audit-backed units set `work_unit_id == id == cluster_id == legacy_cluster_id`,
+  `kind="audit-cluster"`, `producer="audit"`, and `source_ref="audit-iter-N.md#<cluster-id>"`.
+- Preserve existing cluster fields for audit section lookup, markers, artifact filenames, branch
+  names, and GitHub issue routing during v1 compatibility.
+- Future non-audit producers may write WorkUnitV1 items into `clusters_planned` with
+  `kind != audit-cluster` and `producer != audit`; they must not fabricate `cluster_id` or
+  `legacy_cluster_id`.
 
 - Two clusters that touch the same `$BUILD_CMD 目标/工程文件` or share a file path go in different batches.
 - Two clusters that touch the same proto file → different batches.
@@ -702,11 +719,13 @@ For every cluster with `requires_design: true`:
 2. Record in state.json:
    ```json
    "design_pending": [
-     {"cluster_id": "cluster-NNN", "issue_number": 234,
+     {"work_unit_id": "cluster-NNN", "cluster_id": "cluster-NNN", "issue_number": 234,
       "opened_at": "<ISO8601>", "last_checked": "<ISO8601>",
       "last_comment_count": 0, "status": "awaiting_design"}
    ]
    ```
+   `design_pending.work_unit_id` is canonical. `design_pending.cluster_id` remains a legacy alias
+   for current audit-backed issues and existing controller routing.
 3. Skip the cluster in Phase 2 (do NOT batch it).
 4. PushNotification: "iter<N> opened design issue #<issue> for cluster-<id>. Auto-loop paused on this cluster pending human design decision."
 
@@ -758,11 +777,15 @@ For each cluster in the current batch:
      .refactor-loop/worktrees/<cluster-id> HEAD
    ```
 
-2. Materialize prompt: copy `prompts/implement.md`, replace placeholders (`{{cluster_id}}`, `{{worktree_path}}`, `{{branch}}`, `{{old_pattern}}`, `{{new_principle}}`, `{{scope_paths}}`, `{{verification_hints}}`). Save to `.refactor-loop/prompts/implement-<cluster-id>.md`.
+2. Materialize prompt: copy `prompts/implement.md`, replace placeholders (`{{work_unit_id}}`,
+   `{{cluster_id}}`, `{{worktree_path}}`, `{{branch}}`, `{{old_pattern}}`, `{{new_principle}}`,
+   `{{scope_paths}}`, `{{verification_hints}}`). For current audit-backed units, export
+   `WORK_UNIT_ID=$CLUSTER_ID` before `envsubst` / placeholder replacement. Save to
+   `.refactor-loop/prompts/implement-<cluster-id>.md`.
 
 3. Dispatch via `spawn-codex.sh --cd <worktree>` with `--stall 5400` (5400s no-output stall window).
 
-4. Update `clusters_active` with `bg_task` id.
+4. Update `clusters_active` with the WorkUnitV1 identity/provenance fields plus `bg_task` id.
 
 After all parallel dispatches, schedule wakeup 1800s safety net. **End turn.**
 
@@ -778,7 +801,9 @@ Do **not** advance the whole batch in lockstep; verify each cluster independentl
 
 For each cluster whose implement finished `ok`:
 
-1. Materialize `prompts/verify.md` → `.refactor-loop/prompts/verify-<cluster-id>.md`.
+1. Materialize `prompts/verify.md` → `.refactor-loop/prompts/verify-<cluster-id>.md`. For current
+   audit-backed units, export `WORK_UNIT_ID=$CLUSTER_ID`; `WORK_UNIT_ID` is the canonical prompt
+   identity, while `CLUSTER_ID` remains the v1 compatibility alias for markers and artifacts.
 2. Dispatch in the same worktree (verify reads `git diff HEAD`, runs full test/guard suite, gates merge):
 
    ```bash
@@ -1554,7 +1579,14 @@ A single reviewer codex would weigh all dimensions and might trade tests for arc
 
 ## Phase 9 — Multi-solver design consensus (sole authorization gate)
 
-Runs when a `state.design_pending[i]` cluster needs a concrete implementation decision. Goal: 3 independent solver codexes propose framings from different biases; a 4th meta-judge codex arbitrates; **3/3 unanimous + meta-judge consensus → auto-dispatch implement**. Deep consensus is the only sufficient authorization gate for every change, including Tier I, Tier II, `CLAUDE.md`, `SPEC.md`, conformance, and core abstractions. There is no post-consensus maintainer approval, physical GPG ratification, reinstall ratification, or philosophy escalation gate.
+Runs when a `state.design_pending[i]` WorkUnitV1 item needs a concrete implementation decision.
+Current audit-backed items expose `WORK_UNIT_ID=$CLUSTER_ID` so Phase 9 can frame the decision as
+work-unit design while preserving `cluster_id` as legacy routing metadata. Goal: 3 independent
+solver codexes propose framings from different biases; a 4th meta-judge codex arbitrates; **3/3
+unanimous + meta-judge consensus → auto-dispatch implement**. Deep consensus is the only sufficient
+authorization gate for every change, including Tier I, Tier II, `CLAUDE.md`, `SPEC.md`,
+conformance, and core abstractions. There is no post-consensus maintainer approval, physical GPG
+ratification, reinstall ratification, or philosophy escalation gate.
 
 Policy: **3/3 unanimous required** — anything less goes through convergence until consensus or true stall.
 

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -633,7 +633,8 @@ Write initial `state.json`:
 `clusters_failed` are the authoritative v1 queue containers, but each item is a WorkUnitV1 record
 as specified in [REFERENCE.md](REFERENCE.md). If an existing state file lacks
 `work_unit_schema_version`, read it as v1 legacy state: derive `work_unit_id` from each item's
-`id`, treat audit clusters as `kind=producer=audit`, and continue without migration.
+`id`, treat audit clusters as `kind="audit-cluster"` and `producer="audit"`, and continue without
+migration.
 
 **Default integration branch**: `auto-refact-dev`. This is the long-lived branch where all auto-refactor cluster PRs land before rolling up to `dev`. On a fresh loop:
 

--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -1,6 +1,7 @@
-# 任务：实施 ${CLUSTER_ID}
+# 任务：实施 ${WORK_UNIT_ID}
 
 你以无人值守模式在 worktree `${WORKTREE_PATH}` 中工作，对应分支 `${BRANCH}`。
+当前 v1 audit-backed work unit 的兼容 cluster alias 是 `${CLUSTER_ID}`；审计段查找、既有 artifact 文件名、分支/worktree 名和 marker 仍使用该 alias。
 
 ## 必读上下文
 

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -1,6 +1,6 @@
 # Role: Meta-judge — Phase 9 consensus arbiter
 
-You are the **4th codex** for design-issue **${ISSUE_NUMBER}** (cluster `${CLUSTER_ID}`). You did NOT propose a solution. Your job: read all 3 solver outputs and decide ONE of:
+You are the **4th codex** for design-issue **${ISSUE_NUMBER}** (work unit `${WORK_UNIT_ID}`, v1 audit cluster alias `${CLUSTER_ID}`). You did NOT propose a solution. Your job: read all 3 solver outputs and decide ONE of:
 
 1. **Consensus reached** → auto-dispatch implement (3/3 same framing; this is sufficient authorization for any file or tier)
 2. **Convergence round needed** → re-dispatch the 3 solvers with a narrowed question (no hard round cap; stall is evaluated after ≥3 no-progress rounds)

--- a/skills/codex-refactor-loop/prompts/verify.md
+++ b/skills/codex-refactor-loop/prompts/verify.md
@@ -1,6 +1,7 @@
-# 任务：验证 ${CLUSTER_ID} 的实施改动
+# 任务：验证 ${WORK_UNIT_ID} 的实施改动
 
 你以无人值守模式在 worktree `${WORKTREE_PATH}` 中工作。前一个 codex 已完成实施，改动在工作树未提交。
+当前 v1 audit-backed work unit 的兼容 cluster alias 是 `${CLUSTER_ID}`；既有实施摘要、artifact 文件名和 marker 仍使用该 alias。
 
 ## 必读
 

--- a/skills/codex-refactor-loop/scripts/controller_lib.sh
+++ b/skills/codex-refactor-loop/scripts/controller_lib.sh
@@ -124,10 +124,11 @@ open_pr_with_label() {
 
 # Substitute {{handlebars}} placeholders in a template using current env vars
 # Usage: render_template <template-file> <output-file>
-# Reads $CLUSTER_ID, $ITERATION, $WORKTREE_PATH, $BRANCH, $OLD_PATTERN, $NEW_PRINCIPLE, $SCOPE_PATHS, $VERIFICATION_HINTS, and $VAR in template.
+# Reads $WORK_UNIT_ID, $CLUSTER_ID, $ITERATION, $WORKTREE_PATH, $BRANCH, $OLD_PATTERN, $NEW_PRINCIPLE, $SCOPE_PATHS, $VERIFICATION_HINTS, and $VAR in template.
 render_template() {
   local in="$1" out="$2"
   perl -pe '
+    s/\{\{work_unit_id\}\}/($ENV{WORK_UNIT_ID} || $ENV{CLUSTER_ID})/ge;
     s/\{\{cluster_id\}\}/$ENV{CLUSTER_ID}/g;
     s/\{\{iteration\}\}/$ENV{ITERATION}/g;
     s/\{\{worktree_path\}\}/$ENV{WORKTREE_PATH}/g;

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -273,6 +273,45 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
     # Refactor (iter2/cluster-007-work-unit-contract-schema):
     #   Old pattern: work-unit state contract existed only as prose, so migration/envelope terms could re-enter the skill unnoticed
     #   New principle: source-regression coverage keeps WorkUnitV1 v1 containers authoritative and blocks premature work_units_* migration surface
+    def render_work_unit_template(self, *, work_unit_id: str | None, cluster_id: str) -> str:
+        with tempfile.TemporaryDirectory() as tmp:
+            template = Path(tmp) / "template.md"
+            output = Path(tmp) / "rendered.md"
+            template.write_text(
+                "primary={{work_unit_id}}\nlegacy={{cluster_id}}\nunresolved={{work_unit_id}}\n",
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env.update(
+                {
+                    "REPO_ROOT": str(REPO_ROOT),
+                    "CLUSTER_ID": cluster_id,
+                    "ITERATION": "2",
+                    "WORKTREE_PATH": "/tmp/worktree",
+                    "BRANCH": "refactor/test",
+                    "OLD_PATTERN": "old",
+                    "NEW_PRINCIPLE": "new",
+                    "SCOPE_PATHS": "skills/codex-refactor-loop",
+                    "VERIFICATION_HINTS": "render test",
+                }
+            )
+            if work_unit_id is None:
+                env.pop("WORK_UNIT_ID", None)
+            else:
+                env["WORK_UNIT_ID"] = work_unit_id
+
+            script = f'source "{SKILL_ROOT / "scripts" / "controller_lib.sh"}"; render_template "$TEMPLATE" "$OUTPUT"'
+            result = subprocess.run(
+                ["bash", "-lc", script],
+                env={**env, "TEMPLATE": str(template), "OUTPUT": str(output)},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return output.read_text(encoding="utf-8")
+
     def test_work_unit_v1_contract_markers_are_present(self) -> None:
         reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
         skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
@@ -314,6 +353,19 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             for token in forbidden_tokens:
                 with self.subTest(path=path.name, token=token):
                     self.assertNotIn(token, text)
+
+    def test_render_template_prefers_work_unit_id_over_cluster_alias(self) -> None:
+        rendered = self.render_work_unit_template(work_unit_id="unit-123", cluster_id="cluster-007")
+
+        self.assertIn("primary=unit-123", rendered)
+        self.assertIn("legacy=cluster-007", rendered)
+        self.assertNotIn("{{work_unit_id}}", rendered)
+
+    def test_render_template_falls_back_to_cluster_id_when_work_unit_id_is_unset(self) -> None:
+        rendered = self.render_work_unit_template(work_unit_id=None, cluster_id="cluster-007")
+
+        self.assertIn("primary=cluster-007", rendered)
+        self.assertNotIn("{{work_unit_id}}", rendered)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -269,5 +269,52 @@ class ProjectRulesPromptContractTests(unittest.TestCase):
         self.assertIn("helper 退出非 0 → bootstrap fail closed", skill_text)
 
 
+class WorkUnitV1SourceRegressionTests(unittest.TestCase):
+    # Refactor (iter2/cluster-007-work-unit-contract-schema):
+    #   Old pattern: work-unit state contract existed only as prose, so migration/envelope terms could re-enter the skill unnoticed
+    #   New principle: source-regression coverage keeps WorkUnitV1 v1 containers authoritative and blocks premature work_units_* migration surface
+    def test_work_unit_v1_contract_markers_are_present(self) -> None:
+        reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+        skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        implement_prompt = (SKILL_ROOT / "prompts" / "implement.md").read_text(encoding="utf-8")
+        verify_prompt = (SKILL_ROOT / "prompts" / "verify.md").read_text(encoding="utf-8")
+        controller_lib = (SKILL_ROOT / "scripts" / "controller_lib.sh").read_text(encoding="utf-8")
+        combined = "\n".join([reference_text, skill_text, implement_prompt, verify_prompt, controller_lib])
+
+        required_markers = (
+            "WorkUnitV1",
+            "work_unit_schema_version",
+            "work_unit_id == id == cluster_id == legacy_cluster_id",
+            "WORK_UNIT_ID=$CLUSTER_ID",
+            "must not fabricate `cluster_id` or",
+            "`legacy_cluster_id`",
+            "s/\\{\\{work_unit_id\\}\\}/($ENV{WORK_UNIT_ID} || $ENV{CLUSTER_ID})/ge",
+        )
+
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, combined)
+
+    def test_work_unit_v1_forbidden_migration_surface_is_absent(self) -> None:
+        checked_paths = [
+            SKILL_ROOT / "REFERENCE.md",
+            SKILL_ROOT / "SKILL.md",
+            SKILL_ROOT / "prompts" / "implement.md",
+            SKILL_ROOT / "prompts" / "verify.md",
+            SKILL_ROOT / "prompts" / "meta-judge.md",
+        ]
+        forbidden_tokens = tuple(f"work_units_{name}" for name in ("planned", "active", "done", "failed")) + (
+            "WorkUnit" + "EnvelopeV1",
+            "WorkUnit" + "ProducerV1",
+            "work_unit_" + "producer.py",
+        )
+
+        for path in checked_paths:
+            text = path.read_text(encoding="utf-8")
+            for token in forbidden_tokens:
+                with self.subTest(path=path.name, token=token):
+                    self.assertNotIn(token, text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

实现 issue #3(cluster-007)Phase 9 r3 共识(structural):v1 work-unit 契约 —— `clusters_*` 保持权威 + 新增 `WorkUnitV1` items + `WORK_UNIT_ID` alias,**零迁移**(不引入 WorkUnitEnvelopeV1),向后兼容。文档层落于 SKILL.md + REFERENCE.md。

契合 maintainer 指令「重构即开发也可以,别过度泛化」——薄契约、零迁移。

共识链路:#3 r1→r3(converge×2 → 3/3 consensus structural)。完整记录见 issue #3。

🤖 Auto-loop · 共识 implement(#3)

⟦AI:AUTO-LOOP⟧