### PR TITLE
refactor(skill): Phase 8 merge gate 真值表 + comment 终态 advisory(#26 共识)

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -267,7 +267,7 @@ validate_prompt out.md                                    # check 0 unresolved {
 
 **强制**:
 - 派 codex 前必须 `validate_prompt` — 防 codex blocked on unresolved placeholder
-- merge PR 必须用 `merge_pr <pr>` — auto-close + label cleanup,不留尾巴
+- merge PR 必须用 `merge_pr <pr>` — auto-close + label cleanup,不留尾巴。`merge_pr` is a post-decision lifecycle primitive: call it only after the controller has already decided `MERGE` or `MERGE_WITH_COMMENTS`; it never computes Phase 8 reviewer policy.
 - worktree 创建必须用 `safe_worktree` — 处理 "already exists" race
 - PR 号捕获必须用 `open_pr_with_label`(直接 export PR_NUM)— **禁止** `pr_num=$(...grep -oE...)` 这种 subshell 变量传值模式
 
@@ -1041,7 +1041,9 @@ Controller 每 wakeup sweep `--label "auto-loop-triage"`(daemon 漏了兜底),�
 
 ## Phase 8 — Multi-codex PR review with consensus merge
 
-Runs when a cluster PR's remote CI is green (Phase 5 settled with pass) and the PR is mergeable. Goal: 3 (or more) independent codex reviewers from **different angles** verify the PR; **unanimous approve → auto-merge to `integration_branch`**; any reject → human review required.
+<!-- Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识) -->
+
+Runs when a cluster PR's remote CI is green (Phase 5 settled with pass) and the PR is mergeable. Goal: 3 (or more) independent codex reviewers from **different angles** verify the PR at the current head SHA; the controller then chooses exactly one action from `MERGE`, `MERGE_WITH_COMMENTS`, `WAIT_EXPLICIT_APPROVAL`, `FIX`, or `WAIT_OR_REDISPATCH`.
 
 ### Default reviewer roles
 
@@ -1073,18 +1075,19 @@ All reviewers in parallel background; one task-notification per reviewer when do
 
 Each reviewer outputs `REVIEW_DONE:${PR}:${role}:<approve|comment|reject>` marker.
 
-| Combined verdicts                       | Action |
+`comment` is terminal advisory evidence. It is not approval and is not a fix trigger; comments are surfaced to the PR and to fix codex as context only when a `FIX` round happens for rejects.
+
+| Preconditions | Latest complete required round | Controller action |
 |---|---|
-| **All approve**                         | Auto-merge: `gh pr merge ${PR} --merge --auto`. Post bilingual "auto-merged after consensus" comment. Cluster moves to `clusters_done`. |
-| **All approve except 1 comment**        | Same auto-merge. Surface comment's "Evidence" in merge comment. |
-| **2 approve + 1 comment**               | Same auto-merge with surfaced comment. |
-| **3+ comment, 0 reject**                | Surface all comments in PR review comment; **do not** merge; PushNotification: "PR #N: 3 comments, no rejects — human decision recommended." |
-| **Any reject**                          | **Enter fix-retry loop** (see next subsection). Do NOT escalate to human on first reject. |
-| **Reviewer crashes / no marker**        | Re-dispatch that reviewer once. Second crash → `reject:reviewer-stuck`, escalate. |
+| CI green, PR mergeable, reviewed head SHA current, every required role has exactly one valid marker after `EXIT=0` | `reject=0`, `approve=R`, `comment=0` | `MERGE`: post bilingual merge comment, then call `merge_pr <pr>`. |
+| Same preconditions | `reject=0`, `approve>=1`, `comment>=1`, `approve+comment=R` | `MERGE_WITH_COMMENTS`: surface comment evidence, post bilingual merge comment, then call `merge_pr <pr>`. |
+| Same preconditions | `reject=0`, `approve=0`, `comment=R` | `WAIT_EXPLICIT_APPROVAL`: surface comments, do not merge, do not dispatch fix. |
+| Same preconditions | `reject>=1` | `FIX`: enter fix-retry loop; fix codex consumes reject evidence as blocking input and comments as context. Do NOT escalate to human on first reject. |
+| Any gate incomplete or invalid | missing role, duplicate/unknown verdict, no `EXIT=0`, stale head SHA, CI pending/fail, or non-mergeable PR | `WAIT_OR_REDISPATCH`: wait or re-dispatch invalid/missing reviewer once; never merge. |
 
 ### Fix-retry loop (AI iterates until consensus)
 
