### PR TITLE
cluster-008: audit-as-producer 适配(#4 共识)

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -38,6 +38,53 @@ Audit compatibility:
   markers, artifact names, branch names, and audit section lookups may continue to use
   `CLUSTER_ID` during v1 compatibility.
 
+## Producers in v1
+
+`WorkUnitV1` separates the queue item contract from the source that produced the item. The v1
+controller recognizes exactly these producer values:
+
+- `audit`
+- `manual-issue`
+
+This is a documented normalization boundary, not a new producer framework. Do not add new
+producer abstractions, registry helpers, envelope wrappers, or migrated work-unit state containers
+for v1.
+
+### `audit` producer
+
+`audit` remains the default producer. It reads the raw artifact contract from
+`prompts/audit.md` and the resulting `.refactor-loop/runs/audit-iter-N.md` cluster sections.
+The controller leaves `prompts/audit.md` unchanged and projects each accepted audit cluster into
+`WorkUnitV1` before adding it to `clusters_planned`:
+
+- `work_unit_id: <cluster-id>`
+- `id: <cluster-id>`
+- `cluster_id: <cluster-id>`
+- `kind: audit-cluster`
+- `producer: audit`
+- `source_ref: .refactor-loop/runs/audit-iter-N.md#<cluster-id>`
+- `legacy_cluster_id: <cluster-id>` optional but recommended during v1 compatibility
+
+Audit-backed units may keep using `<cluster-id>` for branch names, worktree paths, artifact
+filenames, markers, and audit section lookup while `WORK_UNIT_ID=$CLUSTER_ID` remains the v1 alias.
+
+### `manual-issue` producer
+
+`manual-issue` is the Phase 7 `auto-loop-triage` intake path for maintainer-selected GitHub
+issues. Accepted issues must be reshaped into a `WorkUnitV1`-backed design issue before Phase 9
+solver dispatch:
+
+- `work_unit_id: issue-<N>`
+- `kind: manual-work-unit`
+- `producer: manual-issue`
+- `source_ref: gh-issue-<N>`
+- `scope_paths`
+- problem / invariant text
+- `verification_hints`
+
+Manual issues must not fabricate `cluster_id` or `legacy_cluster_id`; those fields are audit
+compatibility aliases only.
+
 ## State schema (`.refactor-loop/state.json`)
 
 ```json

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -400,7 +400,7 @@ This skill complements `refactor-team` (Agent-subagent based). Use this skill wh
 /loop <task description... 完全无人值守模式>
 ```
 
-**首次唤醒(first wakeup)→ 必须按序跑完「Phase 0 — Bootstrap」节的「首次唤醒强制序列」全部步骤再 end turn**:host.env 自检 → state + integration 分支 → 建全套 labels → **起并挂载全部 5 个 daemon** → 派 audit codex → ScheduleWakeup。漏任一步 = bootstrap 失败。
+**首次唤醒(first wakeup)→ 必须按序跑完「Phase 0 — Bootstrap」节的「首次唤醒强制序列」全部步骤再 end turn**:host.env 自检 → state + integration 分支 → 建全套 labels → **起并挂载全部 5 个 daemon** → 派默认 v1 work-unit producer(默认 audit) → ScheduleWakeup。漏任一步 = bootstrap 失败。
 
 **默认走 GitHub 全流程,这不是「本地分析任务」。** 本 skill 的本体 = GitHub 状态面 + 5 daemon + codex 多角度共识闭环。❌ 严禁把首次唤醒降级成「只在本地读代码 / 出 markdown 报告 / 本地改文件 commit」而**不 bootstrap GitHub、不起 daemon、不派 audit**——那等于根本没跑这个 skill。若 host 现状(如无应用代码 / host.env 缺失)让 GitHub 全流程暂不可行,正确动作是停下来 PushNotification 请 maintainer 补 host.env / 确认范围,而**不是**擅自改跑成本地任务。
 
@@ -591,12 +591,12 @@ Controller turn 间 / session 间 / `/clear` 后,**后台 codex 继续跑不中�
 1. **state + integration 分支**:`mkdir -p .refactor-loop/{...}` + 写 `state.json` + idempotent 建/推 `$INTEGRATION_BRANCH`(下方细节)。
 2. **建全套 labels**:跑「Label 系统」节的 Bootstrap —— 9 个 phase label + 3 个 human label 创建循环。**漏建 = 后续 phase transition 无 label 可挂、comment-monitor 查 `--label auto-loop` 漏掉 PR**。
 3. **起并挂载全部 5 个 daemon**:按「Host 运行编排 → Daemon 启动」节的 `bash -c 'source host.env && exec'` pattern 起齐 `concurrency_monitor.py` / `codex-progress-reporter.sh` / `comment-monitor.sh` / `dev_sync_daemon.py` / `triage-monitor.sh`,逐个 `pgrep -f <daemon>` 验 = 1。**首轮就必须把 5 个全起起来——它不是「以后某次 wakeup 才做的 liveness 检查」**。
-4. **派 audit codex**(Phase 1,`spawn-codex.sh` + Bash `run_in_background:true`)+ ScheduleWakeup 兜底 + end turn。
+4. **派默认 v1 work-unit producer**(Phase 1,默认 audit,`spawn-codex.sh` + Bash `run_in_background:true`)+ ScheduleWakeup 兜底 + end turn。
 
 每步做完才进下一步。3 漏起任一 daemon、2 漏建 labels = bootstrap 失败,下次 wakeup 第一件事补齐。
 
 #### ❌ 严禁(首次唤醒反模式 — 均来自 baseline 失败)
-- ❌ 只 bootstrap state + 派 audit,不起 5 daemon(baseline 默认失败模式)
+- ❌ 只 bootstrap state + 派默认 producer,不起 5 daemon(baseline 默认失败模式)
 - ❌ 不建 labels 就派 codex(phase transition 时无 label 可挂)
 - ❌ 把整个 skill 降级成「本地读代码 + 出 markdown 报告 + 本地 commit」而不碰 GitHub、不起 daemon、不派 audit
 - ❌ host.env 缺失时猜值硬跑
@@ -659,7 +659,12 @@ Create top-level TaskCreate items: audit / dispatch / merge.
 
 ---
 
-## Phase 1 — Audit (one codex + controller validation)
+## Phase 1 — Work-unit production (audit default)
+
+The default v1 work-unit producer is `audit`. Producer normalization is documented in
+[REFERENCE.md](REFERENCE.md): v1 accepts only `producer: audit` and `producer: manual-issue`.
+`audit` is the raw artifact producer for this phase; `manual-issue` enters through Phase 7
+triage and must already be reshaped before Phase 9.
 
 1. Copy `prompts/audit.md` (this skill's template) to `.refactor-loop/prompts/audit-iter-N.md`.
 2. Replace `{{iteration}}` placeholder.
@@ -690,17 +695,20 @@ When task notification fires → **controller validation** before accepting the 
 
 Anti-anchoring: **do not** include phrases like "prefer 0", "loop saturated", "healthy signal" in the audit prompt body. These bias codex toward terminating instead of digging. Use the mechanical thresholds in `prompts/audit.md` as the only stop criteria.
 
-After validation: read `audit-iter-N.md`, normalize each accepted audit cluster into a WorkUnitV1
-record, populate `clusters_planned`, split into batches (max `max_parallel_clusters` per batch) by
+After validation: read `audit-iter-N.md`; the controller projects each accepted audit cluster into
+the WorkUnitV1 fields documented in `REFERENCE.md` (`work_unit_id`, `kind`, `producer`,
+`source_ref`, and v1 audit compatibility aliases), populate `clusters_planned`, split into batches
+(max `max_parallel_clusters` per batch) by
 **file/project disjointness**:
 
 - Current audit-backed units set `work_unit_id == id == cluster_id == legacy_cluster_id`,
   `kind="audit-cluster"`, `producer="audit"`, and `source_ref="audit-iter-N.md#<cluster-id>"`.
 - Preserve existing cluster fields for audit section lookup, markers, artifact filenames, branch
   names, and GitHub issue routing during v1 compatibility.
-- Future non-audit producers may write WorkUnitV1 items into `clusters_planned` with
-  `kind != audit-cluster` and `producer != audit`; they must not fabricate `cluster_id` or
-  `legacy_cluster_id`.
+- Phase 7 `manual-issue` intake may write WorkUnitV1 items into `clusters_planned` only after the
+  accepted GitHub issue has been reshaped with `kind="manual-work-unit"`,
+  `producer="manual-issue"`, `source_ref="gh-issue-<N>"`, `scope_paths`, problem/invariant text,
+  and `verification_hints`. It must not fabricate `cluster_id` or `legacy_cluster_id`.
 
 - Two clusters that touch the same `$BUILD_CMD 目标/工程文件` or share a file path go in different batches.
 - Two clusters that touch the same proto file → different batches.
@@ -1168,9 +1176,16 @@ Controller 下次 wakeup sweep `gh issue list --label "auto-loop,phase9-auto-sol
 
 **前提**:issue body 至少要描述 "what's broken + relevant file paths"。Body 越结构化(evidence / fix boundary / decision questions)solver 越准。
 
-#### Path B — Triage codex(推荐,更安全)
+#### Path B — Triage codex / `manual-issue` producer(推荐,更安全)
 
 maintainer 只加 1 label:`auto-loop-triage`
+
+This path is the v1 `manual-issue` producer. The triage codex accepts only concrete repository
+work units suitable for consensus, reshapes the issue into a WorkUnitV1-backed design issue, and
+then label-routes it to Phase 9. Accepted manual issues must contain `work_unit_id: issue-<N>`,
+`kind: manual-work-unit`, `producer: manual-issue`, `source_ref: gh-issue-<N>`, `scope_paths`,
+problem/invariant text, and `verification_hints`; they must not include fabricated `cluster_id` or
+`legacy_cluster_id`.
 
 **Daemon 自包含**:
 
@@ -1189,9 +1204,9 @@ maintainer 只加 1 label:`auto-loop-triage`
 
 Controller 每 wakeup sweep `--label "auto-loop-triage"`(daemon 漏了兜底),对每个新 issue:
 1. 派 **triage codex**(`prompts/triage-external-issue.md`)读 issue body + 判断:
-   - 是否属于本 refactor loop 范畴(违反 CLAUDE/AGENTS 条款)?
-   - 若是 → 调研代码 + 补 evidence / Fix Boundary / human_brief / decision questions + 重写 issue body 成 standardized design issue 格式 + label 切换为 `auto-loop,phase9-auto-solve,🔍 phase:design-solving,🤖 human:auto-推进`(移除 `auto-loop-triage`)
-   - 若否 → 评论"非 refactor loop 范畴(原因 XXX),退出 auto-loop";移除 `auto-loop-triage` label;不再处理
+   - 是否是 concrete repository work unit suitable for consensus?
+   - 若是 → 调研代码 + 补 evidence / Fix Boundary / human_brief / decision questions + 重写 issue body 成含 `manual-issue` WorkUnitV1 字段的 standardized design issue 格式 + label 切换为 `auto-loop,phase9-auto-solve,🔍 phase:design-solving,🤖 human:auto-推进`(移除 `auto-loop-triage`)
+   - 若否 → 评论"不适合作为 manual-issue work unit(原因 XXX),退出 auto-loop";移除 `auto-loop-triage` label;不再处理
 2. Triage codex 完成后 issue 进 Phase 9 标准链路
 
 **triage codex 输出 marker**:`TRIAGE_DONE:<issue>:<accept|reject>:<reason>`
@@ -1199,14 +1214,14 @@ Controller 每 wakeup sweep `--label "auto-loop-triage"`(daemon 漏了兜底),�
 **优势 vs Path A**:
 - maintainer 只加 1 label(易记)
 - body reshaping 由 codex 自动做(maintainer 不用学 design-issue body 模板)
-- 非 refactor 范畴会被自动拒绝(防 controller 把任意 issue 当 cluster 跑)
+- 不适合 consensus 的 issue 会被自动拒绝(防 controller 把任意 issue 当 work unit 跑)
 - triage codex 调研代码补 evidence,solver 后续准
 
 ### 反面(❌ 禁止)
 
 - ❌ controller 无 sweep `auto-loop-triage` label → 外部 issue 加 label 也无人接
 - ❌ Path B triage codex 直接派 solver 而不 reshape body → solver 找不到 evidence
-- ❌ triage codex 接受 non-refactor issue(产品需求 / bug 报告 / feature request)→ Phase 9 完全错位
+- ❌ triage codex 接受产品需求 / runtime bug report / duplicate / unclear / >50 files issue → Phase 9 完全错位
 - ❌ 加 `auto-loop` label 但忘加 `phase9-auto-solve` → controller 当普通 design issue 等 maintainer,不自动派 solver
 
 

--- a/skills/codex-refactor-loop/prompts/triage-external-issue.md
+++ b/skills/codex-refactor-loop/prompts/triage-external-issue.md
@@ -1,8 +1,8 @@
 # Triage codex — 外部 issue 评估 + 接入(or 拒绝)
 
 你是 triage codex,任务:把 maintainer 加了 `auto-loop-triage` label 的**外部 issue** 评估为:
-- **accept** — 属于本 refactor loop 范畴(违反 PROJECT_RULES/AGENTS 条款),reshape body + 切换 label 进入 Phase 9 三 solver 流程
-- **reject** — 不属于(产品需求 / bug 报告 / feature request / 文档问题 / 第三方工具问题),评论解释 + 移除 triage label
+- **accept** — 是 concrete repository work unit suitable for consensus;reshape body 为 `manual-issue` WorkUnitV1-backed design issue + 切换 label 进入 Phase 9 三 solver 流程
+- **reject** — 不适合作为 consensus work unit(产品需求 / runtime bug report / 外部依赖 / duplicate / unclear / scope 过大),评论解释 + 移除 triage label
 
 ## Context
 
@@ -17,31 +17,37 @@
 读 `gh issue view ${ISSUE_NUMBER} --json title,body,labels,author`。
 
 **Accept 标准(全部满足)**:
-- 描述的问题对应到具体 source file:line(在本 repo 内,不是外部依赖)
-- 违反某条 PROJECT_RULES 或 AGENTS.md 强制条款(查证条款,引原文)
+- 描述的是一个 concrete repository work unit:可落到本 repo 内具体 files / docs / prompts / scripts / config,且需要实现决策或执行边界
+- 能给出 repo-owned invariant / policy / desired end state(优先引用 PROJECT_RULES 或 AGENTS.md;若是 skill 文档/prompt/tooling 工作,引用相应权威文档或 issue 决策)
 - 不是产品 feature request("加 X 功能")或 bug report("Y 不工作")
-- 不是 docs-only 或 tooling-only(本 loop 处理 production code 违反)
+- 不是外部依赖工作;不是只要求第三方服务/上游仓库变更
 - 范围合理(≤ 50 files;过大需 maintainer split,reject + 解释)
 
 **Reject 类型**:
 - product-feature-request — 加新功能 / 改 UI 行为
-- runtime-bug-report — 用户报告功能失常(走 bug tracker)
-- docs-only — 仅文档问题
-- tooling-only — CLI / build / IDE 问题(走 tooling repo)
+- runtime-bug-report — 用户报告功能失常,但没有 repo-owned implementation decision
 - out-of-scope — 在外部依赖($EXTERNAL_REPOS 等)
 - duplicate — 已有 open auto-loop issue 覆盖(grep 现有 issue title/body)
 - scope-too-large — 范围 > 50 files,需 maintainer 先 split
-- unclear — body 不够具体,无法定位 file:line 或 CLAUDE 条款
+- unclear — body 不够具体,无法定位 repo-owned work unit / scope_paths / invariant
 
 ### Step 2A — Accept path(reshape body + 切 label)
 
-1. 调研代码(grep / read)补充 evidence:`file:line` + 代码片段 + 违反的 CLAUDE 条款(引原文)
+1. 调研代码(grep / read)补充 evidence:`file:line` + 必要片段 + repo-owned invariant / policy / desired end state(引原文或 issue 决策)
 2. 写 Fix Boundary(明确 scope_paths)
 3. 写 human_brief(中文 problem_title / problem_statement / problem_example / why_needs_design / design_question / original_authors via git blame)
-4. 用 `gh issue edit ${ISSUE_NUMBER} --body-file <new-body.md>` 把 body 替换成 standardized design issue 格式(参考 audit codex 产出的 issue body 风格)
+4. 用 `gh issue edit ${ISSUE_NUMBER} --body-file <new-body.md>` 把 body 替换成 standardized design issue 格式(参考 audit codex 产出的 issue body 风格),并在 body 中明确写入:
+   - `work_unit_id: issue-${ISSUE_NUMBER}`
+   - `kind: manual-work-unit`
+   - `producer: manual-issue`
+   - `source_ref: gh-issue-${ISSUE_NUMBER}`
+   - `scope_paths: [...]`
+   - problem / invariant text
+   - `verification_hints`
+   - 不写 `cluster_id` 或 `legacy_cluster_id`
 5. label 切换:`gh issue edit ${ISSUE_NUMBER} --remove-label "auto-loop-triage" --add-label "auto-loop,phase9-auto-solve,🔍 phase:design-solving,🤖 human:auto-推进,refactor-design-needed"`
-6. 评论(comment)解释:"Triage 接受:identified as refactor cluster (cluster-XXX-yyy 命名建议);已 reshape body + 切 label 进入 Phase 9 三 solver 流程"
-7. 末尾打印 `TRIAGE_DONE:${ISSUE_NUMBER}:accept:<cluster-id-suggestion>`
+6. 评论(comment)解释:"Triage 接受:identified as manual-issue work unit issue-${ISSUE_NUMBER};已 reshape body + 切 label 进入 Phase 9 三 solver 流程"
+7. 末尾打印 `TRIAGE_DONE:${ISSUE_NUMBER}:accept:issue-${ISSUE_NUMBER}`
 
 ### Step 2B — Reject path(评论 + 移除 label)
 
@@ -52,7 +58,7 @@
 
 ## 必读
 
-1. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 强制条款全文(判 accept 必须引证某条)
+1. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 强制条款全文(能适用时必须引证)
 2. `$REPO_ROOT/AGENTS.md`(若存在,辅助规则)
 3. 现有 open auto-loop issues:`gh issue list --label "auto-loop" --state open --json number,title`(查重)
 4. 现有 open auto-loop PRs:`gh pr list --label "auto-loop" --state open --json number,title`(查重)
@@ -67,7 +73,7 @@
 ## GitHub post
 
 按 accept / reject 分别:
-- accept 评论头行 `## 🤖 Triage codex — accept: <cluster-id-suggestion>`
+- accept 评论头行 `## 🤖 Triage codex — accept: issue-${ISSUE_NUMBER}`
 - reject 评论头行 `## 🤖 Triage codex — reject: <reject-type>`
 - 中文 TL;DR + raw artifact 折叠 + sentinel
 

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -338,6 +338,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
         checked_paths = [
             SKILL_ROOT / "REFERENCE.md",
             SKILL_ROOT / "SKILL.md",
+            SKILL_ROOT / "prompts" / "triage-external-issue.md",
             SKILL_ROOT / "prompts" / "implement.md",
             SKILL_ROOT / "prompts" / "verify.md",
             SKILL_ROOT / "prompts" / "meta-judge.md",
@@ -346,6 +347,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             "WorkUnit" + "EnvelopeV1",
             "WorkUnit" + "ProducerV1",
             "work_unit_" + "producer.py",
+            "producer " + "registry",
         )
 
         for path in checked_paths:
@@ -366,6 +368,69 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
 
         self.assertIn("primary=cluster-007", rendered)
         self.assertNotIn("{{work_unit_id}}", rendered)
+
+    def test_v1_producer_contract_markers_are_present(self) -> None:
+        reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+        skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        triage_prompt = (SKILL_ROOT / "prompts" / "triage-external-issue.md").read_text(encoding="utf-8")
+        combined = "\n".join([reference_text, skill_text, triage_prompt])
+
+        required_markers = (
+            "Producers in v1",
+            "- `audit`",
+            "- `manual-issue`",
+            "kind: audit-cluster",
+            "kind: manual-work-unit",
+            "producer: audit",
+            "producer: manual-issue",
+            "source_ref: .refactor-loop/runs/audit-iter-N.md#<cluster-id>",
+            "source_ref: gh-issue-<N>",
+            "source_ref: gh-issue-${ISSUE_NUMBER}",
+            "Work-unit production (audit default)",
+        )
+
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, combined)
+
+    def test_manual_issue_reshape_requires_work_unit_v1_fields_without_audit_aliases(self) -> None:
+        triage_prompt = (SKILL_ROOT / "prompts" / "triage-external-issue.md").read_text(encoding="utf-8")
+
+        required_markers = (
+            "work_unit_id: issue-${ISSUE_NUMBER}",
+            "kind: manual-work-unit",
+            "producer: manual-issue",
+            "source_ref: gh-issue-${ISSUE_NUMBER}",
+            "scope_paths",
+            "problem / invariant text",
+            "verification_hints",
+            "\u4e0d\u5199 `cluster_id` \u6216 `legacy_cluster_id`",
+        )
+
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, triage_prompt)
+
+    def test_triage_prompt_drops_old_refactor_only_and_docs_tooling_gates(self) -> None:
+        triage_prompt = (SKILL_ROOT / "prompts" / "triage-external-issue.md").read_text(encoding="utf-8")
+
+        forbidden_markers = (
+            "\u5c5e\u4e8e\u672c refactor loop \u8303\u7574(\u8fdd\u53cd PROJECT_RULES/AGENTS \u6761\u6b3e)",
+            "\u4e0d\u662f docs-only \u6216 tooling-only",
+            "docs-only \u2014 \u4ec5\u6587\u6863\u95ee\u9898",
+            "tooling-only \u2014 CLI / build / IDE \u95ee\u9898",
+        )
+
+        for marker in forbidden_markers:
+            with self.subTest(marker=marker):
+                self.assertNotIn(marker, triage_prompt)
+
+    def test_audit_prompt_remains_raw_artifact_contract(self) -> None:
+        audit_prompt = (SKILL_ROOT / "prompts" / "audit.md").read_text(encoding="utf-8")
+
+        for marker in ("producer: audit", "WorkUnitV1", "manual-issue"):
+            with self.subTest(marker=marker):
+                self.assertNotIn(marker, audit_prompt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

实现 #4(cluster-008)共识(structural):audit 成为 work-unit producer 之一 —— **audit.md 零改动**,producer 规范化文档化于 REFERENCE/SKILL,triage-external-issue 接 manual-issue intake。基于 #3 已合并的 v1 契约。契合 maintainer「别过度泛化」。

共识链路:#4 r1→r3(converge×2 → 3/3 consensus)。

🤖 Auto-loop · 共识 implement(#4)

⟦AI:AUTO-LOOP⟧