### PR TITLE
refactor(skill): host-agnostic skill root 自定位,脱 .claude/skills 硬编码(#19 共识)

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -1,6 +1,6 @@
 # codex-refactor-loop — Reference
 
-Detailed specifications, heavy templates, schemas, command bodies, and recovery playbooks for [SKILL.md](SKILL.md). The entrypoint keeps the controller contract and phase index; this file carries the material that should be loaded lazily by anchor.
+Detailed specifications, heavy templates, schemas, command bodies, and recovery playbooks for [SKILL.md](SKILL.md). The entrypoint keeps the controller contract and phase index; this file carries the material that should be loaded lazily by anchor. Keep full command bodies, long path examples, schemas, and recovery matrices here; keep only short invariants and anchor links in `SKILL.md`.
 
 <a id="controller-contract-details"></a>
 ## Controller contract details

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -17,7 +17,7 @@ dogfood 运行中固化的操作经验。host 注入的配置集中放 `$REPO_RO
 **禁止** 裸 `nohup python3 <daemon> &`(拿不到 host 配置)与 `nohup env $(grep ... host.env) <daemon> &`(`BUILD_CMD="cargo build --workspace"` 含空格 → `env` 把 `build` 当命令崩)。**唯一正确**:用 `bash -c 'source host.env && exec'` 注入后再 exec:
 
 ```bash
-nohup bash -c 'source .refactor-loop/host.env && exec python3 .claude/skills/codex-refactor-loop/scripts/<daemon>.py' \
+nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scripts/<daemon>.py' \
   >> .refactor-loop/logs/<daemon>.log 2>&1 & disown
 ```
 
@@ -142,7 +142,7 @@ gh issue view <N> --json comments --jq '
 - **Controller 自己 post banner** 使用 `maintainer` 或 host 配置的安全称谓,不写裸人名。
 - **@-mention whitelist** 来自 `$MAINTAINER_WHITELIST`,并且必须经 git blame / host 配置验证。
 
-### Wakeup 第一动作:`bash .claude/skills/codex-refactor-loop/scripts/peek.sh`(强制)
+### Wakeup 第一动作:`bash <skill-root>/scripts/peek.sh`(强制)
 
 减少人工 grep / parse 错误。一眼看全:
 - 活跃 codex 数(只数本 loop:命令行含 `.refactor-loop/logs/` 或 `.refactor-loop/prompts/`)
@@ -165,7 +165,7 @@ gh issue view <N> --json comments --jq '
 
 **铁律**:任何 active phase issue/PR(`🔍 design-solving` / `🔧 fixing` / `👀 reviewing` / `🛠️ implementing`)存在时,**应至少有 1 个本 loop codex 在跑**。本 loop codex = `spawn-codex.sh` 命令行含 `.refactor-loop/logs/` 或 `.refactor-loop/prompts/`。实际为 0 且 GitHub 有 active phase → **P0 bug**(no-gap-violation)。
 
-**Controller wakeup 第一动作**:`bash .claude/skills/codex-refactor-loop/scripts/peek.sh`。如果活跃 codex == 0:
+**Controller wakeup 第一动作**:`bash <skill-root>/scripts/peek.sh`。如果活跃 codex == 0:
 1. **不允许** `ScheduleWakeup` 后 end-turn — 必须派下一步 codex 才允许 ScheduleWakeup
 2. **不允许**只看 marker 不 sweep:必须扫所有刚 finished marker(implement/judge/reviewer/fix/reflector)并按 marker→spawn-next 表派至少 1 codex
 3. 如果所有 active issue/PR 都真在等 maintainer(全是 `👤 human:需-maintainer-决策` / `⏸️ phase:blocked`),那 0 codex 才 OK — 但仍要在 status 报告中说明 "0 codex by design:N issue 全等人"
@@ -216,13 +216,13 @@ controller 严格按 judge marker 判 escalate,**不允许**自己以"累了/rou
 
 ### Spawn / merge / banner 后必须 peek(强制 — 防 maintainer 漏读)
 
-任何 controller turn 派 codex / merge PR / post banner / close issue 之后,**turn 结束前必须 `bash .claude/skills/codex-refactor-loop/scripts/peek.sh | tail -80` 一次扫 maintainer 评论 + 0-codex 漏洞**。
+任何 controller turn 派 codex / merge PR / post banner / close issue 之后,**turn 结束前必须 `bash <skill-root>/scripts/peek.sh | tail -80` 一次扫 maintainer 评论 + 0-codex 漏洞**。
 
 理由:`task-notification` 触发的 turn 容易陷入"处理 marker → spawn 下一步 → end turn"线性思维,会跳过 peek 而错过 maintainer 与此 task 并行的新评论。曾出现 controller 派出下一步 judge 期间漏读新的架构反馈,直到 maintainer 报错才发现;peek 是防漏读的强制尾部检查。
 
 例外:turn 唯一动作是 ScheduleWakeup(纯休眠)可省 peek。
 
-### Concurrency monitor:`.claude/skills/codex-refactor-loop/scripts/concurrency_monitor.py`(强制)
+### Concurrency monitor:`<skill-root>/scripts/concurrency_monitor.py`(强制)
 
 **60s** 周期 daemon,只监控 no-gap sentinel:
 - expected = active issue/PR 数(per phase 表)
@@ -237,7 +237,7 @@ controller 严格按 judge marker 判 escalate,**不允许**自己以"累了/rou
 
 启动:
 ```bash
-nohup bash -c 'source .refactor-loop/host.env && exec python3 .claude/skills/codex-refactor-loop/scripts/concurrency_monitor.py' \
+nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scripts/concurrency_monitor.py' \
   >> .refactor-loop/logs/concurrency-monitor.log 2>&1 &
 disown
 ```
@@ -250,12 +250,12 @@ disown
 - ❌ 看到 concurrency-alert.log 有 entry 但 controller 不读
 - ❌ active issue 0 codex 跑 >= 1 wakeup 周期(说明 controller 漏派)
 
-### Controller helper 库:`.claude/skills/codex-refactor-loop/scripts/controller_lib.sh`(强制)
+### Controller helper 库:`<skill-root>/scripts/controller_lib.sh`(强制)
 
 7 个曾发生的 bug 都来自 controller boilerplate 重复 + bash 变量传值 bug。统一抽 helper:
 
 ```bash
-source .claude/skills/codex-refactor-loop/scripts/controller_lib.sh
+source <skill-root>/scripts/controller_lib.sh
 
 safe_worktree iterN cluster-026 origin/auto-refact-dev   # → exports WT_PATH + BRANCH
 open_pr_with_label "iterN cluster-XXX: title" body.md    # → exports PR_NUM(原地传值,无 grep subshell bug)
@@ -308,7 +308,7 @@ rollup PR:
 
 1. **先 post banner**(blocking Bash,几秒):
    ```bash
-   python3 .claude/skills/codex-refactor-loop/scripts/post_banner.py \
+   python3 <skill-root>/scripts/post_banner.py \
      --banner-target <issue-or-pr> --banner-kind <issue|pr> \
      --banner-role <role> --banner-detail "..." \
      --log <log-path> --cd <worktree> --stall <s>
@@ -316,7 +316,7 @@ rollup PR:
 
 2. **再 spawn codex**(Bash `run_in_background: true`):
    ```bash
-   .claude/skills/codex-refactor-loop/scripts/spawn-codex.sh \
+   <skill-root>/scripts/spawn-codex.sh \
      --cd <worktree> --add-dir $REPO_ROOT \
      --prompt <prompt-file> --log <log-file> --stall 5400
    ```
@@ -458,7 +458,7 @@ triage and must already be reshaped before Phase 9.
 3. Dispatch:
 
    ```bash
-   .claude/skills/codex-refactor-loop/scripts/spawn-codex.sh \
+   <skill-root>/scripts/spawn-codex.sh \
      --cd "$REPO_ROOT" \
      --prompt .refactor-loop/prompts/audit-iter-N.md \
      --log .refactor-loop/logs/audit-iter-N.log \
@@ -516,7 +516,7 @@ For every cluster with `requires_design: true`:
    gh issue create \
      --title "[refactor-design] <cluster-id>: <one-line problem from audit>" \
      --label "refactor-design-needed,auto-loop" \
-     --body "$(envsubst < .claude/skills/codex-refactor-loop/prompts/design-issue-body.md)"
+     --body "$(envsubst < <skill-root>/prompts/design-issue-body.md)"
    ```
    The body template at `prompts/design-issue-body.md` includes: the cluster's YAML block from audit, full evidence section, the audit's `Fix boundary` paragraph, and an explicit "decision needed" checklist (proto schema? new contract? backward-compat strategy? whether to split into multiple PRs?).
 2. Record in state.json:
@@ -610,7 +610,7 @@ For each cluster whose implement finished `ok`:
 2. Dispatch in the same worktree (verify reads `git diff HEAD`, runs full test/guard suite, gates merge):
 
    ```bash
-   .claude/skills/codex-refactor-loop/scripts/spawn-codex.sh \
+   <skill-root>/scripts/spawn-codex.sh \
      --cd <worktree> \
      --prompt .refactor-loop/prompts/verify-<cluster-id>.md \
      --log .refactor-loop/logs/verify-<cluster-id>.log \
@@ -846,10 +846,10 @@ Runs **first** on every controller wakeup, before Phase 7 design-issue sweep and
 
 ### Phase 6 现在由独立 daemon 自主完成
 
-**`.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py`** 是独立 daemon,**600s 周期**自主跑 sync,不依赖 controller wakeup:
+**`<skill-root>/scripts/dev_sync_daemon.py`** 是独立 daemon,**600s 周期**自主跑 sync,不依赖 controller wakeup:
 
 ```bash
-nohup bash -c 'source .refactor-loop/host.env && exec python3 .claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py' \
+nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scripts/dev_sync_daemon.py' \
   >> .refactor-loop/logs/dev-sync-daemon.log 2>&1 &
 disown
 ```
@@ -1001,13 +1001,13 @@ problem/invariant text, and `verification_hints`; they must not include fabricat
 
 **Daemon 自包含**:
 
-`.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh` 60s 周期:
+`<skill-root>/scripts/triage-monitor.sh` 60s 周期:
 - 扫 `gh issue list --label "auto-loop-triage" --state open`
 - 新 issue → mark seen + **直接 spawn triage codex**(nohup + disown,daemon 自己派)
 - triage codex 自己读 issue body + update GitHub(reshape or 评论 + label 切换)
 - daemon 不依赖 controller 中转,无中间 event log
 - state 存 `.refactor-loop/triage-monitor-state.json` 防重复
-- 启动:`nohup bash -c 'source .refactor-loop/host.env && exec bash .claude/skills/codex-refactor-loop/scripts/triage-monitor.sh' >> .refactor-loop/logs/triage-monitor.log 2>&1 & disown`
+- 启动:`nohup bash -c 'source .refactor-loop/host.env && exec bash <skill-root>/scripts/triage-monitor.sh' >> .refactor-loop/logs/triage-monitor.log 2>&1 & disown`
 - Liveness:每 wakeup `ps -ef | grep triage-monitor.sh` 必须 ≥1,死了 restart
 - Codex 完成 marker:`TRIAGE_DONE:<issue>:<accept|reject>:<reason>`(写 issue 评论 + 切 label)
 - Controller 下次 wakeup 从 GitHub state derive(issue label 改了即看见)
@@ -1057,9 +1057,9 @@ For each cluster PR with `CI green AND mergeable AND not yet auto-reviewed`:
 
 ```bash
 for role in architect tests quality; do
-  envsubst < .claude/skills/codex-refactor-loop/prompts/reviewer-${role}.md \
+  envsubst < <skill-root>/prompts/reviewer-${role}.md \
     > .refactor-loop/prompts/review-pr${PR_NUMBER}-${role}.md
-  .claude/skills/codex-refactor-loop/scripts/spawn-codex.sh \
+  <skill-root>/scripts/spawn-codex.sh \
     --cd "$REPO_ROOT" \
     --prompt .refactor-loop/prompts/review-pr${PR_NUMBER}-${role}.md \
     --log .refactor-loop/logs/review-pr${PR_NUMBER}-${role}.log \
@@ -1091,7 +1091,7 @@ Loop:
 1. **Round entry** — `state.pr_reviews[PR].fix_round += 1`. If `fix_round > max_fix_rounds`, escalate (see below).
 2. **Dispatch fix codex** in PR's own worktree:
    ```bash
-   .claude/skills/codex-refactor-loop/scripts/spawn-codex.sh \
+   <skill-root>/scripts/spawn-codex.sh \
      --cd "$PR_WORKTREE" --add-dir "$REPO_ROOT" \
      --prompt .refactor-loop/prompts/fixes/fix-pr${PR}-round-${N}.md \
      --log .refactor-loop/logs/fix-pr${PR}-round-${N}.log \
@@ -1266,9 +1266,9 @@ For each cluster needing Phase 9:
 
 ```bash
 for role in minimal structural delete; do
-  envsubst < .claude/skills/codex-refactor-loop/prompts/solver-${role}.md \
+  envsubst < <skill-root>/prompts/solver-${role}.md \
     > .refactor-loop/prompts/phase9/solve-issue${ISSUE_NUMBER}-r${ROUND}-${role}.md
-  .claude/skills/codex-refactor-loop/scripts/spawn-codex.sh \
+  <skill-root>/scripts/spawn-codex.sh \
     --cd "$REPO_ROOT" \
     --prompt .refactor-loop/prompts/phase9/solve-issue${ISSUE_NUMBER}-r${ROUND}-${role}.md \
     --log .refactor-loop/logs/phase9-issue${ISSUE_NUMBER}-r${ROUND}-${role}.log \
@@ -1279,9 +1279,9 @@ done
 All 3 solvers in parallel; each emits `SOLVER_DONE:<role>:<verdict>:<summary>`. When all 3 done, dispatch meta-judge:
 
 ```bash
-envsubst < .claude/skills/codex-refactor-loop/prompts/meta-judge.md \
+envsubst < <skill-root>/prompts/meta-judge.md \
   > .refactor-loop/prompts/phase9/judge-issue${ISSUE_NUMBER}-r${ROUND}.md
-.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh \
+<skill-root>/scripts/spawn-codex.sh \
   --cd "$REPO_ROOT" \
   --prompt .refactor-loop/prompts/phase9/judge-issue${ISSUE_NUMBER}-r${ROUND}.md \
   --log .refactor-loop/logs/phase9-issue${ISSUE_NUMBER}-r${ROUND}-judge.log \
@@ -1618,7 +1618,7 @@ Concretely, this means:
 1. **下一 iter audit**(若上一 iter audit `AUDIT_DONE` 且对应 N+1 audit log 不存在)— 最有价值,产出新 cluster 链路
 2. **next-next iter audit**(N+2,speculative parallel)— 即使 iter N+1 audit 仍在跑也可派
 3. **历史 closed design issue retrospective codex** — 检查最近 5 个 closed design issue,是否有 follow-up cluster 被漏(典型:reflector r4 提到的 "cross-stream unification" 应该被独立 cluster 捕获)
-4. **.claude/skills/codex-refactor-loop/scripts self-audit codex** — 审计 skill / scripts 自身 tech debt(过长 section / 重复 helper / 老 prompt 文件可删)
+4. **<skill-root>/scripts self-audit codex** — 审计 skill / scripts 自身 tech debt(过长 section / 重复 helper / 老 prompt 文件可删)
 5. **docs sync codex** — 用最近 merged PRs 自动更新 `docs/audit-scorecard/`(如缺)
 6. **CI guard completeness codex** — 检查 `$CI_GUARDS` 是否覆盖所有 CLAUDE 条款
 
@@ -1904,7 +1904,7 @@ If a push fails (network, conflict, branch protection): controller MUST surface 
 - `META_RESOLVED:escalate-human`: meta-layer 也无法解,真的需要 maintainer 决策(reason 必须说明 rework / deadlock / ci-stuck 等原因)
 
 ```bash
-.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh \
+<skill-root>/scripts/spawn-codex.sh \
   --cd $REPO_ROOT \
   --prompt .refactor-loop/prompts/meta-reflect-pr<N>.md \
   --log .refactor-loop/logs/meta-reflect-pr<N>.log \
@@ -2035,7 +2035,7 @@ PR 同理(`gh pr edit` instead of `gh issue edit`)。
 
 ```python
 Bash(
-  command=".claude/skills/codex-refactor-loop/scripts/spawn-codex.sh "
+  command="<skill-root>/scripts/spawn-codex.sh "
           "--cd <dir> --prompt <prompt-file> --log <log-file> --stall 5400",
   run_in_background=True,    # 必须 true → 进 Claude Code shells panel
   description="cluster-XXX implement"

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -63,6 +63,8 @@ Host config rules:
 
 `<skill-root>` means the installed `skills/codex-refactor-loop` directory containing this `SKILL.md`, `scripts/spawn-codex.sh`, and `prompts/`. Runtime scripts self-locate from their own file path; `CODEX_REFACTOR_LOOP_SKILL_ROOT` is optional and only for wrappers or nonstandard packaging. If that override is set but invalid, scripts fail closed instead of falling back to `.claude/skills`.
 
+Detailed path examples and host installation variants stay in `REFERENCE.md`; `SKILL.md` keeps only controller-contract self-location invariants.
+
 ## Wakeup Skeleton
 
 Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event wakeup follows this skeleton.

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -59,11 +59,15 @@ Host config rules:
 5. Detailed daemon start examples live in [daemon command bodies](REFERENCE.md#daemon-command-bodies), including the `bash -c 'source .refactor-loop/host.env && exec` pattern and why `env $(grep ...)` is unsafe.
 6. The ProjectRules fixed-point target is `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}`.
 
+## Skill Root Contract
+
+`<skill-root>` means the installed `skills/codex-refactor-loop` directory containing this `SKILL.md`, `scripts/spawn-codex.sh`, and `prompts/`. Runtime scripts self-locate from their own file path; `CODEX_REFACTOR_LOOP_SKILL_ROOT` is optional and only for wrappers or nonstandard packaging. If that override is set but invalid, scripts fail closed instead of falling back to `.claude/skills`.
+
 ## Wakeup Skeleton
 
 Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event wakeup follows this skeleton.
 
-1. Run `bash .claude/skills/codex-refactor-loop/scripts/peek.sh | tail -80` first.
+1. Run `bash <skill-root>/scripts/peek.sh | tail -80` first.
 2. Load host config with `source .refactor-loop/host.env`; if missing or malformed, fail closed and post a status explaining the blocked bootstrap.
 3. Sweep GitHub comments and pending events, excluding sentinel comments, AI banner prefixes, and bot authors.
 4. Sweep all recent logs. A worker is complete only when `tail -5 <log>` contains `^EXIT=0`.
@@ -222,7 +226,7 @@ More detail is in [concurrency floor details](REFERENCE.md#concurrency-floor-det
 Mainline spawn contract:
 
 1. Use one harness background task per codex. Do not batch multiple codexes inside one detached shell.
-2. Invoke `.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh --cd <absolute-dir> --prompt <prompt> --log <log> --stall <seconds>`.
+2. Invoke `<skill-root>/scripts/spawn-codex.sh --cd <absolute-dir> --prompt <prompt> --log <log> --stall <seconds>`.
 3. `--cd` must be absolute so process counting can scope to `$REPO_ROOT`.
 4. Prompt files live under `.refactor-loop/prompts/`; logs live under `.refactor-loop/logs/`.
 5. Completion detection primary path is harness task notification; fallback is log tail `EXIT=0` sweep.

--- a/skills/codex-refactor-loop/prompts/_github-post-rules.md
+++ b/skills/codex-refactor-loop/prompts/_github-post-rules.md
@@ -33,7 +33,7 @@ escalation / consensus pick **必须**给清晰"方案 1/2/3"表格,cell 一行�
 
 ## 硬约束
 
-- **第一行 `## 🤖 ` 开头**:`.claude/skills/codex-refactor-loop/scripts/comment-monitor.sh` 据此识别 controller-post 跳过 👀 react。漏 🤖 → monitor 会把你的 post 当成 maintainer 评论 react 自己 → 误循环。
+- **第一行 `## 🤖 ` 开头**:本 skill 的 `scripts/comment-monitor.sh` 据此识别 controller-post 跳过 👀 react。漏 🤖 → monitor 会把你的 post 当成 maintainer 评论 react 自己 → 误循环。
 - **中文 only**:per [SKILL.md 工作语言规则],不要平行 EN section。Code identifier / file path / proto 字段名保留原英文。CLAUDE/AGENTS 条款引用 verbatim 不翻译。
 - **TL;DR ≤ 6 行**(3 bullet + 可选 cc 行)。
 - **raw artifact 必折叠**:不要让 TL;DR 之后立刻出现 raw YAML / verbatim spec dump。先用人话讲,raw 都进 `<details>`。

--- a/skills/codex-refactor-loop/prompts/design-issue-reply.md
+++ b/skills/codex-refactor-loop/prompts/design-issue-reply.md
@@ -86,7 +86,7 @@ NyxId API keys / secrets / 内部 URL 之类敏感信息绝对禁止出现在 re
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本仓库 `.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
 
 - body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
 - 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -137,7 +137,7 @@ End with EXACTLY ONE marker:
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本仓库 `.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
 
 - body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
 - 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -110,7 +110,7 @@ Begin.
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本仓库 `.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
 
 - body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
 - 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`

--- a/skills/codex-refactor-loop/prompts/reviewer-architect.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-architect.md
@@ -73,7 +73,7 @@ End with marker line: `REVIEW_DONE:${PR_NUMBER}:architect:<verdict>`
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本仓库 `.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
 
 - body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
 - 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`

--- a/skills/codex-refactor-loop/prompts/reviewer-quality.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-quality.md
@@ -64,7 +64,7 @@ End with marker: `REVIEW_DONE:${PR_NUMBER}:quality:<verdict>`
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本仓库 `.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
 
 - body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
 - 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`

--- a/skills/codex-refactor-loop/prompts/reviewer-tests.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-tests.md
@@ -66,7 +66,7 @@ End with marker: `REVIEW_DONE:${PR_NUMBER}:tests:<verdict>`
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本仓库 `.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
 
 - body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
 - 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`

--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -112,7 +112,7 @@ End with EXACTLY ONE marker line:
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本仓库 `.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
 
 - body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
 - 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -90,7 +90,7 @@ End with EXACTLY ONE marker line:
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本仓库 `.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
 
 - body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
 - 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -97,7 +97,7 @@ End with EXACTLY ONE marker line:
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本仓库 `.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
 
 - body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
 - 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`

--- a/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
+++ b/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
@@ -12,7 +12,7 @@ daemon 跑在独立 worktree,main repo controller 工作不受 daemon 的 merge 
 - main repo working tree 不被 merge 状态污染
 
 启动:
-  nohup python3 <skill-root>/scripts/dev_sync_daemon.py \
+  nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scripts/dev_sync_daemon.py' \
     >> .refactor-loop/logs/dev-sync-daemon.log 2>&1 &
   disown
 
@@ -50,7 +50,7 @@ def git_repo_root() -> Path:
 
 
 def skill_root() -> Path:
-    # Refactor (iter3/skill-skill-root-contract): Old: .claude/skills 硬编码  New: inline self-location + env 可选 override(#19 structural 共识)
+    # Refactor (iter3/skill-skill-root-contract): Old pattern: .claude/skills hardcoded lookup. New principle: self-locate from this script path, with optional validated CODEX_REFACTOR_LOOP_SKILL_ROOT override.
     """Return this installed skill root, failing closed on invalid overrides."""
     override = os.environ.get("CODEX_REFACTOR_LOOP_SKILL_ROOT")
     root = Path(override).expanduser().resolve() if override else Path(__file__).resolve().parents[1]

--- a/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
+++ b/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
@@ -12,7 +12,7 @@ daemon 跑在独立 worktree,main repo controller 工作不受 daemon 的 merge 
 - main repo working tree 不被 merge 状态污染
 
 启动:
-  nohup python3 .claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py \
+  nohup python3 <skill-root>/scripts/dev_sync_daemon.py \
     >> .refactor-loop/logs/dev-sync-daemon.log 2>&1 &
   disown
 
@@ -49,12 +49,30 @@ def git_repo_root() -> Path:
     return Path(r.stdout.strip())
 
 
+def skill_root() -> Path:
+    # Refactor (iter3/skill-skill-root-contract): Old: .claude/skills 硬编码  New: inline self-location + env 可选 override(#19 structural 共识)
+    """Return this installed skill root, failing closed on invalid overrides."""
+    override = os.environ.get("CODEX_REFACTOR_LOOP_SKILL_ROOT")
+    root = Path(override).expanduser().resolve() if override else Path(__file__).resolve().parents[1]
+    required = (
+        root / "SKILL.md",
+        root / "scripts" / "spawn-codex.sh",
+        root / "prompts",
+    )
+    missing = [str(path) for path in required if not path.exists()]
+    if missing:
+        source = "CODEX_REFACTOR_LOOP_SKILL_ROOT" if override else "__file__"
+        raise RuntimeError(f"invalid codex-refactor-loop skill root from {source}: missing {', '.join(missing)}")
+    return root
+
+
 INTERVAL = int(os.environ.get("INTERVAL", "600"))
+SKILL_ROOT = skill_root()
 MAIN_REPO = git_repo_root()
 WORKTREE = Path(os.environ.get("WORKTREE", f"{MAIN_REPO}-wt-dev-sync"))
 INTEGRATION = os.environ.get("INTEGRATION_BRANCH") or os.environ.get("INTEGRATION") or "auto-refact-dev"
 REVIEW_BASE = os.environ.get("REVIEW_BASE_BRANCH") or os.environ.get("REVIEW_BASE") or "dev"
-SPAWN_CODEX = MAIN_REPO / ".claude" / "skills" / "codex-refactor-loop" / "scripts" / "spawn-codex.sh"
+SPAWN_CODEX = SKILL_ROOT / "scripts" / "spawn-codex.sh"
 LOCK_FILE = MAIN_REPO / ".refactor-loop" / "dev-sync-daemon.lock"
 
 

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -1120,31 +1120,11 @@ exit 0
             self.assertEqual(edit_call.count(label), 1)
             self.assertNotIn("eval", (SKILL_ROOT / "scripts" / "controller_lib.sh").read_text(encoding="utf-8"))
 
-# Refactor (iter3/skill-contract-test-suite):
-#   Old pattern: skill contract regressions were documented in prompts/SKILL text but not enforced by the host TEST_CMD.
-#   New principle: a contiguous source-regression suite makes those contracts fail under the dogfood TEST_CMD without adding a new runner or scanner abstraction.
-class SkillContractSourceRegressionTests(unittest.TestCase):
-    """Issue #16 consensus skill contract source-regression suite.
-
-    Keep this contiguous in the sole direct test file until the split threshold:
-    second real test file, this class >250 LOC, whole file >750 LOC, or scanner
-    helpers needed by multiple independent classes/files.
-    """
+class SkillRootContractSourceRegressionTests(unittest.TestCase):
+    """Source and behavior regressions for the host-agnostic skill root contract."""
 
     def read_rel(self, rel: str) -> str:
         return (REPO_ROOT / rel).read_text(encoding="utf-8")
-
-    def rel_paths(self, *patterns: str) -> list[Path]:
-        return [path for pattern in patterns for path in sorted(REPO_ROOT.glob(pattern))]
-
-    def assert_absent(self, needle: str, paths: list[Path], allowlist: tuple[str, ...] = ()) -> None:
-        for path in paths:
-            rel = path.relative_to(REPO_ROOT).as_posix()
-            if rel in allowlist:
-                continue
-            text = path.read_text(encoding="utf-8")
-            with self.subTest(path=rel, needle=needle):
-                self.assertNotIn(needle, text)
 
     def test_dev_sync_daemon_self_locates_skill_root_inline(self) -> None:
         text = self.read_rel("skills/codex-refactor-loop/scripts/dev_sync_daemon.py")
@@ -1217,6 +1197,7 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
         self.assertIn('resolved_skill_root="$(resolve_skill_root)"', text)
         self.assertIn('TRIAGE_PROMPT_TEMPLATE="$resolved_skill_root/prompts/triage-external-issue.md"', text)
         self.assertIn('SPAWN_CODEX="$resolved_skill_root/scripts/spawn-codex.sh"', text)
+        self.assertIn("CODEX_REFACTOR_LOOP_SKILL_ROOT_PRINT", text)
         self.assertIn('"$TRIAGE_PROMPT_TEMPLATE"', text)
         self.assertIn('nohup bash "$SPAWN_CODEX"', text)
         self.assertIn(
@@ -1224,10 +1205,43 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
             text,
         )
         self.assertLess(text.index('resolved_skill_root="$(resolve_skill_root)"'), text.index('STATE_FILE="$REPO_ROOT/.refactor-loop/triage-monitor-state.json"'))
+        self.assertLess(text.index("CODEX_REFACTOR_LOOP_SKILL_ROOT_PRINT"), text.index('STATE_FILE="$REPO_ROOT/.refactor-loop/triage-monitor-state.json"'))
         self.assertLess(text.index('resolved_skill_root="$(resolve_skill_root)"'), text.index('[ -f "$STATE_FILE" ] || echo "{}" > "$STATE_FILE"'))
         self.assertLess(text.index('resolved_skill_root="$(resolve_skill_root)"'), text.index('jq --arg n "$issue"'))
         self.assertNotIn('$REPO_ROOT/.claude/skills/codex-refactor-loop/prompts/triage-external-issue.md', text)
         self.assertNotIn('$REPO_ROOT/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh', text)
+
+    def test_triage_monitor_default_self_location_uses_bash_source_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            installed = Path(tmp) / "skills" / "codex-refactor-loop"
+            scripts = installed / "scripts"
+            prompts = installed / "prompts"
+            scripts.mkdir(parents=True)
+            prompts.mkdir()
+            (installed / "SKILL.md").write_text("---\nname: codex-refactor-loop\n---\n", encoding="utf-8")
+            triage = scripts / "triage-monitor.sh"
+            triage.write_text((SKILL_ROOT / "scripts" / "triage-monitor.sh").read_text(encoding="utf-8"), encoding="utf-8")
+            triage.chmod(0o755)
+            spawn = scripts / "spawn-codex.sh"
+            spawn.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            spawn.chmod(0o755)
+            (prompts / "triage-external-issue.md").write_text("Issue ${ISSUE_NUMBER}\n", encoding="utf-8")
+
+            env = os.environ.copy()
+            env.pop("CODEX_REFACTOR_LOOP_SKILL_ROOT", None)
+            env["CODEX_REFACTOR_LOOP_SKILL_ROOT_PRINT"] = "1"
+            result = subprocess.run(
+                ["bash", str(triage)],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, f"{installed.resolve()}\n")
+            self.assertEqual(result.stderr, "")
+            self.assertFalse((installed / ".refactor-loop").exists())
 
     def test_invalid_specific_skill_root_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -1318,6 +1332,33 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
         self.assertIn("`CODEX_REFACTOR_LOOP_SKILL_ROOT` is optional", skill_text)
         self.assertIn("<skill-root>/scripts/peek.sh", skill_text)
         self.assertIn("<skill-root>/scripts/spawn-codex.sh", skill_text)
+
+
+# Refactor (iter3/skill-contract-test-suite):
+#   Old pattern: skill contract regressions were documented in prompts/SKILL text but not enforced by the host TEST_CMD.
+#   New principle: a contiguous source-regression suite makes those contracts fail under the dogfood TEST_CMD without adding a new runner or scanner abstraction.
+class SkillContractSourceRegressionTests(unittest.TestCase):
+    """Issue #16 consensus skill contract source-regression suite.
+
+    Keep this contiguous in the sole direct test file until the split threshold:
+    second real test file, this class >250 LOC, whole file >750 LOC, or scanner
+    helpers needed by multiple independent classes/files.
+    """
+
+    def read_rel(self, rel: str) -> str:
+        return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+    def rel_paths(self, *patterns: str) -> list[Path]:
+        return [path for pattern in patterns for path in sorted(REPO_ROOT.glob(pattern))]
+
+    def assert_absent(self, needle: str, paths: list[Path], allowlist: tuple[str, ...] = ()) -> None:
+        for path in paths:
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            if rel in allowlist:
+                continue
+            text = path.read_text(encoding="utf-8")
+            with self.subTest(path=rel, needle=needle):
+                self.assertNotIn(needle, text)
 
     def test_active_prompt_post_rules_locators_are_skill_relative(self) -> None:
         prompt_names = (

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -803,11 +803,16 @@ print(check(f"bash -c {repo}/.claude/skills/codex-refactor-loop/scripts/spawn-co
             state_file = root / ".refactor-loop" / "triage-monitor-state.json"
             log_file = root / ".refactor-loop" / "logs" / "triage-issue-42.log"
             prompt_file = root / ".claude" / "skills" / "codex-refactor-loop" / "prompts" / "triage-external-issue.md"
+            skill_root = root / ".claude" / "skills" / "codex-refactor-loop"
+            spawn_file = skill_root / "scripts" / "spawn-codex.sh"
             state_file.parent.mkdir(parents=True)
             log_file.parent.mkdir(parents=True)
             prompt_file.parent.mkdir(parents=True)
+            spawn_file.parent.mkdir(parents=True)
             state_file.write_text('{"42":"2026-01-01T00:00:00Z"}\n', encoding="utf-8")
+            (skill_root / "SKILL.md").write_text("---\nname: codex-refactor-loop\n---\n", encoding="utf-8")
             prompt_file.write_text("Issue ${ISSUE_NUMBER}\nAuthor: maintainer\n", encoding="utf-8")
+            spawn_file.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
             triage_source = (SKILL_ROOT / "scripts" / "triage-monitor.sh").read_text(encoding="utf-8")
             triage_prefix = triage_source.split('log "triage-monitor started: interval=${INTERVAL}s"', 1)[0]
             triage_lib = root / "triage-monitor-functions.sh"
@@ -836,6 +841,7 @@ jq -r '"failed=" + .["42"].status + " retries=" + (.["42"].retries|tostring) + "
             env.update(
                 {
                     "REPO_ROOT": str(root),
+                    "CODEX_REFACTOR_LOOP_SKILL_ROOT": str(skill_root),
                     "STATE_FILE": str(state_file),
                     "LOG_FILE": str(log_file),
                     "TRIAGE_LIB": str(triage_lib),
@@ -878,6 +884,10 @@ jq -r '"failed=" + .["42"].status + " retries=" + (.["42"].retries|tostring) + "
 
             (skill_prompts / "triage-external-issue.md").write_text(
                 "Issue ${ISSUE_NUMBER}\nAuthor: maintainer\n",
+                encoding="utf-8",
+            )
+            (root / ".claude" / "skills" / "codex-refactor-loop" / "SKILL.md").write_text(
+                "---\nname: codex-refactor-loop\n---\n",
                 encoding="utf-8",
             )
             (logs / "triage-issue-14-attempt-1.log").write_text("SPAWN: old\nEXIT=0\n", encoding="utf-8")
@@ -962,6 +972,7 @@ esac
                 {
                     "PATH": f"{fakebin}{os.pathsep}{env['PATH']}",
                     "REPO_ROOT": str(root),
+                    "CODEX_REFACTOR_LOOP_SKILL_ROOT": str(root / ".claude" / "skills" / "codex-refactor-loop"),
                     "GH_REPO_SLUG": "owner/repo",
                     "TRIAGE_MONITOR_ONCE": "1",
                     "TRIAGE_MONITOR_TEST_WAIT_SPAWN": "1",
@@ -1134,6 +1145,159 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
             text = path.read_text(encoding="utf-8")
             with self.subTest(path=rel, needle=needle):
                 self.assertNotIn(needle, text)
+
+    def test_dev_sync_daemon_self_locates_skill_root_inline(self) -> None:
+        text = self.read_rel("skills/codex-refactor-loop/scripts/dev_sync_daemon.py")
+
+        self.assertIn("def skill_root() -> Path:", text)
+        self.assertIn("CODEX_REFACTOR_LOOP_SKILL_ROOT", text)
+        self.assertIn("Path(__file__).resolve().parents[1]", text)
+        self.assertIn('root / "SKILL.md"', text)
+        self.assertIn('root / "scripts" / "spawn-codex.sh"', text)
+        self.assertIn('root / "prompts"', text)
+        self.assertIn("invalid codex-refactor-loop skill root", text)
+        self.assertIn('SPAWN_CODEX = SKILL_ROOT / "scripts" / "spawn-codex.sh"', text)
+        self.assertNotIn('SPAWN_CODEX = MAIN_REPO / ".claude"', text)
+        self.assertNotIn(".claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py", text)
+        self.assertIn(
+            "# Refactor (iter3/skill-skill-root-contract): Old: .claude/skills 硬编码  New: inline self-location + env 可选 override(#19 structural 共识)",
+            text,
+        )
+
+    def test_triage_monitor_self_locates_before_state_mutation(self) -> None:
+        text = self.read_rel("skills/codex-refactor-loop/scripts/triage-monitor.sh")
+
+        self.assertIn("resolve_skill_root()", text)
+        self.assertIn('CODEX_REFACTOR_LOOP_SKILL_ROOT', text)
+        self.assertIn('${BASH_SOURCE[0]}', text)
+        self.assertIn('resolved_skill_root="$(resolve_skill_root)"', text)
+        self.assertIn('TRIAGE_PROMPT_TEMPLATE="$resolved_skill_root/prompts/triage-external-issue.md"', text)
+        self.assertIn('SPAWN_CODEX="$resolved_skill_root/scripts/spawn-codex.sh"', text)
+        self.assertIn('"$TRIAGE_PROMPT_TEMPLATE"', text)
+        self.assertIn('nohup bash "$SPAWN_CODEX"', text)
+        self.assertIn(
+            "# Refactor (iter3/skill-skill-root-contract): Old: .claude/skills 硬编码  New: inline self-location + env 可选 override(#19 structural 共识)",
+            text,
+        )
+        self.assertLess(text.index('resolved_skill_root="$(resolve_skill_root)"'), text.index('STATE_FILE="$REPO_ROOT/.refactor-loop/triage-monitor-state.json"'))
+        self.assertLess(text.index('resolved_skill_root="$(resolve_skill_root)"'), text.index('[ -f "$STATE_FILE" ] || echo "{}" > "$STATE_FILE"'))
+        self.assertLess(text.index('resolved_skill_root="$(resolve_skill_root)"'), text.index('jq --arg n "$issue"'))
+        self.assertNotIn('$REPO_ROOT/.claude/skills/codex-refactor-loop/prompts/triage-external-issue.md', text)
+        self.assertNotIn('$REPO_ROOT/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh', text)
+
+    def test_invalid_specific_skill_root_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            invalid_skill = root / "invalid-skill"
+            fakebin = root / "bin"
+            repo.mkdir()
+            invalid_skill.mkdir()
+            fakebin.mkdir()
+            state_file = repo / ".refactor-loop" / "triage-monitor-state.json"
+            gh = fakebin / "gh"
+            gh.write_text("#!/usr/bin/env bash\nprintf '42 alice\\n'\n", encoding="utf-8")
+            gh.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{fakebin}{os.pathsep}{env['PATH']}",
+                    "REPO_ROOT": str(repo),
+                    "CODEX_REFACTOR_LOOP_SKILL_ROOT": str(invalid_skill),
+                    "GH_REPO_SLUG": "owner/repo",
+                    "TRIAGE_MONITOR_ONCE": "1",
+                    "PYTHONPATH": str(SKILL_ROOT / "scripts"),
+                }
+            )
+            triage = subprocess.run(
+                ["bash", str(SKILL_ROOT / "scripts" / "triage-monitor.sh")],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(triage.returncode, 0)
+            self.assertIn("invalid codex-refactor-loop skill root", triage.stderr)
+            self.assertFalse(state_file.exists())
+
+            dev_sync = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import dev_sync_daemon",
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(dev_sync.returncode, 0)
+            self.assertIn("invalid codex-refactor-loop skill root", dev_sync.stderr)
+            self.assertNotIn(".claude/skills/codex-refactor-loop", dev_sync.stderr + dev_sync.stdout)
+
+    def test_no_shared_locator_or_generic_env_contract(self) -> None:
+        self.assertFalse((SKILL_ROOT / "scripts" / "skill_root.py").exists())
+        self.assertFalse((SKILL_ROOT / "scripts" / "skill-root.sh").exists())
+        self.assertNotIn("CODEX_REFACTOR_LOOP_SKILL_ROOT", self.read_rel("skills/codex-refactor-loop/host.env.example"))
+
+        runtime_texts = {
+            "dev_sync_daemon.py": self.read_rel("skills/codex-refactor-loop/scripts/dev_sync_daemon.py"),
+            "triage-monitor.sh": self.read_rel("skills/codex-refactor-loop/scripts/triage-monitor.sh"),
+        }
+        for name, text in runtime_texts.items():
+            with self.subTest(runtime=name):
+                self.assertNotIn("import skill_root", text)
+                self.assertNotIn("source skill-root.sh", text)
+                self.assertNotIn("${SKILL_ROOT", text)
+                self.assertNotIn("$SKILL_ROOT", text)
+                self.assertNotIn('os.environ.get("SKILL_ROOT"', text)
+
+    def test_active_skill_launch_dispatch_docs_are_skill_relative(self) -> None:
+        checked = [
+            SKILL_ROOT / "SKILL.md",
+            SKILL_ROOT / "REFERENCE.md",
+            SKILL_ROOT / "scripts" / "dev_sync_daemon.py",
+            SKILL_ROOT / "scripts" / "triage-monitor.sh",
+        ]
+        for path in checked:
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            text = path.read_text(encoding="utf-8")
+            with self.subTest(path=rel):
+                self.assertNotIn(".claude/skills/codex-refactor-loop/scripts/", text)
+                self.assertNotIn(".claude/skills/codex-refactor-loop/prompts/", text)
+
+        skill_text = self.read_rel("skills/codex-refactor-loop/SKILL.md")
+        self.assertIn("## Skill Root Contract", skill_text)
+        self.assertIn("`<skill-root>` means the installed `skills/codex-refactor-loop` directory", skill_text)
+        self.assertIn("Runtime scripts self-locate", skill_text)
+        self.assertIn("`CODEX_REFACTOR_LOOP_SKILL_ROOT` is optional", skill_text)
+        self.assertIn("<skill-root>/scripts/peek.sh", skill_text)
+        self.assertIn("<skill-root>/scripts/spawn-codex.sh", skill_text)
+
+    def test_active_prompt_post_rules_locators_are_skill_relative(self) -> None:
+        prompt_names = (
+            "reviewer-quality.md",
+            "solver-structural.md",
+            "design-issue-reply.md",
+            "solver-delete.md",
+            "solver-minimal.md",
+            "review-fix.md",
+            "reviewer-architect.md",
+            "reviewer-tests.md",
+            "meta-judge.md",
+            "_github-post-rules.md",
+        )
+        for name in prompt_names:
+            path = SKILL_ROOT / "prompts" / name
+            text = path.read_text(encoding="utf-8")
+            with self.subTest(prompt=name):
+                self.assertNotIn(".claude/skills/codex-refactor-loop/prompts/_github-post-rules.md", text)
+                self.assertNotIn(".claude/skills/codex-refactor-loop/scripts/comment-monitor.sh", text)
+        for name in prompt_names[:-1]:
+            with self.subTest(prompt=name, expected="post-rules"):
+                self.assertIn("本 skill 的 `prompts/_github-post-rules.md`", (SKILL_ROOT / "prompts" / name).read_text(encoding="utf-8"))
+        self.assertIn("本 skill 的 `scripts/comment-monitor.sh`", self.read_rel("skills/codex-refactor-loop/prompts/_github-post-rules.md"))
 
     def test_spawn_with_banner_cli_hard_fails_as_tombstone(self) -> None:
         result = subprocess.run(

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -1160,9 +1160,53 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
         self.assertNotIn('SPAWN_CODEX = MAIN_REPO / ".claude"', text)
         self.assertNotIn(".claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py", text)
         self.assertIn(
-            "# Refactor (iter3/skill-skill-root-contract): Old: .claude/skills 硬编码  New: inline self-location + env 可选 override(#19 structural 共识)",
+            "# Refactor (iter3/skill-skill-root-contract): Old pattern: .claude/skills hardcoded lookup. New principle: self-locate from this script path, with optional validated CODEX_REFACTOR_LOOP_SKILL_ROOT override.",
             text,
         )
+
+    def test_dev_sync_daemon_uses_valid_specific_skill_root_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            override = root / "override-skill"
+            (override / "scripts").mkdir(parents=True)
+            (override / "prompts").mkdir()
+            repo.mkdir()
+            (override / "SKILL.md").write_text("---\nname: codex-refactor-loop\n---\n", encoding="utf-8")
+            spawn = override / "scripts" / "spawn-codex.sh"
+            spawn.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            spawn.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "REPO_ROOT": str(repo),
+                    "CODEX_REFACTOR_LOOP_SKILL_ROOT": str(override),
+                    "PYTHONPATH": str(SKILL_ROOT / "scripts"),
+                }
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    (
+                        "import dev_sync_daemon; "
+                        "print(dev_sync_daemon.SKILL_ROOT); "
+                        "print(dev_sync_daemon.SPAWN_CODEX)"
+                    ),
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout.splitlines(),
+                [str(override.resolve()), str((override / "scripts" / "spawn-codex.sh").resolve())],
+            )
+            self.assertEqual(result.stderr, "")
 
     def test_triage_monitor_self_locates_before_state_mutation(self) -> None:
         text = self.read_rel("skills/codex-refactor-loop/scripts/triage-monitor.sh")
@@ -1176,7 +1220,7 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
         self.assertIn('"$TRIAGE_PROMPT_TEMPLATE"', text)
         self.assertIn('nohup bash "$SPAWN_CODEX"', text)
         self.assertIn(
-            "# Refactor (iter3/skill-skill-root-contract): Old: .claude/skills 硬编码  New: inline self-location + env 可选 override(#19 structural 共识)",
+            "# Refactor (iter3/skill-skill-root-contract): Old pattern: .claude/skills hardcoded lookup. New principle: self-locate from this script path, with optional validated CODEX_REFACTOR_LOOP_SKILL_ROOT override.",
             text,
         )
         self.assertLess(text.index('resolved_skill_root="$(resolve_skill_root)"'), text.index('STATE_FILE="$REPO_ROOT/.refactor-loop/triage-monitor-state.json"'))

--- a/skills/codex-refactor-loop/scripts/triage-monitor.sh
+++ b/skills/codex-refactor-loop/scripts/triage-monitor.sh
@@ -13,7 +13,7 @@
 set -u
 
 resolve_skill_root() {
-  # Refactor (iter3/skill-skill-root-contract): Old: .claude/skills 硬编码  New: inline self-location + env 可选 override(#19 structural 共识)
+  # Refactor (iter3/skill-skill-root-contract): Old pattern: .claude/skills hardcoded lookup. New principle: self-locate from this script path, with optional validated CODEX_REFACTOR_LOOP_SKILL_ROOT override.
   local root
   if [ -n "${CODEX_REFACTOR_LOOP_SKILL_ROOT:-}" ]; then
     root="$CODEX_REFACTOR_LOOP_SKILL_ROOT"

--- a/skills/codex-refactor-loop/scripts/triage-monitor.sh
+++ b/skills/codex-refactor-loop/scripts/triage-monitor.sh
@@ -6,11 +6,36 @@
 # - 对每个未处理的 issue:
 #   - state 存 .refactor-loop/triage-monitor-state.json(claimed/spawned/failed/done)
 #   - materialize prompt and spawn triage codex
-# - 启动: nohup bash .claude/skills/codex-refactor-loop/scripts/triage-monitor.sh >> .refactor-loop/logs/triage-monitor.log 2>&1 & disown
+# - 启动: nohup bash <skill-root>/scripts/triage-monitor.sh >> .refactor-loop/logs/triage-monitor.log 2>&1 & disown
 #
 # ⟦AI:AUTO-LOOP⟧
 
 set -u
+
+resolve_skill_root() {
+  # Refactor (iter3/skill-skill-root-contract): Old: .claude/skills 硬编码  New: inline self-location + env 可选 override(#19 structural 共识)
+  local root
+  if [ -n "${CODEX_REFACTOR_LOOP_SKILL_ROOT:-}" ]; then
+    root="$CODEX_REFACTOR_LOOP_SKILL_ROOT"
+  else
+    root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+  fi
+  if ! root="$(cd "$root" 2>/dev/null && pwd -P)"; then
+    echo "FATAL: invalid codex-refactor-loop skill root: ${CODEX_REFACTOR_LOOP_SKILL_ROOT:-${BASH_SOURCE[0]}}" >&2
+    exit 2
+  fi
+  if [ ! -f "$root/SKILL.md" ] || [ ! -f "$root/prompts/triage-external-issue.md" ] || [ ! -f "$root/scripts/spawn-codex.sh" ]; then
+    echo "FATAL: invalid codex-refactor-loop skill root: missing SKILL.md, prompts/triage-external-issue.md, or scripts/spawn-codex.sh under $root" >&2
+    exit 2
+  fi
+  printf '%s\n' "$root"
+}
+
+if ! resolved_skill_root="$(resolve_skill_root)"; then
+  exit 2
+fi
+TRIAGE_PROMPT_TEMPLATE="$resolved_skill_root/prompts/triage-external-issue.md"
+SPAWN_CODEX="$resolved_skill_root/scripts/spawn-codex.sh"
 
 if [ -z "${REPO_ROOT:-}" ]; then
   if [ "${ALLOW_GIT_ROOT_FALLBACK:-0}" = "1" ]; then
@@ -195,15 +220,15 @@ while true; do
     set_state "$issue" "claimed" "$retries" "$((now + TRIAGE_RETRY_BACKOFF_SECONDS))" "$log_file"
     if ! ISSUE_NUMBER="$issue" COMMENT_AUTHOR="$author" \
       perl -pe 's/\Q${ISSUE_NUMBER}\E/$ENV{ISSUE_NUMBER}/g; s/Author: maintainer/Author: $ENV{COMMENT_AUTHOR}/g' \
-        "$REPO_ROOT/.claude/skills/codex-refactor-loop/prompts/triage-external-issue.md" \
+        "$TRIAGE_PROMPT_TEMPLATE" \
         > "$prompt_file" 2>/dev/null; then
-      if ! cp "$REPO_ROOT/.claude/skills/codex-refactor-loop/prompts/triage-external-issue.md" "$prompt_file" 2>/dev/null; then
+      if ! cp "$TRIAGE_PROMPT_TEMPLATE" "$prompt_file" 2>/dev/null; then
         mark_failed_retry "$issue" "$retries" "$log_file" "prompt-materialization"
         continue
       fi
     fi
 
-    ISSUE_NUMBER="$issue" nohup bash "$REPO_ROOT/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh" \
+    ISSUE_NUMBER="$issue" nohup bash "$SPAWN_CODEX" \
       --cd "$REPO_ROOT" \
       --prompt "$prompt_file" \
       --log "$log_file" \

--- a/skills/codex-refactor-loop/scripts/triage-monitor.sh
+++ b/skills/codex-refactor-loop/scripts/triage-monitor.sh
@@ -36,6 +36,11 @@ if ! resolved_skill_root="$(resolve_skill_root)"; then
 fi
 TRIAGE_PROMPT_TEMPLATE="$resolved_skill_root/prompts/triage-external-issue.md"
 SPAWN_CODEX="$resolved_skill_root/scripts/spawn-codex.sh"
+if [ -n "${CODEX_REFACTOR_LOOP_SKILL_ROOT_PRINT:-}" ]; then
+  # Refactor (iter3/skill-skill-root-contract): Old: triage-monitor default self-location was only observable after repo-state setup. New: deterministic print hook exposes the resolved skill root before mutation for contract tests.
+  printf '%s\n' "$resolved_skill_root"
+  exit 0
+fi
 
 if [ -z "${REPO_ROOT:-}" ]; then
   if [ "${ALLOW_GIT_ROOT_FALLBACK:-0}" = "1" ]; then


### PR DESCRIPTION
## 🤖 refactor(skill): host-agnostic skill root 自定位(#19 r4 共识)

**Phase 9 r4 structural 共识落地**(4 轮收敛,直击 README 泛化路线):
- `dev_sync_daemon.py` / `triage-monitor.sh`:**inline self-location** —— `CODEX_REFACTOR_LOOP_SKILL_ROOT` 可选 override,否则 `__file__`/`BASH_SOURCE` parent 自定位(验证 SKILL.md/spawn-codex.sh/prompts/),invalid override **fail-closed**,**不** fallback `.claude/skills`
- `SKILL.md`/`REFERENCE.md`:active launch/dispatch 路径示例改 skill-relative + 加 `Skill root contract` 段
- 9 个 prompt + `_github-post-rules.md`:locator 措辞 skill-relative
- +4 个 self-location 测试

不引入 SkillRootLocatorV1/skill_root.py/外部 `$SKILL_ROOT`/host.env 字段。无 SCOPE_EXTEND。

Closes #19

⟦AI:AUTO-LOOP⟧
