### PR TITLE
skill: Human label taxonomy 收敛为两个 active label(#15 共识)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -168,13 +168,18 @@ gh issue view <N> --json comments --jq '
 输出格式稳定,易于直接判断派什么。
 
 ### 0 codex + active task = bug(强制)
+<!--
+# Refactor (iter3/skill-human-label-taxonomy):
+#   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+#   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
+-->
 
 **铁律**:任何 active phase issue/PR(`🔍 design-solving` / `🔧 fixing` / `👀 reviewing` / `🛠️ implementing`)存在时,**应至少有 1 个本 loop codex 在跑**。本 loop codex = `spawn-codex.sh` 命令行含 `.refactor-loop/logs/` 或 `.refactor-loop/prompts/`。实际为 0 且 GitHub 有 active phase → **P0 bug**(no-gap-violation)。
 
 **Controller wakeup 第一动作**:`bash .claude/skills/codex-refactor-loop/scripts/peek.sh`。如果活跃 codex == 0:
 1. **不允许** `ScheduleWakeup` 后 end-turn — 必须派下一步 codex 才允许 ScheduleWakeup
 2. **不允许**只看 marker 不 sweep:必须扫所有刚 finished marker(implement/judge/reviewer/fix/reflector)并按 marker→spawn-next 表派至少 1 codex
-3. 如果所有 active issue/PR 都真在等 maintainer(全是 `🆘 human:卡死` / `⏸️ phase:blocked`),那 0 codex 才 OK — 但仍要在 status 报告中说明 "0 codex by design:N issue 全等人"
+3. 如果所有 active issue/PR 都真在等 maintainer(全是 `👤 human:需-maintainer-决策` / `⏸️ phase:blocked`),那 0 codex 才 OK — 但仍要在 status 报告中说明 "0 codex by design:N issue 全等人"
 
 **concurrency_monitor.py** P0 alert:`expected > 0 AND actual == 0` → IMMEDIATE(streak=1 即写 alert + pending event,不等 2 tick)。controller 看到 alert → 立即 wake 自查。
 
@@ -198,22 +203,27 @@ Controller wakeup 处理 markers 后,**必须在同 turn 内派出下一步 code
 派出后 ScheduleWakeup;**不允许** "wakeup → sweep → 0 派出 → 下 wakeup" pattern(空 wakeup)。
 
 ### Controller 严禁自升 escalate(强制 — 防偷懒标人)
+<!--
+# Refactor (iter3/skill-human-label-taxonomy):
+#   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+#   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
+-->
 
-controller 严格按 judge marker 判 escalate,**不允许**自己以"累了/round 多 / 触及 Tier 或哲学"等理由直接 label `🆘 human:卡死`。
+controller 严格按 judge marker 判 escalate,**不允许**自己以"累了/round 多 / 触及 Tier 或哲学"等理由直接 label `👤 human:需-maintainer-决策`。
 
 **判定铁律**:
 
 | Judge marker | Controller 动作 | 不允许 |
 |---|---|---|
 | `converge:round-N` | 派 r-N 三 solver(不管 N 多大) | ❌ "round 多了"自升 escalate |
-| `escalate:stalled` | 派 reflector codex | ❌ 直接 label `🆘 human` |
+| `escalate:stalled` | 派 reflector codex | ❌ 直接 label `👤 human` |
 | `escalate:philosophy:<reason>` / `escalate:gpg-ratification:<reason>` / `escalate:<其他>` | 视为 legacy judge 输出:重派 judge 或派 reflector,要求回到 consensus / converge / stalled 三出口 | ❌ 因 CLAUDE.md / Tier I/II / GPG / reinstall 直接 label 人 |
 | `consensus` | 派 implement | — |
 | 无 judge marker / judge crash | 重派 judge | ❌ 自判 escalate |
 
-**正确"label 人"的唯一路径**:`reflector` 输出 `META_RESOLVED:escalate-human:<reason>` → controller 才允许 label `🆘 human:卡死` + ASCII A/B/C banner。该路径只表示**共识机制本身无法收敛**,不是因为触及 Tier I/II、CLAUDE.md、核心抽象、GPG 或 reinstall。
+**正确"label 人"的唯一路径**:`reflector` 输出 `META_RESOLVED:escalate-human:<reason>` → controller 才允许 label `👤 human:需-maintainer-决策` + ASCII A/B/C reason banner。该路径只表示**共识机制本身无法收敛**,不是因为触及 Tier I/II、CLAUDE.md、核心抽象、GPG 或 reinstall。
 
-结构性教训:controller 曾把多数 issue 误升为 `🆘 human:卡死`,根因是没有严格区分 `converge`、`stalled`、`philosophy` 三类 judge marker。只有 reflector 输出 `META_RESOLVED:escalate-human:<reason>` 后才允许 label 人;`converge` 继续派 solver,`stalled` 先派 reflector,可由 reflector 处理的 philosophy 分歧不得直接升人。
+结构性教训:controller 曾把多数 issue 误升为人工等待,根因是没有严格区分 `converge`、`stalled`、`philosophy` 三类 judge marker。只有 reflector 输出 `META_RESOLVED:escalate-human:<reason>` 后才允许 label 人;`converge` 继续派 solver,`stalled` 先派 reflector,可由 reflector 处理的 philosophy 分歧不得直接升人。
 
 ### Spawn / merge / banner 后必须 peek(强制 — 防 maintainer 漏读)
 
@@ -273,6 +283,11 @@ validate_prompt out.md                                    # check 0 unresolved {
 - PR 号捕获必须用 `open_pr_with_label`(直接 export PR_NUM)— **禁止** `pr_num=$(...grep -oE...)` 这种 subshell 变量传值模式
 
 **Label 生命周期(强制状态机)**:
+<!--
+# Refactor (iter3/skill-human-label-taxonomy):
+#   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+#   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
+-->
 
 ```
 issue/PR 状态 → 期望 label
@@ -280,14 +295,14 @@ issue/PR 状态 → 期望 label
 design issue:
   open + 🤖 ai → 🔍 design-solving       (solver/judge 跑)
   open + 🤖 ai → 🛠 implementing         (implement 派出)
-  open + 🆘 human:卡死-需-rework         (escalate philosophy/split)
+  open + 👤 human:需-maintainer-决策     (rework/deadlock reason in banner/comment)
   closed       → 🎉 phase:merged          (via PR merge)
   closed       → wontfix                  (per maintainer drop directive)
 
 cluster PR:
   open + 🤖 ai → 🚀 phase:pr-open + 👀 reviewing  (reviewer 派出)
   open + 🤖 ai → 🚀 phase:pr-open + 🔧 fixing     (fix codex)
-  open + 🆘 human:卡死-需-rework                  (reflector escalate-human)
+  open + 👤 human:需-maintainer-决策              (reflector escalate-human with reason banner)
   closed merged → 🎉 phase:merged                  (via merge_pr)
   closed       → (no phase, branch deleted)
 
@@ -587,7 +602,7 @@ Controller turn 间 / session 间 / `/clear` 后,**后台 codex 继续跑不中�
      #   Old pattern: host 的 PROJECT_RULES/CLAUDE.md 不保证基础不动点(泛化理论)在场,跑 loop 时基础理论未被可靠加载
      #   New principle: Phase 0 ProjectRulesFixedPointEnsurer 幂等向 $PROJECT_RULES 写入带 sentinel 的 managed 不动点区块(consensus:minimal,不覆盖 host 已有内容)
 1. **state + integration 分支**:`mkdir -p .refactor-loop/{...}` + 写 `state.json` + idempotent 建/推 `$INTEGRATION_BRANCH`(下方细节)。
-2. **建全套 labels**:跑「Label 系统」节的 Bootstrap —— 9 个 phase label + 3 个 human label 创建循环。**漏建 = 后续 phase transition 无 label 可挂、comment-monitor 查 `--label auto-loop` 漏掉 PR**。
+2. **建全套 labels**:跑「Label 系统」节的 Bootstrap —— 9 个 phase label + 2 个 human label 创建循环。**漏建 = 后续 phase transition 无 label 可挂、comment-monitor 查 `--label auto-loop` 漏掉 PR**。
 3. **起并挂载全部 5 个 daemon**:按「Host 运行编排 → Daemon 启动」节的 `bash -c 'source host.env && exec'` pattern 起齐 `concurrency_monitor.py` / `codex-progress-reporter.sh` / `comment-monitor.sh` / `dev_sync_daemon.py` / `triage-monitor.sh`,逐个 `pgrep -f <daemon>` 验 = 1。**首轮就必须把 5 个全起起来——它不是「以后某次 wakeup 才做的 liveness 检查」**。
 4. **派默认 v1 work-unit producer**(Phase 1,默认 audit,`spawn-codex.sh` + Bash `run_in_background:true`)+ ScheduleWakeup 兜底 + end turn。
 
@@ -1666,9 +1681,14 @@ Meta-judge emits `META_JUDGE_DONE:<decision>:<...>`,**controller 路由表(强�
 - ❌ r1 三 solver 分歧,meta-judge 输出 `escalate:stalled`,controller 直接派 reflector。
 - ❌ r2 verdict 变化但未 unanimous,controller 以"看起来卡了"自判 stalled。
 
-reflector spawn 模板见 "Meta-layer escalation" 节。reflector 输出 `META_RESOLVED:<kind>:<reason>` 后 controller 再按 retry-fix / re-design / re-cluster / drop / escalate-human 路由。**只有** reflector 显式输出 `META_RESOLVED:escalate-human:<reason>` 时,controller 才允许 label `🆘 human:卡死`;这只用于"共识机制本身无法收敛",非"触及 Tier/哲学/签名"。
+reflector spawn 模板见 "Meta-layer escalation" 节。reflector 输出 `META_RESOLVED:<kind>:<reason>` 后 controller 再按 retry-fix / re-design / re-cluster / drop / escalate-human 路由。**只有** reflector 显式输出 `META_RESOLVED:escalate-human:<reason>` 时,controller 才允许 label `👤 human:需-maintainer-决策` 并写 reason banner;这只用于"共识机制本身无法收敛",非"触及 Tier/哲学/签名"。
 
 ### Reflector 完成 → 立即回到共识阶段(强制)
+<!--
+# Refactor (iter3/skill-human-label-taxonomy):
+#   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+#   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
+-->
 
 **关键 bug**:之前 `escalate:stalled` 触发后挂 `auto-loop-stuck` + `👤 human:需-maintainer-决策` label,**reflector 完成后没清掉**,导致 issue 视觉上仍卡在"等人"状态;controller sweep 时也会看到 stuck label 误以为不需处理。
 
@@ -1679,13 +1699,14 @@ gh issue edit <N> \
   --remove-label "auto-loop-stuck" \
   --remove-label "👤 human:需-maintainer-决策" \
   --remove-label "🆘 human:卡死" \
+  --remove-label "🆘 human:卡死-需-rework" \
   --add-label "🔍 phase:design-solving" \
   --add-label "🤖 human:auto-推进"
 ```
 
 然后按 `META_RESOLVED:<kind>` 路由立刻做下一步(派 fresh 3 solver 轮 / 关 issue / re-cluster);**不允许**停在"reflector done but stuck label still on"暧昧态。整个系统核心是多角色多角度共识——reflector 是中介调和角色,完成后必须把控制权交回 solver 共识循环。
 
-唯一例外:`META_RESOLVED:escalate-human` → 保留 / 加 `🆘 human:卡死` label,这才是真正 human 介入态;它必须说明为什么 3 solver + meta-judge + reflector 的共识机制无法继续收敛。
+唯一例外:`META_RESOLVED:escalate-human` → 保留 / 加 `👤 human:需-maintainer-决策` label 并写明 reason/banner,这才是真正 human 介入态;它必须说明为什么 3 solver + meta-judge + reflector 的共识机制无法继续收敛。
 
 ### Daemon → controller event channel + 自适应 wakeup(强制, 关于 daemon detect → controller 25 min gap 问题)
 
@@ -1745,7 +1766,7 @@ ScheduleWakeup(delaySeconds=$NEXT_WAKEUP_SECONDS, ...)
 
 ### Stuck label 4h 超时自动新一轮 meta-reflect(强制)
 
-每次 controller wakeup 第一动作之后(per-wakeup sweep step 1 完成后),对每个带 `auto-loop-stuck` OR `👤 human:需-maintainer-决策` OR `🆘 human:卡死` label 的 issue:
+每次 controller wakeup 第一动作之后(per-wakeup sweep step 1 完成后),对每个带 `auto-loop-stuck` OR `👤 human:需-maintainer-决策` label 的 issue:
 
 ```bash
 last_human_at=$(gh issue view <N> --json comments --jq '[.comments[] | select(.body | contains("⟦AI:AUTO-LOOP⟧") | not) | .createdAt][-1] // .createdAt' | tr -d '"')
@@ -1917,7 +1938,7 @@ Policy:the loop continues until 3/3 unanimous consensus, true stall reaches refl
   - `re-design` → reset Phase 9 round counter,prompt 重写带 reflector 总结的新 framing 角度
   - `re-cluster` → close design issue + audit re-split(下 iter 拆 cluster)
   - `drop` → close design issue with `wontfix`
-  - `escalate-human` → `🆘 human:卡死` + PushNotification(仅 reflector 也无解)
+  - `escalate-human` → `👤 human:需-maintainer-决策` + reason banner + PushNotification(仅 reflector 也无解)
 - **Maintainer reply RESETS stall counter** — fresh round dispatched with their comment as constraint; stall counter goes back to 0.
 - Solver may not repeat a framing that prior rounds showed to be underspecified without adding new exact text/evidence; doing so counts toward stall detection.
 - Cumulative solver runtime across all rounds capped at 12h per issue (raised from 6h to account for maintainer-reset iterations); over → escalate as `stalled:budget-exhausted`.
@@ -2204,6 +2225,11 @@ If a push fails (network, conflict, branch protection): controller MUST surface 
 - ❌ "需要人介入"用模糊措辞 → 人类还是不知道要不要看
 
 ## Meta-layer escalation — 强制
+<!--
+# Refactor (iter3/skill-human-label-taxonomy):
+#   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+#   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
+-->
 
 **问题**:Phase 8 fix r6 仍 reject,或 CI same-check 6 次仍 fail,**第一反应不是喊 human**,而是**反思上一层是否本身错了**。喊 human 是最后的手段。
 
@@ -2213,7 +2239,7 @@ If a push fails (network, conflict, branch protection): controller MUST surface 
 3. **Phase 9 re-design**:重派 3 solver + meta-judge,prompt 带 "previous design caused 6 round non-converge"
 4. **Cluster re-split**:audit 阶段 re-evaluate,把当前 cluster 拆 / 合 / 撤回
 5. **Drop / wontfix**:确认任务本身价值不足,关 PR + close issue with wontfix
-6. **Human escalation**:`🆘 human:卡死` + PushNotification(只在 meta-layer 也无法解时)
+6. **Human escalation**:`👤 human:需-maintainer-决策` + reason banner + PushNotification(只在 meta-layer 也无法解时)
 
 ### 触发 meta-layer 反思
 
@@ -2242,7 +2268,7 @@ If a push fails (network, conflict, branch protection): controller MUST surface 
 - `META_RESOLVED:re-design`: design 错位,关 PR / 撤回当前 implement,re-Phase 9 with reflector prompt
 - `META_RESOLVED:re-cluster`: cluster scope 错位,关 PR + audit 阶段 re-split(拆为 2-3 个小 cluster)
 - `META_RESOLVED:drop`: 任务价值不足或代价 > 收益,关 PR + close issue wontfix
-- `META_RESOLVED:escalate-human`: meta-layer 也无法解,真的需要 maintainer 决策
+- `META_RESOLVED:escalate-human`: meta-layer 也无法解,真的需要 maintainer 决策(reason 必须说明 rework / deadlock / ci-stuck 等原因)
 
 ```bash
 .claude/skills/codex-refactor-loop/scripts/spawn-codex.sh \
@@ -2257,7 +2283,7 @@ Controller 读 marker 后路由:
 - `re-design` → 关 PR / 撤回 commits / re-Phase 9 with constraint = reject evidence pattern
 - `re-cluster` → 关 PR / audit re-split(产新 cluster 在 next iter)
 - `drop` → close PR + close issue with `wontfix` label + 转 phase merged-no-op
-- `escalate-human` → label `🆘 human:卡死` + PushNotification(只 meta-layer 也无路时)
+- `escalate-human` → label `👤 human:需-maintainer-决策` + reason banner + PushNotification(只 meta-layer 也无路时)
 
 ### 反面(❌ 禁止)
 
@@ -2298,7 +2324,7 @@ done
    - codecov/patch → 派 `prompts/test-add.md` codex(uncovered patch lines)
 3. **label 转 `🔧 phase:fixing`** + post `## 📊` banner
 4. **fix codex 完成 → controller 立刻 commit + push + 重 watch CI**
-5. **3 次 fix 同 check 仍 fail → label 升 `🆘 human:卡死-需-rework` + PushNotification + 停 loop**
+5. **3 次 fix 同 check 仍 fail → label 升 `👤 human:需-maintainer-决策` + `ci-stuck` reason banner + PushNotification + 停 loop**
 
 ### 反面(❌ 禁止)
 
@@ -2369,12 +2395,16 @@ echo "{}" > .refactor-loop/codex-progress-state.json
 | `⏸️ phase:blocked` | blocked-on(等其他 issue) | dependency 链上游未完成 |
 
 ### Label 组 2 — Human(任意时刻**恰好一个**)
+<!--
+# Refactor (iter3/skill-human-label-taxonomy):
+#   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+#   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
+-->
 
 | Label | 含义 | 触发 |
 |---|---|---|
 | `🤖 human:auto-推进` | 完全自动,**不需要人介入** | 默认 |
-| `👤 human:需-maintainer-决策` | 共识机制无法继续收敛,需要外部输入 | 仅 `META_RESOLVED:escalate-human` |
-| `🆘 human:卡死-需-rework` | 2 次 fix 仍失败 | fix r2 仍 reject / CI 2 次 fail |
+| `👤 human:需-maintainer-决策` | 共识机制无法继续收敛或自动修复耗尽,需要外部输入 | `META_RESOLVED:escalate-human` / rework / ci-stuck / deadlock reason |
 
 ### Bootstrap(一次性 - controller 在首次跑 loop 时确保 label 存在)
 
@@ -2388,7 +2418,6 @@ done
 # 创建所有 human label
 gh label create "🤖 human:auto-推进" --color "0e8a16" 2>/dev/null || true
 gh label create "👤 human:需-maintainer-决策" --color "d93f0b" 2>/dev/null || true
-gh label create "🆘 human:卡死-需-rework" --color "b60205" 2>/dev/null || true
 ```
 
 ### 转移时刻代码模板
@@ -2418,8 +2447,8 @@ PR 同理(`gh pr edit` instead of `gh issue edit`)。
 
 - **Label 与 banner 同步发**:不允许 label 转移但不发 banner,或发 banner 但 label 没改。
 - **同一组只允许一个**:不能同时有 `🛠️ phase:implementing` 和 `🚀 phase:pr-open`(实施完成 → 立刻改 pr-open)。
-- **`👤` 与 `🆘` 出现 = 共识机制停滞**:其他 label(`🤖`) = 完全自动。人类只 watch `👤` / `🆘` issue 即可。
-- **escalation 不等于人工授权 gate**:Phase 9 只有 `escalate:stalled` → reflector;只有 `META_RESOLVED:escalate-human` 才配 `👤` 或 `🆘`。
+- **`👤` 出现 = 共识机制停滞或自动修复耗尽**:其他 active human label(`🤖`) = 完全自动。`🆘 human:` 只允许作为 legacy cleanup target。
+- **escalation 不等于人工授权 gate**:Phase 9 只有 `escalate:stalled` → reflector;只有 `META_RESOLVED:escalate-human` 才配 `👤`。
 
 ### 反面(❌ 禁止)
 

--- a/skills/codex-refactor-loop/scripts/concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/concurrency_monitor.py
@@ -183,10 +183,13 @@ def list_auto_loop_issues() -> list[dict]:
 
 def compute_expected(items: list[dict]) -> tuple[int, list[dict]]:
     """Return (total_expected, breakdown)."""
+    # Refactor (iter3/skill-human-label-taxonomy):
+    #   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+    #   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
     breakdown = []
     total = 0
     for it in items:
-        if it["human"] in ("👤 human:需-maintainer-决策", "🆘 human:卡死", "🆘 human:卡死-需-rework"):
+        if it["human"] == "👤 human:需-maintainer-决策":
             # 等人介入,不期望 codex
             continue
         n = PHASE_EXPECTED.get(it["phase"], 0)

--- a/skills/codex-refactor-loop/scripts/controller_lib.sh
+++ b/skills/codex-refactor-loop/scripts/controller_lib.sh
@@ -59,6 +59,9 @@ safe_worktree() {
 # Post-merge cleanup: merge PR + close linked issue + cleanup labels on both
 # Usage: merge_pr <pr-number> [linked-issue]
 merge_pr() {
+  # Refactor (iter3/skill-human-label-taxonomy):
+  #   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+  #   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
   local pr="$1" linked_issue="${2:-}"
   if [ -z "$pr" ]; then
     echo "merge_pr: missing pr number" >&2
@@ -76,6 +79,9 @@ merge_pr() {
     --remove-label "🔧 phase:fixing" \
     --remove-label "⏸️ phase:blocked" \
     --remove-label "auto-loop-stuck" \
+    --remove-label "👤 human:需-maintainer-决策" \
+    --remove-label "🆘 human:卡死" \
+    --remove-label "🆘 human:卡死-需-rework" \
     --add-label "🎉 phase:merged" 2>&1 >/dev/null
   # Close linked issue + cleanup its labels
   if [ -n "$linked_issue" ]; then
@@ -84,8 +90,10 @@ merge_pr() {
       --remove-label "🔍 phase:design-solving" \
       --remove-label "🛠️ phase:implementing" \
       --remove-label "🤖 human:auto-推进" \
+      --remove-label "👤 human:需-maintainer-决策" \
       --remove-label "⏸️ phase:blocked" \
       --remove-label "auto-loop-stuck" \
+      --remove-label "🆘 human:卡死" \
       --remove-label "🆘 human:卡死-需-rework" \
       --add-label "🎉 phase:merged" 2>&1 >/dev/null
   fi
@@ -143,6 +151,9 @@ render_template() {
 # Sweep all closed auto-loop issues/PRs and clean stale in-flight phase labels
 # Usage: sweep_stale_labels
 sweep_stale_labels() {
+  # Refactor (iter3/skill-human-label-taxonomy):
+  #   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+  #   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
   local n_fixed=0
   for kind in issue pr; do
     gh "$kind" list "${gh_repo_args[@]}" --label "auto-loop" --state closed --limit 50 --json number,labels 2>/dev/null | \
@@ -152,7 +163,7 @@ try:
     d = json.load(sys.stdin)
 except Exception:
     sys.exit(0)
-stale = ['🚀 phase:pr-open', '👀 phase:reviewing', '🔧 phase:fixing', '⏸️ phase:blocked', 'auto-loop-stuck', '🆘 human:卡死-需-rework', '🔍 phase:design-solving', '🛠️ phase:implementing', '🤖 human:auto-推进']
+stale = ['🚀 phase:pr-open', '👀 phase:reviewing', '🔧 phase:fixing', '⏸️ phase:blocked', 'auto-loop-stuck', '👤 human:需-maintainer-决策', '🆘 human:卡死', '🆘 human:卡死-需-rework', '🔍 phase:design-solving', '🛠️ phase:implementing', '🤖 human:auto-推进']
 for x in d:
     bad = [l['name'] for l in x['labels'] if l['name'] in stale]
     if bad:

--- a/skills/codex-refactor-loop/scripts/peek.sh
+++ b/skills/codex-refactor-loop/scripts/peek.sh
@@ -110,6 +110,9 @@ if [ "$n" -gt 0 ]; then
 fi
 
 # 2. Recently finished markers (last 60 min) + routing hint
+# Refactor (iter3/skill-human-label-taxonomy):
+#   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+#   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
 echo ""
 echo "▍最近 60 min 完成 codex(marker → 推荐下一步):"
 find .refactor-loop/logs -name "*.log" -mmin -60 -type f 2>/dev/null | while read f; do
@@ -139,7 +142,7 @@ find .refactor-loop/logs -name "*.log" -mmin -60 -type f 2>/dev/null | while rea
     META_RESOLVED:re-design:*)   hint="→ close PR + Phase 9 fresh round" ;;
     META_RESOLVED:re-cluster:*)  hint="→ close PR + audit re-split" ;;
     META_RESOLVED:drop:*)        hint="→ close PR + close issue wontfix" ;;
-    META_RESOLVED:escalate-human:*) hint="→ label 🆘 + push notify" ;;
+    META_RESOLVED:escalate-human:*) hint="→ label 👤 + reason banner + push notify" ;;
     AUDIT_DONE:*)            hint="→ 验证 cluster evidence + 开 design issues + 派 implement" ;;
     AUDIT_INCOMPLETE:*)      hint="→ re-dispatch audit with missing pieces" ;;
     TEST_ADD_DONE:*)         hint="→ commit/push 等 CI" ;;

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -24,6 +24,13 @@ SCRIPT_PATH = Path(__file__).with_name("ensure_project_rules_fixed_points.py")
 SKILL_ROOT = SCRIPT_PATH.parents[1]
 REPO_ROOT = SCRIPT_PATH.parents[3]
 
+# Refactor (iter3/skill-human-label-taxonomy):
+#   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+#   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
+CANONICAL_HUMAN_LABELS = {"🤖 human:auto-推进", "👤 human:需-maintainer-决策"}  # refactor helper, no behavior change
+NON_AUTO_HUMAN_LABEL = "👤 human:需-maintainer-决策"  # refactor helper, no behavior change
+REMOVED_HUMAN_LABELS = {"🆘 human:卡死", "🆘 human:卡死-需-rework"}  # refactor helper, no behavior change
+
 PROMPTS_WITH_MANDATORY_PROJECT_RULES_INPUT = (
     "audit.md",
     "design-issue-reply.md",
@@ -507,6 +514,115 @@ class ConcurrencyFloorSourceRegressionTests(unittest.TestCase):
         self.assertNotIn("codex-floor-deficit", skill_text)
         self.assertNotIn("ACTIVE <= 2", skill_text)
         self.assertEqual(skill_text.count("**判定脚本**(controller wakeup step 1.5):"), 1)
+
+
+class HumanLabelTaxonomySourceRegressionTests(unittest.TestCase):
+    # Refactor (iter3/skill-human-label-taxonomy):
+    #   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
+    #   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
+    def skill_text(self) -> str:
+        return (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+
+    def label_group_2(self) -> str:
+        text = self.skill_text()
+        start = text.index("### Label 组 2 — Human")
+        end = text.index("### Bootstrap", start)
+        return text[start:end]
+
+    def bootstrap_block(self) -> str:
+        text = self.skill_text()
+        start = text.index("# 创建所有 human label")
+        end = text.index("### 转移时刻代码模板", start)
+        return text[start:end]
+
+    def test_human_label_taxonomy_has_single_non_auto_label(self) -> None:
+        label_group = self.label_group_2()
+        bootstrap = self.bootstrap_block()
+
+        for label in CANONICAL_HUMAN_LABELS:
+            with self.subTest(canonical=label):
+                self.assertIn(label, label_group)
+                self.assertIn(f'gh label create "{label}"', bootstrap)
+
+        self.assertEqual(label_group.count("| `🤖 human:auto-推进` |"), 1)
+        self.assertEqual(label_group.count("| `👤 human:需-maintainer-决策` |"), 1)
+        self.assertEqual(bootstrap.count("gh label create"), 2)
+
+        for label in REMOVED_HUMAN_LABELS:
+            with self.subTest(removed=label):
+                self.assertNotIn(label, label_group)
+                self.assertNotIn(f'gh label create "{label}"', bootstrap)
+
+    def test_human_escalation_routes_use_reason_surface(self) -> None:
+        skill = self.skill_text()
+        route_start = skill.index("Policy:the loop continues")
+        route_end = skill.index("### When to trigger Phase 9", route_start)
+        route_table = skill[route_start:route_end]
+        meta_start = skill.index("## Meta-layer escalation")
+        meta_end = skill.index("## CI 监控即时推进", meta_start)
+        meta_layer = skill[meta_start:meta_end]
+        ci_start = skill.index("### CI red 处理流水")
+        ci_end = skill.index("## Codex 进展实时上报", ci_start)
+        ci_flow = skill[ci_start:ci_end]
+        combined = "\n".join([route_table, meta_layer, ci_flow])
+
+        self.assertIn("META_RESOLVED:escalate-human", combined)
+        self.assertIn(NON_AUTO_HUMAN_LABEL, combined)
+        for token in ("reason", "banner", "PushNotification", "ci-stuck"):
+            with self.subTest(reason_surface=token):
+                self.assertIn(token, combined)
+        for label in REMOVED_HUMAN_LABELS:
+            with self.subTest(removed=label):
+                self.assertNotIn(f"label `{label}`", combined)
+                self.assertNotIn(f"`{label}` + PushNotification", combined)
+
+    def test_monitor_waiting_predicate_only_accepts_maintainer_decision(self) -> None:
+        sys.path.insert(0, str(SKILL_ROOT / "scripts"))
+        old_env = os.environ.copy()
+        os.environ.setdefault("REPO_ROOT", str(REPO_ROOT))
+        try:
+            import importlib
+            import concurrency_monitor
+
+            monitor = importlib.reload(concurrency_monitor)
+            base = {"number": 1, "kind": "issue", "phase": "🔍 phase:design-solving"}
+
+            expected, _ = monitor.compute_expected([{**base, "human": NON_AUTO_HUMAN_LABEL}])
+            self.assertEqual(expected, 0)
+
+            for label in REMOVED_HUMAN_LABELS:
+                with self.subTest(removed=label):
+                    expected, _ = monitor.compute_expected([{**base, "human": label}])
+                    self.assertEqual(expected, 1)
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
+
+    def test_controller_cleanup_removes_removed_human_labels_without_producing_them(self) -> None:
+        controller_lib = (SKILL_ROOT / "scripts" / "controller_lib.sh").read_text(encoding="utf-8")
+
+        for label in REMOVED_HUMAN_LABELS | {NON_AUTO_HUMAN_LABEL}:
+            with self.subTest(cleanup_label=label):
+                self.assertIn(f'--remove-label "{label}"', controller_lib)
+
+        for line in controller_lib.splitlines():
+            with self.subTest(line=line):
+                self.assertFalse("--add-label" in line and "🆘 human:" in line)
+
+    def test_peek_hints_do_not_recommend_emergency_human_label(self) -> None:
+        peek = (SKILL_ROOT / "scripts" / "peek.sh").read_text(encoding="utf-8")
+
+        self.assertIn('META_RESOLVED:escalate-human:*) hint="→ label 👤 + reason banner + push notify" ;;', peek)
+        self.assertNotIn("label 🆘 + push notify", peek)
+
+        for line in peek.splitlines():
+            if "🆘" in line:
+                with self.subTest(legacy_line=line):
+                    self.assertTrue(
+                        "startswith(\"🆘\")" in line
+                        or "lstrip().startswith(('## 📊', '## 🤖', '## ✅', '## 🆘'))" in line
+                        or "Old: 四个 Human label(含两个 🆘)" in line
+                    )
 
 
 class NamingPolicySourceRegressionTests(unittest.TestCase):


### PR DESCRIPTION
## 🤖 skill: Human label taxonomy 收敛为两个 active label(#15 r4 共识)

**Phase 9 r4 structural 共识落地**。active Human label 仅保留:
- `🤖 human:auto-推进`
- `👤 human:需-maintainer-决策`

移除 `🆘 human:卡死` / `🆘 human:卡死-需-rework` 出 active taxonomy / bootstrap / producer / waiting 判定;rework / deadlock / CI-耗尽 等原因改放 reason surface(`auto-loop-stuck`、phase label、banner/comment、PushNotification、marker reason)。

5 文件:SKILL.md、concurrency_monitor.py、controller_lib.sh、peek.sh、test_ensure_project_rules_fixed_points.py(+5 source-regression 测试)。

共识依据:`.refactor-loop/runs/phase9-issue15-r4-judge.md`。

Closes #15

⟦AI:AUTO-LOOP⟧
