### PR TITLE
cluster-010: 澄清通用定位(#6 共识 minimal,不重命名)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 | skill | 说明 | 状态 |
 |---|---|---|
-| `codex-refactor-loop` | 无人值守三阶段循环(audit → implement → verify),codex CLI 驱动,GitHub 为状态面 | 自 host 项目移植,verbatim;待泛化(见下) |
+| `codex-refactor-loop` | Consensus R&D 循环的稳定 skill 入口;默认以 audit/refactor 作为兼容 intake / producer,codex CLI 驱动,GitHub 为状态面 | 自 host 项目移植,verbatim;保留 refactor 作为合法 work-unit 隐喻 |
 
 ## 仓库结构
 
@@ -71,7 +71,7 @@
 
 1. **抽出引擎脊柱**(`solve → consensus → implement → verify`),让 audit 这一步(产生工作单元的种子)可替换 —— 换成任意 work-unit 来源(设计提案 / 文档任务 / 营销产出 / spec 变更),其余整套共识机制原样复用。
 2. **参数化漏入的 host 主张**:如"工作语言规则"应成为可注入的 host policy,而非写死。
-3. 重命名以脱离 "refactor" 语义。
+3. 对外以 "Consensus R&D" 为主产品身份; 保留 codex-refactor-loop 作为稳定 skill 入口,因为 maintainer 已接受 "refactor = development" 通用隐喻; 不新增重复 alias skill,除非未来出现真实平台发现/安装问题。
 
 > 泛化引擎本身宜走引擎自己那套共识 gate —— 用这个引擎来通用化这个引擎。
 

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -9,6 +9,11 @@ Detailed specifications, edge cases, and recovery playbook. The main workflow is
 historical but authoritative for state schema v1; do not add migrated queue containers, envelope
 wrappers, a normalizer helper, or a state-v2 migration for this contract.
 
+Naming policy: this engine's public product identity is Consensus R&D, and `codex-refactor-loop`
+remains the stable installed skill entrypoint. In v1, `refactor` is a valid development/work-unit
+metaphor and compatibility intake, not a requirement to rename the skill, add an alias, or create a
+new identity contract.
+
 Required identity/provenance fields:
 
 - `work_unit_id`: canonical work-unit identity.

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: codex-refactor-loop
-description: Unattended three-phase refactor loop (analyze → implement → verify) driven by codex CLI in isolated git worktrees. Use when user wants fully autonomous parallel refactoring against CLAUDE.md violations, with /loop dynamic wakeups and per-cluster worktree merges.
+description: Use when the user wants an unattended Consensus R&D work-unit loop driven by codex CLI in isolated git worktrees, with audit/refactor as the default compatibility intake, dynamic /loop wakeups, GitHub status, and per-work-unit merges.
 ---
 
-# Codex Refactor Loop — Unattended Three-Phase Mode
+# Codex Refactor Loop — Consensus R&D Work-Unit Mode
 
 ## Host 配置(通用化注入点)
 

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -433,5 +433,34 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
                 self.assertNotIn(marker, audit_prompt)
 
 
+class NamingPolicySourceRegressionTests(unittest.TestCase):
+    # Refactor (iter2/cluster-010-rename-alias-strategy):
+    #   Old pattern: public copy could drift back toward a mandatory rename or grow a duplicate alias identity
+    #   New principle: Consensus R&D is the product identity while codex-refactor-loop remains the only installed skill entrypoint
+    def test_consensus_identity_keeps_stable_skill_entrypoint_without_alias_surface(self) -> None:
+        skill_files = sorted(path.relative_to(REPO_ROOT).as_posix() for path in (REPO_ROOT / "skills").glob("*/SKILL.md"))
+        skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+        readme_text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        public_copy = "\n".join([readme_text, skill_text, reference_text])
+
+        self.assertEqual(skill_files, ["skills/codex-refactor-loop/SKILL.md"])
+        self.assertIn("name: codex-refactor-loop", skill_text)
+        self.assertIn("Consensus R&D", public_copy)
+        self.assertIn("stable installed skill entrypoint", reference_text)
+        self.assertIn("不新增重复 alias skill", readme_text)
+
+        forbidden_markers = (
+            "SkillIdentityV1",
+            "name: consensus-rnd-loop",
+            "name: codex-consensus-loop",
+            "aliases:",
+            "alias:",
+        )
+        for marker in forbidden_markers:
+            with self.subTest(marker=marker):
+                self.assertNotIn(marker, public_copy)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

实现 #6(cluster-010)共识(minimal):纯 public copy/policy 文档编辑澄清「通用 work-unit 共识引擎,refactor 为合法隐喻」。**不重命名、不加 alias、不引入 SkillIdentityV1**。完全对齐 maintainer「重构即开发也可以」。

🤖 Auto-loop · 共识 implement(#6)

⟦AI:AUTO-LOOP⟧