-Policy: AI keeps iterating until unanimous-approve consensus, OR until escalation criteria are hit. Default `max_fix_rounds = 3` per PR。
+Policy: AI keeps iterating until the fixed Phase 8 truth table resolves to `MERGE` or `MERGE_WITH_COMMENTS`, OR until escalation criteria are hit. Default `max_fix_rounds = 3` per PR。
 
 Loop:
 
@@ -1179,7 +1182,7 @@ Required PR comments (controller posts via `gh pr comment <PR> --body-file <file
 | Reviewer round N complete | Bilingual table of 3 verdicts + reject demands per role + "next action" (fix-retry dispatched OR auto-merge OR escalation). Link to commit SHA reviewed. |
 | Fix codex round N complete (FIX_DONE) | Bilingual FIX_REPORT excerpt: applied / rejected-as-false-positive / blocked counts, build+test status, files changed. Link to fix commit SHA. |
 | Fix codex blocked (FIX_BLOCKED) | Bilingual: which reason category (conflict / human-decision / build-broken), reviewer demand text, controller's escalation decision. |
-| Consensus reached (unanimous approve) | Bilingual: round count, final reviewer outputs, "auto-merging now". Then merge + a second "merged at <commit>" comment. |
+| Consensus reached (`MERGE` / `MERGE_WITH_COMMENTS`) | Bilingual: round count, final reviewer outputs, surfaced comment evidence when present, "auto-merging now". Then merge + a second "merged at <commit>" comment. |
 | Escalation triggered | Add `needs-human-review` label. Comment includes: full round history, latest verdicts, why escalation criteria hit, what controller tried. PushNotification mirrors the headline. |
 | Reviewer crash | Bilingual: which reviewer, log path, re-dispatch attempt. Second crash → escalate per above. |
 
@@ -1210,7 +1213,7 @@ Forbidden:
       "tests": {...},
       "quality": {...}
     },
-    "consensus": "auto-merge | block-human-review | partial-comment",
+    "consensus": "MERGE | MERGE_WITH_COMMENTS | WAIT_EXPLICIT_APPROVAL | FIX | WAIT_OR_REDISPATCH",
     "merged_at": "<ISO8601|null>",
     "auto_merge_commit": "<sha|null>"
   }

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -155,8 +155,10 @@ Routing is marker-driven, but markers are trusted only after `EXIT=0` at the tai
 | `META_RESOLVED:escalate-human:<reason>` | Only then label `👤 human:需-maintainer-决策` and post reason banner. |
 | `IMPLEMENT_DONE:ok` | Controller commits/pushes/opens PR, then dispatches Phase 8 reviewers. |
 | `IMPLEMENT_DONE:blocked` | Route to recovery or Phase 9 depending on reason. |
-| Three `REVIEW_DONE` with all approve/comment non-blocking | Merge path. |
-| Any `REVIEW_DONE` reject | Dispatch fix codex for next round. |
+| Latest complete Phase 8 reviewer round resolves to `MERGE` or `MERGE_WITH_COMMENTS` | Merge path; surface comments for `MERGE_WITH_COMMENTS`. |
+| Latest complete Phase 8 reviewer round resolves to `WAIT_EXPLICIT_APPROVAL` | Surface comments and wait; do not merge or dispatch fix. |
+| Latest complete Phase 8 reviewer round resolves to `FIX` | Dispatch fix codex for next round using reject evidence as blocking input. |
+| Phase 8 gate incomplete or invalid (`WAIT_OR_REDISPATCH`) | Wait or re-dispatch the missing/invalid reviewer; never merge. |
 | `FIX_DONE` | Dispatch reviewers again. |
 | `TEST_ADD_DONE` | Commit/push and resume CI watch. |
 
@@ -288,13 +290,17 @@ Hard label rules:
 
 Phase 8 keeps the consensus merge gate local enough for routing:
 
+<!-- Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识) -->
+
 1. Dispatch three reviewers in parallel: architect, tests, quality.
 2. Each reviewer posts or emits a `REVIEW_DONE` verdict.
-3. Approval requires all three reviewers to avoid reject after the same PR head SHA.
-4. Any reject dispatches fix codex; fix completion dispatches reviewers again.
-5. After repeated fix failure, dispatch meta-layer reflector before any human label.
-6. Every Phase 8 action posts to the PR for traceability.
-7. Detailed reviewer prompts, retry rules, and anti-spiral safeguards are in [phase 8 details](REFERENCE.md#phase-8-details).
+3. Controller computes one fixed action vocabulary after the latest complete required round: `MERGE`, `MERGE_WITH_COMMENTS`, `WAIT_EXPLICIT_APPROVAL`, `FIX`, or `WAIT_OR_REDISPATCH`.
+4. Truth table: `reject=0`, `approve=R`, `comment=0` → `MERGE`; `reject=0`, `approve>=1`, `comment>=1`, `approve+comment=R` → `MERGE_WITH_COMMENTS`; `reject=0`, `approve=0`, `comment=R` → `WAIT_EXPLICIT_APPROVAL`; `reject>=1` → `FIX`; missing role, duplicate/unknown verdict, no `EXIT=0`, stale head SHA, CI pending/fail, or non-mergeable PR → `WAIT_OR_REDISPATCH`.
+5. `comment` is terminal advisory evidence: surface it, but do not count it as approval and do not dispatch fix for comments alone.
+6. `FIX` dispatches fix codex; fix completion dispatches reviewers again.
+7. After repeated fix failure, dispatch meta-layer reflector before any human label.
+8. Every Phase 8 action posts to the PR for traceability.
+9. Detailed reviewer prompts, retry rules, and anti-spiral safeguards are in [phase 8 details](REFERENCE.md#phase-8-details).
 
 ## Phase 9 — Multi-Solver Design Consensus
 

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -1,8 +1,10 @@
 # Role: Fix codex — address all reject demands on PR
 
+<!-- Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识) -->
+
 You are the fix-codex for PR **${PR_NUMBER}** (`${PR_TITLE}`). Round **${FIX_ROUND}** of max **${MAX_FIX_ROUNDS}**.
 
-Your job: read every reviewer's reject/comment evidence and apply concrete fixes so the next Phase 8 review round can reach unanimous approve.
+Your job: read every reviewer's output, treat only `reject` evidence as blocking, and apply concrete fixes so the next Phase 8 review round can reach `MERGE` or `MERGE_WITH_COMMENTS`.
 
 ## Inputs (read first, in order)
 
@@ -21,10 +23,12 @@ Your job: read every reviewer's reject/comment evidence and apply concrete fixes
 
 ### Step 1 — Build the demand list
 
-Open the 3 reviewer files. For each `reject` AND each `comment`, extract:
+Open the 3 reviewer files. For each `reject`, extract:
 - file:line citations
 - the exact "What would change your verdict" / suggestion text
 - which PROJECT_RULES/AGENTS clause is cited (if any)
+
+blocking demands come only from `reject` reviewer evidence. Comments are context: read them and surface them in the report, but do not treat them as mandatory fix demands.
 
 Categorize each demand into one of:
 

--- a/skills/codex-refactor-loop/prompts/reviewer-architect.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-architect.md
@@ -51,9 +51,13 @@ verdict: approve | comment | reject
 ```
 
 Verdict semantics:
+<!-- Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识) -->
+
 - **approve**: no architectural concerns; merge OK from architect angle.
 - **comment**: minor observations or improvements; not blocking but worth surfacing in the PR comment.
 - **reject**: real PROJECT_RULES/AGENTS clause violation introduced or worsened; merge would degrade architecture compliance.
