### PR TITLE
feat(skill): consensus-rnd-ci workflow + manifest-version-sync 独立 checker(#31 共识)

### DIFF
--- a/.github/workflows/consensus-rnd-ci.yml
+++ b/.github/workflows/consensus-rnd-ci.yml
@@ -1,0 +1,95 @@
+name: consensus-rnd-ci
+
+on:
+  pull_request:
+    branches:
+      - auto-refact-dev
+      - dev
+  push:
+    branches:
+      - auto-refact-dev
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: consensus-rnd-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-tests:
+    name: contract-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run contract tests
+        run: python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'
+
+  manifest-version-sync:
+    name: manifest-version-sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check manifest version sync
+        run: python3 skills/codex-refactor-loop/scripts/check_manifest_version_sync.py
+
+  lint-advisory:
+    name: lint-advisory
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install advisory lint tools
+        shell: bash
+        run: |
+          set +e
+          python3 -m pip install --user ruff
+          RUFF_INSTALL_STATUS=$?
+          npm install -g markdownlint-cli2
+          MARKDOWNLINT_INSTALL_STATUS=$?
+          {
+            echo "## lint-advisory installs"
+            echo "- ruff install exit: ${RUFF_INSTALL_STATUS}"
+            echo "- markdownlint-cli2 install exit: ${MARKDOWNLINT_INSTALL_STATUS}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
+      - name: Run advisory linters
+        shell: bash
+        run: |
+          set +e
+          shellcheck skills/codex-refactor-loop/scripts/*.sh
+          SHELLCHECK_STATUS=$?
+          python3 -m ruff check --select E9,F63,F7,F82 skills/codex-refactor-loop/scripts/*.py
+          RUFF_STATUS=$?
+          markdownlint-cli2 "**/*.md" "!node_modules" "!.git" "!.refactor-loop"
+          MARKDOWNLINT_STATUS=$?
+          {
+            echo "## lint-advisory results"
+            echo "- shellcheck exit: ${SHELLCHECK_STATUS}"
+            echo "- ruff exit: ${RUFF_STATUS}"
+            echo "- markdownlint-cli2 exit: ${MARKDOWNLINT_STATUS}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0

--- a/skills/codex-refactor-loop/scripts/check_manifest_version_sync.py
+++ b/skills/codex-refactor-loop/scripts/check_manifest_version_sync.py
@@ -60,7 +60,7 @@ def _resolve_field(document: Any, field: str, *, path: str) -> Any:
     return current
 
 
-# Refactor (iter3/skill-ci-harness): Old: 无机械 manifest-version-sync 检查  New: standalone check_manifest_version_sync.py + CI required check(#31 structural 共识)
+# Refactor (iter3/skill-ci-harness): Old pattern: no mechanical manifest-version-sync check. New principle: standalone checker plus required CI status enforces CLAUDE.md version sync.
 def load_manifest_records(repo_root: Path) -> list[VersionRecord]:
     version_bump_path = repo_root / ".version-bump.json"
     version_bump = _load_json(version_bump_path)

--- a/skills/codex-refactor-loop/scripts/check_manifest_version_sync.py
+++ b/skills/codex-refactor-loop/scripts/check_manifest_version_sync.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Check that all published plugin manifests share one version."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ManifestVersionSyncError(Exception):
+    """Raised when manifest version mappings cannot be resolved or synced."""
+
+
+@dataclass(frozen=True)
+class VersionRecord:
+    path: str
+    field: str
+    value: str
+
+
+def _repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError as exc:
+        raise ManifestVersionSyncError(f"missing file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ManifestVersionSyncError(f"invalid JSON in {path}: {exc}") from exc
+
+
+def _resolve_field(document: Any, field: str, *, path: str) -> Any:
+    current = document
+    for segment in field.split("."):
+        if isinstance(current, dict):
+            if segment not in current:
+                raise ManifestVersionSyncError(f"{path}:{field}: missing field segment {segment!r}")
+            current = current[segment]
+            continue
+
+        if isinstance(current, list):
+            try:
+                index = int(segment)
+            except ValueError as exc:
+                raise ManifestVersionSyncError(f"{path}:{field}: expected numeric list index, got {segment!r}") from exc
+            if index < 0 or index >= len(current):
+                raise ManifestVersionSyncError(f"{path}:{field}: list index {index} out of range")
+            current = current[index]
+            continue
+
+        raise ManifestVersionSyncError(f"{path}:{field}: cannot resolve segment {segment!r} through {type(current).__name__}")
+
+    return current
+
+
+# Refactor (iter3/skill-ci-harness): Old: 无机械 manifest-version-sync 检查  New: standalone check_manifest_version_sync.py + CI required check(#31 structural 共识)
+def load_manifest_records(repo_root: Path) -> list[VersionRecord]:
+    version_bump_path = repo_root / ".version-bump.json"
+    version_bump = _load_json(version_bump_path)
+    files = version_bump.get("files") if isinstance(version_bump, dict) else None
+    if not isinstance(files, list):
+        raise ManifestVersionSyncError(".version-bump.json: expected top-level files list")
+
+    records: list[VersionRecord] = []
+    for index, entry in enumerate(files):
+        if not isinstance(entry, dict):
+            raise ManifestVersionSyncError(f".version-bump.json: files.{index} must be an object")
+        manifest_path = entry.get("path")
+        field = entry.get("field")
+        if not isinstance(manifest_path, str) or not manifest_path:
+            raise ManifestVersionSyncError(f".version-bump.json: files.{index}.path must be a non-empty string")
+        if not isinstance(field, str) or not field:
+            raise ManifestVersionSyncError(f".version-bump.json: files.{index}.field must be a non-empty string")
+
+        manifest = _load_json(repo_root / manifest_path)
+        value = _resolve_field(manifest, field, path=manifest_path)
+        if not isinstance(value, str) or not value:
+            raise ManifestVersionSyncError(f"{manifest_path}:{field}: version value must be a non-empty string")
+        records.append(VersionRecord(path=manifest_path, field=field, value=value))
+
+    return records
+
+
+def check_manifest_version_sync(repo_root: Path) -> list[VersionRecord]:
+    records = load_manifest_records(repo_root)
+    values = {record.value for record in records}
+    if len(values) > 1:
+        lines = ["manifest versions are not synced:"]
+        lines.extend(f"- {record.path}:{record.field}={record.value}" for record in records)
+        raise ManifestVersionSyncError("\n".join(lines))
+    return records
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=_repo_root_from_script(), help="repository root to check")
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    try:
+        records = check_manifest_version_sync(repo_root)
+    except ManifestVersionSyncError as exc:
+        print(f"MANIFEST_VERSION_SYNC_ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    for record in records:
+        print(f"{record.path}:{record.field}={record.value}")
+    if records:
+        print(f"MANIFEST_VERSION_SYNC_OK:{records[0].value}")
+    else:
+        print("MANIFEST_VERSION_SYNC_OK:no-records")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex-refactor-loop/scripts/test_manifest_version_sync.py
+++ b/skills/codex-refactor-loop/scripts/test_manifest_version_sync.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Behavior tests for check_manifest_version_sync.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_manifest_version_sync import (
+    ManifestVersionSyncError,
+    check_manifest_version_sync,
+    load_manifest_records,
+)
+
+SCRIPT_PATH = Path(__file__).with_name("check_manifest_version_sync.py")
+REPO_ROOT = SCRIPT_PATH.parents[3]
+
+EXPECTED_VERSION_RECORDS = {
+    ("package.json", "version"),
+    (".claude-plugin/plugin.json", "version"),
+    (".claude-plugin/marketplace.json", "plugins.0.version"),
+    (".codex-plugin/plugin.json", "version"),
+    (".cursor-plugin/plugin.json", "version"),
+    ("gemini-extension.json", "version"),
+}
+
+
+class ManifestVersionSyncTests(unittest.TestCase):
+    def write_json(self, root: Path, relative_path: str, value: object) -> None:
+        target = root / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+    def write_fixture(self, root: Path, *, gemini_version: str = "1.2.3", include_gemini_field: bool = True) -> None:
+        files = [
+            {"path": "package.json", "field": "version"},
+            {"path": ".claude-plugin/plugin.json", "field": "version"},
+            {"path": ".claude-plugin/marketplace.json", "field": "plugins.0.version"},
+            {"path": ".codex-plugin/plugin.json", "field": "version"},
+            {"path": ".cursor-plugin/plugin.json", "field": "version"},
+            {"path": "gemini-extension.json", "field": "version"},
+        ]
+        self.write_json(root, ".version-bump.json", {"files": files})
+        self.write_json(root, "package.json", {"version": "1.2.3"})
+        self.write_json(root, ".claude-plugin/plugin.json", {"version": "1.2.3"})
+        self.write_json(root, ".claude-plugin/marketplace.json", {"plugins": [{"version": "1.2.3"}]})
+        self.write_json(root, ".codex-plugin/plugin.json", {"version": "1.2.3"})
+        self.write_json(root, ".cursor-plugin/plugin.json", {"version": "1.2.3"})
+        gemini_manifest = {"version": gemini_version} if include_gemini_field else {"name": "consensus-rnd"}
+        self.write_json(root, "gemini-extension.json", gemini_manifest)
+
+    def test_real_repo_version_bump_entries_all_resolve_to_one_version(self) -> None:
+        records = load_manifest_records(REPO_ROOT)
+
+        self.assertEqual({(record.path, record.field) for record in records}, EXPECTED_VERSION_RECORDS)
+        self.assertEqual(len({record.value for record in records}), 1)
+
+    def test_mismatched_temp_fixture_reports_path_and_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self.write_fixture(repo, gemini_version="9.9.9")
+
+            with self.assertRaisesRegex(
+                ManifestVersionSyncError,
+                r"gemini-extension\.json:version=9\.9\.9",
+            ):
+                check_manifest_version_sync(repo)
+
+    def test_missing_field_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self.write_fixture(repo, include_gemini_field=False)
+
+            with self.assertRaisesRegex(
+                ManifestVersionSyncError,
+                r"gemini-extension\.json:version: missing field segment 'version'",
+            ):
+                check_manifest_version_sync(repo)
+
+    def test_cli_smoke_real_repo_succeeds(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("MANIFEST_VERSION_SYNC_OK:", result.stdout)
+        self.assertEqual(result.stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_manifest_version_sync.py
+++ b/skills/codex-refactor-loop/scripts/test_manifest_version_sync.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -183,6 +184,34 @@ class ManifestVersionSyncTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("MANIFEST_VERSION_SYNC_OK:", result.stdout)
         self.assertEqual(result.stderr, "")
+
+    def test_cli_mismatched_manifest_fixture_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            for relative_path, _field in EXPECTED_VERSION_RECORDS:
+                source = REPO_ROOT / relative_path
+                target = repo / relative_path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source, target)
+            shutil.copyfile(REPO_ROOT / ".version-bump.json", repo / ".version-bump.json")
+
+            gemini_path = repo / "gemini-extension.json"
+            gemini_manifest = json.loads(gemini_path.read_text(encoding="utf-8"))
+            gemini_manifest["version"] = "999.999.999"
+            gemini_path.write_text(json.dumps(gemini_manifest, indent=2) + "\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), "--repo-root", str(repo)],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn("MANIFEST_VERSION_SYNC_ERROR", result.stderr)
+        self.assertIn("gemini-extension.json:version=999.999.999", result.stderr)
+        self.assertNotIn("MANIFEST_VERSION_SYNC_OK", result.stdout)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_manifest_version_sync.py
+++ b/skills/codex-refactor-loop/scripts/test_manifest_version_sync.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from check_manifest_version_sync import (
     ManifestVersionSyncError,
     check_manifest_version_sync,
+    _load_json,
     load_manifest_records,
 )
 
@@ -53,6 +54,17 @@ class ManifestVersionSyncTests(unittest.TestCase):
         gemini_manifest = {"version": gemini_version} if include_gemini_field else {"name": "consensus-rnd"}
         self.write_json(root, "gemini-extension.json", gemini_manifest)
 
+    def write_single_record_fixture(
+        self,
+        root: Path,
+        *,
+        manifest: object,
+        path: str = "manifest.json",
+        field: str = "version",
+    ) -> None:
+        self.write_json(root, ".version-bump.json", {"files": [{"path": path, "field": field}]})
+        self.write_json(root, path, manifest)
+
     def test_real_repo_version_bump_entries_all_resolve_to_one_version(self) -> None:
         records = load_manifest_records(REPO_ROOT)
 
@@ -80,6 +92,84 @@ class ManifestVersionSyncTests(unittest.TestCase):
                 r"gemini-extension\.json:version: missing field segment 'version'",
             ):
                 check_manifest_version_sync(repo)
+
+    def test_load_json_fails_closed_for_missing_file_and_invalid_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+
+            with self.assertRaisesRegex(ManifestVersionSyncError, "missing file:"):
+                _load_json(repo / "missing.json")
+
+            invalid = repo / "invalid.json"
+            invalid.write_text("{not valid json\n", encoding="utf-8")
+            with self.assertRaisesRegex(ManifestVersionSyncError, "invalid JSON in"):
+                _load_json(invalid)
+
+    def test_version_bump_schema_fails_closed(self) -> None:
+        cases = [
+            ("missing files", {}, "expected top-level files list"),
+            ("non-list files", {"files": {"path": "manifest.json", "field": "version"}}, "expected top-level files list"),
+            ("non-object entry", {"files": ["manifest.json"]}, "files.0 must be an object"),
+            ("missing path", {"files": [{"field": "version"}]}, "files.0.path must be a non-empty string"),
+            ("empty path", {"files": [{"path": "", "field": "version"}]}, "files.0.path must be a non-empty string"),
+            ("non-string path", {"files": [{"path": 7, "field": "version"}]}, "files.0.path must be a non-empty string"),
+            ("missing field", {"files": [{"path": "manifest.json"}]}, "files.0.field must be a non-empty string"),
+            ("empty field", {"files": [{"path": "manifest.json", "field": ""}]}, "files.0.field must be a non-empty string"),
+            ("non-string field", {"files": [{"path": "manifest.json", "field": 7}]}, "files.0.field must be a non-empty string"),
+        ]
+        for label, version_bump, message in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                self.write_json(repo, ".version-bump.json", version_bump)
+
+                with self.assertRaisesRegex(ManifestVersionSyncError, message):
+                    load_manifest_records(repo)
+
+    def test_dotted_field_resolution_fails_closed(self) -> None:
+        cases = [
+            (
+                "non-numeric list index",
+                {"plugins": [{"version": "1.2.3"}]},
+                "plugins.zero.version",
+                "expected numeric list index",
+            ),
+            (
+                "out-of-range list index",
+                {"plugins": [{"version": "1.2.3"}]},
+                "plugins.1.version",
+                "list index 1 out of range",
+            ),
+            (
+                "scalar traversal",
+                {"version": "1.2.3"},
+                "version.major",
+                "cannot resolve segment 'major' through str",
+            ),
+        ]
+        for label, manifest, field, message in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                self.write_single_record_fixture(repo, manifest=manifest, field=field)
+
+                with self.assertRaisesRegex(ManifestVersionSyncError, message):
+                    load_manifest_records(repo)
+
+    def test_version_values_must_be_non_empty_strings(self) -> None:
+        cases = [
+            ("empty string", {"version": ""}),
+            ("null", {"version": None}),
+            ("numeric", {"version": 123}),
+        ]
+        for label, manifest in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                self.write_single_record_fixture(repo, manifest=manifest)
+
+                with self.assertRaisesRegex(
+                    ManifestVersionSyncError,
+                    "manifest.json:version: version value must be a non-empty string",
+                ):
+                    check_manifest_version_sync(repo)
 
     def test_cli_smoke_real_repo_succeeds(self) -> None:
         result = subprocess.run(


### PR DESCRIPTION
## Phase 9 r4 共识(structural option A)

Closes #31

### What

- 新增 `.github/workflows/consensus-rnd-ci.yml`(workflow `consensus-rnd-ci`):
  - `contract-tests`(required):`python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'`
  - `manifest-version-sync`(required):`python3 skills/codex-refactor-loop/scripts/check_manifest_version_sync.py`
  - `lint-advisory`(非阻塞):shellcheck + ruff + markdownlint;写 `$GITHUB_STEP_SUMMARY`
  - triggers:pull_request + push(auto-refact-dev/dev) + workflow_dispatch
- 新增 `skills/codex-refactor-loop/scripts/check_manifest_version_sync.py`:
  - 读 `.version-bump.json`,解析 dotted/list-index 字段
  - exit 1 on missing/mismatch
- 新增 `skills/codex-refactor-loop/scripts/test_manifest_version_sync.py`(unittest 行为覆盖)

不动 `test_ensure_project_rules_fixed_points.py`(共识明示)。

### Verify

- 本地 `python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → **66 tests OK**
- 真实仓库 `python3 skills/codex-refactor-loop/scripts/check_manifest_version_sync.py` → **MANIFEST_VERSION_SYNC_OK:0.1.0**

⟦AI:AUTO-LOOP⟧