### PR TITLE
chore(skill): worktree 改约定 inside `<repo>/.worktrees/<name>/`(audit-derived hygiene)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ __pycache__/
 node_modules/
 
 # Git worktrees(skill 运行时可能创建)
-.worktrees/
+/.worktrees/
 
 # Claude Code 本地设置(.claude/skills 软链需 track,故只忽略本地设置)
 .claude/settings.local.json

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -12,6 +12,10 @@ The following excerpts preserve the detailed controller runbook that was moved o
 
 dogfood 运行中固化的操作经验。host 注入的配置集中放 `$REPO_ROOT/.refactor-loop/host.env`(`export REPO_ROOT/GH_REPO_SLUG/INTEGRATION_BRANCH/REVIEW_BASE_BRANCH/BUILD_CMD/TEST_CMD/CI_GUARDS/SOURCE_GLOBS/MAINTAINER_WHITELIST` 等)。
 
+### Worktree 位置约定(强制)
+
+所有 daemon/codex/implement worktree 都在 `$REPO_ROOT/.worktrees/` 内,路径形如 `$REPO_ROOT/.worktrees/<name>/`。仓库根 `.gitignore` 必须包含 `/.worktrees/`,因此这些运行时 worktree 不进入发布产物。旧 sibling pattern `<repo>-wt-<name>/` 只作为历史兼容/清理线索出现,不得作为新 worktree 创建位置。
+
 ### Daemon 启动(强制 pattern — 必须注入 host.env)
 
 **禁止** 裸 `nohup python3 <daemon> &`(拿不到 host 配置)与 `nohup env $(grep ... host.env) <daemon> &`(`BUILD_CMD="cargo build --workspace"` 含空格 → `env` 把 `build` 当命令崩)。**唯一正确**:用 `bash -c 'source host.env && exec'` 注入后再 exec:
@@ -54,7 +58,7 @@ ScheduleWakeup 是 daemon-event Monitor bridge / task-notification 丢失时**�
 **更隐蔽的同机多 loop 过计(dogfood 实测)**:即使只数「含 `spawn-codex.sh`」的 codex,如果再用**相对子串** `.refactor-loop/logs/` / `.refactor-loop/prompts/` 做 scope,**同一台机器跑两个不同仓库的本 skill 时会互相过计**——两个 loop 的相对路径子串完全相同。实测另一 host 的 loop 在跑时,本仓库 `concurrency_monitor` 报 `actual=8` 而本仓库实际只有 1 个 codex,floor 被骗成"满",本仓库 codex 永远补不上去、可能长期单线程。
 
 **修正(强制)**:floor 只数**本仓库(本 loop)的 codex** —— 命令行含 `spawn-codex.sh` **且含本仓库绝对路径 `$REPO_ROOT`**。
-- spawn 时 caller **必须传绝对 `--cd`**(audit 用 `--cd $REPO_ROOT`;implement/verify 用绝对 worktree 路径),使 `$REPO_ROOT` 进入进程 cmdline;sibling worktree `<repo>-wt-*` 以 `$REPO_ROOT` 为前缀,亦匹配。
+- spawn 时 caller **必须传绝对 `--cd`**(audit 用 `--cd $REPO_ROOT`;implement/verify 用绝对 worktree 路径),使 `$REPO_ROOT` 进入进程 cmdline;inside worktree `<repo>/.worktrees/*` 以 `$REPO_ROOT` 为前缀,亦匹配。
 - ❌ **不要**只用相对子串 `.refactor-loop/logs/` 做 scope(同机多 loop 互相过计)。
 - **去重(强制)**:每个 codex 会派生**两个**含 `spawn-codex.sh` 的进程 —— 真 supervisor(`bash <path>/spawn-codex.sh --cd ...`)+ 一个 shell `-c` wrapper(harness 后台任务回显整条命令)。两个都数 = 每个真 codex 被算成 2,`CODEX_FLOOR=2` 会被**单个**真 codex 满足 → 永远凑不到真正 2 并行。**排除含 ` -c ` 的行**,只数真 supervisor(spawn-codex.sh 自身不带 ` -c ` flag)。
 - 不数 host 其它系统 / 其它仓库的 codex。
