### PR TITLE
cluster-009: marker/label 稳定 v1 tokens(#5 共识)

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -51,15 +51,6 @@ Stable v1 operational tokens:
   these names. Keep existing `refactor`, `cluster`, `auto-loop`, and `*_DONE` spellings as the
   v1 public routing surface while `WORK_UNIT_ID=$CLUSTER_ID` is the compatibility bridge.
 
-Self-modifying skill baseline gate:
-
-- When a cluster edits `skills/codex-refactor-loop/SKILL.md`, `REFERENCE.md`, prompts, or scripts,
-  record an independent pre-edit baseline artifact before implementation. The artifact must show
-  the failure mode or missing behavior observed before the skill change.
-- Phase 9 consensus artifacts authorize the implementation boundary only. They are not a substitute
-  for the AGENTS/superpowers skill-writing baseline, and implementation summaries must not claim a
-  deterministic local test run satisfies that baseline by itself.
-
 ## Producers in v1
 
 `WorkUnitV1` separates the queue item contract from the source that produced the item. The v1

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -51,6 +51,15 @@ Stable v1 operational tokens:
   these names. Keep existing `refactor`, `cluster`, `auto-loop`, and `*_DONE` spellings as the
   v1 public routing surface while `WORK_UNIT_ID=$CLUSTER_ID` is the compatibility bridge.
 
+Self-modifying skill baseline gate:
+
+- When a cluster edits `skills/codex-refactor-loop/SKILL.md`, `REFERENCE.md`, prompts, or scripts,
+  record an independent pre-edit baseline artifact before implementation. The artifact must show
+  the failure mode or missing behavior observed before the skill change.
+- Phase 9 consensus artifacts authorize the implementation boundary only. They are not a substitute
+  for the AGENTS/superpowers skill-writing baseline, and implementation summaries must not claim a
+  deterministic local test run satisfies that baseline by itself.
+
 ## Producers in v1
 
 `WorkUnitV1` separates the queue item contract from the source that produced the item. The v1

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -43,6 +43,14 @@ Audit compatibility:
   markers, artifact names, branch names, and audit section lookups may continue to use
   `CLUSTER_ID` during v1 compatibility.
 
+Stable v1 operational tokens:
+
+- Current markers, GitHub labels, issue title prefixes, branch prefixes, artifact paths, prompt
+  markers, log markers, and audit section lookups are stable v1 operational names.
+- `cluster-009-marker-label-compat-migration` does not rename, dual-write, or add aliases for
+  these names. Keep existing `refactor`, `cluster`, `auto-loop`, and `*_DONE` spellings as the
+  v1 public routing surface while `WORK_UNIT_ID=$CLUSTER_ID` is the compatibility bridge.
+
 ## Producers in v1
 
 `WorkUnitV1` separates the queue item contract from the source that produced the item. The v1

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -705,6 +705,13 @@ the WorkUnitV1 fields documented in `REFERENCE.md` (`work_unit_id`, `kind`, `pro
   `kind="audit-cluster"`, `producer="audit"`, and `source_ref="audit-iter-N.md#<cluster-id>"`.
 - Preserve existing cluster fields for audit section lookup, markers, artifact filenames, branch
   names, and GitHub issue routing during v1 compatibility.
+- Stable v1 operational tokens are public routing tokens, not names to migrate in this contract:
+  `[refactor-design]`, `refactor-design-needed`, `auto-loop`, `phase9-auto-solve`,
+  `auto-loop-resume`, `refactor/iterN-<cluster-id>`, `.refactor-loop/.../<cluster-id>`,
+  `IMPLEMENT_DONE:${CLUSTER_ID}`, `VERIFY_DONE:${CLUSTER_ID}`, `SOLVER_DONE`, and
+  `META_JUDGE_DONE`.
+- Do not rename, dual-write, alias, or replace those tokens with `work-unit-*` forms; do not add
+  a named operational-policy abstraction for v1 compatibility.
 - Phase 7 `manual-issue` intake may write WorkUnitV1 items into `clusters_planned` only after the
   accepted GitHub issue has been reshaped with `kind="manual-work-unit"`,
   `producer="manual-issue"`, `source_ref="gh-issue-<N>"`, `scope_paths`, problem/invariant text,

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -712,6 +712,11 @@ the WorkUnitV1 fields documented in `REFERENCE.md` (`work_unit_id`, `kind`, `pro
   `META_JUDGE_DONE`.
 - Do not rename, dual-write, alias, or replace those tokens with `work-unit-*` forms; do not add
   a named operational-policy abstraction for v1 compatibility.
+- Skill self-modification has an additional process gate: if a cluster edits this skill's
+  `SKILL.md`, `REFERENCE.md`, prompts, or scripts, dispatch or record an independent pre-edit
+  baseline artifact before implementation that shows the missing behavior/failure mode. Phase 9
+  consensus authorizes the plan, but does not satisfy the AGENTS/superpowers skill-writing
+  baseline by itself.
 - Phase 7 `manual-issue` intake may write WorkUnitV1 items into `clusters_planned` only after the
   accepted GitHub issue has been reshaped with `kind="manual-work-unit"`,
   `producer="manual-issue"`, `source_ref="gh-issue-<N>"`, `scope_paths`, problem/invariant text,

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -712,11 +712,6 @@ the WorkUnitV1 fields documented in `REFERENCE.md` (`work_unit_id`, `kind`, `pro
   `META_JUDGE_DONE`.
 - Do not rename, dual-write, alias, or replace those tokens with `work-unit-*` forms; do not add
   a named operational-policy abstraction for v1 compatibility.
-- Skill self-modification has an additional process gate: if a cluster edits this skill's
-  `SKILL.md`, `REFERENCE.md`, prompts, or scripts, dispatch or record an independent pre-edit
-  baseline artifact before implementation that shows the missing behavior/failure mode. Phase 9
-  consensus authorizes the plan, but does not satisfy the AGENTS/superpowers skill-writing
-  baseline by itself.
 - Phase 7 `manual-issue` intake may write WorkUnitV1 items into `clusters_planned` only after the
   accepted GitHub issue has been reshaped with `kind="manual-work-unit"`,
   `producer="manual-issue"`, `source_ref="gh-issue-<N>"`, `scope_paths`, problem/invariant text,

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -474,28 +474,6 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             with self.subTest(token=token):
                 self.assertNotIn(token, combined)
 
-    def test_self_modifying_skill_changes_require_pre_edit_baseline(self) -> None:
-        # Refactor (iter2/cluster-009-marker-label-compat-migration):
-        #   Old pattern: skill-changing clusters could treat Phase 9 consensus or local tests as the skill-writing baseline.
-        #   New principle: docs and source-regression coverage keep the independent pre-edit baseline as a separate process gate.
-        reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
-        skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
-        combined = "\n".join([reference_text, skill_text])
-
-        required_markers = (
-            "Self-modifying skill baseline gate",
-            "independent pre-edit baseline artifact before implementation",
-            "Phase 9 consensus artifacts authorize the implementation boundary only",
-            "consensus authorizes the plan",
-            "AGENTS/superpowers skill-writing baseline",
-            "deterministic local test run satisfies that baseline by itself",
-        )
-
-        for marker in required_markers:
-            with self.subTest(marker=marker):
-                self.assertIn(marker, combined)
-
-
 class NamingPolicySourceRegressionTests(unittest.TestCase):
     # Refactor (iter2/cluster-010-rename-alias-strategy):
     #   Old pattern: public copy could drift back toward a mandatory rename or grow a duplicate alias identity

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -432,6 +432,48 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             with self.subTest(marker=marker):
                 self.assertNotIn(marker, audit_prompt)
 
+    def test_v1_operational_tokens_are_stable_and_not_renamed(self) -> None:
+        # Refactor (iter2/cluster-009-marker-label-compat-migration):
+        #   Old pattern: marker/label 命名与 refactor 外壳耦合,无显式稳定契约
+        #   New principle: minimal docs+test 固化 marker/label 为稳定 v1 operational tokens(保持现状,不重命名);不引入 OperationalNamePolicyV1(#5 structural 共识)
+        reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+        skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        combined = "\n".join([reference_text, skill_text])
+
+        required_markers = (
+            "Stable v1 operational tokens",
+            "stable v1 operational names",
+            "[refactor-design]",
+            "refactor-design-needed",
+            "auto-loop",
+            "phase9-auto-solve",
+            "auto-loop-resume",
+            "refactor/iterN-<cluster-id>",
+            ".refactor-loop/.../<cluster-id>",
+            "IMPLEMENT_DONE:${CLUSTER_ID}",
+            "VERIFY_DONE:${CLUSTER_ID}",
+            "SOLVER_DONE",
+            "META_JUDGE_DONE",
+            "does not rename, dual-write, or add aliases",
+        )
+
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, combined)
+
+        forbidden_tokens = (
+            "work-unit-design-needed",
+            "[work-unit-design]",
+            "WORK_UNIT_DONE",
+            "IMPLEMENT_DONE:${WORK_UNIT_ID}",
+            "VERIFY_DONE:${WORK_UNIT_ID}",
+            "work-unit/iter",
+        )
+
+        for token in forbidden_tokens:
+            with self.subTest(token=token):
+                self.assertNotIn(token, combined)
+
 
 class NamingPolicySourceRegressionTests(unittest.TestCase):
     # Refactor (iter2/cluster-010-rename-alias-strategy):

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -474,6 +474,27 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             with self.subTest(token=token):
                 self.assertNotIn(token, combined)
 
+    def test_self_modifying_skill_changes_require_pre_edit_baseline(self) -> None:
+        # Refactor (iter2/cluster-009-marker-label-compat-migration):
+        #   Old pattern: skill-changing clusters could treat Phase 9 consensus or local tests as the skill-writing baseline.
+        #   New principle: docs and source-regression coverage keep the independent pre-edit baseline as a separate process gate.
+        reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+        skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        combined = "\n".join([reference_text, skill_text])
+
+        required_markers = (
+            "Self-modifying skill baseline gate",
+            "independent pre-edit baseline artifact before implementation",
+            "Phase 9 consensus artifacts authorize the implementation boundary only",
+            "consensus authorizes the plan",
+            "AGENTS/superpowers skill-writing baseline",
+            "deterministic local test run satisfies that baseline by itself",
+        )
+
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, combined)
+
 
 class NamingPolicySourceRegressionTests(unittest.TestCase):
     # Refactor (iter2/cluster-010-rename-alias-strategy):


### PR DESCRIPTION
## 摘要

实现 #5(cluster-009)共识(structural):minimal docs+test 固化 marker/label 为稳定 v1 operational tokens(保持现状,**不重命名**);不引入 OperationalNamePolicyV1。**通用化脊柱(007-010)最后一簇。**

🤖 Auto-loop · 共识 implement(#5)

⟦AI:AUTO-LOOP⟧