### PR TITLE
feat(skill): 6 个 HOST_* 可选空默认 + prompt 引用脱 C#/.NET/proto 写死(#20 共识)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -50,6 +50,21 @@ These variables are injected by the host project. The skill must not hardcode pr
 | `$GH_REPO_SLUG` | GitHub `OWNER/REPO` slug | required for `gh --repo` |
 | `$GH_OWNER` / `$GH_REPO_NAME` | compatibility fields for slug construction | optional |
 
+### Host language policy
+
+These optional fields carry host language, test-layout, comment, schema, and architecture-review policy into prompt text. Their default is empty. Empty means the prompt must infer from existing repository evidence plus `$PROJECT_RULES`, `$SOURCE_GLOBS`, `$TEST_CMD`, `$BUILD_CMD`, and the actual diff; it must not invent C#, .NET, protobuf, or any other host-specific default.
+
+| Variable | Prompt meaning | Empty behavior |
+|---|---|---|
+| `$HOST_TEST_FILE_GLOBS` | writable test file glob or location hints for test-writing/review prompts | infer from existing tests; fail closed if unsafe |
+| `$HOST_TEST_NAMING_RULE` | host test file and test method naming rule | mirror existing tests; do not assume a suffix or extension |
+| `$HOST_COMMENT_RULE` | refactor/self-documentation comment syntax and applicability | match surrounding file style or mark not applicable |
+| `$HOST_CODE_FENCE_LANG` | language tag for illustrative code fences in generated prompt text | omit the language tag |
+| `$HOST_PROTO_POLICY` | schema/protocol review and regeneration policy when applicable | treat schema checks as diff/project-rule driven only |
+| `$HOST_ARCHITECTURE_GREP_CHECKS` | host-specific architecture anti-pattern grep hints for reviewers | use `$PROJECT_RULES`, `$SOURCE_GLOBS`, `$CI_GUARDS`, and diff evidence only |
+
+Prompt templates reference these fields as `${HOST_*}` placeholders so normal `host.env` sourcing plus `render_template`/`envsubst` injects them at prompt construction time. Do not add aliases for the rejected Set B names.
+
 Host config rules:
 
 1. `host.env` is the only runtime fact injection point.

--- a/skills/codex-refactor-loop/host.env.example
+++ b/skills/codex-refactor-loop/host.env.example
@@ -50,6 +50,15 @@ export PROJECT_RULES="CLAUDE.md"
 # CI 守卫脚本(本地跑的架构守卫;留空表示无)。
 export CI_GUARDS=""                               # 例:scripts/ci-guards.sh
 
+# Host language policy(可选,空默认):prompt 文本注入;为空时从现有仓库证据 +
+# PROJECT_RULES/SOURCE_GLOBS/TEST_CMD/BUILD_CMD/实际 diff 推断,不得臆造语言默认。
+export HOST_TEST_FILE_GLOBS=""
+export HOST_TEST_NAMING_RULE=""
+export HOST_COMMENT_RULE=""
+export HOST_CODE_FENCE_LANG=""
+export HOST_PROTO_POLICY=""
+export HOST_ARCHITECTURE_GREP_CHECKS=""
+
 # 并发 floor:controller 确保始终有 ≥ 此数个**本仓库** codex 并行(防单线程死等)。
 # 未设默认 5;**硬下限 2**(设 <2 一律按 2)。小型仓(文档/skills,可派独立工作少)设 2;
 # 大型代码仓可设 5+。计数按 $REPO_ROOT 绝对路径 scope,只算本仓库 codex。

--- a/skills/codex-refactor-loop/prompts/design-issue-body.md
+++ b/skills/codex-refactor-loop/prompts/design-issue-body.md
@@ -1,5 +1,7 @@
 # ${PROBLEM_TITLE_EN} / ${PROBLEM_TITLE_ZH}
 
+<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+
 > **Bilingual / 双语**. English and 中文 sections are fully equivalent. Read either. Reply in either.
 
 ---
@@ -22,7 +24,7 @@ The code below is the actual offending pattern in the current codebase. Each lin
 
 下面是当前代码里的真实问题模式。标 `← problem` 的行就是触发违反的位置。
 