@@ -537,9 +541,9 @@ Update state, advance to Phase 2 (with requires_design clusters excluded).
 
 ### Stale-worktree audit pollution(强制 pre-audit cleanup)
 
-**Bug 来源**:audit codex 默认在 `--cd $REPO_ROOT` 下扫描,但 `find` / `rg` 会无视 git boundary 扫到 sibling worktrees(`<repo>-wt-iterN-cluster-*` 等)。已 merge 但未清理的 worktree 里仍保留 pre-refactor src 文件,audit 把那些当成"现状"出 evidence,导致 cluster 描述指向 main 中**已删除**的文件路径(file:line 在 main 不存在)。
+**Bug 来源**:audit codex 默认在 `--cd $REPO_ROOT` 下扫描,但 `find` / `rg` 会无视 git boundary 扫到 inside worktrees(`$REPO_ROOT/.worktrees/iterN-cluster-*` 等)。已 merge 但未清理的 worktree 里仍保留 pre-refactor src 文件,audit 把那些当成"现状"出 evidence,导致 cluster 描述指向 main 中**已删除**的文件路径(file:line 在 main 不存在)。
 
-结构性教训:曾出现 audit 从已合并但未清理的 sibling worktree 读取过期 evidence,导致 cluster 指向 main 中已删除的 file:line。pre-audit 必须清理 stale worktree,并抽查 evidence file:line 在当前 main 真实存在。
+结构性教训:曾出现 audit 从已合并但未清理的 worktree 读取过期 evidence,导致 cluster 指向 main 中已删除的 file:line。pre-audit 必须清理 stale worktree,并抽查 evidence file:line 在当前 main 真实存在。
 
 **强制 pre-audit 步骤**(每次派 audit codex 前 controller 执行):
 