+- In-scope must-fix-before-merge findings must be `reject`.
+- Out-of-scope, non-flippable, or advisory findings must be `comment`.
 
 End with marker line: `REVIEW_DONE:${PR_NUMBER}:architect:<verdict>`
 

--- a/skills/codex-refactor-loop/prompts/reviewer-quality.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-quality.md
@@ -49,9 +49,13 @@ verdict: approve | comment | reject
 ```
 
 Verdict semantics:
+<!-- Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识) -->
+
 - **approve**: code is readable, focused, no over/under-engineering smell, refactor self-docs are present and clear.
 - **comment**: small naming/clarity nits; unrelated drive-by changes worth surfacing; host 项目的复杂度分析器 borderline.
 - **reject**: significant dead code, harmful single-implementer abstraction, missing/illegible self-doc on a major refactor, or scope creep into unrelated cleanup.
+- In-scope must-fix-before-merge findings must be `reject`.
+- Out-of-scope, non-flippable, or advisory findings must be `comment`.
 
 End with marker: `REVIEW_DONE:${PR_NUMBER}:quality:<verdict>`
 

--- a/skills/codex-refactor-loop/prompts/reviewer-tests.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-tests.md
@@ -54,9 +54,13 @@ verdict: approve | comment | reject
 ```
 
 Verdict semantics:
+<!-- Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识) -->
+
 - **approve**: test coverage and quality are adequate for the diff.
 - **comment**: missing nice-to-have tests, minor naming issues, or polling-allowlist addition lacks justification but is plausible.
 - **reject**: real coverage gap on net-new logic, or `[Skip]` added to bypass failure, or `sleep/delay` added without allowlist entry, or assertions weakened.
+- In-scope must-fix-before-merge findings must be `reject`.
+- Out-of-scope, non-flippable, or advisory findings must be `comment`.
 
 End with marker: `REVIEW_DONE:${PR_NUMBER}:tests:<verdict>`
 

--- a/skills/codex-refactor-loop/scripts/peek.sh
+++ b/skills/codex-refactor-loop/scripts/peek.sh
@@ -113,6 +113,7 @@ fi
 # Refactor (iter3/skill-human-label-taxonomy):
 #   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
 #   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
+# Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识)
 echo ""
 echo "▍最近 60 min 完成 codex(marker → 推荐下一步):"
 find .refactor-loop/logs -name "*.log" -mmin -60 -type f 2>/dev/null | while read f; do
@@ -130,8 +131,8 @@ find .refactor-loop/logs -name "*.log" -mmin -60 -type f 2>/dev/null | while rea
     IMPLEMENT_BLOCKED:*)     hint="→ inspect blocker + meta-reflect" ;;
     FIX_DONE:*)              hint="→ commit/push + 3 reviewer r+1" ;;
     FIX_BLOCKED:*)           hint="→ meta-reflect" ;;
-    REVIEW_DONE:*:approve)   hint="→ wait other 2 reviewers,then merge if all approve / mixed: ≥2 approve + 0 reject = merge" ;;
-    REVIEW_DONE:*:comment)   hint="→ advisory; wait other reviewers" ;;
+    REVIEW_DONE:*:approve)   hint="→ latest complete reviewer round: reject=0 + approve>=1 => merge; all-comment => WAIT_EXPLICIT_APPROVAL" ;;
+    REVIEW_DONE:*:comment)   hint="→ advisory; wait reviewers; all-comment => WAIT_EXPLICIT_APPROVAL, not fix" ;;
     REVIEW_DONE:*:reject)    hint="→ wait other 2 reviewers,then fix r+1" ;;
     SOLVER_DONE:*)           hint="→ wait other 2 solvers,then meta-judge" ;;
     META_JUDGE_DONE:consensus:*) hint="→ implement codex (worktree + spawn)" ;;
@@ -174,6 +175,7 @@ zero_now=$(tail -1 .refactor-loop/logs/concurrency-monitor.log 2>/dev/null | gre
 [ -n "$zero_now" ] && echo "  当前: ${zero_now}"
 
 # 5. Mergeable PRs (per reviewer consensus + CI green)
+# Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识)
 echo ""
 echo "▍可合并 PR(controller 应立即 merge):"
 gh pr list "${gh_repo_args[@]}" --label "auto-loop" --state open --json number,title --jq '.[].number' 2>/dev/null | while read pr_num; do
@@ -202,9 +204,11 @@ gh pr list "${gh_repo_args[@]}" --label "auto-loop" --state open --json number,t
       reject)  reject=$((reject+1)) ;;
     esac
   done
-  # Merge rule: 0 reject AND >= 2 approve (mixed comment OK)
-  if [ "$reject" = "0" ] && [ "$approve" -ge 2 ]; then
-    echo "  ✅ PR #${pr_num} [${state}] r${max_round}: approve=${approve} comment=${comment} reject=0 — gh pr merge ${pr_num} --admin --squash --delete-branch"
+  # Merge rule: latest complete required round, 0 reject AND >= 1 approve (mixed comment OK)
+  if [ "$reject" = "0" ] && [ "$approve" -ge 1 ]; then
+    echo "  ✅ PR #${pr_num} [${state}] r${max_round}: MERGE_READY approve=${approve} comment=${comment} reject=0 — gh pr merge ${pr_num} --admin --squash --delete-branch"
+  elif [ "$reject" = "0" ] && [ "$approve" = "0" ] && [ "$comment" -ge 1 ]; then
+    echo "  ⏸ PR #${pr_num} [${state}] r${max_round}: WAIT_EXPLICIT_APPROVAL approve=0 comment=${comment} reject=0 — do not merge"
   fi
 done
 