-```csharp
+```${HOST_CODE_FENCE_LANG}
 ${PROBLEM_EXAMPLE_CODE}
 ```
 
@@ -49,7 +51,7 @@ ${WHY_NEEDS_DESIGN_ZH}
 Please answer the following before adding the `auto-loop-resume` label. The implement codex will read your latest comment verbatim, so be specific.
 
 - [ ] **Pattern choice / 模式选择**: ${DESIGN_QUESTION_PATTERN_EN}
-- [ ] **Proto schema impact / Proto 影响**: If new typed fields are needed, sketch them (message names + field numbers). If no proto change, say so.
+- [ ] **Schema/protocol impact / Schema 影响**: Apply host policy `${HOST_PROTO_POLICY}` if non-empty. If new typed fields or protocol/schema changes are needed, sketch them using the host's schema conventions. If none, say so.
 - [ ] **Backward compatibility / 向后兼容**: How to handle existing persisted state (reserved field numbers, alias, migration, accepted reset)?
 - [ ] **Scope split / 拆分**: One cluster or split into N PRs? If split, sketch the cluster ids.
 - [ ] **Test surface / 测试面**: What behavior MUST be tested beyond `verification_hints` in the cluster spec below?
@@ -60,7 +62,7 @@ Please answer the following before adding the `auto-loop-resume` label. The impl
 加 `auto-loop-resume` 标签前请回答以下问题。Implement codex 会**原样**读取你的最新评论作为设计输入，所以请具体。
 
 - [ ] **Pattern choice / 模式选择**：${DESIGN_QUESTION_PATTERN_ZH}
-- [ ] **Proto schema 影响**：如需新增 typed field，列出 message 名 + field number；无 proto 改动请明确说明。
+- [ ] **Schema 影响**：若 `${HOST_PROTO_POLICY}` 非空,按该 host schema/protocol 策略回答。如需新增 typed field 或 schema/protocol 变更,按 host 约定列出；无变更请明确说明。
 - [ ] **向后兼容**：现有持久态如何处理？（reserved 字段号 / type alias / schema migration / 可接受的重置）
 - [ ] **Scope 拆分**：保留单 cluster 还是拆 N 个 PR？拆则给出 cluster id 草案。
 - [ ] **测试面**：除了下方 cluster spec 里 `verification_hints` 之外，**必须**被测试的行为？

--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -1,5 +1,7 @@
 # 任务：实施 ${WORK_UNIT_ID}
 
+<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+
 你以无人值守模式在 worktree `${WORKTREE_PATH}` 中工作，对应分支 `${BRANCH}`。
 当前 v1 audit-backed work unit 的兼容 cluster alias 是 `${CLUSTER_ID}`；审计段查找、既有 artifact 文件名、分支/worktree 名和 marker 仍使用该 alias。
 
@@ -18,18 +20,18 @@
 
 1. **作用域**：仅修改下列文件；扩展前必须打印 `SCOPE_EXTEND: <file> <reason>`：
 ${SCOPE_PATHS}
-2. **代码注释**：被重构的每个类/关键方法必须新增/更新一段：
+2. **代码注释**：被重构的每个类/关键方法必须按 `${HOST_COMMENT_RULE}` 新增/更新一段 Refactor self-documentation；为空时匹配目标文件已有注释风格，文件类型不支持注释时在实施摘要说明 not applicable。内容必须包含：
    ```
