### PR TITLE
feat(skill): phase9_router_daemon.py narrow Phase 9 direct-dispatch(#37 共识)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **meta-judge 仲裁**:把分歧收敛成 `consensus` / `converge` / `stalled` 三个出口,不达成一致就继续收敛,直到真停滞才升 reflector 调和。
 - **任何 concrete plan 都必须过这道闸**:哪怕方向已明确,也不允许单个 agent 直接落地 —— 用多角度验证把"明显方向"证成"明显方案"。
 - **验证侧同构**:产物再经多 reviewer(架构 / 质量 / 测试)共识 gate 才允许合并。
-- **controller 纯编排**:所有思考、分析、诊断、验证都 delegate 给 agent;controller 只读 marker、走路由、管 git 与状态面。
+- **controller 纯编排**:所有思考、分析、诊断、验证都 delegate 给 agent;确定性脚本可按 allowlist 读 marker 并派发下一 actor;LLM controller 保留语义 fallback、未知状态、git 与状态面。
 
 ## skills
 

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -867,55 +867,21 @@ Daemon 工作流:
 9. codex 完成 marker:`DEV_SYNC_RESOLVED:<files>` 或 `DEV_SYNC_BLOCKED:<reason>`
 
 ### Phase 9 router daemon command body
-
-`phase9_router_daemon.py` 是单例 daemon,只读 clean-exit logs 和私有 ledger。启动:
-
-```bash
-nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scripts/phase9_router_daemon.py --daemon --repo-root "$REPO_ROOT"' \
-  >> .refactor-loop/logs/phase9-router-daemon.log 2>&1 &
-disown
-```
-
-One-shot / monitor:
-
-```bash
-python3 <skill-root>/scripts/phase9_router_daemon.py --once --repo-root "$REPO_ROOT"
-python3 <skill-root>/scripts/phase9_router_daemon.py --once --dry-run --repo-root "$REPO_ROOT"
-tail -50 .refactor-loop/logs/phase9-router-daemon.log
-```
-
+`phase9_router_daemon.py` 是单例 daemon,只读 clean-exit logs 和私有 ledger。启动:`nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scripts/phase9_router_daemon.py --daemon --repo-root "$REPO_ROOT"' >> .refactor-loop/logs/phase9-router-daemon.log 2>&1 & disown`
+One-shot:`python3 <skill-root>/scripts/phase9_router_daemon.py --once --repo-root "$REPO_ROOT"`; dry-run:`python3 <skill-root>/scripts/phase9_router_daemon.py --once --dry-run --repo-root "$REPO_ROOT"`; monitor:`tail -50 .refactor-loop/logs/phase9-router-daemon.log`。
 Allowlist(唯一 direct spawn authority):
 - `SOLVER_DONE:<minimal|structural|delete>:*` x3, same issue/round, clean `^EXIT=0`, non-placeholder, not ledgered, not in-flight → spawn same-round meta-judge.
 - `META_JUDGE_DONE:converge:round-<N>:*`, clean exit, not ledgered/in-flight → spawn round-N minimal/structural/delete solvers.
 - `META_JUDGE_DONE:escalate:stalled:*`, clean exit + stalled predicate(`round >= 3` and solver verdict text unchanged across 3 rounds) → spawn reflector.
-
-Everything else is fallback only: `META_JUDGE_DONE:consensus`, `IMPLEMENT_DONE`, `VERIFY_DONE`, `REVIEW_DONE`, `FIX_DONE`, `FIX_BLOCKED`, `TEST_ADD_DONE`, `META_RESOLVED`, and unknown markers append `.refactor-loop/.controller-pending-events.log`; no spawn, no git, no GitHub, no lifecycle authority.
-
-Ledger: append-only `.refactor-loop/phase9-router-ledger.jsonl`, one JSON line per dispatch: `{key, marker, log_path, dispatched_at}` where `key="<issue>-<round>-<role/judge>"`. Fallback event uses the same JSON fields and is appended to `.controller-pending-events.log` with a `phase9-router-fallback` prefix.
-
-Duplicate-dispatch recovery: if daemon crashes after spawn but before ledger, unfinished target log or a live `spawn-codex.sh --log <target>` is treated as in-flight and suppresses re-dispatch. If two daemons start, the lock file `.refactor-loop/phase9-router.lock` permits only one. If duplicate ledger rows ever appear, keep the first row and do not delete logs; controller fallback sweep can reconcile the completed marker.
-
-Staged expansion gates: r2 may add `META_JUDGE_DONE:consensus -> implement` only after r1 shows no duplicate dispatch and no missed Phase 9 continuation in one live round or equivalent replay. r3 may add Phase 8 reviewer/fix dispatch only after the route ledger proves triplet aggregation. Lifecycle/CI/banner/floor/merge_pr require later evidence and must not introduce ControllerEvent, ControllerCommand, ControllerOrchestrator, WorkUnitV2, public marker aliases, or lifecycle authority.
-
+Fallback/ledger/recovery: lifecycle/unknown markers append `.refactor-loop/.controller-pending-events.log`; no spawn, no git, no GitHub, no lifecycle authority. Append-only `.refactor-loop/phase9-router-ledger.jsonl` records `{key, marker, log_path, dispatched_at}`; fallback events use prefix `phase9-router-fallback`. In-flight target logs or live `spawn-codex.sh --log <target>` suppress re-dispatch, `.refactor-loop/phase9-router.lock` enforces singleton, and duplicate ledger rows never delete logs. Staged expansion requires route-ledger evidence and must not introduce ControllerEvent, ControllerCommand, ControllerOrchestrator, WorkUnitV2, public marker aliases, or lifecycle authority.
 ### Daemon vs controller 分工
-
-| 任务 | 谁做 |
-|---|---|
-| dev → auto-refact-dev sync(常规 + 冲突解决) | **daemon**(600s 自主) |
-| Phase 9 triplet/converge/valid-stalled continuation | **phase9_router_daemon.py** narrow allowlist; controller fallback sweep retained |
-| 处理 design issue / Phase 9 consensus/implement / Phase 8 fix loop | controller(wakeup) |
-| 派 reviewer / fix / implement codex | controller |
-| 监控 daemon liveness + restart | controller per-wakeup |
-| Sync 异常 escalation(DEV_SYNC_BLOCKED) | controller 读 daemon log + escalate |
-
+dev sync stays with daemon; Phase 9 triplet/converge/valid-stalled continuation may use **phase9_router_daemon.py** narrow allowlist with controller fallback sweep retained; design/consensus/implement/review/fix/liveness/escalation stay with controller wakeups.
 ### Controller 每 wakeup 责任(改为只 verify daemon)
-
 ```bash
 # Phase 6 现在 controller 只 verify daemon 健康
 ps -ef | grep dev-sync-daemon.sh | grep -v grep | wc -l  # 必须 >=1
 tail -10 .refactor-loop/logs/dev-sync-daemon.log | grep -E "(DEV_SYNC_BLOCKED|FAIL|FATAL)" | tail -3
 ```
-
 若 daemon 死 → restart `nohup ... >> log 2>&1 & disown`。
 若发现 `DEV_SYNC_BLOCKED` → controller post 卡片到 rollup PR / 通知 maintainer。
 

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -21,7 +21,7 @@ nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scrip
   >> .refactor-loop/logs/<daemon>.log 2>&1 & disown
 ```
 
-**5 个长跑 daemon 全部要起**(监控面 = 这 5 个):`concurrency_monitor.py`(60s codex 并发)、`codex-progress-reporter.sh`(600s 进度回贴)、`comment-monitor.sh`(30s maintainer 评论 eyes-react)、`dev_sync_daemon.py`(600s integration ← review_base 同步)、`triage-monitor.sh`(60s 外部 `auto-loop-triage` issue)。
+**6 个长跑 daemon 全部要起**(监控面 = 这 6 个):`concurrency_monitor.py`(60s codex 并发)、`codex-progress-reporter.sh`(600s 进度回贴)、`comment-monitor.sh`(30s maintainer 评论 eyes-react)、`dev_sync_daemon.py`(600s integration ← review_base 同步)、`triage-monitor.sh`(60s 外部 `auto-loop-triage` issue)、`phase9_router_daemon.py`(30s narrow Phase 9 deterministic routing)。
 
 **单例强制**(尤其 `dev_sync_daemon` 多实例会 race):每 wakeup `pgrep -f <daemon>` 应 = 1(`comment-monitor.sh` 偶显 2 是 script+内部子循环,正常)。重复 → `pkill -f <daemon>` 全清后按上面 pattern 重启 1 个,验 `pgrep` = 1。
 
@@ -361,7 +361,7 @@ You are the **Controller**. You never edit production code yourself. You orchest
 
 ### 首次唤醒强制序列(MANDATORY — 按序跑完才能 end turn)
 
-> 这是 first wakeup 唯一合法路径。baseline 测试证明:不把以下步骤钉成强制有序首步,controller 会只 bootstrap state + 派 audit,**漏起全部 5 daemon、漏建 labels**(把 daemon / label 误当成「别处已起好」的 steady-state 检查)。下面把它们钉成不可跳过的有序步骤。
+> 这是 first wakeup 唯一合法路径。baseline 测试证明:不把以下步骤钉成强制有序首步,controller 会只 bootstrap state + 派 audit,**漏起全部 6 daemon、漏建 labels**(把 daemon / label 误当成「别处已起好」的 steady-state 检查)。下面把它们钉成不可跳过的有序步骤。
 
 0. **host.env 自检(缺失即停,绝不臆造)**:`source .refactor-loop/host.env` 取 `$REPO_ROOT/$GH_REPO_SLUG/$BUILD_CMD/$TEST_CMD/...`。
    - 不存在 → 从 `skills/codex-refactor-loop/host.env.example` 复制到 `.refactor-loop/host.env` 并填必填项;无法确定必填值(REPO_ROOT/GH_REPO_SLUG/BUILD_CMD/TEST_CMD)→ **PushNotification 请 maintainer 填,end turn,不 spawn 任何东西**。
@@ -377,13 +377,13 @@ You are the **Controller**. You never edit production code yourself. You orchest
      #   New principle: Phase 0 ProjectRulesFixedPointEnsurer 幂等向 $PROJECT_RULES 写入带 sentinel 的 managed 不动点区块(consensus:minimal,不覆盖 host 已有内容)
 1. **state + integration 分支**:`mkdir -p .refactor-loop/{...}` + 写 `state.json` + idempotent 建/推 `$INTEGRATION_BRANCH`(下方细节)。
 2. **建全套 labels**:跑「Label 系统」节的 Bootstrap —— 9 个 phase label + 2 个 human label 创建循环。**漏建 = 后续 phase transition 无 label 可挂、comment-monitor 查 `--label auto-loop` 漏掉 PR**。
-3. **起并挂载全部 5 个 daemon**:按「Host 运行编排 → Daemon 启动」节的 `bash -c 'source host.env && exec'` pattern 起齐 `concurrency_monitor.py` / `codex-progress-reporter.sh` / `comment-monitor.sh` / `dev_sync_daemon.py` / `triage-monitor.sh`,逐个 `pgrep -f <daemon>` 验 = 1。**首轮就必须把 5 个全起起来——它不是「以后某次 wakeup 才做的 liveness 检查」**。
+3. **起并挂载全部 6 个 daemon**:按「Host 运行编排 → Daemon 启动」节的 `bash -c 'source host.env && exec'` pattern 起齐 `concurrency_monitor.py` / `codex-progress-reporter.sh` / `comment-monitor.sh` / `dev_sync_daemon.py` / `triage-monitor.sh` / `phase9_router_daemon.py`,逐个 `pgrep -f <daemon>` 验 = 1。**首轮就必须把 6 个全起起来——它不是「以后某次 wakeup 才做的 liveness 检查」**。
 4. **派默认 v1 work-unit producer**(Phase 1,默认 audit,`spawn-codex.sh` + Bash `run_in_background:true`)+ ScheduleWakeup 兜底 + end turn。
 
 每步做完才进下一步。3 漏起任一 daemon、2 漏建 labels = bootstrap 失败,下次 wakeup 第一件事补齐。
 
 #### ❌ 严禁(首次唤醒反模式 — 均来自 baseline 失败)
-- ❌ 只 bootstrap state + 派默认 producer,不起 5 daemon(baseline 默认失败模式)
+- ❌ 只 bootstrap state + 派默认 producer,不起 6 daemon(baseline 默认失败模式)
 - ❌ 不建 labels 就派 codex(phase transition 时无 label 可挂)
 - ❌ 把整个 skill 降级成「本地读代码 + 出 markdown 报告 + 本地 commit」而不碰 GitHub、不起 daemon、不派 audit
 - ❌ host.env 缺失时猜值硬跑
@@ -866,12 +866,44 @@ Daemon 工作流:
 8. codex 在同一 worktree resolve 文件 + `git add` + `git merge --continue`(不 push,daemon 后续 push)
 9. codex 完成 marker:`DEV_SYNC_RESOLVED:<files>` 或 `DEV_SYNC_BLOCKED:<reason>`
 
+### Phase 9 router daemon command body
+
+`phase9_router_daemon.py` 是单例 daemon,只读 clean-exit logs 和私有 ledger。启动:
+
+```bash
+nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scripts/phase9_router_daemon.py --daemon --repo-root "$REPO_ROOT"' \
+  >> .refactor-loop/logs/phase9-router-daemon.log 2>&1 &
+disown
+```
+
+One-shot / monitor:
+
+```bash
+python3 <skill-root>/scripts/phase9_router_daemon.py --once --repo-root "$REPO_ROOT"
+python3 <skill-root>/scripts/phase9_router_daemon.py --once --dry-run --repo-root "$REPO_ROOT"
+tail -50 .refactor-loop/logs/phase9-router-daemon.log
+```
+
+Allowlist(唯一 direct spawn authority):
+- `SOLVER_DONE:<minimal|structural|delete>:*` x3, same issue/round, clean `^EXIT=0`, non-placeholder, not ledgered, not in-flight → spawn same-round meta-judge.
+- `META_JUDGE_DONE:converge:round-<N>:*`, clean exit, not ledgered/in-flight → spawn round-N minimal/structural/delete solvers.
+- `META_JUDGE_DONE:escalate:stalled:*`, clean exit + stalled predicate(`round >= 3` and solver verdict text unchanged across 3 rounds) → spawn reflector.
+
+Everything else is fallback only: `META_JUDGE_DONE:consensus`, `IMPLEMENT_DONE`, `VERIFY_DONE`, `REVIEW_DONE`, `FIX_DONE`, `FIX_BLOCKED`, `TEST_ADD_DONE`, `META_RESOLVED`, and unknown markers append `.refactor-loop/.controller-pending-events.log`; no spawn, no git, no GitHub, no lifecycle authority.
+
+Ledger: append-only `.refactor-loop/phase9-router-ledger.jsonl`, one JSON line per dispatch: `{key, marker, log_path, dispatched_at}` where `key="<issue>-<round>-<role/judge>"`. Fallback event uses the same JSON fields and is appended to `.controller-pending-events.log` with a `phase9-router-fallback` prefix.
+
+Duplicate-dispatch recovery: if daemon crashes after spawn but before ledger, unfinished target log or a live `spawn-codex.sh --log <target>` is treated as in-flight and suppresses re-dispatch. If two daemons start, the lock file `.refactor-loop/phase9-router.lock` permits only one. If duplicate ledger rows ever appear, keep the first row and do not delete logs; controller fallback sweep can reconcile the completed marker.
+
+Staged expansion gates: r2 may add `META_JUDGE_DONE:consensus -> implement` only after r1 shows no duplicate dispatch and no missed Phase 9 continuation in one live round or equivalent replay. r3 may add Phase 8 reviewer/fix dispatch only after the route ledger proves triplet aggregation. Lifecycle/CI/banner/floor/merge_pr require later evidence and must not introduce ControllerEvent, ControllerCommand, ControllerOrchestrator, WorkUnitV2, public marker aliases, or lifecycle authority.
+
 ### Daemon vs controller 分工
 
 | 任务 | 谁做 |
 |---|---|
 | dev → auto-refact-dev sync(常规 + 冲突解决) | **daemon**(600s 自主) |
-| 处理 design issue / Phase 9 / Phase 8 fix loop | controller(wakeup) |
+| Phase 9 triplet/converge/valid-stalled continuation | **phase9_router_daemon.py** narrow allowlist; controller fallback sweep retained |
+| 处理 design issue / Phase 9 consensus/implement / Phase 8 fix loop | controller(wakeup) |
 | 派 reviewer / fix / implement codex | controller |
 | 监控 daemon liveness + restart | controller per-wakeup |
 | Sync 异常 escalation(DEV_SYNC_BLOCKED) | controller 读 daemon log + escalate |
@@ -1292,13 +1324,15 @@ envsubst < <skill-root>/prompts/meta-judge.md \
   --stall 3600
 ```
 
+This triplet dispatch is now the first Phase 9 daemon-first route: `phase9_router_daemon.py` may do it directly after clean-exit gating, placeholder exclusion, ledger de-dupe, and in-flight checks. Controller fallback sweep remains required.
+
 Meta-judge emits `META_JUDGE_DONE:<decision>:<...>`,**controller 路由表(强制)**:
 
 | Decision | Category | Controller 动作 |
 |---|---|---|
 | `consensus:<framing>:<summary>` | — | auto-applies(派 implement,见 "Consensus action";implement 可改 Tier I/II/CLAUDE.md/SPEC/核心抽象) |
-| `converge:round-N:<question>` | — | 派 r-N+1 三 solver(把 convergence question prepend prompt) |
-| `escalate:stalled:<...>` | `CONVERGENCE_ROUND >= 3` 且 3+ round 无 maintainer input 且 solver verdict 文本连续无变化 | **必须先派 reflector codex**(走 meta-layer reflect 节);**禁止**直接 label 人 |
+| `converge:round-N:<question>` | — | 派 r-N+1 三 solver(把 convergence question prepend prompt); `phase9_router_daemon.py` may direct-dispatch this route |
+| `escalate:stalled:<...>` | `CONVERGENCE_ROUND >= 3` 且 3+ round 无 maintainer input 且 solver verdict 文本连续无变化 | **必须先派 reflector codex**(走 meta-layer reflect 节);**禁止**直接 label 人; `phase9_router_daemon.py` may direct-dispatch only when the stalled predicate holds |
 | `escalate:<其他 category>` | legacy / judge 异常 | 重派 judge 或派 reflector,要求归一到 `consensus` / `converge` / `escalate:stalled`;**禁止**直接 label 人 |
 
 结构性教训:曾出现多个 `escalate:stalled` 被直接 label 人,**没派 reflector**。原因是路由只写了"escalate → label",没有明确 `stalled` 子类必须 reflector 优先。上表 `escalate:stalled` 行强制 reflector。
@@ -1940,7 +1974,7 @@ CI sweep contract: every controller wakeup checks open auto-loop PR checks, imme
 
 ## Codex 进展实时上报 — 强制
 
-`codex-progress-reporter.sh` is one of the five required daemons. It edits one progress comment per in-flight codex, includes elapsed time plus log tail, skips old finished logs, deletes the progress comment when the codex finishes, and uses only log-tail `^EXIT=` for finished detection.
+`codex-progress-reporter.sh` is one of the six required daemons. It edits one progress comment per in-flight codex, includes elapsed time plus log tail, skips old finished logs, deletes the progress comment when the codex finishes, and uses only log-tail `^EXIT=` for finished detection.
 
 <a id="label-bootstrap-loops"></a>
 ## Label bootstrap loops

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -19,7 +19,7 @@ Read `REFERENCE.md` only when a phase needs the detailed body. Use normal Markdo
 |---|---|---|---|---|
 | Host config | Host facts come only from `host.env`; skill text remains host-agnostic. | `source .refactor-loop/host.env` before running actors; fail closed if required vars are absent. | [host runtime details](REFERENCE.md#host-runtime-details) | `host.env.example`, `controller_lib.sh` |
 | GitHub state | GitHub 是系统状态唯一显示面. Maintainer must see current state without local logs. | Post status banners and labels in the same turn as every spawn, completion, consensus, merge, block, or escalation. | [status and escalation templates](REFERENCE.md#status-and-escalation-templates) | `post_banner.py`, GitHub labels |
-| Pure orchestration | Controller = pure orchestration. It routes, posts, labels, spawns, commits, pushes, merges; codex workers change code. | Never implement product/refactor code in the controller conversation. Dispatch a codex for implementation, verification, fixing, review, and design solving. | [controller contract details](REFERENCE.md#controller-contract-details) | `spawn-codex.sh`, prompt files |
+| Pure orchestration | Controller = pure orchestration. It routes, posts, labels, spawns, commits, pushes, merges; codex workers change code. Narrow Phase 9 allowlist dispatch is the named daemon exception. | Never implement product/refactor code in the controller conversation. Dispatch a codex for implementation, verification, fixing, review, and design solving; let `phase9_router_daemon.py` handle only its allowlisted deterministic routes. | [controller contract details](REFERENCE.md#controller-contract-details) | `spawn-codex.sh`, prompt files |
 | Sentinel | Every AI-authored GitHub body ends with a final independent `⟦AI:AUTO-LOOP⟧` line. | Filter AI comments by sentinel and AI banner prefixes; never react to own comments as maintainer input. | [sentinel and comment filters](REFERENCE.md#sentinel-and-comment-filters) | prompts, `comment-monitor.sh` |
 <!-- Refactor (iter3/skill-monitor-wake-source): Old pattern: 2-lane wake source(harness task-notification + ScheduleWakeup). New principle: 3-lane wake source adds daemon-event Monitor lane(daemon writes event file -> mounted persistent Monitor bridge -> controller wakes immediately; daemon alone is not a wake source). -->
 | Wake source | Each turn must end with a confirmed future wake source. | Confirm one of three lanes before ending: active daemon-event Monitor bridge, in-flight codex task-notification, or confirmed ScheduleWakeup. | [wake source rules](REFERENCE.md#wake-source-rules) | Monitor bridge, harness Bash background tasks, ScheduleWakeup |
@@ -83,7 +83,7 @@ Detailed path examples and host installation variants stay in `REFERENCE.md`; `S
 
 ## Wakeup Skeleton
 
-Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event wakeup follows this skeleton. Daemon pending-event wakeups are valid only through a mounted persistent Monitor or equivalent harness bridge; daemon alone is not a wake source.
+Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event wakeup follows this skeleton. Daemon pending-event wakeups are valid only through a mounted persistent Monitor or equivalent harness bridge; daemon alone is not a wake source. The Phase 9 router daemon may replace controller dispatch for SOLVER_DONE triplets, converge, and valid stalled continuation; controller fallback sweep remains authoritative for every other marker.
 
 1. Run `bash <skill-root>/scripts/peek.sh | tail -80` first.
 2. Load host config with `source .refactor-loop/host.env`; if missing or malformed, fail closed and post a status explaining the blocked bootstrap.
@@ -125,7 +125,7 @@ Phase 0 is mandatory and ordered. Do not spawn normal actors before it completes
 5. initialize state in `.refactor-loop/state.json` if missing, using WorkUnitV1 v1 containers only.
 6. Ensure the integration branch exists locally and remotely; create it from `$REVIEW_BASE_BRANCH` only when missing.
 7. ensure labels for the exact phase/human taxonomy; bootstrap command loops live in [label bootstrap loops](REFERENCE.md#label-bootstrap-loops).
-8. ensure all 5 daemons are alive as singletons: `concurrency_monitor.py`, `codex-progress-reporter.sh`, `comment-monitor.sh`, `dev_sync_daemon.py`, and `triage-monitor.sh`.
+8. ensure all 6 daemons are alive as singletons: `concurrency_monitor.py`, `codex-progress-reporter.sh`, `comment-monitor.sh`, `dev_sync_daemon.py`, `triage-monitor.sh`, and `phase9_router_daemon.py`.
 9. arm persistent daemon-event Monitor bridge for `.refactor-loop/.controller-pending-events.log` and `.refactor-loop/.concurrency-alert.log`.
 10. dispatch producer: audit by default, or manual issue intake only when explicit GitHub labels select it.
 11. Post a GitHub status card for Phase 0 completion or blocked state.
@@ -135,7 +135,7 @@ Phase 0 anti-patterns stay local because they are safety gates:
 
 - Do not continue with missing `host.env` under guessed defaults.
 - Do not skip `ProjectRulesFixedPointEnsurer` because `$PROJECT_RULES` already exists.
-- Do not start fewer than the five required daemons.
+- Do not start fewer than the six required daemons.
 - Do not initialize a state-v2, alternate queue, wrapper envelope, or renamed work-unit schema.
 - Do not post local-only bootstrap status; GitHub must show the state.
 
@@ -146,10 +146,10 @@ Routing is marker-driven, but markers are trusted only after `EXIT=0` at the tai
 | Finished marker | Same-wakeup controller action |
 |---|---|
 | `AUDIT_DONE` | Create design issues for `requires_design` units; dispatch direct implement work where allowed. |
-| `SOLVER_DONE` from minimal, structural, and delete for same issue/round | Spawn same issue/round meta-judge. |
+| `SOLVER_DONE` from minimal, structural, and delete for same issue/round | Spawn same issue/round meta-judge; this triplet route may be executed directly by `phase9_router_daemon.py`. |
 | `META_JUDGE_DONE:consensus:<framing>` | Post consensus card, move labels, dispatch implement codex. |
-| `META_JUDGE_DONE:converge:round-N` | Dispatch round N solvers; no hard round cap. |
-| `META_JUDGE_DONE:escalate:stalled` | Dispatch meta-reflector; do not label human directly. |
+| `META_JUDGE_DONE:converge:round-N` | Dispatch round N solvers; no hard round cap; this route may be executed directly by `phase9_router_daemon.py`. |
+| `META_JUDGE_DONE:escalate:stalled` | Dispatch meta-reflector only when the stalled predicate holds; do not label human directly; this route may be executed directly by `phase9_router_daemon.py`. |
 | `META_RESOLVED:retry-fix` | Dispatch fix with reflector constraints and bounded retry window. |
 | `META_RESOLVED:re-design` | Close/withdraw current path and restart Phase 9 with new framing. |
 | `META_RESOLVED:re-cluster` | Close current PR/issue path and queue re-split. |
@@ -219,6 +219,7 @@ Controller duties:
 - Spawn codex workers.
 - Own git topology: commit, merge, push, PR create/merge/close.
 - Maintain wake source and concurrency floor.
+- Named exception: `phase9_router_daemon.py` owns only the narrow Phase 9 allowlist (`SOLVER_DONE` triplet, `META_JUDGE_DONE:converge`, valid `META_JUDGE_DONE:escalate:stalled`) and appends fallback pending events for everything else.
 
 Controller non-duties:
 
@@ -226,7 +227,7 @@ Controller non-duties:
 - Do not run reviewer, solver, implementer, or verifier reasoning inline when a codex role exists.
 - Do not fabricate consensus without Phase 9.
 - Do not hide status in local files only.
-- Do not create new runtime abstractions, event envelopes, state versions, or producer registries for this split.
+- Do not create new runtime abstractions, event envelopes, state versions, or producer registries for this split, except the Phase 9-authorized phase9_router_daemon.py private ledger plus existing-format pending-event append for narrow deterministic Phase 9 dispatch; do not introduce WorkUnitV2, public marker aliases, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority.
 
 ## Concurrency Floor
 
@@ -416,6 +417,7 @@ Historical bilingual notes are moved to [historical bilingual notes](REFERENCE.m
 - [scripts/comment-monitor.sh](scripts/comment-monitor.sh) — maintainer comment monitor.
 - [scripts/dev_sync_daemon.py](scripts/dev_sync_daemon.py) — integration sync daemon.
 - [scripts/triage-monitor.sh](scripts/triage-monitor.sh) — external issue triage daemon.
+- [scripts/phase9_router_daemon.py](scripts/phase9_router_daemon.py) — narrow Phase 9 direct-dispatch daemon.
 - [REFERENCE.md](REFERENCE.md) — heavy runbooks, templates, schemas, and recovery details.
 
 ## Controller Wakeup Checklist

--- a/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+# Refactor (iter3/skill-daemon-first-refactor): Old pattern: 所有 Phase 9 route 由 LLM controller 手动派(易漏 marker). New principle: narrow allowlist daemon 直接派 SOLVER_DONE triplet/converge/stalled,其余 marker append fallback event(#37 structural B 共识)。
+"""Narrow Phase 9 deterministic router daemon.
+
+This daemon owns only three Phase 9 direct-dispatch routes:
+solver triplet -> meta-judge, converge -> next solver triplet, and valid
+stalled -> reflector. Every other marker is forwarded to the existing
+controller pending-event file without spawning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable, TextIO
+
+
+ROLES = ("minimal", "structural", "delete")
+LIFECYCLE_PREFIXES = (
+    "META_JUDGE_DONE:consensus",
+    "IMPLEMENT_DONE",
+    "VERIFY_DONE",
+    "REVIEW_DONE",
+    "FIX_DONE",
+    "FIX_BLOCKED",
+    "TEST_ADD_DONE",
+    "META_RESOLVED",
+)
+KNOWN_PREFIXES = (
+    "SOLVER_DONE:",
+    "META_JUDGE_DONE:",
+    *LIFECYCLE_PREFIXES,
+)
+MARKER_RE = re.compile(r"\b(?:[A-Z][A-Z0-9_]*_(?:DONE|RESOLVED|BLOCKED)|META_JUDGE_DONE):[^\s`]+")
+
+
+@dataclass(frozen=True)
+class Marker:
+    marker: str
+    log_path: Path
+    issue: str
+    round: int
+    role: str | None = None
+
+
+class Phase9Router:
+    def __init__(
+        self,
+        repo_root: Path,
+        *,
+        dry_run: bool = False,
+        command_runner: Callable[[list[str]], None] | None = None,
+    ) -> None:
+        self.repo_root = repo_root.resolve()
+        self.dry_run = dry_run
+        self.loop_dir = self.repo_root / ".refactor-loop"
+        self.logs_dir = self.loop_dir / "logs"
+        self.prompts_dir = self.loop_dir / "prompts" / "phase9"
+        self.ledger_path = self.loop_dir / "phase9-router-ledger.jsonl"
+        self.pending_events_path = self.loop_dir / ".controller-pending-events.log"
+        self.lock_path = self.loop_dir / "phase9-router.lock"
+        self.spawn_codex = Path(__file__).resolve().parent / "spawn-codex.sh"
+        self.command_runner = command_runner or self._default_runner
+        self._fallback_seen: set[str] = set()
+
+    def tick(self) -> None:
+        self.loop_dir.mkdir(parents=True, exist_ok=True)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        self.prompts_dir.mkdir(parents=True, exist_ok=True)
+        ledger = self._read_ledger()
+        markers = self._collect_markers()
+        self._dispatch_solver_triplets(markers, ledger)
+        self._dispatch_meta_judge_routes(markers, ledger)
+        self._append_fallbacks(markers, ledger)
+
+    @contextlib.contextmanager
+    def singleton(self) -> Iterable[None]:
+        self.loop_dir.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("w", encoding="utf-8") as lock:
+            try:
+                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                raise SystemExit(f"another phase9_router_daemon holds {self.lock_path}")
+            lock.write(f"pid={os.getpid()}\n")
+            lock.flush()
+            yield
+
+    def _collect_markers(self) -> list[Marker]:
+        markers: list[Marker] = []
+        for log_path in sorted(self.logs_dir.glob("*.log")):
+            if not self._is_clean_exit(log_path):
+                continue
+            issue, round_no, role_hint = self._identity_from_path(log_path)
+            if issue is None or round_no is None:
+                continue
+            for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+                marker = self._extract_marker(line)
+                if marker is None:
+                    continue
+                role = role_hint
+                if marker.startswith("SOLVER_DONE:"):
+                    role = marker.split(":", 2)[1]
+                    if role not in ROLES:
+                        continue
+                markers.append(Marker(marker, log_path, issue, round_no, role))
+        return markers
+
+    def _extract_marker(self, line: str) -> str | None:
+        stripped = line.strip().strip("`")
+        if self._is_placeholder_or_echo(stripped):
+            return None
+        for prefix in KNOWN_PREFIXES:
+            index = stripped.find(prefix)
+            if index == -1:
+                continue
+            marker = stripped[index:].split()[0]
+            return marker.rstrip("`.,)")
+        match = MARKER_RE.search(stripped)
+        if match:
+            return match.group(0).rstrip("`.,)")
+        return None
+
+    def _is_placeholder_or_echo(self, text: str) -> bool:
+        if "<" in text and ">" in text:
+            return True
+        lowered = text.lower()
+        if "template" in lowered or "example" in lowered or "emits `" in lowered:
+            return True
+        if "round-n" in lowered:
+            return True
+        return False
+
+    def _identity_from_path(self, path: Path) -> tuple[str | None, int | None, str | None]:
+        match = re.search(
+            r"phase9[-_]?issue(?P<issue>\d+)[-_]r(?:ound-)?(?P<round>\d+)(?:[-_](?P<role>minimal|structural|delete|judge|reflector))?",
+            path.name,
+        )
+        if not match:
+            return None, None, None
+        role = match.group("role")
+        return match.group("issue"), int(match.group("round")), role
+
+    def _is_clean_exit(self, path: Path) -> bool:
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            return False
+        return any(re.match(r"^EXIT=0$", line) for line in lines[-5:])
+
+    def _dispatch_solver_triplets(self, markers: list[Marker], ledger: set[str]) -> None:
+        by_issue_round: dict[tuple[str, int], dict[str, Marker]] = {}
+        for marker in markers:
+            if not marker.marker.startswith("SOLVER_DONE:") or marker.role not in ROLES:
+                continue
+            by_issue_round.setdefault((marker.issue, marker.round), {})[marker.role] = marker
+
+        for (issue, round_no), role_markers in by_issue_round.items():
+            if set(role_markers) != set(ROLES):
+                continue
+            key = self._key(issue, round_no, "judge")
+            log_path = self._log_path(issue, round_no, "judge")
+            if key in ledger or self._in_flight(log_path):
+                continue
+            prompt = self._write_prompt(issue, round_no, "judge", self._meta_judge_prompt(issue, round_no, role_markers.values()))
+            if self._spawn(prompt, log_path):
+                self._append_ledger(key, "SOLVER_DONE:triplet", log_path)
+                ledger.add(key)
+
+    def _dispatch_meta_judge_routes(self, markers: list[Marker], ledger: set[str]) -> None:
+        for marker in markers:
+            if marker.marker.startswith("META_JUDGE_DONE:converge:round-"):
+                target_round = self._round_from_converge(marker.marker)
+                if target_round is None:
+                    continue
+                for role in ROLES:
+                    key = self._key(marker.issue, target_round, role)
+                    log_path = self._log_path(marker.issue, target_round, role)
+                    if key in ledger or self._in_flight(log_path):
+                        continue
+                    prompt = self._write_prompt(
+                        marker.issue,
+                        target_round,
+                        role,
+                        self._solver_prompt(marker.issue, target_round, role, marker.marker),
+                    )
+                    if self._spawn(prompt, log_path):
+                        self._append_ledger(key, marker.marker, log_path)
+                        ledger.add(key)
+                continue
+
+            if marker.marker.startswith("META_JUDGE_DONE:escalate:stalled:"):
+                key = self._key(marker.issue, marker.round, "reflector")
+                log_path = self._log_path(marker.issue, marker.round, "reflector")
+                if key in ledger or self._in_flight(log_path):
+                    continue
+                if not self._stalled_predicate_holds(marker.issue, marker.round):
+                    continue
+                prompt = self._write_prompt(marker.issue, marker.round, "reflector", self._reflector_prompt(marker))
+                if self._spawn(prompt, log_path):
+                    self._append_ledger(key, marker.marker, log_path)
+                    ledger.add(key)
+
+    def _append_fallbacks(self, markers: list[Marker], ledger: set[str]) -> None:
+        for marker in markers:
+            if self._directly_handled(marker, ledger):
+                continue
+            if marker.marker.startswith("SOLVER_DONE:"):
+                continue
+            event_key = f"fallback:{marker.log_path}:{marker.marker}"
+            if event_key in self._fallback_seen:
+                continue
+            self._fallback_seen.add(event_key)
+            self._append_pending_event(marker)
+
+    def _directly_handled(self, marker: Marker, ledger: set[str]) -> bool:
+        if marker.marker.startswith("META_JUDGE_DONE:converge:round-"):
+            target_round = self._round_from_converge(marker.marker)
+            return target_round is not None and all(self._key(marker.issue, target_round, role) in ledger for role in ROLES)
+        if marker.marker.startswith("META_JUDGE_DONE:escalate:stalled:"):
+            return self._key(marker.issue, marker.round, "reflector") in ledger
+        return False
+
+    def _round_from_converge(self, marker: str) -> int | None:
+        match = re.match(r"META_JUDGE_DONE:converge:round-(\d+):", marker)
+        return int(match.group(1)) if match else None
+
+    def _stalled_predicate_holds(self, issue: str, round_no: int) -> bool:
+        if round_no < 3:
+            return False
+        recent: list[set[str]] = []
+        for r in range(round_no - 2, round_no + 1):
+            verdicts: set[str] = set()
+            for role in ROLES:
+                path = self._log_path(issue, r, role)
+                if not self._is_clean_exit(path):
+                    return False
+                for marker in self._collect_markers_from_path(path):
+                    if marker.startswith(f"SOLVER_DONE:{role}:"):
+                        verdicts.add(self._solver_verdict_text(marker))
+            if not verdicts:
+                return False
+            recent.append(verdicts)
+        return recent[0] == recent[1] == recent[2]
+
+    def _collect_markers_from_path(self, path: Path) -> list[str]:
+        if not path.exists():
+            return []
+        markers: list[str] = []
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            marker = self._extract_marker(line)
+            if marker:
+                markers.append(marker)
+        return markers
+
+    def _solver_verdict_text(self, marker: str) -> str:
+        parts = marker.split(":", 3)
+        return parts[2] if len(parts) >= 3 else marker
+
+    def _in_flight(self, log_path: Path) -> bool:
+        if log_path.exists():
+            return True
+        try:
+            ps = subprocess.run(["ps", "-eo", "command="], capture_output=True, text=True, check=False)
+        except OSError:
+            return False
+        target = str(log_path)
+        for line in ps.stdout.splitlines():
+            if "spawn-codex.sh" in line and target in line and " -c " not in line:
+                return True
+        return False
+
+    def _read_ledger(self) -> set[str]:
+        keys: set[str] = set()
+        if not self.ledger_path.exists():
+            return keys
+        for line in self.ledger_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            key = entry.get("key")
+            if isinstance(key, str):
+                keys.add(key)
+        return keys
+
+    def _append_ledger(self, key: str, marker: str, log_path: Path) -> None:
+        self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "key": key,
+            "marker": marker,
+            "log_path": str(log_path),
+            "dispatched_at": self._now(),
+        }
+        with self.ledger_path.open("a", encoding="utf-8") as ledger:
+            ledger.write(json.dumps(entry, ensure_ascii=False, sort_keys=True) + "\n")
+
+    def _append_pending_event(self, marker: Marker) -> None:
+        self.pending_events_path.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "key": f"fallback:{marker.issue}-{marker.round}",
+            "marker": marker.marker,
+            "log_path": str(marker.log_path),
+            "dispatched_at": self._now(),
+        }
+        with self.pending_events_path.open("a", encoding="utf-8") as pending:
+            pending.write(f"{self._now()} phase9-router-fallback {json.dumps(event, ensure_ascii=False, sort_keys=True)}\n")
+
+    def _spawn(self, prompt: Path, log_path: Path) -> bool:
+        command = [
+            str(self.spawn_codex),
+            "--cd",
+            str(self.repo_root),
+            "--prompt",
+            str(prompt),
+            "--log",
+            str(log_path),
+            "--stall",
+            "3600",
+        ]
+        if self.dry_run:
+            return False
+        self.command_runner(command)
+        return True
+
+    def _default_runner(self, command: list[str]) -> None:
+        subprocess.Popen(
+            ["nohup", *command],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+    def _write_prompt(self, issue: str, round_no: int, actor: str, body: str) -> Path:
+        prompt = self.prompts_dir / f"phase9-issue{issue}-r{round_no}-{actor}.md"
+        prompt.parent.mkdir(parents=True, exist_ok=True)
+        prompt.write_text(body, encoding="utf-8")
+        return prompt
+
+    def _meta_judge_prompt(self, issue: str, round_no: int, markers: Iterable[Marker]) -> str:
+        marker_lines = "\n".join(f"- {m.role}: {m.log_path}" for m in sorted(markers, key=lambda m: m.role or ""))
+        return (
+            f"# Phase 9 meta-judge\n\nIssue: #{issue}\nRound: {round_no}\n\n"
+            f"Read the three completed solver logs and emit META_JUDGE_DONE.\n\n{marker_lines}\n"
+        )
+
+    def _solver_prompt(self, issue: str, round_no: int, role: str, marker: str) -> str:
+        return (
+            f"# Phase 9 {role} solver\n\nIssue: #{issue}\nRound: {round_no}\n"
+            f"Convergence marker: {marker}\n\nUse prompts/solver-{role}.md contract and emit SOLVER_DONE:{role}:...\n"
+        )
+
+    def _reflector_prompt(self, marker: Marker) -> str:
+        return (
+            f"# Phase 9 stalled reflector\n\nIssue: #{marker.issue}\nRound: {marker.round}\n"
+            f"Stalled marker: {marker.marker}\n\nReflect on the convergence failure and emit META_RESOLVED.\n"
+        )
+
+    def _log_path(self, issue: str, round_no: int, actor: str) -> Path:
+        return self.logs_dir / f"phase9-issue{issue}-r{round_no}-{actor}.log"
+
+    def _key(self, issue: str, round_no: int, actor: str) -> str:
+        return f"{issue}-{round_no}-{actor}"
+
+    def _now(self) -> str:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Narrow Phase 9 router daemon")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--daemon", action="store_true", help="run persistently")
+    mode.add_argument("--once", action="store_true", help="run one scan and exit")
+    parser.add_argument("--dry-run", action="store_true", help="do not spawn codex workers")
+    parser.add_argument("--repo-root", required=True, help="absolute host repository root")
+    parser.add_argument("--interval", type=int, default=int(os.environ.get("INTERVAL", "30")))
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    repo_root = Path(args.repo_root)
+    if not repo_root.is_absolute():
+        raise SystemExit("--repo-root must be absolute")
+    router = Phase9Router(repo_root, dry_run=args.dry_run)
+    with router.singleton():
+        if args.once:
+            router.tick()
+            return 0
+        while True:
+            router.tick()
+            time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
@@ -386,12 +386,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: list[str] | None = None, command_runner: Callable[[list[str]], None] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     repo_root = Path(args.repo_root)
     if not repo_root.is_absolute():
         raise SystemExit("--repo-root must be absolute")
-    router = Phase9Router(repo_root, dry_run=args.dry_run)
+    router = Phase9Router(repo_root, dry_run=args.dry_run, command_runner=command_runner)
     with router.singleton():
         if args.once:
             router.tick()

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -42,6 +42,11 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             return []
         return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
 
+    def write_ledger_key(self, key: str) -> None:
+        path = self.repo / ".refactor-loop" / "phase9-router-ledger.jsonl"
+        with path.open("a", encoding="utf-8") as ledger:
+            ledger.write(json.dumps({"key": key}, sort_keys=True) + "\n")
+
     def pending_events(self) -> str:
         path = self.repo / ".refactor-loop" / ".controller-pending-events.log"
         return path.read_text(encoding="utf-8") if path.exists() else ""
@@ -161,12 +166,30 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.commands.clear()
         for round_no in (1, 2, 3):
             self.solver_triplet(issue=38, round_no=round_no, verdict="same")
+        self.write_ledger_key("38-1-judge")
+        self.write_ledger_key("38-2-judge")
         self.write_log("phase9-issue38-r3-judge.log", "META_JUDGE_DONE:escalate:stalled:no-change")
         self.router.tick()
 
-        self.assertEqual(len(self.commands), 3)
-        self.assertTrue(any("phase9-issue38-r3-reflector.log" in " ".join(command) for command in self.commands))
+        reflector_commands = [
+            command for command in self.commands if "phase9-issue38-r3-reflector.log" in " ".join(command)
+        ]
+        self.assertEqual(len(reflector_commands), 1)
+        self.assertEqual(len(self.commands), 1)
         self.assertIn("38-3-reflector", [entry["key"] for entry in self.ledger_entries()])
+
+    def test_phase9_router_stalled_rejects_changed_recent_verdict_text(self) -> None:
+        for round_no, verdict in ((1, "same"), (2, "changed"), (3, "same")):
+            self.solver_triplet(issue=39, round_no=round_no, verdict=verdict)
+        self.write_ledger_key("39-1-judge")
+        self.write_ledger_key("39-2-judge")
+        self.write_log("phase9-issue39-r3-judge.log", "META_JUDGE_DONE:escalate:stalled:no-change")
+
+        self.router.tick()
+
+        self.assertFalse(any("reflector" in " ".join(command) for command in self.commands))
+        self.assertNotIn("39-3-reflector", [entry["key"] for entry in self.ledger_entries()])
+        self.assertIn("META_JUDGE_DONE:escalate:stalled:no-change", self.pending_events())
 
     def test_phase9_router_lifecycle_markers_never_spawn(self) -> None:
         markers = (

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -14,6 +14,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from phase9_router_daemon import Phase9Router
 
 
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PHASE9_ROUTER = REPO_ROOT / "skills" / "codex-refactor-loop" / "scripts" / "phase9_router_daemon.py"
+
+
 class Phase9RouterDaemonTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.TemporaryDirectory()
@@ -149,6 +153,27 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         events = self.pending_events()
         for marker in markers:
             self.assertIn(marker, events)
+
+    def test_phase9_router_source_does_not_introduce_forbidden_abstractions(self) -> None:
+        """#37 consensus exception allows only private ledger plus fallback event."""
+        src = PHASE9_ROUTER.read_text(encoding="utf-8")
+        for forbidden in (
+            "WorkUnitV2",
+            "ControllerOrchestrator",
+            "ControllerEvent",
+            "ControllerCommand",
+            "gh pr create",
+            "gh pr merge",
+            "git commit",
+            "git push",
+            "merge_pr(",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(
+                    forbidden,
+                    src,
+                    f"phase9_router_daemon.py must not introduce forbidden boundary token: {forbidden}",
+                )
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from phase9_router_daemon import Phase9Router
+from phase9_router_daemon import Phase9Router, main
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -174,6 +174,35 @@ class Phase9RouterDaemonTests(unittest.TestCase):
                     src,
                     f"phase9_router_daemon.py must not introduce forbidden boundary token: {forbidden}",
                 )
+
+    def test_main_once_dispatches_via_temp_repo_root(self) -> None:
+        self.solver_triplet(issue=37, round_no=4)
+        commands: list[list[str]] = []
+
+        exit_code = main(["--once", "--repo-root", str(self.repo)], command_runner=commands.append)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(len(commands), 1)
+        self.assertIn(str(self.repo.resolve()), commands[0])
+        self.assertEqual([entry["key"] for entry in self.ledger_entries()], ["37-4-judge"])
+
+    def test_main_rejects_relative_repo_root(self) -> None:
+        commands: list[list[str]] = []
+
+        with self.assertRaisesRegex(SystemExit, "must be absolute"):
+            main(["--once", "--repo-root", "relative/path"], command_runner=commands.append)
+
+        self.assertEqual(commands, [])
+
+    def test_main_dry_run_records_no_dispatch(self) -> None:
+        self.solver_triplet(issue=37, round_no=4)
+        commands: list[list[str]] = []
+
+        exit_code = main(["--once", "--repo-root", str(self.repo), "--dry-run"], command_runner=commands.append)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(commands, [])
+        self.assertEqual(self.ledger_entries(), [])
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -79,6 +80,40 @@ class Phase9RouterDaemonTests(unittest.TestCase):
 
         self.assertEqual(len(self.commands), 1)
         self.assertEqual([entry["key"] for entry in self.ledger_entries()], ["37-4-judge"])
+
+    def test_phase9_router_singleton_lock_conflict_fail_closed_before_dispatch(self) -> None:
+        self.solver_triplet()
+
+        with mock.patch("phase9_router_daemon.fcntl.flock", side_effect=BlockingIOError):
+            with self.assertRaises(SystemExit):
+                with self.router.singleton():
+                    self.router.tick()
+
+        self.assertEqual(self.commands, [])
+        self.assertEqual(self.ledger_entries(), [])
+
+    def test_phase9_router_in_flight_suppresses_duplicate_dispatch_before_ledger(self) -> None:
+        with self.subTest("existing target log"):
+            self.solver_triplet(issue=37, round_no=4)
+            self.router._log_path("37", 4, "judge").write_text("reserved by existing worker\n", encoding="utf-8")
+
+            self.router.tick()
+
+            self.assertEqual(self.commands, [])
+            self.assertEqual(self.ledger_entries(), [])
+
+        with self.subTest("ps command line"):
+            self.tmp.cleanup()
+            self.setUp()
+            self.solver_triplet(issue=38, round_no=5)
+            target_log = self.router._log_path("38", 5, "judge")
+            ps_output = f"/bin/sh /tmp/spawn-codex.sh --cd {self.repo.resolve()} --log {target_log} --stall 3600\n"
+
+            with mock.patch("phase9_router_daemon.subprocess.run", return_value=mock.Mock(stdout=ps_output)):
+                self.router.tick()
+
+            self.assertEqual(self.commands, [])
+            self.assertEqual(self.ledger_entries(), [])
 
     def test_phase9_router_placeholder_exclusion_ignores_prompt_echo(self) -> None:
         for role in ("minimal", "structural", "delete"):

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Behavior tests for the narrow Phase 9 router daemon."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from phase9_router_daemon import Phase9Router
+
+
+class Phase9RouterDaemonTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        (self.repo / ".refactor-loop" / "logs").mkdir(parents=True)
+        self.commands: list[list[str]] = []
+        self.router = Phase9Router(self.repo, command_runner=self.commands.append)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write_log(self, name: str, *lines: str, exit_zero: bool = True) -> Path:
+        path = self.repo / ".refactor-loop" / "logs" / name
+        tail = ["EXIT=0"] if exit_zero else ["EXIT=1"]
+        path.write_text("\n".join([*lines, *tail, ""]), encoding="utf-8")
+        return path
+
+    def ledger_entries(self) -> list[dict]:
+        path = self.repo / ".refactor-loop" / "phase9-router-ledger.jsonl"
+        if not path.exists():
+            return []
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+    def pending_events(self) -> str:
+        path = self.repo / ".refactor-loop" / ".controller-pending-events.log"
+        return path.read_text(encoding="utf-8") if path.exists() else ""
+
+    def solver_triplet(self, issue: int = 37, round_no: int = 4, verdict: str = "same") -> None:
+        for role in ("minimal", "structural", "delete"):
+            self.write_log(
+                f"phase9-issue{issue}-r{round_no}-{role}.log",
+                f"SOLVER_DONE:{role}:{verdict}:summary",
+            )
+
+    def test_phase9_router_clean_exit_gating_requires_tail_exit_zero(self) -> None:
+        self.write_log("phase9-issue37-r4-minimal.log", "SOLVER_DONE:minimal:ok:x")
+        self.write_log("phase9-issue37-r4-structural.log", "SOLVER_DONE:structural:ok:x")
+        self.write_log("phase9-issue37-r4-delete.log", "SOLVER_DONE:delete:ok:x", exit_zero=False)
+
+        self.router.tick()
+
+        self.assertEqual(self.commands, [])
+        self.assertEqual(self.ledger_entries(), [])
+
+    def test_phase9_router_unknown_marker_fallback_appends_event_only(self) -> None:
+        self.write_log("phase9-issue37-r4-judge.log", "SOMETHING_DONE:surprise:payload")
+
+        self.router.tick()
+
+        self.assertEqual(self.commands, [])
+        self.assertIn("SOMETHING_DONE:surprise:payload", self.pending_events())
+        self.assertEqual(self.ledger_entries(), [])
+
+    def test_phase9_router_idempotency_spawns_once_per_dedupe_key(self) -> None:
+        self.solver_triplet()
+
+        self.router.tick()
+        self.router.tick()
+
+        self.assertEqual(len(self.commands), 1)
+        self.assertEqual([entry["key"] for entry in self.ledger_entries()], ["37-4-judge"])
+
+    def test_phase9_router_placeholder_exclusion_ignores_prompt_echo(self) -> None:
+        for role in ("minimal", "structural", "delete"):
+            self.write_log(
+                f"phase9-issue37-r4-{role}.log",
+                f"prompt template says SOLVER_DONE:<{role}>:<verdict>:<summary>",
+            )
+
+        self.router.tick()
+
+        self.assertEqual(self.commands, [])
+        self.assertEqual(self.ledger_entries(), [])
+
+    def test_phase9_router_solver_triplet_dispatches_meta_judge_once(self) -> None:
+        self.solver_triplet(issue=37, round_no=4)
+
+        self.router.tick()
+
+        self.assertEqual(len(self.commands), 1)
+        command = self.commands[0]
+        self.assertIn(str(self.repo.resolve()), command)
+        self.assertIn(str((self.repo / ".refactor-loop" / "logs" / "phase9-issue37-r4-judge.log").resolve()), command)
+        self.assertEqual(self.ledger_entries()[0]["key"], "37-4-judge")
+
+    def test_phase9_router_converge_dispatches_next_round_solvers(self) -> None:
+        self.write_log("phase9-issue37-r4-judge.log", "META_JUDGE_DONE:converge:round-5:need-more")
+
+        self.router.tick()
+
+        self.assertEqual(len(self.commands), 3)
+        logs = " ".join(" ".join(command) for command in self.commands)
+        self.assertIn("phase9-issue37-r5-minimal.log", logs)
+        self.assertIn("phase9-issue37-r5-structural.log", logs)
+        self.assertIn("phase9-issue37-r5-delete.log", logs)
+        self.assertEqual(
+            sorted(entry["key"] for entry in self.ledger_entries()),
+            ["37-5-delete", "37-5-minimal", "37-5-structural"],
+        )
+
+    def test_phase9_router_stalled_requires_valid_predicate(self) -> None:
+        self.write_log("phase9-issue37-r2-judge.log", "META_JUDGE_DONE:escalate:stalled:no-change")
+        self.router.tick()
+        self.assertEqual(self.commands, [])
+
+        self.commands.clear()
+        for round_no in (1, 2, 3):
+            self.solver_triplet(issue=38, round_no=round_no, verdict="same")
+        self.write_log("phase9-issue38-r3-judge.log", "META_JUDGE_DONE:escalate:stalled:no-change")
+        self.router.tick()
+
+        self.assertEqual(len(self.commands), 3)
+        self.assertTrue(any("phase9-issue38-r3-reflector.log" in " ".join(command) for command in self.commands))
+        self.assertIn("38-3-reflector", [entry["key"] for entry in self.ledger_entries()])
+
+    def test_phase9_router_lifecycle_markers_never_spawn(self) -> None:
+        markers = (
+            "META_JUDGE_DONE:consensus:structural:summary",
+            "IMPLEMENT_DONE:cluster:ok",
+            "VERIFY_DONE:cluster:ok",
+            "REVIEW_DONE:pr:quality:approve",
+            "FIX_DONE:pr:ok",
+            "FIX_BLOCKED:pr:reason",
+            "TEST_ADD_DONE:pr:ok",
+            "META_RESOLVED:retry-fix:reason",
+        )
+        for index, marker in enumerate(markers, start=1):
+            self.write_log(f"phase9-issue{index}-r1-judge.log", marker)
+
+        self.router.tick()
+
+        self.assertEqual(self.commands, [])
+        events = self.pending_events()
+        for marker in markers:
+            self.assertIn(marker, events)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -84,7 +84,7 @@ class SkillEntrypointContractTests(unittest.TestCase):
             "initialize state",
             "integration branch",
             "ensure labels",
-            "ensure all 5 daemons",
+            "ensure all 6 daemons",
             "arm persistent daemon-event Monitor",
             "dispatch producer",
             "confirm a wake source",
@@ -124,6 +124,14 @@ class SkillEntrypointContractTests(unittest.TestCase):
         self.assertNotIn("@REFERENCE.md", self.skill)
         self.assertNotRegex(self.skill, r"\]\(/Users/[^)]+REFERENCE\.md")
         self.assertRegex(self.skill, r"\(REFERENCE\.md#[^)]+\)")
+
+    def test_phase9_router_daemon_boundary_is_narrow(self) -> None:
+        self.assertIn("phase9_router_daemon.py", self.skill)
+        self.assertIn("narrow Phase 9 allowlist", self.skill)
+        self.assertIn("SOLVER_DONE", self.skill)
+        self.assertIn("META_JUDGE_DONE:converge", self.skill)
+        self.assertIn("META_JUDGE_DONE:escalate:stalled", self.skill)
+        self.assertIn("do not introduce WorkUnitV2, public marker aliases, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority", self.skill)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -71,7 +71,7 @@ class SkillReferenceAnchorTests(unittest.TestCase):
         skill_lines = len(self.skill.splitlines())
 
         self.assertGreaterEqual(reference_lines, 2000)
-        self.assertLessEqual(reference_lines, 2505)
+        self.assertLessEqual(reference_lines, 2450)
         self.assertGreater(reference_lines, skill_lines * 2)
 
     def test_no_absolute_reference_links_in_entrypoint(self) -> None:

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -71,7 +71,7 @@ class SkillReferenceAnchorTests(unittest.TestCase):
         skill_lines = len(self.skill.splitlines())
 
         self.assertGreaterEqual(reference_lines, 2000)
-        self.assertLessEqual(reference_lines, 2450)
+        self.assertLessEqual(reference_lines, 2505)
         self.assertGreater(reference_lines, skill_lines * 2)
 
     def test_no_absolute_reference_links_in_entrypoint(self) -> None:
@@ -102,6 +102,15 @@ class SkillReferenceAnchorTests(unittest.TestCase):
         scripts_dir = SKILL_ROOT / "scripts"
         self.assertFalse((scripts_dir / "daemon_event_monitor.sh").exists())
         self.assertFalse((scripts_dir / "daemon-event-monitor-bridge.sh").exists())
+
+    def test_reference_documents_phase9_router_daemon_boundary(self) -> None:
+        self.assertIn("phase9_router_daemon.py --daemon --repo-root", self.reference)
+        self.assertIn("Allowlist(唯一 direct spawn authority)", self.reference)
+        self.assertIn("clean `^EXIT=0`", self.reference)
+        self.assertIn(".refactor-loop/phase9-router-ledger.jsonl", self.reference)
+        self.assertIn(".controller-pending-events.log", self.reference)
+        self.assertIn("no lifecycle authority", self.reference)
+        self.assertIn("must not introduce ControllerEvent, ControllerCommand, ControllerOrchestrator", self.reference)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Phase 9 r4 共识(structural→B,3/3 propose)

Closes #37

### What

**首块 daemon-first refactor**:narrow `phase9_router_daemon.py` 直接派发 deterministic Phase 9 路由,其他全部仍 controller。

新增:
- `skills/codex-refactor-loop/scripts/phase9_router_daemon.py`(~250 LOC)
- `skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py`(8 行为测试)

修订:
- `SKILL.md`:daemon count 5→6 + Phase 0 启动 + named exception 允许 narrow allowlist 例外
- `REFERENCE.md`:daemon body + allowlist + ledger format + fallback event + staged expansion gates
- `README.md`:核心 controller 行加确定性脚本 narrow dispatch 例外
- 2 个 source-regression test 文件扩 daemon-count/anchors 断言

**Allowlist**(daemon 唯一直派):
- `SOLVER_DONE:<minimal|structural|delete>:*` × 3 → 1 meta-judge
- `META_JUDGE_DONE:converge:round-<N>:*` → 3 next-round solvers
- `META_JUDGE_DONE:escalate:stalled:*` + 满足 predicate → reflector

其他 marker(`consensus`/`IMPLEMENT_DONE`/`REVIEW_DONE`/`FIX_DONE`/`META_RESOLVED`)→ append fallback event,**不 spawn**。

**不引入**(共识明示拒):`ControllerOrchestrator`、`ControllerEvent`、`ControllerCommand`、`WorkUnitV2`、public marker aliases、lifecycle authority。

### Verify

- 本地 `python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → **114 tests OK**(+34 from baseline 80)
- Daemon 在 r1 不获 harness task-notification(直接 spawn 子进程),fallback:Monitor event append + ScheduleWakeup + controller fallback sweep。r2 再考虑 harness 集成。

⟦AI:AUTO-LOOP⟧