--- a/skills/codex-refactor-loop/scripts/post_banner.py
+++ b/skills/codex-refactor-loop/scripts/post_banner.py
@@ -33,7 +33,8 @@ from pathlib import Path
 ROLE_NEXT_STEPS = {
     "test-add": "1. test-add 完成 marker `TEST_ADD_DONE:...`  2. controller 自动 commit + push  3. codecov 重测",
     "fix": "1. fix r<N> 完成 marker `FIX_DONE:...`  2. controller commit + push  3. 派 reviewer r<N+1>",
-    "reviewer": "1. 三 reviewer 完成 verdict marker  2. controller 计算 consensus  3. unanimous → auto-merge / reject → fix r<N+1>",
+    # Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识)
+    "reviewer": "1. 三 reviewer 完成 verdict marker  2. controller 计算 consensus  3. reject=0 + approve>=1 -> merge; all-comment -> wait explicit approval; reject -> fix",
     "implement": "1. implement 完成 marker `IMPLEMENT_DONE:<cluster>:<status>`  2. controller commit + push  3. open PR + 派 reviewer r1",
     "solver": "1. 三 solver `SOLVER_DONE:...`  2. controller 派 meta-judge r<N>  3. consensus → implement / converge → fresh round",
     "judge": "1. judge `META_JUDGE_DONE:...`  2. consensus → implement / converge → fresh round / escalate → reflector or 人介入",

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -325,6 +325,101 @@ class ProjectRulesPromptContractTests(unittest.TestCase):
                 self.assertIn("⟦AI:AUTO-LOOP⟧", text)
 
 
+class Phase8MergePolicySourceRegressionTests(unittest.TestCase):
+    # Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识)
+    def read_skill(self) -> str:
+        return (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+
+    def read_reference(self) -> str:
+        return (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+
+    def phase8_docs(self) -> str:
+        return "\n".join([self.read_skill(), self.read_reference()])
+
+    def test_phase8_docs_define_option_a_truth_table(self) -> None:
+        docs = self.phase8_docs()
+
+        required_markers = (
+            "`MERGE`",
+            "`MERGE_WITH_COMMENTS`",
+            "`WAIT_EXPLICIT_APPROVAL`",
+            "`FIX`",
+            "`WAIT_OR_REDISPATCH`",
+            "`reject=0`, `approve=R`, `comment=0`",
+            "`reject=0`, `approve>=1`, `comment>=1`, `approve+comment=R`",
+            "`reject=0`, `approve=0`, `comment=R`",
+            "`reject>=1`",
+            "missing role, duplicate/unknown verdict, no `EXIT=0`, stale head SHA, CI pending/fail, or non-mergeable PR",
+        )
+
+        for marker in required_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, docs)
+
+    def test_phase8_docs_do_not_use_unanimous_approve_as_merge_gate(self) -> None:
+        docs = self.phase8_docs()
+
+        forbidden_gate_terms = (
+            "unanimous approve",
+            "unanimous-approve consensus",
+            "All approve except 1 comment",
+            "2 approve + 1 comment",
+            "partial-comment",
+        )
+
+        for term in forbidden_gate_terms:
+            with self.subTest(term=term):
+                self.assertNotIn(term, docs)
+
+    def test_peek_uses_option_a_threshold(self) -> None:
+        peek = (SKILL_ROOT / "scripts" / "peek.sh").read_text(encoding="utf-8")
+
+        self.assertIn('hint="→ latest complete reviewer round: reject=0 + approve>=1 => merge; all-comment => WAIT_EXPLICIT_APPROVAL"', peek)
+        self.assertIn('if [ "$reject" = "0" ] && [ "$approve" -ge 1 ]; then', peek)
+        self.assertNotIn('"$approve" -ge 2', peek)
+        self.assertNotIn("≥2 approve", peek)
+
+    def test_peek_all_comment_round_is_not_merge_ready(self) -> None:
+        peek = (SKILL_ROOT / "scripts" / "peek.sh").read_text(encoding="utf-8")
+
+        self.assertIn('elif [ "$reject" = "0" ] && [ "$approve" = "0" ] && [ "$comment" -ge 1 ]; then', peek)
+        self.assertIn("WAIT_EXPLICIT_APPROVAL", peek)
+        self.assertIn("do not merge", peek)
+
+    def test_review_fix_blocks_only_on_reject(self) -> None:
+        review_fix = (SKILL_ROOT / "prompts" / "review-fix.md").read_text(encoding="utf-8")
+
+        self.assertIn("blocking demands come only from `reject` reviewer evidence", review_fix)
+        self.assertIn("Comments are context: read them and surface them in the report, but do not treat them as mandatory fix demands", review_fix)
+        self.assertNotIn("For each `reject` AND each `comment`, extract", review_fix)
+        self.assertNotIn("unanimous approve", review_fix)
+
+    def test_reviewer_prompts_force_must_fix_to_reject(self) -> None:
+        prompt_names = ("reviewer-architect.md", "reviewer-tests.md", "reviewer-quality.md")
+
+        for prompt_name in prompt_names:
+            text = (SKILL_ROOT / "prompts" / prompt_name).read_text(encoding="utf-8")
+            with self.subTest(prompt=prompt_name):
+                self.assertIn("verdict: approve | comment | reject", text)
+                self.assertIn("In-scope must-fix-before-merge findings must be `reject`", text)
+                self.assertIn("Out-of-scope, non-flippable, or advisory findings must be `comment`", text)
+
+    def test_no_shared_phase8_policy_module_added(self) -> None:
+        self.assertFalse((SKILL_ROOT / "scripts" / "phase8_review_policy.py").exists())
+
+    def test_controller_lib_stays_post_decision_lifecycle_primitive(self) -> None:
+        controller_lib = (SKILL_ROOT / "scripts" / "controller_lib.sh").read_text(encoding="utf-8")
+        reference = self.read_reference()
+
+        self.assertIn("merge_pr()", controller_lib)
+        self.assertIn("gh pr merge", controller_lib)
+        self.assertIn("post-decision lifecycle primitive", reference)
+        self.assertIn("already decided `MERGE` or `MERGE_WITH_COMMENTS`", reference)
+        for forbidden in ("REVIEW_DONE", "MERGE_WITH_COMMENTS", "WAIT_EXPLICIT_APPROVAL", "approve>=", "reject=0"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, controller_lib)
+
+
 class WorkUnitV1SourceRegressionTests(unittest.TestCase):
     # Refactor (iter2/cluster-007-work-unit-contract-schema):
     #   Old pattern: work-unit state contract existed only as prose, so migration/envelope terms could re-enter the skill unnoticed


### PR DESCRIPTION
## Phase 9 r6 共识(minimal option B)

Closes #26

### What

固定 Phase 8 真值表(5 个 action vocabulary):
- `MERGE` (reject=0, approve=R, comment=0)
- `MERGE_WITH_COMMENTS` (reject=0, approve>=1, comment>=1)
- `WAIT_EXPLICIT_APPROVAL` (reject=0, approve=0, comment=R — 不 merge 不 fix)
- `FIX` (reject>=1)
- `WAIT_OR_REDISPATCH` (gate 不完整/无效/CI 未过)

明确 `comment` = 终态 advisory evidence(不是 approval,也不是 fix 触发)。

文件:
- `SKILL.md` / `REFERENCE.md`:Phase 8 段固定真值表,移除 unanimous-approve 文案;253-270 helper 注明 `merge_pr` 仅 post-decision lifecycle primitive
- `scripts/peek.sh`:阈值改 `reject=0 && approve>=1`;all-comment round → `WAIT_EXPLICIT_APPROVAL`
- `scripts/post_banner.py`:reviewer banner wording
- `prompts/reviewer-{architect,tests,quality}.md`:scope-内必修=reject / advisory=comment 规则
- `prompts/review-fix.md`:fix codex 仅 reject 触发
- `scripts/test_ensure_project_rules_fixed_points.py`:8 个 source-regression tests

**不引入** `phase8_review_policy.py`,**不改** `controller_lib.sh::merge_pr` 做 reviewer policy(共识明示拒)。

### Verify

- 本地 `python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → **80 tests OK**

⟦AI:AUTO-LOOP⟧