-   // Refactor (iter${ITERATION}/${CLUSTER_ID}):
-   //   Old pattern: ${OLD_PATTERN}
-   //   New principle: ${NEW_PRINCIPLE}
+   Refactor (iter${ITERATION}/${CLUSTER_ID}):
+     Old pattern: ${OLD_PATTERN}
+     New principle: ${NEW_PRINCIPLE}
    ```
    3-5 行内；不是 changelog，是代码自我说明。
 3. **不新增功能**：不引入新接口、新 flag、新模块；只清理违反点。新增极小辅助类型须注释 "refactor helper, no behavior change"。
 4. **测试**：按 `verification_hints` 跑测试，必须通过；测试不足必须补；任何 `sleep/delay` 轮询测试必须改为确定性断言。
 5. **架构守卫**：跑 host 配置的 `$CI_GUARDS`，必须通过。其它 cluster 特定守卫见 verification hints。
 6. **不依赖外部仓库**：禁止建议在 $EXTERNAL_REPOS/$EXTERNAL_REPOS 改动。
-7. **Protobuf**：如改 proto，必须本地重生成并确认编译通过。
+7. **Schema/protocol**：如 `${HOST_PROTO_POLICY}` 非空或 diff / `$PROJECT_RULES` 显示改了 schema/protocol 文件，按 host policy 本地重生成/验证并确认编译通过。
 8. **构建命令**：使用 host 配置的 `$BUILD_CMD` / `$TEST_CMD`。
 
 ## 流程

--- a/skills/codex-refactor-loop/prompts/reviewer-architect.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-architect.md
@@ -1,5 +1,7 @@
 # Role: Architect reviewer (CLAUDE.md compliance angle)
 
+<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+
 You are reviewing PR **${PR_NUMBER}** (`${PR_TITLE}`) against `${BASE_BRANCH}` from an **architecture compliance** perspective.
 
 You are **one of N independent reviewers**; you do not see the other reviewers' verdicts. Reach your own conclusion. Consensus is computed by the controller.
@@ -13,20 +15,12 @@ You are **one of N independent reviewers**; you do not see the other reviewers' 
 
 ## Your checklist (architect angle only — other reviewers cover other angles)
 
-- [ ] **Old/New pattern comment**: each refactored type/method has `// Refactor (iterN/cluster-XXX): Old pattern: …  New principle: …`. Missing or vague → comment.
-- [ ] **CLAUDE clause compliance**: each net-changed concept maps to a clause; no new violation introduced. Use grep on diff to look for known anti-patterns:
-  - `actor.HandleEventAsync(` outside runtime allowlist
-  - `SubscribeAsync<EventEnvelope>` in host/application
-  - JSON serializer for actor state / committed payloads
-  - `sleep/delay(` in production paths (not tests)
-  - `sync-over-async blocking`, `host structural primitive.Contains(...)`
-  - `Dictionary<,>` holding cross-actor/cross-request facts in middle layer
-  - new constructor with raw `HttpClient`
-  - `[Skip]` / disabled tests
+- [ ] **Old/New pattern comment**: each refactored type/method follows `${HOST_COMMENT_RULE}` for refactor self-documentation. If empty, require the same Old/New intent in the surrounding file's comment style; if the file type cannot carry comments, accept a documented not-applicable reason.
+- [ ] **CLAUDE clause compliance**: each net-changed concept maps to a clause; no new violation introduced. Use `$PROJECT_RULES`, `$SOURCE_GLOBS`, actual diff evidence, `$CI_GUARDS`, and `${HOST_ARCHITECTURE_GREP_CHECKS}` for host-specific grep checks. If `${HOST_ARCHITECTURE_GREP_CHECKS}` is empty, do not invent language/framework-specific anti-patterns.
 - [ ] **Scope honesty**: diff stays within the cluster's declared `scope_paths` (or has a documented SCOPE_EXTEND in implement summary). Diff drift → comment.
 - [ ] **Single business entity per actor**: no new `*WriteActor` / `*ReadActor` / `*Store` splits of one entity.
 - [ ] **No new external repo references** ($EXTERNAL_REPOS).
-- [ ] **proto changes**: if the diff touches `.proto`, field numbers are not reused, `reserved` is used for removed fields, no field-number renumbering.
+- [ ] **Schema/protocol changes**: apply `${HOST_PROTO_POLICY}` when non-empty. Otherwise, review only schema/protocol files actually present in the diff and rules actually stated in `$PROJECT_RULES`; do not assume a schema technology.
 - [ ] **Deletion-first**: the cluster wasn't supposed to add a compat shim. If the diff introduces an empty-forwarding interface / dead wrapper / parallel pathway, → comment.
 
 ## Out of scope for this role (other reviewers handle)

