### PR TITLE
skill: GitHub post 契约收窄为两组 roster + 行为测试(#13 共识)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1533,8 +1533,14 @@ The controller's only inline composition allowed for GitHub:
 
 EVERYTHING ELSE(reviewer verdict、fix-done body、consensus 公告、escalation rationale、design issue body、cross-post 通知、PR description 包括 rollup PR)由**正在跑的那个 codex 自己 post**,**不需要专门的 writer-codex 中介**:
 
-- solver / meta-judge / fix / reviewer / clarifier / investigator / analyst / implement codex 各自跑完内部 artifact 后,自己 `gh issue comment` 或 `gh pr comment` post 中文 user-facing 摘要
-- 所有 prompts 末尾都有 `## GitHub post (强制)` 块引用 `prompts/_github-post-rules.md` 共享规则
+<!--
+# Refactor (iter3/skill-github-post-contract):
+#   Old: 宽泛 all-prompts direct-post 主张
+#   New: 两组明确 roster + 可枚举行为测试(#13 structural 共识)
+-->
+
+- Direct-post prompts: `solver-minimal.md`, `solver-structural.md`, `solver-delete.md`, `meta-judge.md`, `reviewer-architect.md`, `reviewer-quality.md`, `reviewer-tests.md`, `review-fix.md`, `design-issue-reply.md`, `triage-external-issue.md`. Only these prompts must contain a `## GitHub post` section referencing `prompts/_github-post-rules.md`.
+- Marker/artifact-only prompts: `audit.md`, `design-issue-body.md`, `implement.md`, `verify.md`, `remote-ci-fix.md`, `test-add.md`. They keep the AI sentinel plus their marker/body contract, are surfaced by controller / PR / CI status, and must not claim direct posting.
 - body 必须 `## 🤖 <headline>` 开头(comment-monitor.sh 据此识别 controller-post 跳 react)
 - 中文 only / TL;DR ≤ 6 行 / raw artifact 折叠 `<details>` / 若 situation 给 `original_authors:` 加 `📢 cc`
 - codex 自己抓 gh 输出的 URL,打 `POSTED:<role>:<N>:<URL>:<headline>` 或 `POST_FAILED:...`

--- a/skills/codex-refactor-loop/prompts/triage-external-issue.md
+++ b/skills/codex-refactor-loop/prompts/triage-external-issue.md
@@ -72,6 +72,8 @@
 
 ## GitHub post
 
+遵循 `prompts/_github-post-rules.md`。
+
 按 accept / reject 分别:
 - accept 评论头行 `## 🤖 Triage codex — accept: issue-${ISSUE_NUMBER}`
 - reject 评论头行 `## 🤖 Triage codex — reject: <reject-type>`

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -276,6 +276,53 @@ class ProjectRulesPromptContractTests(unittest.TestCase):
         self.assertIn("$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}", skill_text)
         self.assertIn("helper 退出非 0 → bootstrap fail closed", skill_text)
 
+    # Refactor (iter3/skill-github-post-contract):
+    #   Old: 宽泛 all-prompts direct-post 主张
+    #   New: 两组明确 roster + 可枚举行为测试(#13 structural 共识)
+    def test_github_post_contract_matches_prompt_roster(self) -> None:
+        prompts_root = SKILL_ROOT / "prompts"
+        skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        direct_post_prompts = {
+            "solver-minimal.md",
+            "solver-structural.md",
+            "solver-delete.md",
+            "meta-judge.md",
+            "reviewer-architect.md",
+            "reviewer-quality.md",
+            "reviewer-tests.md",
+            "review-fix.md",
+            "design-issue-reply.md",
+            "triage-external-issue.md",
+        }
+        marker_only_prompts = {
+            "audit.md",
+            "design-issue-body.md",
+            "implement.md",
+            "verify.md",
+            "remote-ci-fix.md",
+            "test-add.md",
+        }
+        prompt_inventory = {path.name for path in prompts_root.glob("*.md")} - {"_github-post-rules.md"}
+
+        self.assertEqual(prompt_inventory, direct_post_prompts | marker_only_prompts)
+        self.assertFalse(direct_post_prompts & marker_only_prompts)
+        self.assertIn("Direct-post prompts", skill_text)
+        self.assertIn("Marker/artifact-only prompts", skill_text)
+        self.assertNotIn("所有 prompts 末尾都有 `## GitHub post (强制)`", skill_text)
+
+        for prompt_name in sorted(direct_post_prompts):
+            text = (prompts_root / prompt_name).read_text(encoding="utf-8")
+            with self.subTest(prompt=prompt_name, contract="direct-post"):
+                self.assertIn("## GitHub post", text)
+                self.assertIn("_github-post-rules.md", text)
+
+        for prompt_name in sorted(marker_only_prompts):
+            text = (prompts_root / prompt_name).read_text(encoding="utf-8")
+            with self.subTest(prompt=prompt_name, contract="marker-only"):
+                self.assertNotIn("## GitHub post", text)
+                self.assertIn("AI 内容标识符", text)
+                self.assertIn("⟦AI:AUTO-LOOP⟧", text)
+
 
 class WorkUnitV1SourceRegressionTests(unittest.TestCase):
     # Refactor (iter2/cluster-007-work-unit-contract-schema):
@@ -762,7 +809,7 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
         controller_lib = self.read_rel("skills/codex-refactor-loop/scripts/controller_lib.sh")
         monitor_text = self.read_rel("skills/codex-refactor-loop/scripts/concurrency_monitor.py")
         expected_phase = ("🔍 phase:design-solving", "✅ phase:consensus-reached", "🛠️ phase:implementing", "🚀 phase:pr-open", "👀 phase:reviewing", "🔧 phase:fixing", "⚙️ phase:ci-running", "🎉 phase:merged", "⏸️ phase:blocked")
-        expected_human = ("🤖 human:auto-推进", "👤 human:需-maintainer-决策", "🆘 human:卡死-需-rework")
+        expected_human = tuple(sorted(CANONICAL_HUMAN_LABELS))
 
         for label in expected_phase + expected_human:
             with self.subTest(label=label):


### PR DESCRIPTION
## 🤖 skill: GitHub post 契约收窄为两组明确 roster + 行为测试(#13 r2 共识)

**Phase 9 r2 structural 共识落地**。SKILL.md 宽泛「所有 prompt 直接 post」段 → 两组明确清单:
- **Direct-post**(含 `## GitHub post` 引用 `_github-post-rules.md`):solver ×3 / meta-judge / reviewer ×3 / review-fix / design-issue-reply / triage-external-issue
- **Marker/artifact-only**(仅 sentinel + marker 契约):audit / design-issue-body / implement / verify / remote-ci-fix / test-add

新增可枚举行为测试 `test_github_post_contract_matches_prompt_roster`。

SCOPE_EXTEND:triage-external-issue.md 补 `_github-post-rules.md` 引用(同逻辑一行)。

> 注:与 PR#24(#21)共享 test 文件;merge 时后者 rebase。

Closes #13

⟦AI:AUTO-LOOP⟧