@@ -577,8 +581,9 @@ For each cluster in the current batch:
 1. Create worktree:
 
    ```bash
+   mkdir -p "$REPO_ROOT/.worktrees"
    git worktree add -b refactor/iterN-<cluster-id> \
-     .refactor-loop/worktrees/<cluster-id> HEAD
+     "$REPO_ROOT/.worktrees/iterN-<cluster-id>" HEAD
    ```
 
 2. Materialize prompt: copy `prompts/implement.md`, replace placeholders (`{{work_unit_id}}`,
@@ -648,7 +653,7 @@ $BUILD_CMD
 
 结构性教训:两个独立 PR 各自 CI 绿仍可能在顺序 merge 后引入 trunk build break,典型原因是一个 PR 重命名 API、另一个 PR 仍引用旧名。每次 merge 后必须在 trunk 重新跑 `$BUILD_CMD`,失败则立即派 hotfix codex。
 
-**cwd discipline (critical)**: `git merge`, `git push`, and `gh pr create` MUST run from `$REPO_ROOT`, never from a worktree directory. Cwd persists across Bash invocations in the harness, so chained commands that include `cd .refactor-loop/worktrees/<id>` leak cwd into the next call. Always either start the trunk-side command with `cd "$REPO_ROOT" && …` or run it in a separate Bash invocation after the worktree-scoped commit. If you see `Already up to date.` after a merge, that is the signature of cwd leak — diagnose and redo from `$REPO_ROOT`.
+**cwd discipline (critical)**: `git merge`, `git push`, and `gh pr create` MUST run from `$REPO_ROOT`, never from a worktree directory. Cwd persists across Bash invocations in the harness, so chained commands that include `cd "$REPO_ROOT/.worktrees/<id>"` leak cwd into the next call. Always either start the trunk-side command with `cd "$REPO_ROOT" && …` or run it in a separate Bash invocation after the worktree-scoped commit. If you see `Already up to date.` after a merge, that is the signature of cwd leak — diagnose and redo from `$REPO_ROOT`.
 
 For each `pass` cluster, serially:
 
@@ -756,7 +761,7 @@ For each `pass` cluster, serially:
      # If empty, gh pr create --base "<review_base_branch>" --head "<integration_branch>" --title "Refactor iter<N>: rollup" --body <scorecard.md>
      ```
 
-After merge of the cluster branch into its target → `git worktree remove .refactor-loop/worktrees/<cluster-id>`. **Do NOT** delete the cluster branch yet under `stacked` mode — downstream PRs may still reference it as base; let GitHub auto-delete on merge.
+After merge of the cluster branch into its target → `git worktree remove "$REPO_ROOT/.worktrees/<cluster-id>"`. **Do NOT** delete the cluster branch yet under `stacked` mode — downstream PRs may still reference it as base; let GitHub auto-delete on merge.
 
 If no clusters left in current batch → start next batch (Phase 2 again). If no batches left → start next iteration (Phase 1 again) or **start Phase 5 if there is an open PR for the trunk/cluster branches**.
 
@@ -1428,7 +1433,7 @@ This means: even if a previous round escalated with `auto-loop-stuck`, a new mai
 | 下一步自动会做 | 1. 创 worktree + branch  2. 派 implement codex(5400s no-output stall window)  3. implement done 后 open PR + Phase 8 reviewer  4. PR merge 后 close 本 issue |
 | **是否需要人介入** | **❌ 否**(自动推进;maintainer 仍可在本 issue 评论 override) |
 
-📦 implement worktree:\`$REPO_ROOT-wt-iter${ITER}-${CLUSTER_ID}\`
+📦 implement worktree:\`$REPO_ROOT/.worktrees/iter${ITER}-${CLUSTER_ID}\`
 📦 implement branch:\`refactor/iter${ITER}-${CLUSTER_ID}-${SLUG}\`
 
 🤖 controller consensus card
@@ -2330,7 +2335,7 @@ If a cluster cannot fit in any new batch ≤ `max_parallel_clusters`, start a ne
 
 ### cwd leak in Phase 4 ("Already up to date.")
 
-Symptom: `git merge` after a `cd .refactor-loop/worktrees/<id>` chain prints `Already up to date.` instead of merging the branch into trunk.
+Symptom: `git merge` after a `cd "$REPO_ROOT/.worktrees/<id>"` chain prints `Already up to date.` instead of merging the branch into trunk.
 
 Cause: the harness persists Bash cwd across invocations, so an earlier `cd` into the worktree leaks into the merge call. The merge then runs from inside the worktree (which is already at the branch's tip), so git correctly reports no-op.
 

--- a/skills/codex-refactor-loop/scripts/concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/concurrency_monitor.py
@@ -127,7 +127,7 @@ def count_in_flight_codex() -> int:
     OTHER host's codex too (observed actual=8 when this repo had 1) -> floor looks
     permanently "full" and this repo can starve below its minimum. Scope by the
     absolute REPO_ROOT: spawn-codex.sh always carries it (caller passes an absolute
-    --cd; sibling worktree paths `<repo>-wt-...` are REPO_ROOT-prefixed too), so a
+    --cd; inside worktree paths `<repo>/.worktrees/...` are REPO_ROOT-prefixed too), so a
     foreign loop at a different path is correctly excluded.
 
     Contract: callers MUST pass an absolute --cd (and absolute --log/--add-dir) so

--- a/skills/codex-refactor-loop/scripts/controller_lib.sh
+++ b/skills/codex-refactor-loop/scripts/controller_lib.sh
@@ -40,14 +40,16 @@ fi
 # Fixes "git worktree add already exists" — detect-or-create
 # Usage: safe_worktree <iter> <cluster-id> <base-ref>
 # Sets WT_PATH and BRANCH env vars on success.
+# Refactor (iter4/skill-worktree-inside-repo): Old pattern: sibling `<repo>-wt-<name>/`. New principle: inside `<repo>/.worktrees/<name>/` + gitignored.
 safe_worktree() {
   local iter="$1" cluster="$2" base="$3"
-  WT_PATH="${REPO_ROOT}-wt-iter${iter}-${cluster}"
+  WT_PATH="${REPO_ROOT}/.worktrees/iter${iter}-${cluster}"
   BRANCH="refactor/iter${iter}-${cluster}"
   if [ -d "$WT_PATH" ]; then
     echo "  ✓ worktree exists: $WT_PATH" >&2
     return 0
   fi
+  mkdir -p "${REPO_ROOT}/.worktrees"
   if git -C "$REPO_ROOT" show-ref --quiet "refs/heads/$BRANCH"; then
     git -C "$REPO_ROOT" worktree add "$WT_PATH" "$BRANCH" 2>&1 | tail -2 >&2
   else

--- a/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
+++ b/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
+# Refactor (iter4/skill-worktree-inside-repo): Old pattern: sibling `<repo>-wt-<name>/`. New principle: inside `<repo>/.worktrees/<name>/` + gitignored.
 """
 dev_sync_daemon.py — 自动 merge origin/dev → auto-refact-dev 的 daemon
 
 daemon 跑在独立 worktree,main repo controller 工作不受 daemon 的 merge 状态干扰。
 
 设计:
-- 独立 worktree:$REPO_ROOT-wt-dev-sync(off auto-refact-dev)
+- 独立 worktree:$REPO_ROOT/.worktrees/dev-sync(off auto-refact-dev)
 - 600s 周期 check `git rev-list HEAD..origin/dev`
 - behind>0:try ff-only → no-ff merge → 冲突 spawn-codex resolve
 - 成功 → push origin auto-refact-dev → main repo controller 下次 fetch 拉到
@@ -71,7 +72,7 @@ def skill_root() -> Path:
 INTERVAL = int(os.environ.get("INTERVAL", "600"))
 SKILL_ROOT = skill_root()
 MAIN_REPO = git_repo_root()
-WORKTREE = Path(os.environ.get("WORKTREE", f"{MAIN_REPO}-wt-dev-sync"))
+WORKTREE = Path(os.environ.get("WORKTREE", str(MAIN_REPO / ".worktrees" / "dev-sync")))
 INTEGRATION = os.environ.get("INTEGRATION_BRANCH") or os.environ.get("INTEGRATION") or "auto-refact-dev"
 REVIEW_BASE = os.environ.get("REVIEW_BASE_BRANCH") or os.environ.get("REVIEW_BASE") or "dev"
 SPAWN_CODEX = SKILL_ROOT / "scripts" / "spawn-codex.sh"

--- a/skills/codex-refactor-loop/scripts/peek.sh
+++ b/skills/codex-refactor-loop/scripts/peek.sh
@@ -300,7 +300,7 @@ git worktree list --porcelain | grep "^worktree " | sed 's/^worktree //' | while
   base=$(basename "$wt")
   # skip main + dev-sync
   case "$base" in
-    "$(basename "$REPO_ROOT")" | "$(basename "$REPO_ROOT")-wt-dev-sync") continue ;;
+    "$(basename "$REPO_ROOT")" | "$(basename "$REPO_ROOT")-wt-dev-sync" | "dev-sync") continue ;;
   esac
   # If worktree branch is in remote merged-to-master list, mark stale
   branch=$(git -C "$wt" branch --show-current 2>/dev/null)

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -773,6 +773,17 @@ class WorktreeLocationConventionTests(unittest.TestCase):
         self.assertIn("Refactor (iter4/skill-worktree-inside-repo)", text)
         self.assertNotIn('f"{MAIN_REPO}-wt-dev-sync"', text)
 
+    def test_peek_sh_skip_list_covers_both_dev_sync_layouts(self):
+        """#50 共识:peek.sh case 必须 skip 历史 sibling 和新 inside dev-sync。
+        防 PR #50 后人改 peek.sh 漏掉一种导致 dev-sync 被误算成 stale worktree 清理。"""
+        src = (REPO_ROOT / "skills/codex-refactor-loop/scripts/peek.sh").read_text()
+        # 历史 sibling 兼容(已 merge 但未清理的旧 worktree)
+        self.assertIn('"$(basename "$REPO_ROOT")-wt-dev-sync"', src,
+            "peek.sh skip list 漏 sibling dev-sync(PR #50 前的历史路径)")
+        # 新 inside 路径
+        self.assertIn('"dev-sync"', src,
+            "peek.sh skip list 漏 inside dev-sync(PR #50 后的路径)")
+
     def test_no_sibling_worktree_pattern_in_active_scripts(self) -> None:
         allowed = {
             "scripts/peek.sh",

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -751,6 +751,55 @@ class ConcurrencyFloorSourceRegressionTests(unittest.TestCase):
         self.assertEqual(reference_text.count("**判定脚本**(controller wakeup step 1.5):"), 1)
 
 
+class WorktreeLocationConventionTests(unittest.TestCase):
+    # Refactor (iter4/skill-worktree-inside-repo): Old pattern: sibling `<repo>-wt-<name>/`. New principle: inside `<repo>/.worktrees/<name>/` + gitignored.
+    def test_safe_worktree_creates_inside_repo(self) -> None:
+        text = (SKILL_ROOT / "scripts" / "controller_lib.sh").read_text(encoding="utf-8")
+
+        self.assertIn('WT_PATH="${REPO_ROOT}/.worktrees/iter${iter}-${cluster}"', text)
+        self.assertIn('mkdir -p "${REPO_ROOT}/.worktrees"', text)
+        self.assertIn("Refactor (iter4/skill-worktree-inside-repo)", text)
+
+    def test_gitignore_has_worktrees_entry(self) -> None:
+        text = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+
+        self.assertIn("/.worktrees/", text.splitlines())
+
+    def test_dev_sync_daemon_uses_inside_path(self) -> None:
+        text = (SKILL_ROOT / "scripts" / "dev_sync_daemon.py").read_text(encoding="utf-8")
+
+        self.assertIn("独立 worktree:$REPO_ROOT/.worktrees/dev-sync", text)
+        self.assertIn('MAIN_REPO / ".worktrees" / "dev-sync"', text)
+        self.assertIn("Refactor (iter4/skill-worktree-inside-repo)", text)
+        self.assertNotIn('f"{MAIN_REPO}-wt-dev-sync"', text)
+
+    def test_no_sibling_worktree_pattern_in_active_scripts(self) -> None:
+        allowed = {
+            "scripts/peek.sh",
+        }
+        offenders: list[str] = []
+        for path in sorted((SKILL_ROOT / "scripts").glob("*")):
+            if not path.is_file():
+                continue
+            if path.name.startswith("test_"):
+                continue
+            rel = path.relative_to(SKILL_ROOT).as_posix()
+            if rel in allowed:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "${REPO_ROOT}-wt-" in text:
+                offenders.append(rel)
+
+        self.assertEqual(offenders, [])
+
+    def test_reference_md_documents_inside_convention(self) -> None:
+        text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+
+        self.assertIn("`$REPO_ROOT/.worktrees/<name>/`", text)
+        self.assertIn("`/.worktrees/`", text)
+        self.assertIn("所有 daemon/codex/implement worktree 都在 `$REPO_ROOT/.worktrees/` 内", text)
+
+
 class HumanLabelTaxonomySourceRegressionTests(unittest.TestCase):
     # Refactor (iter3/skill-human-label-taxonomy):
     #   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
@@ -935,10 +984,10 @@ class ScriptHygieneSourceRegressionTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             repo = root / "repo"
-            worktree = root / "repo-wt-dev-sync"
+            worktree = repo / ".worktrees" / "dev-sync"
             sibling = root / "sibling"
             repo.mkdir()
-            worktree.mkdir()
+            worktree.mkdir(parents=True)
             sibling.mkdir()
             env = os.environ.copy()
             env.update(
@@ -1191,7 +1240,7 @@ esac
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             repo = root / "repo"
-            wt = root / "repo-wt-dev-sync"
+            wt = repo / ".worktrees" / "dev-sync"
             repo.mkdir()
             self.run_git(repo, "init")
             self.run_git(repo, "config", "user.email", "test@example.invalid")
@@ -1203,6 +1252,7 @@ esac
             self.run_git(repo, "branch", "auto-refact-dev")
             (repo / "conflict.txt").write_text("dev\n", encoding="utf-8")
             self.run_git(repo, "commit", "-am", "dev change")
+            wt.parent.mkdir(parents=True)
             self.run_git(repo, "worktree", "add", "--detach", str(wt), "auto-refact-dev")
             (wt / "conflict.txt").write_text("integration\n", encoding="utf-8")
             self.run_git(wt, "commit", "-am", "integration change")


### PR DESCRIPTION
## 维护者明示

loning(2026-05-26):"worktree 为什么建立在外面, worktree 建立在仓库里面然后 ignores"

7 文件机械改 + 5 source-regression test(`WorktreeLocationConventionTests`)。`.gitignore` 已含 `/.worktrees/` 预先就位。属 audit-derived `requires_design=false` 型 hygiene,软依赖 PR #48(扩 CLAUDE 例外覆盖此类型)。

⟦AI:AUTO-LOOP⟧