--- a/skills/codex-refactor-loop/prompts/reviewer-tests.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-tests.md
@@ -1,5 +1,7 @@
 # Role: Tests reviewer (test coverage + test quality angle)
 
+<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+
 You are reviewing PR **${PR_NUMBER}** (`${PR_TITLE}`) against `${BASE_BRANCH}` from a **test quality** perspective.
 
 You are **one of N independent reviewers**; you do not see other reviewers' verdicts.
@@ -7,10 +9,11 @@ You are **one of N independent reviewers**; you do not see other reviewers' verd
 ## Inputs
 
 1. PR diff: `cd $REPO_ROOT && git diff origin/${BASE_BRANCH}...origin/${HEAD_BRANCH}` **(three dots — symmetric-from-merge-base; two dots would mis-flag dev's new commits as PR deletions)**
-2. Each touched `src/` or `agents/` production file → look for matching `test/.../<TypeName>Tests.cs`.
+2. Each touched production file according to `$SOURCE_GLOBS` and the actual diff → look for matching tests using `${HOST_TEST_FILE_GLOBS}` and `${HOST_TEST_NAMING_RULE}`. If either is empty, infer only from existing repo test conventions.
 3. Implement summary if present: `${IMPLEMENT_SUMMARY_PATH}`.
 4. `$REPO_ROOT/$CI_GUARDS` — for the polling allowlist + stability rules.
-5. `$REPO_ROOT/host 配置的 allowlist` — current allowed `sleep/delay` test files.
+5. `$REPO_ROOT/host 配置的 allowlist` or `$PROJECT_RULES` / `$CI_GUARDS` equivalent — current allowed unstable/polling test exceptions, if any.
+6. Host schema policy `${HOST_PROTO_POLICY}` when non-empty; otherwise infer schema/test exemptions only from `$PROJECT_RULES` and the actual diff.
 
 ## Your checklist (tests angle only)
 
@@ -20,7 +23,7 @@ You are **one of N independent reviewers**; you do not see other reviewers' verd
 - [ ] **No loosening assertions** of existing tests (turning `.Should().Be(X)` into `.Should().NotBeNull()`, etc.).
 - [ ] **Test names describe the behavior** (`AddX_WhenY_ShouldZ`), not the method (`TestAdd1`).
 - [ ] **Source-regression assertions** present when the cluster introduces a "no-regression" rule (e.g. cluster-016 dispatch guard, cluster-018 port guard). Look for `source.Should().NotContain(<forbidden token>)` in matching tests.
-- [ ] **Coverage on net-new production lines**: each new public method, new branch, new event type has at least one test. Pure DTO / record proto fields exempt.
+- [ ] **Coverage on net-new production lines**: each new public method, new branch, new event type has at least one test. Schema/data-container exemptions require `${HOST_PROTO_POLICY}`, `$PROJECT_RULES`, or clear diff evidence.
 - [ ] **No mock-everything pseudo-coverage**: a test that only verifies "mock was called with X args" without exercising real logic is comment-worthy.
 
 ## Out of scope

--- a/skills/codex-refactor-loop/prompts/test-add.md
+++ b/skills/codex-refactor-loop/prompts/test-add.md
@@ -1,5 +1,7 @@
 # 任务：补测试覆盖重构引入的未覆盖代码 — ${CLUSTER_ID}
 
+<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+
 worktree: `${WORKTREE_PATH}`，分支 `${BRANCH}`。
 
 ## 必读
@@ -13,7 +15,7 @@ worktree: `${WORKTREE_PATH}`，分支 `${BRANCH}`。
 ${UNCOVERED_LINES}
 ```
 
-5. 现有测试项目结构（`test/该项目.*.Tests/`），参考同模式现有测试风格。
+5. Host 测试策略(可为空):测试文件位置 `${HOST_TEST_FILE_GLOBS}`；测试命名规则 `${HOST_TEST_NAMING_RULE}`；测试注释规则 `${HOST_COMMENT_RULE}`；代码围栏语言 `${HOST_CODE_FENCE_LANG}`。为空时只从现有测试、`$PROJECT_RULES`、`$TEST_CMD`、实际 diff 推断；无法安全定位测试文件时打印 `TEST_BLOCKED: <reason>` 并停止。
 
 ## 目标
 
@@ -21,29 +23,25 @@ ${UNCOVERED_LINES}
 
 ## 硬约束
 
-1. **作用域**：仅新增/扩展测试文件（`test/**/*.cs`），不改产线代码。如发现产线代码缺 testability hook（如未注入的 dependency、private state 无 internals visibility），打印 `TEST_BLOCKED: <reason>` 并停止 — 不要为了测试改产线。
+1. **作用域**：仅新增/扩展 host 测试文件。优先使用 `${HOST_TEST_FILE_GLOBS}`；为空则从现有测试树和本 PR 已触达代码的相邻测试推断。不改产线代码。如发现产线代码缺 testability hook（如未注入的 dependency、private state 无法被现有测试边界观察），打印 `TEST_BLOCKED: <reason>` 并停止 — 不要为了测试改产线。
 
 2. **覆盖目标 = 行为，不是行数**：每个未覆盖行的测试必须断言**业务语义**（如"调用过 host external client factory.CreateClient with 正确 name"、"head_index 超过阈值时 compaction 触发"、"compiled delegate 在异常路径下不被 TargetInvocationException 包装"），不是机械"call this method to bump coverage"。
 
-3. **测试栈**：host 项目的测试框架（仓库现有）；遵循 `*Tests.cs` 命名 + `test_stability_guards.sh` 约束（禁 `sleep/delay`、确定性 awaiter）。
+3. **测试栈**：host 项目的测试框架（仓库现有）；遵循 `${HOST_TEST_NAMING_RULE}`（为空则照同目录现有测试命名）和 `$PROJECT_RULES` / `$CI_GUARDS` 中的稳定性约束（禁 `sleep/delay`、确定性 awaiter）。
 
-4. **不引入新依赖**：如需 mock 框架，用仓库已有的（host 项目的测试替身框架 / host 项目的测试替身框架 中的一个）。
+4. **不引入新依赖**：如需 mock/test double 框架，用仓库已有的测试替身框架。
 
 5. **不补整个文件覆盖**：只覆盖 codecov 标的 miss/partial 行。其它历史未覆盖行不动（那是另一 cluster 的范围）。
 
-6. **代码注释**：每个新测试 class 加：
-   ```csharp
-   // Test-add (test-coverage/${CLUSTER_ID}):
-   //   Covers refactor-introduced behavior in <file>:<line range>.
-   //   Cluster intent: <one-line summary from implement.md>.
-   ```
+6. **代码注释**：每个新测试单元按 `${HOST_COMMENT_RULE}` 添加简短 test-add 说明；为空则匹配目标测试文件已有注释语法。说明内容为：
+   `${HOST_COMMENT_RULE}` `Test-add (test-coverage/${CLUSTER_ID}): Covers refactor-introduced behavior in <file>:<line range>. Cluster intent: <one-line summary from implement.md>.`
 
 ## 流程
 
 1. 读 cluster spec + implement.md + uncovered lines 列表 + 当前测试文件风格。
 2. 为每个未覆盖文件:行号决定测试归属：
-   - 已有对应 `*Tests.cs` → 在该文件**追加**测试方法（不改已有 test）
-   - 无对应测试文件 → 新建 `<TypeName>Tests.cs` 在合适的 `test/该项目.<Project>.Tests/` 下
+   - 已有符合 `${HOST_TEST_NAMING_RULE}` 或现有命名惯例的对应测试文件 → 在该文件**追加**测试方法（不改已有 test）
+   - 无对应测试文件 → 按 `${HOST_TEST_FILE_GLOBS}` / `${HOST_TEST_NAMING_RULE}` 或现有测试树惯例新建测试文件；无法安全推断则 `TEST_BLOCKED`
 3. 打印 `PLAN:` 列出每个 uncovered 行 → 对应新 test 方法名。
 4. 实施测试。
 5. 跑：

--- a/skills/codex-refactor-loop/prompts/verify.md
+++ b/skills/codex-refactor-loop/prompts/verify.md
@@ -1,5 +1,7 @@
 # 任务：验证 ${WORK_UNIT_ID} 的实施改动
 
+<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+
 你以无人值守模式在 worktree `${WORKTREE_PATH}` 中工作。前一个 codex 已完成实施，改动在工作树未提交。
 当前 v1 audit-backed work unit 的兼容 cluster alias 是 `${CLUSTER_ID}`；既有实施摘要、artifact 文件名和 marker 仍使用该 alias。
 
@@ -16,7 +18,7 @@
 
 ### 1. 改动与设计原则一致
 
-- 检查每个被重构的关键类/方法是否带有 `// Refactor (...):` 注释，包含 Old pattern + New principle。缺失任何一处 → 标记缺陷。
+- 检查每个被重构的关键类/方法是否按 `${HOST_COMMENT_RULE}` 或目标文件现有注释风格带有 Refactor self-documentation，包含 Old pattern + New principle。缺失任何一处且无合理 not-applicable 说明 → 标记缺陷。
 - 检查改动是否真正消除了 `old_pattern` 描述的违反（用 `rg` 抽样确认 anti-pattern 不再出现在 scope_paths 内）。
 
 ### 2. 作用域诚实
@@ -28,7 +30,7 @@
 
 - `verification_hints` 指定的所有测试命令必须能跑且通过。
 - 测试代码不得包含 `sleep/delay` 作为断言节奏。
-- 不得出现 `[Skip]` / `[Trait("Category","Manual")]` 之类的禁用标记，除非实施摘要明确说明且有 CLAUDE.md 依据。
+- 不得出现 `$PROJECT_RULES` / `$CI_GUARDS` 定义的禁用测试逃逸标记，除非实施摘要明确说明且有规则依据。
 - 关键路径测试覆盖率不得下降。
 
 ### 4. CI 守卫
@@ -50,7 +52,7 @@ ${CLUSTER_SPECIFIC_GUARDS}
 
 ### 5. 没有新增依赖
 
-- `git diff -- '*$BUILD_CMD 目标/工程文件' 'Directory.Packages.props' '*.proto'` 若有新增依赖、新增 NuGet 包、新增 proto 文件，必须在实施摘要中有合理说明；否则缺陷。
+- 根据 `$PROJECT_RULES`、`$BUILD_CMD`、实际 diff 文件和 `${HOST_PROTO_POLICY}` 检查新增依赖、build manifest、schema/protocol 文件。若有新增依赖或 schema/protocol 变更，必须在实施摘要中有合理说明；否则缺陷。
 
 ### 6. 外部仓库零改动
 

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -1560,6 +1560,91 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
                 with self.subTest(path=rel, pattern=pattern):
                     self.assertIsNone(re.search(pattern, text))
 
+    # Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识)
+    def test_host_language_policy_uses_exact_set_a_without_aliases(self) -> None:
+        canonical = {
+            "HOST_TEST_FILE_GLOBS",
+            "HOST_TEST_NAMING_RULE",
+            "HOST_COMMENT_RULE",
+            "HOST_CODE_FENCE_LANG",
+            "HOST_PROTO_POLICY",
+            "HOST_ARCHITECTURE_GREP_CHECKS",
+        }
+        rejected_aliases = {
+            "HOST_TEST_LAYOUT_GLOB",
+            "HOST_TEST_LAYOUT_GLOBS",
+            "HOST_TEST_FILE_NAMING",
+            "HOST_COMMENT_STYLE",
+            "HOST_COMMENT_POLICY",
+            "HOST_CODE_LANGUAGE",
+            "HOST_EXAMPLE_FENCE",
+            "HOST_TEST_DISABLE_POLICY",
+            "HOST_DEPENDENCY_MANIFEST_GLOBS",
+        }
+        checked = self.rel_paths(
+            "skills/codex-refactor-loop/SKILL.md",
+            "skills/codex-refactor-loop/host.env.example",
+            "skills/codex-refactor-loop/prompts/*.md",
+        )
+        host_env = self.read_rel("skills/codex-refactor-loop/host.env.example")
+        skill_text = self.read_rel("skills/codex-refactor-loop/SKILL.md")
+
+        self.assertEqual(set(re.findall(r"^export (HOST_[A-Z0-9_]+)=\"\"", host_env, re.MULTILINE)), canonical)
+        for name in canonical:
+            with self.subTest(canonical=name):
+                self.assertIn(f"| `${name}` |", skill_text)
+
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in checked)
+        for alias in rejected_aliases:
+            with self.subTest(alias=alias):
+                self.assertNotIn(alias, combined)
+
+    def test_host_language_policy_replaces_old_prompt_defaults(self) -> None:
+        scoped_prompts = {
+            "test-add.md": ("HOST_TEST_FILE_GLOBS", "HOST_TEST_NAMING_RULE", "HOST_COMMENT_RULE", "HOST_CODE_FENCE_LANG"),
+            "design-issue-body.md": ("HOST_CODE_FENCE_LANG", "HOST_PROTO_POLICY"),
+            "implement.md": ("HOST_COMMENT_RULE", "HOST_PROTO_POLICY"),
+            "reviewer-architect.md": ("HOST_COMMENT_RULE", "HOST_ARCHITECTURE_GREP_CHECKS", "HOST_PROTO_POLICY"),
+            "reviewer-tests.md": ("HOST_TEST_FILE_GLOBS", "HOST_TEST_NAMING_RULE", "HOST_PROTO_POLICY"),
+            "verify.md": ("HOST_COMMENT_RULE", "HOST_PROTO_POLICY"),
+        }
+        forbidden_defaults = (
+            "test/**/*.cs",
+            "*Tests.cs",
+            "<TypeName>Tests.cs",
+            "```csharp",
+            "C#",
+            ".NET",
+            "Directory.Packages.props",
+            "NuGet",
+            "Protobuf",
+            "如改 proto，必须本地重生成",
+            "if the diff touches `.proto`",
+            "Pure DTO / record proto fields exempt",
+        )
+        host_comment = "Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识)"
+
+        for prompt_name, required_names in scoped_prompts.items():
+            text = (SKILL_ROOT / "prompts" / prompt_name).read_text(encoding="utf-8")
+            scan_text = "\n".join(line for line in text.splitlines() if host_comment not in line)
+            with self.subTest(prompt=prompt_name, marker="refactor-comment"):
+                self.assertIn(host_comment, text)
+            for required in required_names:
+                with self.subTest(prompt=prompt_name, required=required):
+                    self.assertIn(required, text)
+            for forbidden in forbidden_defaults:
+                with self.subTest(prompt=prompt_name, forbidden=forbidden):
+                    self.assertNotIn(forbidden, scan_text)
+
+        prompt_text = "\n".join(
+            line
+            for name in scoped_prompts
+            for line in (SKILL_ROOT / "prompts" / name).read_text(encoding="utf-8").splitlines()
+            if host_comment not in line
+        )
+        self.assertIsNone(re.search(r"(?<!HOST_)\bproto\b", prompt_text))
+        self.assertIsNone(re.search(r"\.proto\b", prompt_text))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Phase 9 r7 共识(structural,Set A 无 alias)

Closes #20

### What

新增 host.env 字段(可选,空默认):
- `HOST_TEST_FILE_GLOBS=""`
- `HOST_TEST_NAMING_RULE=""`
- `HOST_COMMENT_RULE=""`
- `HOST_CODE_FENCE_LANG=""`
- `HOST_PROTO_POLICY=""`
- `HOST_ARCHITECTURE_GREP_CHECKS=""`

- `SKILL.md` 加 "Host language policy" 段
- `host.env.example` append 6 行
- 6 个 prompt 文件去 hardcoded host 语言断言(design-issue-body / implement / reviewer-architect / reviewer-tests / test-add / verify)
- source-regression test `PromptHostLanguagePolicySourceRegressionTests`

不动 controller_lib.sh / spawn-codex.sh / runtime(共识明示)。

### Verify

- 本地 `python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → **72 tests OK**

⟦AI:AUTO-LOOP⟧