### PR TITLE
feat(skill): IntegrationSyncDaemonV1 state machine 收编 sync/rollup(#27 共识)

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -843,7 +843,7 @@ For each `bucket: fail` check:
 <a id="daemon-command-bodies"></a>
 ## Daemon command bodies
 
-Runs **first** on every controller wakeup, before Phase 7 design-issue sweep and before any new Phase 2 cluster work. Goal: keep `integration_branch` continuously up-to-date with `review_base_branch` so cluster PRs base on fresh code and the eventual rollup PR has minimal merge conflicts.
+Phase 6 is owned by the singleton daemon, not by controller wakeup shell commands. The goal is to keep `integration_branch` continuously up-to-date with `review_base_branch` so cluster PRs base on fresh code and the eventual rollup PR has minimal merge conflicts.
 
 ### Phase 6 现在由独立 daemon 自主完成
 
@@ -855,16 +855,16 @@ nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scrip
 disown
 ```
 
-Daemon 工作流:
-1. cd `$REPO_ROOT`,确认 HEAD = `auto-refact-dev`(不是则 skip)
-2. Working tree dirty → skip(controller 在工作)
-3. 但若 `.git/MERGE_HEAD` 存在 + 无 in-flight codex → **dispatch codex resolve**(防止上次 codex 死)
-4. `git fetch origin` + `git rev-list --count HEAD..origin/dev`
-5. behind=0 → idle skip
-6. behind>0 → 尝试 `git merge --ff-only`,成功则 push;失败则 `git merge --no-ff`(merge commit)
-7. **冲突** → 写 `prompts/dev-sync-conflict-<ts>.md` + spawn-codex resolve(5400s no-output stall window)
-8. codex 在同一 worktree resolve 文件 + `git add` + `git merge --continue`(不 push,daemon 后续 push)
-9. codex 完成 marker:`DEV_SYNC_RESOLVED:<files>` 或 `DEV_SYNC_BLOCKED:<reason>`
+Daemon 工作流由 `IntegrationSyncDaemonV1` 命名状态机表达:
+1. `FETCH`: fetch origin in the daemon worktree.
+2. `CHECK_MERGE`: if a merge is in progress, observe or dispatch exactly one resolver codex. Resolver codexes resolve files and run `git merge --continue`; they never push, reset, or abort.
+3. `CHECK_DIRTY`: dirty non-merge worktrees skip without reset.
+4. `PRESERVE_LOCAL_AHEAD`: before any reset, compute `local_ahead_count` with `git rev-list --count origin/$INTEGRATION_BRANCH..HEAD`; if the daemon worktree is clean and ahead, push `HEAD:$INTEGRATION_BRANCH` and return. This preserves resolver continuation commits.
+5. `ADOPT_MERGED_ROLLUP`: if a merged rollup PR from `$INTEGRATION_BRANCH` to `$REVIEW_BASE_BRANCH` is provable, capture the old rollup head and current expected remote SHA, reset/replay onto `origin/$REVIEW_BASE_BRANCH`, then push only with exact `--force-with-lease=refs/heads/$INTEGRATION_BRANCH:<expected_remote_sha>`.
+6. `RESET_TO_REMOTE`: reset to `origin/$INTEGRATION_BRANCH` only after local-ahead preservation and rollup adoption checks.
+7. `FORWARD_SYNC`: merge `origin/$REVIEW_BASE_BRANCH` into integration using ff-only first, then no-ff merge; push with ordinary `git push origin HEAD:$INTEGRATION_BRANCH`.
+
+Ambiguous rollup metadata, failed local-ahead push, or adoption conflicts append `.refactor-loop/.controller-pending-events.log` and do not guess. Controller reads pending events and posts the visible GitHub card when action is needed.
 
 ### Phase 9 router daemon command body
 `phase9_router_daemon.py` 是单例 daemon,只读 clean-exit logs 和私有 ledger。启动:`nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scripts/phase9_router_daemon.py --daemon --repo-root "$REPO_ROOT"' >> .refactor-loop/logs/phase9-router-daemon.log 2>&1 & disown`
@@ -876,7 +876,7 @@ Allowlist(唯一 direct spawn authority):
 Fallback/ledger/recovery: lifecycle/unknown markers append `.refactor-loop/.controller-pending-events.log`; no spawn, no git, no GitHub, no lifecycle authority. Append-only `.refactor-loop/phase9-router-ledger.jsonl` records `{key, marker, log_path, dispatched_at}`; fallback events use prefix `phase9-router-fallback`. In-flight target logs or live `spawn-codex.sh --log <target>` suppress re-dispatch, `.refactor-loop/phase9-router.lock` enforces singleton, and duplicate ledger rows never delete logs. Staged expansion requires route-ledger evidence and must not introduce ControllerEvent, ControllerCommand, ControllerOrchestrator, WorkUnitV2, public marker aliases, or lifecycle authority.
 ### Daemon vs controller 分工
 dev sync stays with daemon; Phase 9 triplet/converge/valid-stalled continuation may use **phase9_router_daemon.py** narrow allowlist with controller fallback sweep retained; design/consensus/implement/review/fix/liveness/escalation stay with controller wakeups.
-### Controller 每 wakeup 责任(改为只 verify daemon)
+### Controller 每 wakeup 责任(只 verify daemon)
 ```bash
 # Phase 6 现在 controller 只 verify daemon 健康
 ps -ef | grep dev-sync-daemon.sh | grep -v grep | wc -l  # 必须 >=1
@@ -892,77 +892,19 @@ tail -10 .refactor-loop/logs/dev-sync-daemon.log | grep -E "(DEV_SYNC_BLOCKED|FA
 - ❌ Daemon 派 codex 自己 push(daemon 决定 push 时机,codex 只 resolve + merge --continue)
 - ❌ 多 daemon 实例(`pgrep -c dev-sync-daemon` 必须 = 1)
 
-### Sync procedure
+### Manual recovery
 
-```bash
-cd "$REPO_ROOT" && git fetch origin
-git checkout "$INTEGRATION_BRANCH"
-git pull --ff-only origin "$INTEGRATION_BRANCH" 2>/dev/null || true
+If a maintainer must repair the daemon worktree manually, stop the singleton `dev_sync_daemon.py` first, verify there is no resolver codex in flight, then repair the dedicated worktree. Restart the daemon only after the branch topology is clean and `git status` is clean.
 
-# Compute divergence
-ahead=$(git rev-list --count "origin/$REVIEW_BASE_BRANCH..HEAD")
-behind=$(git rev-list --count "HEAD..origin/$REVIEW_BASE_BRANCH")
+### Post-rollup adoption invariant
 
-if (( behind == 0 )); then
-  echo "integration is up-to-date with $REVIEW_BASE_BRANCH; no sync needed"
-  exit 0
-fi
-
-# Try fast-forward first, then no-ff merge
-if git merge --ff-only "origin/$REVIEW_BASE_BRANCH" 2>/dev/null; then
-  echo "fast-forwarded integration with $REVIEW_BASE_BRANCH (+$behind commits)"
-else
-  if git merge --no-ff -m "Sync integration with $REVIEW_BASE_BRANCH" "origin/$REVIEW_BASE_BRANCH"; then
-    echo "merge-committed $behind commits from $REVIEW_BASE_BRANCH into integration"
-  else
-    git merge --abort
-    echo "SYNC_CONFLICT: $behind commits in $REVIEW_BASE_BRANCH conflict with integration"
-    # PushNotification: "integration branch sync conflicted with dev; manual rebase needed"
-    exit 1
-  fi
-fi
-
-# Run local CI on the post-sync integration head
-if [ -n "${CI_GUARDS:-}" ]; then
-  bash "$CI_GUARDS" && bash "$CI_GUARDS"
-  if [[ $? -ne 0 ]]; then
-    echo "SYNC_CI_FAIL: post-merge guards failed"
-    # PushNotification + halt (do not push a broken integration)
-    exit 1
-  fi
-else
-  echo "guards skipped: CI_GUARDS unset"
-fi
-
-git push origin "$INTEGRATION_BRANCH"
-```
-
-### Sync cadence
-
-- Every controller wakeup (cheap when `behind == 0`).
-- On conflict or post-merge CI fail → halt + PushNotification; do not push. Resume sync only after operator clears the issue.
-- After successful sync, **rebase all open cluster PRs** onto the new integration head (force-with-lease per PR branch). This keeps stacked PR semantics correct: each cluster PR's diff stays scoped to its own changes, not the dev merge.
+After a rollup PR has merged into `review_base_branch`, `IntegrationSyncDaemonV1` must make `integration_branch` contain that merged review-base head before new forward sync work. Any post-rollup integration commits are replayed only after the proven old rollup head; if the old head or expected remote SHA cannot be proven, the daemon writes a pending event and does not force-push.
 
 ### Why this matters
 
 - Without auto-sync, the integration branch drifts from dev and the eventual rollup PR becomes one giant conflict resolution.
 - Cluster PR diffs viewed by reviewers should be just the cluster's changes; if integration is stale, the PR shows a noisy diff that mixes cluster work with "what dev added since" which is reviewer-hostile.
 - Sync conflicts are rare but real (e.g., a dev PR refactored the same area). Surfacing them as halts is better than silently posting a busted integration.
-
-### State tracking
-
-In `state.json`:
-
-```json
-"integration_sync": {
-  "last_sync_at": "<ISO8601>",
-  "last_sync_added_commits": <int>,
-  "last_sync_result": "ff | merge | up_to_date | conflict | ci_fail",
-  "consecutive_failures": <int>
-}
-```
-
-`consecutive_failures >= 3` → escalate to PushNotification with "integration sync stuck — manual review needed" and pause auto-sync until operator clears.
 
 ---
 
@@ -2314,12 +2256,6 @@ compatibility aliases only.
     "pr_number": <int|null>,
     "base": "<review_base_branch>",
     "head": "<integration_branch>"
-  },
-  "integration_sync": {
-    "last_sync_at": "<ISO8601>",
-    "last_sync_added_commits": <int>,
-    "last_sync_result": "ff | merge | up_to_date | conflict | ci_fail",
-    "consecutive_failures": <int>
   },
   "design_pending": [
     {

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -562,6 +562,8 @@ Phase 6 guardrails:
 4. Sync failures must be visible on GitHub.
 5. Daemon command details live in [daemon command bodies](REFERENCE.md#daemon-command-bodies).
 
+Named exception: `IntegrationSyncDaemonV1` owns integration branch auto-sync, resolver continuation push, and merged-rollup adoption. The controller verifies singleton health, reads pending events, fetches after daemon pushes, and does not run checkout/merge/push sync while the daemon is healthy. Resolver codexes resolve conflicts only; they never push, reset, or abort.
+
 Phase 7 guardrails:
 
 1. Sweep design issues every wakeup.

--- a/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
+++ b/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
@@ -24,9 +24,11 @@ import subprocess
 import sys
 import time
 from datetime import datetime, timezone
+from dataclasses import dataclass
 from pathlib import Path
 from contextlib import contextmanager
 import fcntl
+import json
 
 
 def git_repo_root() -> Path:
@@ -74,6 +76,7 @@ INTEGRATION = os.environ.get("INTEGRATION_BRANCH") or os.environ.get("INTEGRATIO
 REVIEW_BASE = os.environ.get("REVIEW_BASE_BRANCH") or os.environ.get("REVIEW_BASE") or "dev"
 SPAWN_CODEX = SKILL_ROOT / "scripts" / "spawn-codex.sh"
 LOCK_FILE = MAIN_REPO / ".refactor-loop" / "dev-sync-daemon.lock"
+PENDING_EVENTS_FILE = MAIN_REPO / ".refactor-loop" / ".controller-pending-events.log"
 
 
 def log(msg: str) -> None:
@@ -224,75 +227,299 @@ def merge_in_progress(cwd: Path) -> bool:
     return False
 
 
-def tick() -> None:
-    cwd = WORKTREE
-    if not cwd.exists():
-        log(f"worktree {cwd} missing, attempting create")
-        if not ensure_worktree():
+@dataclass(frozen=True)
+class RollupAdoption:
+    pr_number: int | None
+    old_head: str
+    expected_remote_sha: str
+
+
+@dataclass(frozen=True)
+class RollupDetection:
+    status: str
+    adoption: RollupAdoption | None = None
+
+
+# Refactor (iter4/skill-dev-sync-state-machine): Old pattern: 散落 active controller-owned sync recipe + 隐含 daemon transition. New principle: named IntegrationSyncDaemonV1 state machine boundary,resolver/rollup/push 全部 daemon-owned,controller 只 verify(#27 structural B 共识)
+class IntegrationSyncDaemonV1:
+    """Narrow state machine for integration-branch sync transitions."""
+
+    def __init__(
+        self,
+        *,
+        worktree: Path = WORKTREE,
+        main_repo: Path = MAIN_REPO,
+        integration: str = INTEGRATION,
+        review_base: str = REVIEW_BASE,
+        command_runner=run,
+        logger=log,
+        ensure_worktree_fn=ensure_worktree,
+        merge_detector=merge_in_progress,
+        dirty_detector=working_tree_dirty,
+        resolver_in_flight=codex_resolve_in_flight,
+        resolver_dispatcher=dispatch_codex_resolve,
+    ) -> None:
+        self.worktree = worktree
+        self.main_repo = main_repo
+        self.integration = integration
+        self.review_base = review_base
+        self.run = command_runner
+        self.log = logger
+        self.ensure_worktree = ensure_worktree_fn
+        self.merge_in_progress = merge_detector
+        self.working_tree_dirty = dirty_detector
+        self.codex_resolve_in_flight = resolver_in_flight
+        self.dispatch_codex_resolve = resolver_dispatcher
+        self.pending_events_file = main_repo / ".refactor-loop" / ".controller-pending-events.log"
+
+    def append_pending_event(self, reason: str, detail: str) -> None:
+        self.pending_events_file.parent.mkdir(parents=True, exist_ok=True)
+        with self.pending_events_file.open("a", encoding="utf-8") as fh:
+            fh.write(f"DEV_SYNC_PENDING:{reason}:{detail}\n")
+
+    def local_ahead_count(self, cwd: Path) -> int:
+        result = self.run(
+            ["git", "rev-list", "--count", f"origin/{self.integration}..HEAD"],
+            cwd=cwd,
+        )
+        try:
+            return int(result.stdout.strip())
+        except ValueError:
+            self.append_pending_event("local-ahead-unknown", result.stderr.strip()[:160])
+            return 0
+
+    def remote_integration_sha(self, cwd: Path) -> str | None:
+        result = self.run(["git", "rev-parse", f"origin/{self.integration}"], cwd=cwd)
+        if result.returncode != 0:
+            self.append_pending_event("remote-sha-unknown", result.stderr.strip()[:160])
+            return None
+        return result.stdout.strip()
+
+    def push_clean_local_ahead_before_reset(self, cwd: Path) -> bool:
+        ahead_n = self.local_ahead_count(cwd)
+        if ahead_n <= 0:
+            return False
+        self.log(f"local HEAD is ahead of origin/{self.integration} by {ahead_n} commits; pushing before reset")
+        push = self.run(["git", "push", "origin", f"HEAD:{self.integration}"], cwd=cwd)
+        if push.returncode == 0:
+            self.log(f"pushed resolver/local-ahead HEAD → origin/{self.integration}")
+        else:
+            self.log(f"FAIL push local-ahead: {push.stderr.strip()[:120]}")
+            self.append_pending_event("local-ahead-push-failed", push.stderr.strip()[:160])
+        return True
+
+    def detect_merged_rollup(self, cwd: Path) -> RollupDetection | None:
+        already_adopted = self.run(
+            ["git", "merge-base", "--is-ancestor", f"origin/{self.review_base}", f"origin/{self.integration}"],
+            cwd=cwd,
+        )
+        if already_adopted.returncode == 0:
+            return None
+
+        expected_remote_sha = self.remote_integration_sha(cwd)
+        if not expected_remote_sha:
+            return RollupDetection("ambiguous")
+
+        query = self.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "merged",
+                "--head",
+                self.integration,
+                "--base",
+                self.review_base,
+                "--limit",
+                "1",
+                "--json",
+                "number,headRefOid,mergedAt",
+            ],
+            cwd=self.main_repo,
+        )
+        if query.returncode != 0 or not query.stdout.strip():
+            return None
+        try:
+            rows = json.loads(query.stdout)
+        except json.JSONDecodeError:
+            self.append_pending_event("rollup-adoption-ambiguous", "gh-json-decode-failed")
+            return RollupDetection("ambiguous")
+        if not rows:
+            return None
+        row = rows[0]
+        old_head = (row.get("headRefOid") or "").strip()
+        if not old_head:
+            self.append_pending_event("rollup-adoption-ambiguous", "missing-headRefOid")
+            return RollupDetection("ambiguous")
+        ancestor = self.run(
+            ["git", "merge-base", "--is-ancestor", old_head, f"origin/{self.integration}"],
+            cwd=cwd,
+        )
+        if ancestor.returncode != 0:
+            self.append_pending_event("rollup-adoption-ambiguous", f"old-head-not-ancestor:{old_head}")
+            return RollupDetection("ambiguous")
+        return RollupDetection(
+            "adopt",
+            RollupAdoption(
+                pr_number=row.get("number"),
+                old_head=old_head,
+                expected_remote_sha=expected_remote_sha,
+            ),
+        )
+
+    def adopt_merged_rollup(self, cwd: Path, adoption: RollupAdoption) -> bool:
+        if not adoption.expected_remote_sha:
+            self.append_pending_event("rollup-adoption-ambiguous", "missing-expected-remote-sha")
+            return True
+
+        replay_count = self.run(
+            ["git", "rev-list", "--count", f"{adoption.old_head}..origin/{self.integration}"],
+            cwd=cwd,
+        )
+        try:
+            replay_n = int(replay_count.stdout.strip())
+        except ValueError:
+            self.append_pending_event("rollup-adoption-ambiguous", "post-rollup-count-unknown")
+            return True
+
+        if replay_n == 0:
+            reset = self.run(["git", "reset", "--hard", f"origin/{self.review_base}"], cwd=cwd)
+            if reset.returncode != 0:
+                self.append_pending_event("rollup-adoption-reset-failed", reset.stderr.strip()[:160])
+                return True
+        else:
+            reset = self.run(["git", "reset", "--hard", f"origin/{self.integration}"], cwd=cwd)
+            if reset.returncode != 0:
+                self.append_pending_event("rollup-adoption-reset-failed", reset.stderr.strip()[:160])
+                return True
+            rebase = self.run(
+                ["git", "rebase", "--rebase-merges", "--onto", f"origin/{self.review_base}", adoption.old_head],
+                cwd=cwd,
+            )
+            if rebase.returncode != 0:
+                self.append_pending_event("rollup-adoption-replay-conflict", rebase.stderr.strip()[:160])
+                return True
+
+        push = self.run(
+            [
+                "git",
+                "push",
+                f"--force-with-lease=refs/heads/{self.integration}:{adoption.expected_remote_sha}",
+                "origin",
+                f"HEAD:{self.integration}",
+            ],
+            cwd=cwd,
+        )
+        if push.returncode == 0:
+            self.log(f"adopted merged rollup PR #{adoption.pr_number or '?'} onto origin/{self.integration}")
+        else:
+            self.append_pending_event("rollup-adoption-push-failed", push.stderr.strip()[:160])
+        return True
+
+    def reset_to_remote(self, cwd: Path) -> bool:
+        result = self.run(["git", "reset", "--hard", f"origin/{self.integration}"], cwd=cwd)
+        if result.returncode != 0:
+            self.log(f"FAIL reset to origin/{self.integration}: {result.stderr.strip()[:120]}")
+            return False
+        return True
+
+    def forward_sync_review_base(self, cwd: Path) -> None:
+        behind = self.run(["git", "rev-list", "--count", f"HEAD..origin/{self.review_base}"], cwd=cwd).stdout.strip()
+        try:
+            behind_n = int(behind)
+        except ValueError:
+            behind_n = 0
+
+        if behind_n == 0:
+            self.log(f"up-to-date with origin/{self.review_base}")
             return
 
-    if merge_in_progress(cwd):
-        if codex_resolve_in_flight():
-            log("skip: merge in progress + codex resolving")
+        self.log(f"behind origin/{self.review_base} by {behind_n} commits, attempting sync")
+
+        ff = self.run(["git", "merge", "--ff-only", f"origin/{self.review_base}"], cwd=cwd)
+        if ff.returncode == 0 and ("Fast-forward" in ff.stdout or "Already up to date" in ff.stdout):
+            self.log(f"ff-merged with origin/{self.review_base} (+{behind_n} commits)")
+            push = self.run(["git", "push", "origin", f"HEAD:{self.integration}"], cwd=cwd)
+            if push.returncode == 0:
+                self.log(f"pushed HEAD → origin/{self.integration}")
+            else:
+                self.log(f"FAIL push: {push.stderr.strip()[:120]}")
+            return
+
+        self.log("ff-only not possible, attempting no-ff merge")
+        merge = self.run(
+            [
+                "git",
+                "merge",
+                "--no-ff",
+                "-m",
+                f"Sync {self.integration} with {self.review_base} (auto by dev_sync_daemon)",
+                f"origin/{self.review_base}",
+            ],
+            cwd=cwd,
+        )
+        if merge.returncode == 0:
+            self.log(f"no-ff merge-committed +{behind_n} commits")
+            push = self.run(["git", "push", "origin", f"HEAD:{self.integration}"], cwd=cwd)
+            if push.returncode == 0:
+                self.log(f"pushed HEAD → origin/{self.integration}")
+            else:
+                self.log(f"FAIL push after merge: {push.stderr.strip()[:120]}")
+            return
+
+        if self.merge_in_progress(cwd):
+            self.log("CONFLICT detected (merge in progress)")
+            if not self.codex_resolve_in_flight():
+                self.dispatch_codex_resolve()
+            else:
+                self.log("codex already resolving, skip this tick")
         else:
-            log("WARN: merge in progress but no codex running — dispatching")
-            dispatch_codex_resolve()
-        return
+            self.log(f"FAIL merge but no MERGE_HEAD: {merge.stderr.strip()[:120]}")
 
-    if working_tree_dirty(cwd):
-        log("skip: worktree dirty (no merge in progress)")
-        return
+    def tick(self) -> None:
+        cwd = self.worktree
+        if not cwd.exists():
+            self.log(f"worktree {cwd} missing, attempting create")
+            if not self.ensure_worktree():
+                return
 
-    # 每 tick reset 到 origin/INTEGRATION 确保最新(detached HEAD)
-    if not reset_to_remote(cwd):
-        return
+        self.run(["git", "fetch", "origin", "--quiet"], cwd=cwd)
 
-    behind = run(["git", "rev-list", "--count", f"HEAD..origin/{REVIEW_BASE}"], cwd=cwd).stdout.strip()
-    try:
-        behind_n = int(behind)
-    except ValueError:
-        behind_n = 0
+        if self.merge_in_progress(cwd):
+            if self.codex_resolve_in_flight():
+                self.log("skip: merge in progress + codex resolving")
+            else:
+                self.log("WARN: merge in progress but no codex running — dispatching")
+                self.dispatch_codex_resolve()
+            return
 
-    if behind_n == 0:
-        log(f"up-to-date with origin/{REVIEW_BASE}")
-        return
+        if self.working_tree_dirty(cwd):
+            self.log("skip: worktree dirty (no merge in progress)")
+            return
 
-    log(f"behind origin/{REVIEW_BASE} by {behind_n} commits, attempting sync")
+        if self.push_clean_local_ahead_before_reset(cwd):
+            return
 
-    # 尝试 ff-only(detached HEAD push 用 HEAD:branch 映射)
-    r = run(["git", "merge", "--ff-only", f"origin/{REVIEW_BASE}"], cwd=cwd)
-    if r.returncode == 0 and ("Fast-forward" in r.stdout or "Already up to date" in r.stdout):
-        log(f"ff-merged with origin/{REVIEW_BASE} (+{behind_n} commits)")
-        push = run(["git", "push", "origin", f"HEAD:{INTEGRATION}"], cwd=cwd)
-        if push.returncode == 0:
-            log(f"pushed HEAD → origin/{INTEGRATION}")
-        else:
-            log(f"FAIL push: {push.stderr.strip()[:120]}")
-        return
+        rollup = self.detect_merged_rollup(cwd)
+        if rollup and rollup.status == "adopt" and rollup.adoption:
+            self.adopt_merged_rollup(cwd, rollup.adoption)
+            return
+        if rollup and rollup.status == "ambiguous":
+            return
 
-    # ff-only 失败 → no-ff merge
-    log("ff-only not possible, attempting no-ff merge")
-    r = run(["git", "merge", "--no-ff", "-m",
-             f"Sync {INTEGRATION} with {REVIEW_BASE} (auto by dev_sync_daemon)",
-             f"origin/{REVIEW_BASE}"], cwd=cwd)
-    if r.returncode == 0:
-        log(f"no-ff merge-committed +{behind_n} commits")
-        push = run(["git", "push", "origin", f"HEAD:{INTEGRATION}"], cwd=cwd)
-        if push.returncode == 0:
-            log(f"pushed HEAD → origin/{INTEGRATION}")
-        else:
-            log(f"FAIL push after merge: {push.stderr.strip()[:120]}")
-        return
+        if not self.reset_to_remote(cwd):
+            return
 
-    # 冲突
-    if merge_in_progress(cwd):
-        log("CONFLICT detected (merge in progress)")
-        if not codex_resolve_in_flight():
-            dispatch_codex_resolve()
-        else:
-            log("codex already resolving, skip this tick")
-    else:
-        log(f"FAIL merge but no MERGE_HEAD: {r.stderr.strip()[:120]}")
+        self.forward_sync_review_base(cwd)
+
+
+def local_ahead_count(cwd: Path) -> int:
+    return IntegrationSyncDaemonV1().local_ahead_count(cwd)
+
+
+def tick() -> None:
+    IntegrationSyncDaemonV1().tick()
 
 
 def main() -> None:

--- a/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
+++ b/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Behavior and source-regression tests for IntegrationSyncDaemonV1."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+os.environ.setdefault("REPO_ROOT", str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import dev_sync_daemon
+from dev_sync_daemon import IntegrationSyncDaemonV1, RollupAdoption
+
+SKILL_ROOT = REPO_ROOT / "skills" / "codex-refactor-loop"
+DEV_SYNC = SKILL_ROOT / "scripts" / "dev_sync_daemon.py"
+SKILL_MD = SKILL_ROOT / "SKILL.md"
+REFERENCE_MD = SKILL_ROOT / "REFERENCE.md"
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+AGENTS_MD = REPO_ROOT / "AGENTS.md"
+
+
+class FakeGit:
+    def __init__(self, *, ahead: int = 0, behind: int = 0, remote_sha: str = "remote-sha") -> None:
+        self.ahead = ahead
+        self.behind = behind
+        self.remote_sha = remote_sha
+        self.commands: list[list[str]] = []
+        self.gh_rows: list[dict] = []
+        self.merge_base_adopted = False
+        self.old_head_is_ancestor = True
+
+    def __call__(self, cmd: list[str], cwd: Path | None = None, check: bool = False) -> subprocess.CompletedProcess:
+        self.commands.append(cmd)
+        stdout = ""
+        returncode = 0
+        stderr = ""
+        if cmd[:2] == ["git", "fetch"]:
+            pass
+        elif cmd[:3] == ["git", "rev-list", "--count"]:
+            spec = cmd[3]
+            if spec.startswith("origin/auto-refact-dev..HEAD"):
+                stdout = f"{self.ahead}\n"
+            elif spec.startswith("HEAD..origin/dev"):
+                stdout = f"{self.behind}\n"
+            else:
+                stdout = "0\n"
+        elif cmd[:3] == ["git", "rev-parse", "origin/auto-refact-dev"]:
+            stdout = f"{self.remote_sha}\n"
+        elif cmd[:3] == ["git", "merge-base", "--is-ancestor"]:
+            if cmd[3] == "origin/dev":
+                returncode = 0 if self.merge_base_adopted else 1
+            else:
+                returncode = 0 if self.old_head_is_ancestor else 1
+        elif cmd[:3] == ["gh", "pr", "list"]:
+            stdout = json.dumps(self.gh_rows)
+        elif cmd[:3] == ["git", "merge", "--ff-only"]:
+            stdout = "Already up to date\n" if self.behind == 0 else "Fast-forward\n"
+        elif cmd[:2] == ["git", "push"]:
+            pass
+        elif cmd[:3] == ["git", "reset", "--hard"]:
+            pass
+        elif cmd[:3] == ["git", "rebase", "--rebase-merges"]:
+            pass
+        return subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
+
+
+class IntegrationSyncDaemonV1BehaviorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.worktree = self.repo / "wt"
+        self.worktree.mkdir()
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def daemon(self, fake: FakeGit, **overrides) -> IntegrationSyncDaemonV1:
+        return IntegrationSyncDaemonV1(
+            worktree=self.worktree,
+            main_repo=self.repo,
+            integration="auto-refact-dev",
+            review_base="dev",
+            command_runner=fake,
+            logger=lambda _msg: None,
+            ensure_worktree_fn=lambda: True,
+            merge_detector=overrides.get("merge_detector", lambda _cwd: False),
+            dirty_detector=overrides.get("dirty_detector", lambda _cwd: False),
+            resolver_in_flight=overrides.get("resolver_in_flight", lambda: False),
+            resolver_dispatcher=overrides.get("resolver_dispatcher", lambda: None),
+        )
+
+    def command_index(self, fake: FakeGit, needle: list[str]) -> int:
+        for index, command in enumerate(fake.commands):
+            if command[: len(needle)] == needle:
+                return index
+        self.fail(f"missing command prefix {needle!r} in {fake.commands!r}")
+
+    def test_clean_local_ahead_is_pushed_before_reset(self) -> None:
+        fake = FakeGit(ahead=2)
+
+        self.daemon(fake).tick()
+
+        push_i = self.command_index(fake, ["git", "push", "origin", "HEAD:auto-refact-dev"])
+        self.assertNotIn(["git", "reset", "--hard", "origin/auto-refact-dev"], fake.commands[:push_i])
+
+    def test_resolver_completed_merge_commit_is_not_discarded(self) -> None:
+        fake = FakeGit(ahead=1)
+
+        self.daemon(fake).tick()
+
+        self.assertIn(["git", "push", "origin", "HEAD:auto-refact-dev"], fake.commands)
+        self.assertNotIn(["git", "reset", "--hard", "origin/auto-refact-dev"], fake.commands)
+
+    def test_dirty_non_merge_worktree_skips_without_reset(self) -> None:
+        fake = FakeGit()
+
+        self.daemon(fake, dirty_detector=lambda _cwd: True).tick()
+
+        self.assertNotIn(["git", "reset", "--hard", "origin/auto-refact-dev"], fake.commands)
+        self.assertFalse(any(command[:2] == ["git", "push"] for command in fake.commands))
+
+    def test_normal_forward_sync_never_uses_force_with_lease(self) -> None:
+        fake = FakeGit(behind=1)
+
+        self.daemon(fake).tick()
+
+        push_commands = [command for command in fake.commands if command[:2] == ["git", "push"]]
+        self.assertTrue(push_commands)
+        self.assertFalse(any("--force-with-lease" in part for command in push_commands for part in command))
+
+    def test_merged_rollup_adoption_uses_expected_remote_sha_force_with_lease(self) -> None:
+        fake = FakeGit(remote_sha="expected-remote")
+        fake.gh_rows = [{"number": 45, "headRefOid": "old-head", "mergedAt": "2026-05-25T00:00:00Z"}]
+
+        self.daemon(fake).tick()
+
+        self.assertIn(
+            [
+                "git",
+                "push",
+                "--force-with-lease=refs/heads/auto-refact-dev:expected-remote",
+                "origin",
+                "HEAD:auto-refact-dev",
+            ],
+            fake.commands,
+        )
+
+    def test_rollup_adoption_unknown_old_head_emits_pending_event_without_push(self) -> None:
+        fake = FakeGit(remote_sha="expected-remote")
+        fake.gh_rows = [{"number": 45, "headRefOid": "", "mergedAt": "2026-05-25T00:00:00Z"}]
+
+        self.daemon(fake).tick()
+
+        events = self.repo / ".refactor-loop" / ".controller-pending-events.log"
+        self.assertIn("DEV_SYNC_PENDING:rollup-adoption-ambiguous:missing-headRefOid", events.read_text())
+        self.assertFalse(any(command[:2] == ["git", "push"] for command in fake.commands))
+
+
+class IntegrationSyncDaemonV1SourceRegressionTests(unittest.TestCase):
+    def test_skill_phase6_names_integration_sync_daemon_v1(self) -> None:
+        text = SKILL_MD.read_text(encoding="utf-8")
+        self.assertIn("Named exception: `IntegrationSyncDaemonV1`", text)
+        self.assertIn("resolver continuation push", text)
+        self.assertIn("merged-rollup adoption", text)
+
+    def test_reference_has_no_active_controller_sync_procedure(self) -> None:
+        text = REFERENCE_MD.read_text(encoding="utf-8")
+        self.assertNotIn("### Sync procedure", text)
+        self.assertNotIn("### Sync cadence", text)
+        self.assertNotIn("Every controller wakeup (cheap when `behind == 0`)", text)
+        self.assertIn("IntegrationSyncDaemonV1", text)
+
+    def test_reference_integration_sync_state_is_absent_or_non_contractual(self) -> None:
+        text = REFERENCE_MD.read_text(encoding="utf-8")
+        self.assertNotIn('"integration_sync"', text)
+        self.assertNotIn("last_sync_added_commits", text)
+        self.assertNotIn("consecutive_failures", text)
+
+    def test_dev_sync_reset_is_after_local_ahead_guard(self) -> None:
+        src = DEV_SYNC.read_text(encoding="utf-8")
+        self.assertLess(src.index("push_clean_local_ahead_before_reset(cwd)"), src.index("reset_to_remote(cwd)"))
+        self.assertIn("def local_ahead_count", src)
+        self.assertIn("rev-list\", \"--count\", f\"origin/{self.integration}..HEAD", src)
+
+    def test_dev_sync_force_with_lease_is_adoption_only(self) -> None:
+        src = DEV_SYNC.read_text(encoding="utf-8")
+        self.assertEqual(src.count("--force-with-lease="), 1)
+        lease_i = src.index("--force-with-lease=")
+        adopt_i = src.index("def adopt_merged_rollup")
+        forward_i = src.index("def forward_sync_review_base")
+        self.assertGreater(lease_i, adopt_i)
+        self.assertLess(lease_i, forward_i)
+
+    def test_project_rules_unchanged_and_no_forbidden_abstractions_for_integration_sync_daemon_v1(self) -> None:
+        for path in (CLAUDE_MD, AGENTS_MD):
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn("IntegrationSyncDaemonV1", text)
+            self.assertNotIn("merged-rollup adoption", text)
+        src = DEV_SYNC.read_text(encoding="utf-8")
+        for forbidden in (
+            "IAsyncEnumerable",
+            "Channel",
+            "actor inbox",
+            "projection pipeline",
+            "event envelope",
+            "WorkUnitV2",
+            "ControllerEvent",
+            "ControllerCommand",
+            "ControllerOrchestrator",
+            "generic event bus",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
+++ b/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
@@ -27,14 +27,67 @@ AGENTS_MD = REPO_ROOT / "AGENTS.md"
 
 
 class FakeGit:
-    def __init__(self, *, ahead: int = 0, behind: int = 0, remote_sha: str = "remote-sha") -> None:
+    def __init__(
+        self,
+        *,
+        ahead: int = 0,
+        behind: int = 0,
+        remote_sha: str = "remote-sha",
+        ahead_stdout: str | None = None,
+        behind_stdout: str | None = None,
+        replay_count: int = 0,
+        replay_count_stdout: str | None = None,
+        remote_sha_returncode: int = 0,
+        remote_sha_stderr: str = "",
+        gh_rows: list[dict] | None = None,
+        gh_stdout: str | None = None,
+        gh_returncode: int = 0,
+        gh_stderr: str = "",
+        merge_base_adopted: bool = False,
+        old_head_is_ancestor: bool = True,
+        ff_returncode: int | None = None,
+        ff_stdout: str | None = None,
+        ff_stderr: str = "",
+        no_ff_returncode: int = 0,
+        no_ff_stdout: str = "",
+        no_ff_stderr: str = "",
+        reset_fail_targets: set[str] | None = None,
+        reset_stderr: str = "",
+        rebase_returncode: int = 0,
+        rebase_stderr: str = "",
+        push_returncode: int = 0,
+        force_push_returncode: int | None = None,
+        push_stderr: str = "",
+    ) -> None:
         self.ahead = ahead
         self.behind = behind
         self.remote_sha = remote_sha
+        self.ahead_stdout = ahead_stdout
+        self.behind_stdout = behind_stdout
+        self.replay_count = replay_count
+        self.replay_count_stdout = replay_count_stdout
+        self.remote_sha_returncode = remote_sha_returncode
+        self.remote_sha_stderr = remote_sha_stderr
+        self.gh_stdout = gh_stdout
+        self.gh_returncode = gh_returncode
+        self.gh_stderr = gh_stderr
+        self.merge_base_adopted = merge_base_adopted
+        self.old_head_is_ancestor = old_head_is_ancestor
+        self.ff_returncode = ff_returncode
+        self.ff_stdout = ff_stdout
+        self.ff_stderr = ff_stderr
+        self.no_ff_returncode = no_ff_returncode
+        self.no_ff_stdout = no_ff_stdout
+        self.no_ff_stderr = no_ff_stderr
+        self.reset_fail_targets = reset_fail_targets or set()
+        self.reset_stderr = reset_stderr
+        self.rebase_returncode = rebase_returncode
+        self.rebase_stderr = rebase_stderr
+        self.push_returncode = push_returncode
+        self.force_push_returncode = force_push_returncode
+        self.push_stderr = push_stderr
         self.commands: list[list[str]] = []
-        self.gh_rows: list[dict] = []
-        self.merge_base_adopted = False
-        self.old_head_is_ancestor = True
+        self.gh_rows: list[dict] = gh_rows or []
 
     def __call__(self, cmd: list[str], cwd: Path | None = None, check: bool = False) -> subprocess.CompletedProcess:
         self.commands.append(cmd)
@@ -46,28 +99,48 @@ class FakeGit:
         elif cmd[:3] == ["git", "rev-list", "--count"]:
             spec = cmd[3]
             if spec.startswith("origin/auto-refact-dev..HEAD"):
-                stdout = f"{self.ahead}\n"
+                stdout = self.ahead_stdout if self.ahead_stdout is not None else f"{self.ahead}\n"
             elif spec.startswith("HEAD..origin/dev"):
-                stdout = f"{self.behind}\n"
+                stdout = self.behind_stdout if self.behind_stdout is not None else f"{self.behind}\n"
+            elif spec.startswith("old-head..origin/auto-refact-dev"):
+                stdout = self.replay_count_stdout if self.replay_count_stdout is not None else f"{self.replay_count}\n"
             else:
                 stdout = "0\n"
         elif cmd[:3] == ["git", "rev-parse", "origin/auto-refact-dev"]:
-            stdout = f"{self.remote_sha}\n"
+            returncode = self.remote_sha_returncode
+            stdout = f"{self.remote_sha}\n" if returncode == 0 else ""
+            stderr = self.remote_sha_stderr
         elif cmd[:3] == ["git", "merge-base", "--is-ancestor"]:
             if cmd[3] == "origin/dev":
                 returncode = 0 if self.merge_base_adopted else 1
             else:
                 returncode = 0 if self.old_head_is_ancestor else 1
         elif cmd[:3] == ["gh", "pr", "list"]:
-            stdout = json.dumps(self.gh_rows)
+            returncode = self.gh_returncode
+            stdout = self.gh_stdout if self.gh_stdout is not None else json.dumps(self.gh_rows)
+            stderr = self.gh_stderr
         elif cmd[:3] == ["git", "merge", "--ff-only"]:
-            stdout = "Already up to date\n" if self.behind == 0 else "Fast-forward\n"
+            returncode = self.ff_returncode if self.ff_returncode is not None else 0
+            stdout = self.ff_stdout if self.ff_stdout is not None else ("Already up to date\n" if self.behind == 0 else "Fast-forward\n")
+            stderr = self.ff_stderr
         elif cmd[:2] == ["git", "push"]:
-            pass
+            is_force_push = any(part.startswith("--force-with-lease=") for part in cmd)
+            if is_force_push and self.force_push_returncode is not None:
+                returncode = self.force_push_returncode
+            else:
+                returncode = self.push_returncode
+            stderr = self.push_stderr
         elif cmd[:3] == ["git", "reset", "--hard"]:
-            pass
+            if cmd[3] in self.reset_fail_targets:
+                returncode = 1
+                stderr = self.reset_stderr
         elif cmd[:3] == ["git", "rebase", "--rebase-merges"]:
-            pass
+            returncode = self.rebase_returncode
+            stderr = self.rebase_stderr
+        elif cmd[:3] == ["git", "merge", "--no-ff"]:
+            returncode = self.no_ff_returncode
+            stdout = self.no_ff_stdout
+            stderr = self.no_ff_stderr
         return subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
 
 
@@ -101,6 +174,12 @@ class IntegrationSyncDaemonV1BehaviorTests(unittest.TestCase):
             if command[: len(needle)] == needle:
                 return index
         self.fail(f"missing command prefix {needle!r} in {fake.commands!r}")
+
+    def pending_events(self) -> list[str]:
+        path = self.repo / ".refactor-loop" / ".controller-pending-events.log"
+        if not path.exists():
+            return []
+        return path.read_text(encoding="utf-8").splitlines()
 
     def test_clean_local_ahead_is_pushed_before_reset(self) -> None:
         fake = FakeGit(ahead=2)
@@ -161,6 +240,467 @@ class IntegrationSyncDaemonV1BehaviorTests(unittest.TestCase):
         events = self.repo / ".refactor-loop" / ".controller-pending-events.log"
         self.assertIn("DEV_SYNC_PENDING:rollup-adoption-ambiguous:missing-headRefOid", events.read_text())
         self.assertFalse(any(command[:2] == ["git", "push"] for command in fake.commands))
+
+    def test_merged_rollup_adoption_replays_post_rollup_commits_before_force_push(self) -> None:
+        fake = FakeGit(
+            remote_sha="expected-remote",
+            gh_rows=[{"number": 45, "headRefOid": "old-head", "mergedAt": "2026-05-25T00:00:00Z"}],
+            replay_count=2,
+        )
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "rev-parse", "origin/auto-refact-dev"],
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--state",
+                    "merged",
+                    "--head",
+                    "auto-refact-dev",
+                    "--base",
+                    "dev",
+                    "--limit",
+                    "1",
+                    "--json",
+                    "number,headRefOid,mergedAt",
+                ],
+                ["git", "merge-base", "--is-ancestor", "old-head", "origin/auto-refact-dev"],
+                ["git", "rev-list", "--count", "old-head..origin/auto-refact-dev"],
+                ["git", "reset", "--hard", "origin/auto-refact-dev"],
+                ["git", "rebase", "--rebase-merges", "--onto", "origin/dev", "old-head"],
+                [
+                    "git",
+                    "push",
+                    "--force-with-lease=refs/heads/auto-refact-dev:expected-remote",
+                    "origin",
+                    "HEAD:auto-refact-dev",
+                ],
+            ],
+        )
+        self.assertEqual(self.pending_events(), [])
+
+    def test_rollup_post_rollup_count_unknown_emits_pending_event(self) -> None:
+        fake = FakeGit(
+            gh_rows=[{"number": 45, "headRefOid": "old-head", "mergedAt": "2026-05-25T00:00:00Z"}],
+            replay_count_stdout="not-a-number\n",
+        )
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(
+            self.pending_events(),
+            ["DEV_SYNC_PENDING:rollup-adoption-ambiguous:post-rollup-count-unknown"],
+        )
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "rev-parse", "origin/auto-refact-dev"],
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--state",
+                    "merged",
+                    "--head",
+                    "auto-refact-dev",
+                    "--base",
+                    "dev",
+                    "--limit",
+                    "1",
+                    "--json",
+                    "number,headRefOid,mergedAt",
+                ],
+                ["git", "merge-base", "--is-ancestor", "old-head", "origin/auto-refact-dev"],
+                ["git", "rev-list", "--count", "old-head..origin/auto-refact-dev"],
+            ],
+        )
+
+    def test_rollup_adoption_reset_failed_emits_pending_event(self) -> None:
+        fake = FakeGit(
+            gh_rows=[{"number": 45, "headRefOid": "old-head", "mergedAt": "2026-05-25T00:00:00Z"}],
+            replay_count=1,
+            reset_fail_targets={"origin/auto-refact-dev"},
+            reset_stderr="reset denied",
+        )
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(
+            self.pending_events(),
+            ["DEV_SYNC_PENDING:rollup-adoption-reset-failed:reset denied"],
+        )
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "rev-parse", "origin/auto-refact-dev"],
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--state",
+                    "merged",
+                    "--head",
+                    "auto-refact-dev",
+                    "--base",
+                    "dev",
+                    "--limit",
+                    "1",
+                    "--json",
+                    "number,headRefOid,mergedAt",
+                ],
+                ["git", "merge-base", "--is-ancestor", "old-head", "origin/auto-refact-dev"],
+                ["git", "rev-list", "--count", "old-head..origin/auto-refact-dev"],
+                ["git", "reset", "--hard", "origin/auto-refact-dev"],
+            ],
+        )
+
+    def test_rollup_adoption_replay_conflict_emits_pending_event(self) -> None:
+        fake = FakeGit(
+            gh_rows=[{"number": 45, "headRefOid": "old-head", "mergedAt": "2026-05-25T00:00:00Z"}],
+            replay_count=1,
+            rebase_returncode=1,
+            rebase_stderr="rebase conflict",
+        )
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(
+            self.pending_events(),
+            ["DEV_SYNC_PENDING:rollup-adoption-replay-conflict:rebase conflict"],
+        )
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "rev-parse", "origin/auto-refact-dev"],
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--state",
+                    "merged",
+                    "--head",
+                    "auto-refact-dev",
+                    "--base",
+                    "dev",
+                    "--limit",
+                    "1",
+                    "--json",
+                    "number,headRefOid,mergedAt",
+                ],
+                ["git", "merge-base", "--is-ancestor", "old-head", "origin/auto-refact-dev"],
+                ["git", "rev-list", "--count", "old-head..origin/auto-refact-dev"],
+                ["git", "reset", "--hard", "origin/auto-refact-dev"],
+                ["git", "rebase", "--rebase-merges", "--onto", "origin/dev", "old-head"],
+            ],
+        )
+
+    def test_rollup_adoption_push_failed_emits_pending_event(self) -> None:
+        fake = FakeGit(
+            remote_sha="expected-remote",
+            gh_rows=[{"number": 45, "headRefOid": "old-head", "mergedAt": "2026-05-25T00:00:00Z"}],
+            force_push_returncode=1,
+            push_stderr="lease rejected",
+        )
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(
+            self.pending_events(),
+            ["DEV_SYNC_PENDING:rollup-adoption-push-failed:lease rejected"],
+        )
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "rev-parse", "origin/auto-refact-dev"],
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--state",
+                    "merged",
+                    "--head",
+                    "auto-refact-dev",
+                    "--base",
+                    "dev",
+                    "--limit",
+                    "1",
+                    "--json",
+                    "number,headRefOid,mergedAt",
+                ],
+                ["git", "merge-base", "--is-ancestor", "old-head", "origin/auto-refact-dev"],
+                ["git", "rev-list", "--count", "old-head..origin/auto-refact-dev"],
+                ["git", "reset", "--hard", "origin/dev"],
+                [
+                    "git",
+                    "push",
+                    "--force-with-lease=refs/heads/auto-refact-dev:expected-remote",
+                    "origin",
+                    "HEAD:auto-refact-dev",
+                ],
+            ],
+        )
+
+    def test_local_ahead_unknown_emits_pending_event_and_continues_to_normal_sync(self) -> None:
+        fake = FakeGit(ahead_stdout="unknown\n", merge_base_adopted=True)
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(
+            self.pending_events(),
+            ["DEV_SYNC_PENDING:local-ahead-unknown:"],
+        )
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "reset", "--hard", "origin/auto-refact-dev"],
+                ["git", "rev-list", "--count", "HEAD..origin/dev"],
+            ],
+        )
+
+    def test_remote_sha_unknown_emits_pending_event_without_reset(self) -> None:
+        fake = FakeGit(remote_sha_returncode=1, remote_sha_stderr="missing remote")
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(
+            self.pending_events(),
+            ["DEV_SYNC_PENDING:remote-sha-unknown:missing remote"],
+        )
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "rev-parse", "origin/auto-refact-dev"],
+            ],
+        )
+
+    def test_local_ahead_push_failed_emits_pending_event_without_reset(self) -> None:
+        fake = FakeGit(ahead=1, push_returncode=1, push_stderr="push rejected")
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(
+            self.pending_events(),
+            ["DEV_SYNC_PENDING:local-ahead-push-failed:push rejected"],
+        )
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "push", "origin", "HEAD:auto-refact-dev"],
+            ],
+        )
+
+    def test_gh_json_decode_failed_emits_pending_event_without_reset(self) -> None:
+        fake = FakeGit(gh_stdout="{not json")
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(
+            self.pending_events(),
+            ["DEV_SYNC_PENDING:rollup-adoption-ambiguous:gh-json-decode-failed"],
+        )
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "rev-parse", "origin/auto-refact-dev"],
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--state",
+                    "merged",
+                    "--head",
+                    "auto-refact-dev",
+                    "--base",
+                    "dev",
+                    "--limit",
+                    "1",
+                    "--json",
+                    "number,headRefOid,mergedAt",
+                ],
+            ],
+        )
+
+    def test_old_head_not_ancestor_emits_pending_event_without_reset(self) -> None:
+        fake = FakeGit(
+            gh_rows=[{"number": 45, "headRefOid": "old-head", "mergedAt": "2026-05-25T00:00:00Z"}],
+            old_head_is_ancestor=False,
+        )
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(
+            self.pending_events(),
+            ["DEV_SYNC_PENDING:rollup-adoption-ambiguous:old-head-not-ancestor:old-head"],
+        )
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "rev-parse", "origin/auto-refact-dev"],
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--state",
+                    "merged",
+                    "--head",
+                    "auto-refact-dev",
+                    "--base",
+                    "dev",
+                    "--limit",
+                    "1",
+                    "--json",
+                    "number,headRefOid,mergedAt",
+                ],
+                ["git", "merge-base", "--is-ancestor", "old-head", "origin/auto-refact-dev"],
+            ],
+        )
+
+    def test_forward_sync_no_ff_merge_success_pushes_integration_branch(self) -> None:
+        fake = FakeGit(
+            behind=2,
+            merge_base_adopted=True,
+            ff_returncode=1,
+            ff_stdout="Not possible\n",
+            no_ff_returncode=0,
+        )
+
+        self.daemon(fake).tick()
+
+        self.assertEqual(self.pending_events(), [])
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "reset", "--hard", "origin/auto-refact-dev"],
+                ["git", "rev-list", "--count", "HEAD..origin/dev"],
+                ["git", "merge", "--ff-only", "origin/dev"],
+                [
+                    "git",
+                    "merge",
+                    "--no-ff",
+                    "-m",
+                    "Sync auto-refact-dev with dev (auto by dev_sync_daemon)",
+                    "origin/dev",
+                ],
+                ["git", "push", "origin", "HEAD:auto-refact-dev"],
+            ],
+        )
+
+    def test_forward_sync_merge_conflict_dispatches_resolver(self) -> None:
+        fake = FakeGit(
+            behind=2,
+            merge_base_adopted=True,
+            ff_returncode=1,
+            no_ff_returncode=1,
+            no_ff_stderr="conflict",
+        )
+        merge_checks = iter([False, True])
+        dispatched: list[bool] = []
+
+        self.daemon(
+            fake,
+            merge_detector=lambda _cwd: next(merge_checks),
+            resolver_in_flight=lambda: False,
+            resolver_dispatcher=lambda: dispatched.append(True),
+        ).tick()
+
+        self.assertEqual(dispatched, [True])
+        self.assertEqual(self.pending_events(), [])
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "reset", "--hard", "origin/auto-refact-dev"],
+                ["git", "rev-list", "--count", "HEAD..origin/dev"],
+                ["git", "merge", "--ff-only", "origin/dev"],
+                [
+                    "git",
+                    "merge",
+                    "--no-ff",
+                    "-m",
+                    "Sync auto-refact-dev with dev (auto by dev_sync_daemon)",
+                    "origin/dev",
+                ],
+            ],
+        )
+
+    def test_forward_sync_merge_conflict_skips_dispatch_when_resolver_in_flight(self) -> None:
+        fake = FakeGit(
+            behind=2,
+            merge_base_adopted=True,
+            ff_returncode=1,
+            no_ff_returncode=1,
+            no_ff_stderr="conflict",
+        )
+        merge_checks = iter([False, True])
+        dispatched: list[bool] = []
+
+        self.daemon(
+            fake,
+            merge_detector=lambda _cwd: next(merge_checks),
+            resolver_in_flight=lambda: True,
+            resolver_dispatcher=lambda: dispatched.append(True),
+        ).tick()
+
+        self.assertEqual(dispatched, [])
+        self.assertEqual(self.pending_events(), [])
+        self.assertEqual(
+            fake.commands,
+            [
+                ["git", "fetch", "origin", "--quiet"],
+                ["git", "rev-list", "--count", "origin/auto-refact-dev..HEAD"],
+                ["git", "merge-base", "--is-ancestor", "origin/dev", "origin/auto-refact-dev"],
+                ["git", "reset", "--hard", "origin/auto-refact-dev"],
+                ["git", "rev-list", "--count", "HEAD..origin/dev"],
+                ["git", "merge", "--ff-only", "origin/dev"],
+                [
+                    "git",
+                    "merge",
+                    "--no-ff",
+                    "-m",
+                    "Sync auto-refact-dev with dev (auto by dev_sync_daemon)",
+                    "origin/dev",
+                ],
+            ],
+        )
 
 
 class IntegrationSyncDaemonV1SourceRegressionTests(unittest.TestCase):


### PR DESCRIPTION
## Phase 9 r4 共识(structural,3/3 endorse B)

Closes #27

### What

在现有 `dev_sync_daemon.py` 内引入**命名** `IntegrationSyncDaemonV1` state machine,**不**新增 daemon process / event envelope / proto / WorkUnitV2。该 state machine 收编:integration branch auto-sync + resolver continuation push + merged-rollup adoption。

- `SKILL.md` 加 Phase 6 named exception 段
- `REFERENCE.md` 清旧 controller-owned sync prose,加 manual recovery + post-rollup adoption invariant
- `dev_sync_daemon.py` 加 state machine + helpers(local_ahead_count / rollup adoption / resolver continuation push)
- `test_dev_sync_daemon_state_machine.py` 新增,12 tests(6 behavior + 6 source-regression)

**不动**:`CLAUDE.md`/`AGENTS.md`(PR #45 已扩例外)、其他 daemon、controller_lib.sh、spawn-codex.sh、phase9_router_daemon.py。

### Verify

- 本地 `python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → 全绿(12 新)

⟦AI:AUTO-LOOP⟧