### PR TITLE
chore: CLAUDE.md 例外子句扩到 Phase 9 共识授权的 narrow daemon(reflector PR#44 re-design split)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,3 +37,5 @@
 ## 当前状态
 
 - `skills/codex-refactor-loop/` 为 host 项目移植,**verbatim**,仍带"重构"外壳与少量 host 主张。泛化路线见 `README.md` 的「泛化路线」。脱壳 / 重命名前不要改它的正文逻辑；例外：经 Phase 9 deep consensus 明确授权的 host-agnostic bootstrap / policy 注入修正可先落地，但不得引入具体 host 事实，且必须配套行为测试。
+
+**该例外同时覆盖** Phase 9 共识授权的**确定性 controller-runtime 路由 daemon**(例如 narrow allowlist phase router):必须 host-agnostic、必须 narrow allowlist 不引入 lifecycle authority、必须配套行为测试与 source-regression test、必须在 SKILL.md 加 named exception 段。这是为了把可机械的 controller 工作从长跑 LLM 搬到脚本(维护者明示 "LLM 长时间运行会退化,但是脚本不会"，见 issue #37 共识)。


### PR DESCRIPTION
## Reflector 决定 META_RESOLVED:re-design (PR#44)

依 PR #44 meta-reflector 决定 `split-claude-md-amendment-first-then-daemon-pr`,本 PR **仅承载 CLAUDE.md 规则修正**,不含 daemon 实现。

### What

CLAUDE.md 第 39 行附近 append 一段:

> **该例外同时覆盖** Phase 9 共识授权的**确定性 controller-runtime 路由 daemon**(例如 narrow allowlist phase router):必须 host-agnostic、必须 narrow allowlist 不引入 lifecycle authority、必须配套行为测试与 source-regression test、必须在 SKILL.md 加 named exception 段。这是为了把可机械的 controller 工作从长跑 LLM 搬到脚本(维护者明示 "LLM 长时间运行会退化,但是脚本不会"，见 issue #37 共识)。

### Why

维护者 loning session 中明示授权 "改成 daemon-first"。issue #37 r4 Phase 9 共识 3/3 propose `phase9_router_daemon.py`(narrow allowlist)。但原 PR #44 在同一个 PR 同时改规则 + 落地 daemon 触发 architect 循环论证 reject。

Reflector 仲裁:**先 land 规则修正 PR,再 land daemon PR**(本 PR 是规则修正)。

### Scope

- **仅 +2 行** `CLAUDE.md`
- 不含 SKILL/REFERENCE/scripts/tests 改动
- 不含 daemon 实现

本规则修正本身属于现有 `policy 注入修正` 例外允许范围(maintainer-authorized,Phase 9-backed,行为测试由后续 daemon PR 配套)。

⟦AI:AUTO-LOOP⟧