### PR TITLE
feat(skill): 最小自动 release 管道:bump_version + release.yml(#32 共识)

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Synchronize release manifest versions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MAP_PATH = ROOT / ".version-bump.json"
+SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+@dataclass(frozen=True)
+class ManifestTarget:
+    path: Path
+    field: str
+    version: str
+    data: Any
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.match(version)
+    if not match:
+        raise ValueError(f"invalid semver: {version}")
+    return tuple(int(part) for part in match.groups())
+
+
+def bump_semver(version: str, level: str) -> str:
+    major, minor, patch = parse_version(version)
+    if level == "major":
+        return f"{major + 1}.0.0"
+    if level == "minor":
+        return f"{major}.{minor + 1}.0"
+    if level == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    raise ValueError(f"invalid bump level: {level}")
+
+
+def resolve_field(data: Any, field: str) -> Any:
+    current = data
+    for part in field.split("."):
+        if isinstance(current, list):
+            if not part.isdigit():
+                raise KeyError(f"expected list index at {part!r} in {field}")
+            index = int(part)
+            current = current[index]
+            continue
+        if not isinstance(current, dict):
+            raise KeyError(f"cannot resolve {part!r} in {field}")
+        current = current[part]
+    return current
+
+
+def set_field(data: Any, field: str, value: str) -> None:
+    current = data
+    parts = field.split(".")
+    for part in parts[:-1]:
+        if isinstance(current, list):
+            if not part.isdigit():
+                raise KeyError(f"expected list index at {part!r} in {field}")
+            current = current[int(part)]
+            continue
+        if not isinstance(current, dict):
+            raise KeyError(f"cannot resolve {part!r} in {field}")
+        current = current[part]
+
+    last = parts[-1]
+    if isinstance(current, list):
+        if not last.isdigit():
+            raise KeyError(f"expected list index at {last!r} in {field}")
+        current[int(last)] = value
+    elif isinstance(current, dict):
+        current[last] = value
+    else:
+        raise KeyError(f"cannot set {last!r} in {field}")
+
+
+def read_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, data: Any) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
+def load_targets(root: Path = ROOT) -> list[ManifestTarget]:
+    mapping = read_json(root / ".version-bump.json")
+    targets: list[ManifestTarget] = []
+    for item in mapping["files"]:
+        path = root / item["path"]
+        field = item["field"]
+        data = read_json(path)
+        version = resolve_field(data, field)
+        if not isinstance(version, str):
+            raise ValueError(f"{item['path']}:{field} is not a string")
+        parse_version(version)
+        targets.append(ManifestTarget(path=path, field=field, version=version, data=data))
+    return targets
+
+
+# Refactor (iter3/skill-release-pipeline): Old: 无机械 release 管道  New: bump_version + release.yml minimal option A(#32 minimal 共识)
+def assert_versions_sync(targets: list[ManifestTarget]) -> str:
+    versions = {target.version for target in targets}
+    if len(versions) != 1:
+        lines = ["manifest versions are not synchronized:"]
+        lines.extend(f"- {target.path.relative_to(ROOT)}:{target.field} = {target.version}" for target in targets)
+        raise ValueError("\n".join(lines))
+    return targets[0].version
+
+
+# Refactor (iter3/skill-release-pipeline): Old: 无机械 release 管道  New: bump_version + release.yml minimal option A(#32 minimal 共识)
+def write_version(targets: list[ManifestTarget], version: str, dry_run: bool) -> None:
+    parse_version(version)
+    for target in targets:
+        set_field(target.data, target.field, version)
+    if dry_run:
+        return
+    for target in targets:
+        write_json(target.path, target.data)
+
+
+# Refactor (iter3/skill-release-pipeline): Old: 无机械 release 管道  New: bump_version + release.yml minimal option A(#32 minimal 共识)
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="validate mapped manifest versions are synchronized")
+    parser.add_argument("--read-version", action="store_true", help="print the synchronized manifest version")
+    parser.add_argument("--dry-run", action="store_true", help="compute changes without writing files")
+    parser.add_argument("--level", choices=("patch", "minor", "major"), help="semver bump level")
+    parser.add_argument("--version", help="exact semver version to write")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.level and args.version:
+            raise ValueError("--level and --version are mutually exclusive")
+        targets = load_targets()
+        current = assert_versions_sync(targets)
+        next_version = args.version or (bump_semver(current, args.level) if args.level else None)
+        if next_version is not None:
+            write_version(targets, next_version, args.dry_run)
+            current = next_version
+        if args.read_version:
+            print(current)
+    except Exception as exc:
+        print(f"bump_version.py: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: release
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview the release without creating a tag or GitHub Release"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  checks: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/github-script@v7
+        name: Verify required checks from issue 31
+        with:
+          script: |
+            const required = ["contract-tests", "manifest-version-sync"];
+            const { owner, repo } = context.repo;
+            const ref = context.sha;
+            const { data } = await github.rest.checks.listForRef({ owner, repo, ref });
+            const byName = new Map(data.check_runs.map((check) => [check.name, check]));
+            for (const name of required) {
+              const check = byName.get(name);
+              if (!check || check.conclusion !== "success") {
+                core.setFailed(`required check ${name} is missing or not successful`);
+                return;
+              }
+            }
+
+      - id: manifest
+        name: Read committed manifest version
+        run: |
+          version="$(python3 .github/scripts/bump_version.py --check --read-version)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - id: mode
+        name: Resolve release mode
+        run: |
+          dry_run="${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}"
+          echo "dry_run=${dry_run}" >> "$GITHUB_OUTPUT"
+
+      - id: tag
+        name: Check tag state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.manifest.outputs.version }}
+        run: |
+          tag="v${VERSION}"
+          if gh release view "$tag" >/dev/null 2>&1 || git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+            echo "Release ${tag} already exists; no-op."
+            exit 0
+          fi
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Enforce semver monotonicity
+        if: steps.tag.outputs.exists != 'true'
+        env:
+          VERSION: ${{ steps.manifest.outputs.version }}
+        run: |
+          latest="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1 | sed 's/^v//')"
+          python3 - "$latest" "$VERSION" <<'PY'
+          import sys
+          def parts(value):
+              return tuple(int(part) for part in value.split("."))
+          latest, current = sys.argv[1], sys.argv[2]
+          if latest and parts(current) <= parts(latest):
+              raise SystemExit(f"version {current} is not newer than latest tag {latest}")
+          PY
+
+      - name: Preview release notes
+        if: steps.tag.outputs.exists != 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          previous="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1)"
+          if [ -n "$previous" ]; then
+            git log --oneline "${previous}..HEAD"
+          else
+            git log --oneline
+          fi
+          echo "Prepared release notes for ${TAG}"
+
+      - name: Create tag and GitHub Release
+        if: steps.tag.outputs.exists != 'true' && steps.mode.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          gh release create "$TAG" --target "$GITHUB_SHA" --generate-notes

