### PR TITLE
skill: 契约 source-regression 测试套件 + TEST_CMD 可跑(#16 共识)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -865,8 +865,12 @@ For each `pass` cluster, serially:
 
 2. **Local CI on the cluster branch** (still in worktree):
    ```bash
-   bash $CI_GUARDS
-   bash $CI_GUARDS
+   if [ -n "${CI_GUARDS:-}" ]; then
+     bash "$CI_GUARDS"
+     bash "$CI_GUARDS"
+   else
+     echo "guards skipped: CI_GUARDS unset"
+   fi
    # plus any cluster-specific guards from audit.verification_hints
    ```
    On fail → `git reset --soft HEAD~1` (undo the commit), mark cluster `rework`, re-dispatch implement codex with the failure log.
@@ -1124,11 +1128,15 @@ else
 fi
 
 # Run local CI on the post-sync integration head
-bash $CI_GUARDS && bash $CI_GUARDS
-if [[ $? -ne 0 ]]; then
-  echo "SYNC_CI_FAIL: post-merge guards failed"
-  # PushNotification + halt (do not push a broken integration)
-  exit 1
+if [ -n "${CI_GUARDS:-}" ]; then
+  bash "$CI_GUARDS" && bash "$CI_GUARDS"
+  if [[ $? -ne 0 ]]; then
+    echo "SYNC_CI_FAIL: post-merge guards failed"
+    # PushNotification + halt (do not push a broken integration)
+    exit 1
+  fi
+else
+  echo "guards skipped: CI_GUARDS unset"
 fi
 
 git push origin "$INTEGRATION_BRANCH"

--- a/skills/codex-refactor-loop/host.env.example
+++ b/skills/codex-refactor-loop/host.env.example
@@ -27,8 +27,9 @@ export GH_REPO_NAME="your-repo"
 # 构建命令。值含空格时本文件能正确保留(source 注入,非 env)。
 export BUILD_CMD="cargo build --workspace"        # 例:dotnet build / npm run build
 
-# 测试命令(host 专属)。
-# Rust 提示:permit 池 / cwd 等共享 fs 状态并行会 race 出假失败,带 --test-threads=1。
+# 测试命令(host 专属)。本 skill 仓库 dogfood 可直接跑契约/回归测试:
+#   export TEST_CMD="python3 skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py"
+# Rust host 提示:permit 池 / cwd 等共享 fs 状态并行会 race 出假失败,带 --test-threads=1。
 export TEST_CMD="cargo test --workspace -- --test-threads=1"
 
 # ─── 有默认值,可覆盖 ────────────────────────────────────────────

--- a/skills/codex-refactor-loop/prompts/design-issue-reply.md
+++ b/skills/codex-refactor-loop/prompts/design-issue-reply.md
@@ -19,10 +19,10 @@ new comment body:
 
 判定流程（按顺序，任一通过即视为团队成员）：
 
-1. `gh api repos/$GH_OWNER/$GH_REPO/collaborators/${COMMENT_AUTHOR}` 返回 204 → 是 repo collaborator → 通过。
+1. `gh api repos/$GH_REPO_SLUG/collaborators/${COMMENT_AUTHOR}` 返回 204 → 是 repo collaborator → 通过。
 2. `gh api orgs/该项目AI/members/${COMMENT_AUTHOR}` 返回 204 → 是 org member → 通过。
 3. `COMMENT_AUTHOR` 出现在已知 maintainer 白名单（maintainer / maintainer / maintainer / maintainer / maintainer / maintainer）→ 通过。
-4. controller 自己 post 的评论（用 `gh api repos/$GH_OWNER/$GH_REPO/issues/${ISSUE_NUMBER}/comments` 看 body 是否以 `## 🤖` 等 controller marker 开头 / 包含 "Generated with Claude Code" / 与上一条 controller comment 内容相似）→ 跳过，不视为新需要回复的评论。
+4. controller 自己 post 的评论（用 `gh api repos/$GH_REPO_SLUG/issues/${ISSUE_NUMBER}/comments` 看 body 是否以 `## 🤖` 等 controller marker 开头 / 包含 "Generated with Claude Code" / 与上一条 controller comment 内容相似）→ 跳过，不视为新需要回复的评论。
 
 如果上述都不通过：
 - 在 `$REPO_ROOT/.refactor-loop/runs/design-issue-${ISSUE_NUMBER}-skipped-$(date +%s).md` 写一行说明"未通过团队成员校验：<author> not collaborator, not org member, not whitelisted"。

--- a/skills/codex-refactor-loop/prompts/remote-ci-fix.md
+++ b/skills/codex-refactor-loop/prompts/remote-ci-fix.md
@@ -32,7 +32,7 @@ PR: `${PR_NUMBER}`，失败 check: `${CHECK_NAME}`，run url: `${RUN_URL}`。
 
 4. **本地验证**：
    - 重跑失败 test：必须 pass
-   - 跑 `bash $CI_GUARDS` + `bash $CI_GUARDS`：必须 pass
+   - 若 `$CI_GUARDS` 非空,跑 `bash "$CI_GUARDS"` + `bash "$CI_GUARDS"`：必须 pass；为空则记录 guards skipped
    - 如果失败是某个特定 guard 出来的，重跑那个 guard
 
 5. **暂存**：

--- a/skills/codex-refactor-loop/prompts/test-add.md
+++ b/skills/codex-refactor-loop/prompts/test-add.md
@@ -56,7 +56,7 @@ ${UNCOVERED_LINES}
    $TEST_CMD
      --settings <coverlet.runsettings if exists> 2>&1 | tail -5
    ```
-7. 跑 `bash $REPO_ROOT/$CI_GUARDS` —— 必须通过（禁 `sleep/delay` 等）。
+7. 若 `$CI_GUARDS` 非空,跑 `bash "$REPO_ROOT/$CI_GUARDS"` —— 必须通过（禁 `sleep/delay` 等）；为空则记录 guards skipped。
 8. `git add -A && git status`。
 9. **不 commit**。
 10. 摘要写入 `$REPO_ROOT/.refactor-loop/runs/test-add-${CLUSTER_ID}.md`：

--- a/skills/codex-refactor-loop/prompts/triage-external-issue.md
+++ b/skills/codex-refactor-loop/prompts/triage-external-issue.md
@@ -88,4 +88,4 @@
 
 ## AI 内容标识符
 
-所有 GitHub comment / artifact 末尾必须独立一行 `⟦AI:AUTO-LOOP⟧`。
+所有 GitHub comment / artifact 必须末尾独立一行 `⟦AI:AUTO-LOOP⟧`。

--- a/skills/codex-refactor-loop/prompts/verify.md
+++ b/skills/codex-refactor-loop/prompts/verify.md
@@ -36,8 +36,12 @@
 按顺序运行（任意失败 → rework）：
 
 ```bash
-bash $REPO_ROOT/$CI_GUARDS
-bash $REPO_ROOT/$CI_GUARDS
+if [ -n "${CI_GUARDS:-}" ]; then
+  bash "$REPO_ROOT/$CI_GUARDS"
+  bash "$REPO_ROOT/$CI_GUARDS"
+else
+  echo "guards skipped: CI_GUARDS unset"
+fi
 # 任何 cluster 特定守卫，例如：
 ${CLUSTER_SPECIFIC_GUARDS}
 ```

--- a/skills/codex-refactor-loop/scripts/spawn_with_banner.py
+++ b/skills/codex-refactor-loop/scripts/spawn_with_banner.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 import sys
 
 
+# Refactor (iter3/skill-contract-test-suite):
+#   Old pattern: this wrapper could detach codex with banner side effects from an untracked Python entrypoint.
+#   New principle: the deprecated path is an executable tombstone; callers must use post_banner.py plus harness-tracked spawn-codex.sh.
 def main() -> int:
     sys.stderr.write(
         "FATAL: spawn_with_banner.py is deprecated; use post_banner.py + "

--- a/skills/codex-refactor-loop/scripts/spawn_with_banner.py
+++ b/skills/codex-refactor-loop/scripts/spawn_with_banner.py
@@ -1,170 +1,21 @@
 #!/usr/bin/env python3
-"""
-spawn_with_banner.py — spawn-codex wrapper 自动 post GitHub status banner
+"""Deprecated detached-spawn tombstone.
 
-:controller 派 codex 时常忘 post banner,导致 GitHub 上看不到运行
-状态。Helper script enforce "spawn 必配 banner"。
-
-Usage:
-  python3 .claude/skills/codex-refactor-loop/scripts/spawn_with_banner.py \\
-    --cd <worktree> --prompt <prompt-file> --log <log-file> \\
-    --stall 5400 \\
-    --banner-target <issue-or-pr-num> \\
-    --banner-kind <issue|pr> \\
-    --banner-role <test-add|fix|reviewer|implement|solver|judge|reflector> \\
-    --banner-detail "<short context, 1 line>"
-  [--add-dir <main-repo-path>]
-
-Behavior:
-- spawn-codex.sh 后台跑(nohup + disown; daemon/autonomous use only)
-- 立即 post banner 到 target issue/pr,format `## 📊 状态卡片 — <role> 派出`
-- banner 含 codex 任务名 / no-output stall window / "下一步自动会做" / 是否需要人介入
-- 末尾 `🤖 controller status banner` + ⟦AI:AUTO-LOOP⟧ sentinel
-- Exit 0 if both succeed;exit 非 0 + 错误信息 otherwise
-
-⟦AI:AUTO-LOOP⟧
+Use post_banner.py, then run spawn-codex.sh via a harness-tracked Bash
+background task. This file intentionally hard-fails before any spawn path.
 """
 
-import argparse
-import os
-import subprocess
+from __future__ import annotations
+
 import sys
-import tempfile
-from pathlib import Path
-
-
-def git_repo_root() -> Path:
-    """Return the host repository root from env, or explicit interactive fallback."""
-    env_root = os.environ.get("REPO_ROOT")
-    if env_root:
-        return Path(env_root)
-    if os.environ.get("ALLOW_GIT_ROOT_FALLBACK") != "1":
-        raise RuntimeError(
-            "REPO_ROOT is unset; source .refactor-loop/host.env or set "
-            "ALLOW_GIT_ROOT_FALLBACK=1 for interactive use"
-        )
-    r = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        capture_output=True,
-        text=True,
-    )
-    if r.returncode != 0:
-        raise RuntimeError("REPO_ROOT is unset and git rev-parse --show-toplevel failed")
-    return Path(r.stdout.strip())
-
-
-REPO_ROOT = git_repo_root()
-SPAWN_CODEX = REPO_ROOT / ".claude" / "skills" / "codex-refactor-loop" / "scripts" / "spawn-codex.sh"
-
-
-def github_repo_slug() -> str | None:
-    slug = os.environ.get("GH_REPO_SLUG")
-    if slug:
-        return slug
-    repo = os.environ.get("GH_REPO")
-    if repo and "/" in repo:
-        return repo
-    owner = os.environ.get("GH_OWNER")
-    name = os.environ.get("GH_REPO_NAME") or repo
-    if owner and name:
-        return f"{owner}/{name}"
-    return None
-
-ROLE_NEXT_STEPS = {
-    "test-add": "1. test-add 完成 marker `TEST_ADD_DONE:...`  2. controller 自动 commit + push  3. codecov 重测",
-    "fix": "1. fix r<N> 完成 marker `FIX_DONE:...`  2. controller commit + push  3. 派 reviewer r<N+1>",
-    "reviewer": "1. 三 reviewer 完成 verdict marker  2. controller 计算 consensus  3. unanimous → auto-merge / reject → fix r<N+1>",
-    "implement": "1. implement 完成 marker `IMPLEMENT_DONE:<cluster>:<status>`  2. controller commit + push  3. open PR + 派 reviewer r1",
-    "solver": "1. 三 solver `SOLVER_DONE:...`  2. controller 派 meta-judge r<N>  3. consensus → implement / converge → fresh round",
-    "judge": "1. judge `META_JUDGE_DONE:...`  2. consensus → implement / converge → fresh round / escalate → reflector or 人介入",
-    "reflector": "1. reflector `META_RESOLVED:<kind>`  2. controller 按 kind 路由(retry-fix / re-design / re-cluster / drop / escalate-human)",
-}
-
-
-def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser()
-    p.add_argument("--cd", required=True, help="cwd for codex(usually worktree)")
-    p.add_argument("--prompt", required=True, help="codex prompt file")
-    p.add_argument("--log", required=True, help="codex log file")
-    p.add_argument("--stall", "--timeout", dest="stall", type=int, required=True,
-                   help="codex no-output stall window seconds")
-    p.add_argument("--add-dir", default=None, help="extra dir for codex(usually main repo when cd is worktree)")
-    p.add_argument("--banner-target", required=True, help="issue/PR number to post banner")
-    p.add_argument("--banner-kind", choices=["issue", "pr"], required=True)
-    p.add_argument("--banner-role", required=True, choices=list(ROLE_NEXT_STEPS.keys()))
-    p.add_argument("--banner-detail", default="", help="one-line context for banner")
-    return p.parse_args()
-
-
-def post_banner(args: argparse.Namespace) -> int:
-    role = args.banner_role
-    next_step = ROLE_NEXT_STEPS[role]
-    log_name = Path(args.log).name
-    body = f"""## 📊 状态卡片 — {role} 派出
-
-| 维度 | 值 |
-|---|---|
-| 阶段 | **派出 codex(role=`{role}`)** |
-| codex log | `{log_name}` |
-| 工作目录 | `{args.cd}` |
-| no-output stall window | {args.stall}s(~{args.stall // 60} min 无输出窗口) |
-| 上下文 | {args.banner_detail or "(none)"} |
-| 下一步自动会做 | {next_step} |
-| **是否需要人介入** | **❌ 否**(自动推进) |
-
-🤖 controller status banner
-
-⟦AI:AUTO-LOOP⟧
-"""
-    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False)
-    tmp.write(body)
-    tmp.close()
-    cmd = ["gh", args.banner_kind, "comment", str(args.banner_target)]
-    repo_slug = github_repo_slug()
-    if repo_slug:
-        cmd.extend(["--repo", repo_slug])
-    cmd.extend(["--body-file", tmp.name])
-    r = subprocess.run(cmd, capture_output=True, text=True)
-    os.unlink(tmp.name)
-    if r.returncode != 0:
-        sys.stderr.write(f"FAIL banner post: {r.stderr.strip()}\n")
-        return 1
-    url = r.stdout.strip()
-    sys.stderr.write(f"BANNER_POSTED: {args.banner_kind} #{args.banner_target} {url}\n")
-    return 0
-
-
-def spawn_codex(args: argparse.Namespace) -> int:
-    cmd = [str(SPAWN_CODEX),
-           "--cd", args.cd,
-           "--prompt", args.prompt,
-           "--log", args.log,
-           "--stall", str(args.stall)]
-    if args.add_dir:
-        cmd.extend(["--add-dir", args.add_dir])
-    # nohup + start_new_session(脱离 parent)
-    subprocess.Popen(
-        ["nohup", *cmd],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
-    sys.stderr.write(f"CODEX_SPAWNED: log={args.log}\n")
-    return 0
 
 
 def main() -> int:
-    args = parse_args()
-    if args.stall < 3600:
-        sys.stderr.write(f"FATAL: stall window {args.stall} < 3600 (per loop floor)\n")
-        return 2
-    # 1. Post banner first(让 maintainer 立即看到状态)
-    rc = post_banner(args)
-    if rc != 0:
-        sys.stderr.write("WARN: banner post failed, continuing with spawn anyway\n")
-    # 2. Spawn codex
-    rc = spawn_codex(args)
-    return rc
+    sys.stderr.write(
+        "FATAL: spawn_with_banner.py is deprecated; use post_banner.py + "
+        "harness-tracked spawn-codex.sh\n"
+    )
+    return 2
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -539,6 +539,9 @@ class NamingPolicySourceRegressionTests(unittest.TestCase):
                 self.assertNotIn(marker, public_copy)
 
 
+# Refactor (iter3/skill-contract-test-suite):
+#   Old pattern: skill contract regressions were documented in prompts/SKILL text but not enforced by the host TEST_CMD.
+#   New principle: a contiguous source-regression suite makes those contracts fail under the dogfood TEST_CMD without adding a new runner or scanner abstraction.
 class SkillContractSourceRegressionTests(unittest.TestCase):
     """Issue #16 consensus skill contract source-regression suite.
 
@@ -561,6 +564,22 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
             text = path.read_text(encoding="utf-8")
             with self.subTest(path=rel, needle=needle):
                 self.assertNotIn(needle, text)
+
+    def test_spawn_with_banner_cli_hard_fails_as_tombstone(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SKILL_ROOT / "scripts" / "spawn_with_banner.py")],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(
+            result.stderr,
+            "FATAL: spawn_with_banner.py is deprecated; use post_banner.py + "
+            "harness-tracked spawn-codex.sh\n",
+        )
 
     def test_spawned_prompts_and_banner_builders_keep_final_independent_sentinel(self) -> None:
         prompt_paths = [p for p in sorted((SKILL_ROOT / "prompts").glob("*.md")) if p.name != "_github-post-rules.md"]

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -536,6 +537,180 @@ class NamingPolicySourceRegressionTests(unittest.TestCase):
         for marker in forbidden_markers:
             with self.subTest(marker=marker):
                 self.assertNotIn(marker, public_copy)
+
+
+class SkillContractSourceRegressionTests(unittest.TestCase):
+    """Issue #16 consensus skill contract source-regression suite.
+
+    Keep this contiguous in the sole direct test file until the split threshold:
+    second real test file, this class >250 LOC, whole file >750 LOC, or scanner
+    helpers needed by multiple independent classes/files.
+    """
+
+    def read_rel(self, rel: str) -> str:
+        return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+    def rel_paths(self, *patterns: str) -> list[Path]:
+        return [path for pattern in patterns for path in sorted(REPO_ROOT.glob(pattern))]
+
+    def assert_absent(self, needle: str, paths: list[Path], allowlist: tuple[str, ...] = ()) -> None:
+        for path in paths:
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            if rel in allowlist:
+                continue
+            text = path.read_text(encoding="utf-8")
+            with self.subTest(path=rel, needle=needle):
+                self.assertNotIn(needle, text)
+
+    def test_spawned_prompts_and_banner_builders_keep_final_independent_sentinel(self) -> None:
+        prompt_paths = [p for p in sorted((SKILL_ROOT / "prompts").glob("*.md")) if p.name != "_github-post-rules.md"]
+        for path in prompt_paths:
+            text = path.read_text(encoding="utf-8")
+            with self.subTest(prompt=path.name):
+                self.assertIn("末尾独立一行", text)
+                self.assertIn("⟦AI:AUTO-LOOP⟧", text)
+
+        for rel in ("skills/codex-refactor-loop/scripts/post_banner.py", "skills/codex-refactor-loop/scripts/comment-monitor.sh"):
+            text = self.read_rel(rel)
+            with self.subTest(builder=rel):
+                self.assertRegex(text, r"\n⟦AI:AUTO-LOOP⟧\n")
+                self.assertIn("--body-file", text)
+
+    def test_github_repo_contract_uses_slug_not_bare_owner_repo_api_paths(self) -> None:
+        checked = self.rel_paths(
+            "skills/codex-refactor-loop/SKILL.md", "skills/codex-refactor-loop/host.env.example",
+            "skills/codex-refactor-loop/prompts/*.md", "skills/codex-refactor-loop/scripts/*.sh",
+            "skills/codex-refactor-loop/scripts/*.py",
+        )
+        checked = [path for path in checked if path.name != Path(__file__).name]
+
+        self.assert_absent("repos/$GH_OWNER/$GH_REPO", checked)
+        host_env = self.read_rel("skills/codex-refactor-loop/host.env.example")
+        self.assertIn('export GH_REPO_SLUG="your-org/your-repo"', host_env)
+        self.assertNotIn("export GH_REPO=", host_env)
+        for rel in ("skills/codex-refactor-loop/scripts/controller_lib.sh", "skills/codex-refactor-loop/scripts/peek.sh", "skills/codex-refactor-loop/scripts/triage-monitor.sh"):
+            with self.subTest(script=rel):
+                self.assertIn('gh_repo_args=(--repo "$GH_REPO_SLUG")', self.read_rel(rel))
+
+    def test_optional_ci_guards_are_conditioned_on_non_empty_value(self) -> None:
+        checked = self.rel_paths("skills/codex-refactor-loop/SKILL.md", "skills/codex-refactor-loop/prompts/*.md", "skills/codex-refactor-loop/scripts/*.sh")
+        for path in checked:
+            text = path.read_text(encoding="utf-8")
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            with self.subTest(path=rel):
+                self.assertNotRegex(text, r"bash\s+\$REPO_ROOT/\$CI_GUARDS")
+                self.assertNotRegex(text, r"bash\s+\$CI_GUARDS")
+                self.assertNotIn("$CI_GUARDS &&", text)
+
+        contract_text = "\n".join(
+            self.read_rel(rel)
+            for rel in ("skills/codex-refactor-loop/SKILL.md", "skills/codex-refactor-loop/prompts/verify.md", "skills/codex-refactor-loop/scripts/controller_lib.sh")
+        )
+        self.assertGreaterEqual(contract_text.count('[ -n "${CI_GUARDS:-}" ]'), 3)
+        self.assertIn("guards skipped: CI_GUARDS unset", contract_text)
+
+    def test_daemon_start_examples_source_host_env_before_exec(self) -> None:
+        skill_text = self.read_rel("skills/codex-refactor-loop/SKILL.md")
+        host_env_text = self.read_rel("skills/codex-refactor-loop/host.env.example")
+        daemon_names = ("concurrency_monitor.py", "codex-progress-reporter.sh", "comment-monitor.sh", "dev_sync_daemon.py", "triage-monitor.sh")
+
+        self.assertIn("bash -c 'source .refactor-loop/host.env && exec", skill_text)
+        self.assertIn("bash -c 'source host.env && exec ...'", host_env_text)
+        for daemon in daemon_names:
+            with self.subTest(daemon=daemon):
+                self.assertIn(daemon, skill_text)
+        self.assertIn("禁止** 裸 `nohup python3 <daemon> &`", skill_text)
+        self.assertIn("不能用 `env $(grep ... host.env)`", host_env_text)
+
+    def test_label_taxonomy_matches_bootstrap_and_script_usage(self) -> None:
+        skill_text = self.read_rel("skills/codex-refactor-loop/SKILL.md")
+        controller_lib = self.read_rel("skills/codex-refactor-loop/scripts/controller_lib.sh")
+        monitor_text = self.read_rel("skills/codex-refactor-loop/scripts/concurrency_monitor.py")
+        expected_phase = ("🔍 phase:design-solving", "✅ phase:consensus-reached", "🛠️ phase:implementing", "🚀 phase:pr-open", "👀 phase:reviewing", "🔧 phase:fixing", "⚙️ phase:ci-running", "🎉 phase:merged", "⏸️ phase:blocked")
+        expected_human = ("🤖 human:auto-推进", "👤 human:需-maintainer-决策", "🆘 human:卡死-需-rework")
+
+        for label in expected_phase + expected_human:
+            with self.subTest(label=label):
+                self.assertIn(label, skill_text)
+        self.assertIn('gh label create "$l" --color "5319e7"', skill_text)
+        for label in expected_human:
+            with self.subTest(human_bootstrap=label):
+                self.assertIn(f'gh label create "{label}"', skill_text)
+
+        for label in ("🚀 phase:pr-open", "👀 phase:reviewing", "🔧 phase:fixing", "🛠️ phase:implementing"):
+            with self.subTest(controller_label=label):
+                self.assertIn(label, controller_lib)
+        for label in ("🔍 phase:design-solving", "👀 phase:reviewing", "🛠️ phase:implementing"):
+            with self.subTest(monitor_label=label):
+                self.assertIn(label, monitor_text)
+
+    def test_spawn_with_banner_is_hard_failing_tombstone_not_mainline_surface(self) -> None:
+        tombstone = self.read_rel("skills/codex-refactor-loop/scripts/spawn_with_banner.py")
+
+        self.assertIn("Deprecated detached-spawn tombstone", tombstone)
+        self.assertIn("return 2", tombstone)
+        self.assertNotIn("subprocess.Popen", tombstone)
+        self.assertNotIn("start_new_session", tombstone)
+        self.assertNotIn("SPAWN_CODEX", tombstone)
+
+        active_docs = "\n".join(self.read_rel(rel) for rel in ("skills/codex-refactor-loop/SKILL.md", "skills/codex-refactor-loop/scripts/post_banner.py"))
+        self.assertIn("post_banner.py", active_docs)
+        self.assertIn("spawn-codex.sh", active_docs)
+        self.assertIn("反模式", active_docs)
+
+    def test_phase9_language_policy_allowlist_is_narrow(self) -> None:
+        allowlist = {
+            "skills/codex-refactor-loop/SKILL.md", "skills/codex-refactor-loop/prompts/audit.md",
+            "skills/codex-refactor-loop/prompts/design-issue-body.md", "skills/codex-refactor-loop/prompts/design-issue-reply.md",
+            "skills/codex-refactor-loop/prompts/meta-judge.md", "skills/codex-refactor-loop/prompts/solver-delete.md",
+            "skills/codex-refactor-loop/prompts/solver-minimal.md", "skills/codex-refactor-loop/prompts/solver-structural.md",
+        }
+        checked = self.rel_paths("skills/codex-refactor-loop/SKILL.md", "skills/codex-refactor-loop/prompts/*.md")
+        patterns = ("Bilingual rule", "双语强制", "## English", "Recommended framing (English)")
+
+        for path in checked:
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            text = path.read_text(encoding="utf-8")
+            for pattern in patterns:
+                if pattern not in text:
+                    continue
+                with self.subTest(path=rel, pattern=pattern):
+                    self.assertIn(rel, allowlist)
+
+        skill_text = self.read_rel("skills/codex-refactor-loop/SKILL.md")
+        self.assertIn("Source files are English-only; external user-facing artifacts are 中文 by default", skill_text)
+        self.assertIn("No mandatory parallel English section", skill_text)
+
+    def test_non_controller_prompts_keep_git_and_lifecycle_boundaries(self) -> None:
+        controller_owned = {"_github-post-rules.md", "remote-ci-fix.md", "triage-external-issue.md"}
+        forbidden = ("git commit", "git push", "git checkout", "gh pr create", "gh pr merge", "gh issue close")
+
+        for path in sorted((SKILL_ROOT / "prompts").glob("*.md")):
+            if path.name in controller_owned:
+                continue
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for token in forbidden:
+                for line in lines:
+                    if token not in line:
+                        continue
+                    with self.subTest(prompt=path.name, token=token, line=line):
+                        self.assertRegex(line, r"禁止|不可调|Do NOT|do not")
+
+    def test_disabled_test_escape_hatches_are_not_recommended(self) -> None:
+        checked = self.rel_paths("skills/codex-refactor-loop/prompts/*.md", "skills/codex-refactor-loop/SKILL.md")
+        recommendation_patterns = (
+            r"(建议|可以|允许|recommend|use).{0,24}`?\[Skip\]`?",
+            r"pytest\.mark\.skip",
+            r"#\[ignore\]",
+            r"(建议|可以|允许|recommend|use).{0,24}Category\",\"Manual",
+        )
+
+        for path in checked:
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            text = path.read_text(encoding="utf-8")
+            for pattern in recommendation_patterns:
+                with self.subTest(path=rel, pattern=pattern):
+                    self.assertIsNone(re.search(pattern, text))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🤖 skill: 契约 source-regression 测试套件 + TEST_CMD 可跑(#16 r4 共识)

**Phase 9 r4 structural 共识落地**:`test_ensure_project_rules_fixed_points.py` 追加 `SkillContractSourceRegressionTests`;`host.env.example` 文档化 `TEST_CMD` 可跑契约测试。

⚠️ **SCOPE_EXTEND(6 项,已在 commit 声明,请 reviewer 评估)**:为使新契约测试通过,implement 顺带修了被测违反点(CI_GUARDS 条件化、GH_REPO_SLUG 契约、spawn_with_banner tombstone)。这与 #20 / self-audit #13 主题重叠;若判越界请 reject → fix 收窄回 test 文件 + host.env.example。

> 注:本 PR 与 PR #22(#15 SKILL.md)共享 SKILL.md + 测试文件;merge 时后者 rebase。

共识依据:`.refactor-loop/runs/phase9-issue16-r4-judge.md`。

Closes #16

⟦AI:AUTO-LOOP⟧