--- a/skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py
@@ -32,6 +32,12 @@ def load_bump_module():
     return module
 
 
+def copy_release_pipeline_repo() -> tempfile.TemporaryDirectory[str]:
+    tmp = tempfile.TemporaryDirectory()
+    shutil.copytree(REPO_ROOT, Path(tmp.name) / "repo", ignore=shutil.ignore_patterns(".git"))
+    return tmp
+
+
 class ReleasePipelineContractTests(unittest.TestCase):
     def setUp(self) -> None:
         self.bump = load_bump_module()
@@ -134,6 +140,39 @@ class ReleasePipelineContractTests(unittest.TestCase):
             marketplace = json.loads(read(repo / ".claude-plugin/marketplace.json"))
             self.assertEqual(marketplace["plugins"][0]["version"], "1.0.0")
 
+    def test_level_and_version_cli_rejection_does_not_mutate_mapped_manifests(self) -> None:
+        with copy_release_pipeline_repo() as tmp:
+            repo = Path(tmp) / "repo"
+            before = self.snapshot_mapped_manifest_versions(repo)
+            result = subprocess.run(
+                ["python3", ".github/scripts/bump_version.py", "--level", "patch", "--version", "1.0.0"],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("--level and --version are mutually exclusive", result.stderr)
+            self.assertEqual(self.snapshot_mapped_manifest_versions(repo), before)
+
+    def test_invalid_exact_version_cli_rejection_does_not_mutate_mapped_manifests(self) -> None:
+        for version in ("v1.0.0", "1.2"):
+            with self.subTest(version=version), copy_release_pipeline_repo() as tmp:
+                repo = Path(tmp) / "repo"
+                before = self.snapshot_mapped_manifest_versions(repo)
+                result = subprocess.run(
+                    ["python3", ".github/scripts/bump_version.py", "--version", version],
+                    cwd=repo,
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(f"invalid semver: {version}", result.stderr)
+                self.assertEqual(self.snapshot_mapped_manifest_versions(repo), before)
+
     def test_workflow_contract(self) -> None:
         self.assertIn("name: release", self.workflow)
         self.assertIn("push:", self.workflow)
@@ -160,6 +199,14 @@ class ReleasePipelineContractTests(unittest.TestCase):
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.workflow)
+
+    def snapshot_mapped_manifest_versions(self, repo: Path) -> dict[tuple[str, str], str]:
+        mapping = json.loads(read(repo / ".version-bump.json"))
+        snapshot = {}
+        for item in mapping["files"]:
+            data = json.loads(read(repo / item["path"]))
+            snapshot[(item["path"], item["field"])] = self.bump.resolve_field(data, item["field"])
+        return snapshot
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py
@@ -87,6 +87,53 @@ class ReleasePipelineContractTests(unittest.TestCase):
             self.assertEqual(result.stdout.strip(), "1.0.0")
             self.assertEqual(json.loads(read(pkg))["version"], "1.0.0")
 
+    def test_manifest_sync_write_covers_all_mapped_platform_manifests(self) -> None:
+        paths = [
+            ".version-bump.json",
+            "package.json",
+            ".claude-plugin/plugin.json",
+            ".claude-plugin/marketplace.json",
+            ".codex-plugin/plugin.json",
+            ".cursor-plugin/plugin.json",
+            "gemini-extension.json",
+            ".github/scripts/bump_version.py",
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            for relative in paths:
+                source = REPO_ROOT / relative
+                target = repo / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, target)
+
+            result = subprocess.run(
+                ["python3", ".github/scripts/bump_version.py", "--version", "1.0.0"],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            result = subprocess.run(
+                ["python3", ".github/scripts/bump_version.py", "--read-version"],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "1.0.0")
+
+            mapping = json.loads(read(repo / ".version-bump.json"))
+            for item in mapping["files"]:
+                with self.subTest(path=item["path"], field=item["field"]):
+                    data = json.loads(read(repo / item["path"]))
+                    self.assertEqual(self.bump.resolve_field(data, item["field"]), "1.0.0")
+
+            marketplace = json.loads(read(repo / ".claude-plugin/marketplace.json"))
+            self.assertEqual(marketplace["plugins"][0]["version"], "1.0.0")
+
     def test_workflow_contract(self) -> None:
         self.assertIn("name: release", self.workflow)
         self.assertIn("push:", self.workflow)

--- a/skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Contract tests for the minimal skill release pipeline."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[3]
+BUMP_PATH = REPO_ROOT / ".github/scripts/bump_version.py"
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release.yml"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def load_bump_module():
+    spec = importlib.util.spec_from_file_location("bump_version", BUMP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleasePipelineContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bump = load_bump_module()
+        self.workflow = read(WORKFLOW_PATH)
+
+    def test_nested_manifest_resolution_and_semver_bumping(self) -> None:
+        data = {"plugins": [{"version": "1.2.3"}]}
+        self.assertEqual(self.bump.resolve_field(data, "plugins.0.version"), "1.2.3")
+        self.assertEqual(self.bump.bump_semver("1.2.3", "patch"), "1.2.4")
+        self.assertEqual(self.bump.bump_semver("1.2.3", "minor"), "1.3.0")
+        self.assertEqual(self.bump.bump_semver("1.2.3", "major"), "2.0.0")
+
+    def test_desync_refuses_before_write_and_dry_run_does_not_write(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            shutil.copytree(REPO_ROOT, root / "repo", ignore=shutil.ignore_patterns(".git"))
+            repo = root / "repo"
+            pkg = repo / "package.json"
+            original = read(pkg)
+            data = json.loads(original)
+            data["version"] = "9.9.9"
+            pkg.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+            result = subprocess.run(
+                ["python3", ".github/scripts/bump_version.py", "--version", "1.0.0"],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(json.loads(read(pkg))["version"], "9.9.9")
+
+            pkg.write_text(original, encoding="utf-8")
+            before = read(pkg)
+            result = subprocess.run(
+                ["python3", ".github/scripts/bump_version.py", "--dry-run", "--level", "patch", "--read-version"],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(read(pkg), before)
+
+            result = subprocess.run(
+                ["python3", ".github/scripts/bump_version.py", "--version", "1.0.0", "--read-version"],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "1.0.0")
+            self.assertEqual(json.loads(read(pkg))["version"], "1.0.0")
+
+    def test_workflow_contract(self) -> None:
+        self.assertIn("name: release", self.workflow)
+        self.assertIn("push:", self.workflow)
+        self.assertIn("branches:", self.workflow)
+        self.assertIn("- dev", self.workflow)
+        self.assertIn("workflow_dispatch:", self.workflow)
+        self.assertNotIn("version:", self.workflow)
+        self.assertNotIn("bump:", self.workflow)
+        self.assertNotIn("workflow_call", self.workflow)
+        self.assertNotIn("schedule:", self.workflow)
+        self.assertNotIn("npm publish", self.workflow)
+        self.assertIn("bump_version.py --check --read-version", self.workflow)
+
+    def test_release_guards_and_rejected_files(self) -> None:
+        self.assertFalse((REPO_ROOT / ".github/scripts/manifest_version_map.py").exists())
+        self.assertFalse((REPO_ROOT / ".github/scripts/release_preflight.py").exists())
+        for needle in (
+            "contract-tests",
+            "manifest-version-sync",
+            "required check",
+            "already exists; no-op",
+            "is not newer than latest tag",
+            "steps.mode.outputs.dry_run != 'true'",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Phase 9 r4 共识(minimal,option A)

Closes #32

### What

- 新增 `.github/scripts/bump_version.py`(~140 LOC):
  - private manifest resolver,支持 dotted/list-index 字段
  - CLI:`--check` / `--read-version` / `--dry-run` / `--level patch|minor|major` / `--version X.Y.Z`
- 新增 `.github/workflows/release.yml`(~75 LOC):
  - workflow `release`;触发**仅** `push@dev + workflow_dispatch`(无 version input、无 workflow_call、无 npm publish)
  - 步骤:`bump_version.py --check --read-version` → workflow-local #31 check name lookup → tag/monotonicity guard → tag+GitHub Release(非 dry-run)
- 新增 `skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py`(~55 LOC):
  - 行为 + 源码契约测试(workflow trigger/no version input/no workflow_call/no npm publish/no manifest_version_map.py/no release_preflight.py/#31 check-name lookup/tag-exists no-op/monotonicity)

**不动** `CLAUDE.md` / `AGENTS.md`(共识明示拒引入 CLAUDE release invariant)。
**不动** `.github/workflows/consensus-rnd-ci.yml`(由 #31 PR #38 引入)。

### Soft dependency

`release.yml` 引用 #31 PR #38 的 required check 名(`contract-tests`、`manifest-version-sync`)。**#38 merge 前 release workflow 在没有 check 时应 fail closed**(共识明示)。本 PR 测试不依赖 #38。

### Verify

- 本地 `python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → **74 tests OK**
- `python3 .github/scripts/bump_version.py --check` → 0(manifests synced 0.1.0)

⟦AI:AUTO-LOOP⟧