### PR TITLE
feat(skill): #51 Claude Code statusline(Phase 9 r3 consensus C minimal)

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -2163,6 +2163,38 @@ compatibility aliases only.
 <a id="state-schema"></a>
 ## State schema (`.refactor-loop/state.json`)
 
+### Statusline snapshot schema
+
+`concurrency_monitor.py` writes `.refactor-loop/state/statusline-snapshot.json` once per tick
+for the Claude Code statusline. The write is atomic (`tmp` file plus rename), and the consumer is
+read-only.
+
+```json
+{
+  "ts": "2026-05-26T08:45:00Z",
+  "actual": 7,
+  "expected": 5,
+  "floor": 4,
+  "p0_streak": 0,
+  "last_p0_at": null,
+  "freeze_minutes": 0,
+  "open_pr_count": 5,
+  "open_issue_count": 4
+}
+```
+
+Fields:
+
+- `ts`: UTC snapshot generation time.
+- `actual`: current this-loop `spawn-codex.sh` process count.
+- `expected`: current no-gap expected worker count from active auto-loop issues/PRs.
+- `floor`: host `CODEX_FLOOR`, with the existing hard lower bound of 2.
+- `p0_streak`: consecutive no-gap violation tick count.
+- `last_p0_at`: UTC timestamp of the latest P0 no-gap violation, or `null`.
+- `freeze_minutes`: whole minutes since the newest local PHASE/REVIEW/FIX/META marker file mtime; 0 when no marker exists.
+- `open_pr_count`: open auto-loop PR count from the same GitHub scan used by the monitor.
+- `open_issue_count`: open auto-loop issue count from the same GitHub scan used by the monitor.
+
 ```json
 {
   "schema_version": 1,

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -81,6 +81,34 @@ Host config rules:
 
 Detailed path examples and host installation variants stay in `REFERENCE.md`; `SKILL.md` keeps only controller-contract self-location invariants.
 
+## Claude Code statusline(per #51 consensus)
+
+`skills/codex-refactor-loop/scripts/statusline.sh` 是 fast (<200ms) read-only Claude Code statusline reader,显示本仓库 loop 实时状态(codex 计数、PR/issue 数、P0 streak、freeze 指示)。
+
+**Producer**:`concurrency_monitor.py` 每 tick 末尾原子写 `.refactor-loop/state/statusline-snapshot.json`(reuse 现有 daemon,**无新 daemon**)。
+
+**Consumer**:`statusline.sh` 读 snapshot,bash + jq < 200ms。
+
+**Install**(host project,**手动一行,无 installer script**):
+
+```json
+// ~/.claude/settings.json
+"statusLine": "/abs/path/to/skills/codex-refactor-loop/scripts/statusline.sh"
+```
+
+(host 用安装后的 `<skill-root>/scripts/statusline.sh` 或拷过去的对应路径。)
+
+**Uninstall**:删 `statusLine` 字段即可。
+
+**Named runtime exception(per #51 consensus)**:
+- **Narrow allowlist**:concurrency_monitor 加一行 snapshot write;不增其他 producer 职责;不引入新 daemon。
+- **Host-agnostic**:snapshot schema 不含 host fact;statusline.sh 不假设 host repo 结构(只依赖 $REPO_ROOT)。
+- **No lifecycle authority**:statusline 只 read,不写 GitHub / git / file lifecycle。
+- **Behavior tests**:`test_statusline.sh` < 200ms + 各 state icon + freeze 指示。
+- **Source-regression**:本段 + Named exception 子段 + install one-liner。
+
+授权来源:`.refactor-loop/runs/phase9-issue51-r3-judge.md`(Phase 9 r3 3/3 unanimous consensus on C framing)。
+
 ## Wakeup Skeleton
 
 Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event wakeup follows this skeleton. Daemon pending-event wakeups are valid only through a mounted persistent Monitor or equivalent harness bridge; daemon alone is not a wake source. The Phase 9 router daemon may replace controller dispatch for SOLVER_DONE triplets, converge, and valid stalled continuation; controller fallback sweep remains authoritative for every other marker.

--- a/skills/codex-refactor-loop/scripts/concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/concurrency_monitor.py
@@ -32,6 +32,7 @@ concurrency_monitor.py — 监控 active work 是否出现 0 codex gap
 
 import json
 import os
+import re
 import subprocess
 import time
 from datetime import datetime, timezone
@@ -65,6 +66,8 @@ REPO_ROOT = git_repo_root()
 GH_REPO_SLUG = github_repo_slug()
 ALERT_LOG = REPO_ROOT / ".refactor-loop" / ".concurrency-alert.log"
 PENDING_EVENTS = REPO_ROOT / ".refactor-loop" / ".controller-pending-events.log"
+STATUSLINE_SNAPSHOT = REPO_ROOT / ".refactor-loop" / "state" / "statusline-snapshot.json"
+PROGRESS_MARKER_RE = re.compile(r"\b(PHASE|REVIEW|FIX|META)[A-Z_]*:")
 
 # phase label → 期望 codex 数(per active issue/PR)
 PHASE_EXPECTED = {
@@ -105,6 +108,72 @@ def load_state() -> dict:
 def save_state(s: dict) -> None:
     STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
     STATE_FILE.write_text(json.dumps(s, indent=2))
+
+
+def codex_floor() -> int:
+    try:
+        floor = int(os.getenv("CODEX_FLOOR", "5"))
+    except ValueError:
+        floor = 5
+    return max(floor, 2)
+
+
+def newest_progress_marker_at() -> float | None:
+    newest: float | None = None
+    for directory in (REPO_ROOT / ".refactor-loop" / "logs", REPO_ROOT / ".refactor-loop" / "runs"):
+        if not directory.exists():
+            continue
+        for path in directory.rglob("*"):
+            if not path.is_file():
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if not PROGRESS_MARKER_RE.search(text):
+                continue
+            mtime = path.stat().st_mtime
+            newest = mtime if newest is None else max(newest, mtime)
+    return newest
+
+
+def freeze_minutes(now: float | None = None) -> int:
+    marker_at = newest_progress_marker_at()
+    if marker_at is None:
+        return 0
+    if now is None:
+        now = time.time()
+    return max(0, int((now - marker_at) / 60))
+
+
+def write_statusline_snapshot(
+    *,
+    actual: int,
+    expected: int,
+    p0_streak: int,
+    last_p0_at: str | None,
+    open_pr_count: int,
+    open_issue_count: int,
+    now: datetime | None = None,
+) -> None:
+    """Write the Claude Code statusline snapshot atomically."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    payload = {
+        "ts": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "actual": actual,
+        "expected": expected,
+        "floor": codex_floor(),
+        "p0_streak": p0_streak,
+        "last_p0_at": last_p0_at,
+        "freeze_minutes": freeze_minutes(now.timestamp()),
+        "open_pr_count": open_pr_count,
+        "open_issue_count": open_issue_count,
+    }
+    STATUSLINE_SNAPSHOT.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATUSLINE_SNAPSHOT.with_name(f".{STATUSLINE_SNAPSHOT.name}.tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    os.rename(tmp, STATUSLINE_SNAPSHOT)
 
 
 def count_in_flight_codex() -> int:
@@ -202,12 +271,18 @@ def tick() -> None:
     # Refactor (iter3/skill-concurrency-floor-enforcement):
     #   Old pattern: concurrency_monitor 有误导性 low-threshold 路径,CODEX_FLOOR 强制职责不清
     #   New principle: monitor 保持 no-gap-only;删 stale low-threshold 路径;CODEX_FLOOR 补给仅 controller wakeup step 1.5;SKILL 澄清职责(#14 delete 共识)
+    # Refactor (iter4/issue51-r3-consensus):
+    #   Old pattern: 无 ambient visibility;maintainer 需手动跑 peek.sh
+    #   New principle: concurrency_monitor tick 原子写 statusline-snapshot.json,statusline.sh consumer < 200ms 读;
+    #     无新 daemon,无 checked-in installer(per #51 r3 META_JUDGE_DONE:consensus:C-minimal-statusline-via-concurrency_monitor-snapshot)
     state = load_state()
     zero_streak = int(state.get("zero_streak", 0))
 
     items = list_auto_loop_issues()
     expected, breakdown = compute_expected(items)
     actual = count_in_flight_codex()
+    open_pr_count = sum(1 for item in items if item["kind"] == "pr")
+    open_issue_count = sum(1 for item in items if item["kind"] == "issue")
 
     log(f"actual={actual} expected={expected} zero_streak={zero_streak}")
 
@@ -215,6 +290,8 @@ def tick() -> None:
     if expected > 0 and actual == 0:
         zero_streak += 1
         state["zero_streak"] = zero_streak
+        p0_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        state["last_p0_at"] = p0_at
         detail = {
             "actual": 0,
             "expected": expected,
@@ -225,11 +302,27 @@ def tick() -> None:
         }
         write_alert(f"P0 no-gap-violation: 0 codex with {expected} active task(s)", detail)
         log(f"P0 ALERT: 0 codex but {expected} active task(s);streak={zero_streak};see {ALERT_LOG}")
+        write_statusline_snapshot(
+            actual=actual,
+            expected=expected,
+            p0_streak=zero_streak,
+            last_p0_at=p0_at,
+            open_pr_count=open_pr_count,
+            open_issue_count=open_issue_count,
+        )
         save_state(state)
         return
     else:
         state["zero_streak"] = 0
 
+    write_statusline_snapshot(
+        actual=actual,
+        expected=expected,
+        p0_streak=0,
+        last_p0_at=state.get("last_p0_at"),
+        open_pr_count=open_pr_count,
+        open_issue_count=open_issue_count,
+    )
     save_state(state)
 
 

--- a/skills/codex-refactor-loop/scripts/statusline.sh
+++ b/skills/codex-refactor-loop/scripts/statusline.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Claude Code statusline reader (per #51 r3 consensus C)
+#
+# Refactor (iter4/issue51-r3-consensus):
+#   Old pattern: no ambient visibility; maintainers had to run peek.sh manually.
+#   New principle: concurrency_monitor tick atomically writes statusline-snapshot.json;
+#     statusline.sh is a read-only < 200ms consumer with no new daemon and no checked-in installer
+#     (per #51 r3 META_JUDGE_DONE:consensus:C-minimal-statusline-via_concurrency_monitor-snapshot).
+
+set -e
+
+repo_root="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+if [ -z "${repo_root:-}" ]; then
+  echo "⏸ no-snapshot"
+  exit 0
+fi
+
+SNAPSHOT="${repo_root}/.refactor-loop/state/statusline-snapshot.json"
+if [ ! -f "$SNAPSHOT" ]; then
+  echo "⏸ no-snapshot"
+  exit 0
+fi
+
+actual=$(jq -r '.actual' "$SNAPSHOT")
+floor=$(jq -r '.floor' "$SNAPSHOT")
+expected=$(jq -r '.expected' "$SNAPSHOT")
+p0=$(jq -r '.p0_streak' "$SNAPSHOT")
+prs=$(jq -r '.open_pr_count' "$SNAPSHOT")
+issues=$(jq -r '.open_issue_count' "$SNAPSHOT")
+freeze=$(jq -r '.freeze_minutes' "$SNAPSHOT")
+
+icon="⚙"
+color=""
+if [ "$actual" -lt "$floor" ]; then
+  icon="⚠"
+  color="\033[31m"
+fi
+if [ "$freeze" -gt 10 ]; then
+  icon="🔴"
+  color="\033[31m"
+fi
+
+reset="\033[0m"
+freeze_seg=""
+if [ "$freeze" -gt 5 ]; then
+  freeze_seg=" [STUCK ${freeze}m]"
+fi
+p0_seg=""
+if [ "$p0" -gt 2 ]; then
+  p0_seg=" P0×${p0}"
+fi
+
+printf "${color}${icon} ${actual}/${floor} PR:${prs} issue:${issues}${p0_seg}${freeze_seg}${reset}\n"

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor_snapshot.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor_snapshot.py
@@ -114,6 +114,61 @@ class ConcurrencyMonitorSnapshotTests(unittest.TestCase):
         self.assertEqual(data["open_pr_count"], 1)
         self.assertEqual(data["open_issue_count"], 2)
 
+    def test_snapshot_includes_last_p0_at_field(self) -> None:
+        with mock.patch.object(self.monitor, "run", side_effect=self.fake_gh):
+            self.monitor.tick()
+
+        data = json.loads(self.snapshot_path().read_text(encoding="utf-8"))
+        self.assertIn("last_p0_at", data)
+        self.assertRegex(data["last_p0_at"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+    def test_non_p0_tick_snapshot_path(self) -> None:
+        state_path = self.repo / ".refactor-loop" / ".concurrency-monitor-state.json"
+        state_path.write_text(
+            json.dumps({"zero_streak": 2, "last_p0_at": "2026-05-26T01:02:03Z"}),
+            encoding="utf-8",
+        )
+
+        def fake_non_p0(cmd: list[str]) -> SimpleNamespace:
+            if cmd[:3] == ["gh", "issue", "list"]:
+                return SimpleNamespace(returncode=0, stdout=json.dumps([]))
+            if cmd[:3] == ["gh", "pr", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=json.dumps(
+                        [
+                            {
+                                "number": 59,
+                                "labels": [
+                                    {"name": "auto-loop"},
+                                    {"name": "👀 phase:reviewing"},
+                                    {"name": "🤖 human:codex"},
+                                ],
+                            }
+                        ]
+                    ),
+                )
+            if cmd[:2] == ["ps", "-eo"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=f"bash {self.monitor.REPO_ROOT}/skills/codex-refactor-loop/scripts/spawn-codex.sh --cd {self.monitor.REPO_ROOT}\n",
+                )
+            return SimpleNamespace(returncode=1, stdout="")
+
+        with mock.patch.object(self.monitor, "run", side_effect=fake_non_p0):
+            self.monitor.tick()
+
+        data = json.loads(self.snapshot_path().read_text(encoding="utf-8"))
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(data["actual"], 1)
+        self.assertEqual(data["expected"], 1)
+        self.assertEqual(data["p0_streak"], 0)
+        self.assertEqual(data["last_p0_at"], "2026-05-26T01:02:03Z")
+        self.assertEqual(data["open_pr_count"], 1)
+        self.assertEqual(data["open_issue_count"], 0)
+        self.assertEqual(state["zero_streak"], 0)
+        self.assertEqual(state["last_p0_at"], "2026-05-26T01:02:03Z")
+
     def test_snapshot_write_is_atomic(self) -> None:
         stop = threading.Event()
         errors: list[str] = []

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor_snapshot.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor_snapshot.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Behavior tests for concurrency_monitor statusline snapshots."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+
+class ConcurrencyMonitorSnapshotTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        (self.repo / ".refactor-loop" / "logs").mkdir(parents=True)
+        self.env = mock.patch.dict(
+            os.environ,
+            {
+                "REPO_ROOT": str(self.repo),
+                "GH_REPO_SLUG": "owner/repo",
+                "CODEX_FLOOR": "4",
+            },
+            clear=False,
+        )
+        self.env.start()
+        sys.modules.pop("concurrency_monitor", None)
+        self.monitor = importlib.import_module("concurrency_monitor")
+
+    def tearDown(self) -> None:
+        self.env.stop()
+        sys.modules.pop("concurrency_monitor", None)
+        self.tmp.cleanup()
+
+    def snapshot_path(self) -> Path:
+        return self.repo / ".refactor-loop" / "state" / "statusline-snapshot.json"
+
+    def fake_gh(self, cmd: list[str]) -> SimpleNamespace:
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "number": 51,
+                            "labels": [
+                                {"name": "auto-loop"},
+                                {"name": "🛠️ phase:implementing"},
+                                {"name": "🤖 human:codex"},
+                            ],
+                        },
+                        {
+                            "number": 52,
+                            "labels": [
+                                {"name": "auto-loop"},
+                                {"name": "⏸️ phase:blocked"},
+                                {"name": "👤 human:需-maintainer-决策"},
+                            ],
+                        },
+                    ]
+                ),
+            )
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "number": 9,
+                            "labels": [
+                                {"name": "auto-loop"},
+                                {"name": "👀 phase:reviewing"},
+                                {"name": "🤖 human:codex"},
+                            ],
+                        }
+                    ]
+                ),
+            )
+        if cmd[:2] == ["ps", "-eo"]:
+            return SimpleNamespace(returncode=0, stdout="")
+        return SimpleNamespace(returncode=1, stdout="")
+
+    def test_tick_writes_snapshot_json_with_required_fields(self) -> None:
+        with mock.patch.object(self.monitor, "run", side_effect=self.fake_gh):
+            self.monitor.tick()
+
+        data = json.loads(self.snapshot_path().read_text(encoding="utf-8"))
+        for field in (
+            "actual",
+            "expected",
+            "floor",
+            "p0_streak",
+            "freeze_minutes",
+            "open_pr_count",
+            "open_issue_count",
+        ):
+            with self.subTest(field=field):
+                self.assertIn(field, data)
+        self.assertEqual(data["actual"], 0)
+        self.assertEqual(data["expected"], 2)
+        self.assertEqual(data["floor"], 4)
+        self.assertEqual(data["p0_streak"], 1)
+        self.assertEqual(data["open_pr_count"], 1)
+        self.assertEqual(data["open_issue_count"], 2)
+
+    def test_snapshot_write_is_atomic(self) -> None:
+        stop = threading.Event()
+        errors: list[str] = []
+
+        def reader() -> None:
+            while not stop.is_set():
+                path = self.snapshot_path()
+                if not path.exists():
+                    continue
+                try:
+                    json.loads(path.read_text(encoding="utf-8"))
+                except json.JSONDecodeError as exc:
+                    errors.append(str(exc))
+                    stop.set()
+
+        thread = threading.Thread(target=reader)
+        thread.start()
+        try:
+            for index in range(200):
+                self.monitor.write_statusline_snapshot(
+                    actual=index,
+                    expected=5,
+                    p0_streak=index % 4,
+                    last_p0_at=None,
+                    open_pr_count=3,
+                    open_issue_count=2,
+                )
+        finally:
+            stop.set()
+            thread.join(timeout=2)
+
+        self.assertEqual(errors, [])
+        data = json.loads(self.snapshot_path().read_text(encoding="utf-8"))
+        self.assertEqual(data["actual"], 199)
+
+    def test_snapshot_open_counts_match_peek(self) -> None:
+        with mock.patch.object(self.monitor, "run", side_effect=self.fake_gh):
+            items = self.monitor.list_auto_loop_issues()
+            expected_prs = sum(1 for item in items if item["kind"] == "pr")
+            expected_issues = sum(1 for item in items if item["kind"] == "issue")
+            self.monitor.tick()
+
+        data = json.loads(self.snapshot_path().read_text(encoding="utf-8"))
+        self.assertEqual(data["open_pr_count"], expected_prs)
+        self.assertEqual(data["open_issue_count"], expected_issues)
+        self.assertEqual((expected_prs, expected_issues), (1, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor_snapshot.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor_snapshot.py
@@ -11,6 +11,7 @@ import tempfile
 import threading
 import time
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -45,6 +46,18 @@ class ConcurrencyMonitorSnapshotTests(unittest.TestCase):
 
     def snapshot_path(self) -> Path:
         return self.repo / ".refactor-loop" / "state" / "statusline-snapshot.json"
+
+    def write_snapshot(self, *, now: datetime | None = None) -> dict:
+        self.monitor.write_statusline_snapshot(
+            actual=1,
+            expected=1,
+            p0_streak=0,
+            last_p0_at=None,
+            open_pr_count=0,
+            open_issue_count=0,
+            now=now,
+        )
+        return json.loads(self.snapshot_path().read_text(encoding="utf-8"))
 
     def fake_gh(self, cmd: list[str]) -> SimpleNamespace:
         if cmd[:3] == ["gh", "issue", "list"]:
@@ -215,6 +228,38 @@ class ConcurrencyMonitorSnapshotTests(unittest.TestCase):
         self.assertEqual(data["open_pr_count"], expected_prs)
         self.assertEqual(data["open_issue_count"], expected_issues)
         self.assertEqual((expected_prs, expected_issues), (1, 2))
+
+    def test_invalid_codex_floor_falls_back_to_default_5(self) -> None:
+        with mock.patch.dict(os.environ, {"CODEX_FLOOR": "invalid"}, clear=False):
+            data = self.write_snapshot()
+
+        self.assertEqual(data["floor"], 5)
+
+    def test_codex_floor_one_clamps_to_minimum_two(self) -> None:
+        with mock.patch.dict(os.environ, {"CODEX_FLOOR": "1"}, clear=False):
+            data = self.write_snapshot()
+
+        self.assertEqual(data["floor"], 2)
+
+    def test_marker_file_with_valid_marker_and_controlled_mtime_yields_freeze_minutes(self) -> None:
+        now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc)
+        marker = self.repo / ".refactor-loop" / "logs" / "worker.log"
+        marker.write_text("PHASE: implementation progress\n", encoding="utf-8")
+        os.utime(marker, (now.timestamp() - 7 * 60, now.timestamp() - 7 * 60))
+
+        data = self.write_snapshot(now=now)
+
+        self.assertEqual(data["freeze_minutes"], 7)
+
+    def test_files_without_valid_markers_keep_freeze_minutes_zero(self) -> None:
+        now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc)
+        non_marker = self.repo / ".refactor-loop" / "logs" / "worker.log"
+        non_marker.write_text("phase implementation progress without marker syntax\n", encoding="utf-8")
+        os.utime(non_marker, (now.timestamp() - 30 * 60, now.timestamp() - 30 * 60))
+
+        data = self.write_snapshot(now=now)
+
+        self.assertEqual(data["freeze_minutes"], 0)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -113,5 +113,55 @@ class SkillReferenceAnchorTests(unittest.TestCase):
         self.assertIn("must not introduce ControllerEvent, ControllerCommand, ControllerOrchestrator", self.reference)
 
 
+class AutoLoopStatuslineContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill = read(SKILL_MD)
+        self.reference = read(REFERENCE_MD)
+
+    def test_skill_contains_statusline_consensus_section(self) -> None:
+        required = (
+            "## Claude Code statusline(per #51 consensus)",
+            "**Producer**",
+            "**Consumer**",
+            "**Install**",
+            "**无新 daemon**",
+            "**手动一行,无 installer script**",
+            "Named runtime exception",
+        )
+        for needle in required:
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.skill)
+
+    def test_statusline_contract_does_not_add_daemon_or_installer(self) -> None:
+        scripts_dir = SKILL_ROOT / "scripts"
+        self.assertFalse((scripts_dir / "installer.sh").exists())
+        self.assertFalse((scripts_dir / "install-statusline.sh").exists())
+        combined = self.skill + "\n" + self.reference
+        forbidden = (
+            "StatuslineDaemon",
+            "StatusLineDaemon",
+            "StatuslineController",
+            "new daemon class",
+            "自动修改 settings.json",
+        )
+        for token in forbidden:
+            with self.subTest(token=token):
+                self.assertNotIn(token, combined)
+
+    def test_reference_documents_statusline_snapshot_schema(self) -> None:
+        self.assertIn("### Statusline snapshot schema", self.reference)
+        for field in (
+            '"actual"',
+            '"expected"',
+            '"floor"',
+            '"p0_streak"',
+            '"freeze_minutes"',
+            '"open_pr_count"',
+            '"open_issue_count"',
+        ):
+            with self.subTest(field=field):
+                self.assertIn(field, self.reference)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_statusline.sh
+++ b/skills/codex-refactor-loop/scripts/test_statusline.sh
@@ -89,10 +89,19 @@ JSON
   assert_contains "$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")" "[STUCK 15m]" "test_freeze_minutes_over_10_shows_stuck"
 }
 
+test_p0_streak_over_2_shows_highlight() {
+  setup_repo
+  write_snapshot <<'JSON'
+{"actual":7,"expected":5,"floor":4,"p0_streak":3,"open_pr_count":5,"open_issue_count":4,"freeze_minutes":0}
+JSON
+  assert_contains "$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")" "P0×3" "test_p0_streak_over_2_shows_highlight"
+}
+
 test_statusline_runs_under_200ms
 test_no_snapshot_returns_placeholder
 test_healthy_state_shows_actual_floor
 test_below_floor_shows_warning_icon
 test_freeze_minutes_over_10_shows_stuck
+test_p0_streak_over_2_shows_highlight
 
 echo "statusline tests ok"

--- a/skills/codex-refactor-loop/scripts/test_statusline.sh
+++ b/skills/codex-refactor-loop/scripts/test_statusline.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+STATUSLINE="${SCRIPT_DIR}/statusline.sh"
+TMP_DIR=""
+
+cleanup() {
+  if [ -n "${TMP_DIR:-}" ]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+setup_repo() {
+  TMP_DIR="$(mktemp -d)"
+  mkdir -p "$TMP_DIR/.refactor-loop/state"
+}
+
+write_snapshot() {
+  cat > "$TMP_DIR/.refactor-loop/state/statusline-snapshot.json"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "FAIL ${label}: expected output to contain ${needle}; got: ${haystack}" >&2
+    exit 1
+  fi
+}
+
+test_statusline_runs_under_200ms() {
+  setup_repo
+  write_snapshot <<'JSON'
+{"actual":7,"expected":5,"floor":4,"p0_streak":0,"open_pr_count":5,"open_issue_count":4,"freeze_minutes":0}
+JSON
+  local start end elapsed output
+  start="$(python3 - <<'PY'
+import time
+print(time.monotonic_ns())
+PY
+)"
+  output="$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")"
+  end="$(python3 - <<'PY'
+import time
+print(time.monotonic_ns())
+PY
+)"
+  elapsed=$(( (end - start) / 1000000 ))
+  if [ "$elapsed" -ge 200 ]; then
+    echo "FAIL test_statusline_runs_under_200ms: elapsed=${elapsed}ms output=${output}" >&2
+    exit 1
+  fi
+}
+
+test_no_snapshot_returns_placeholder() {
+  setup_repo
+  local output
+  output="$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")"
+  if [ "$output" != "⏸ no-snapshot" ]; then
+    echo "FAIL test_no_snapshot_returns_placeholder: ${output}" >&2
+    exit 1
+  fi
+}
+
+test_healthy_state_shows_actual_floor() {
+  setup_repo
+  write_snapshot <<'JSON'
+{"actual":7,"expected":5,"floor":4,"p0_streak":0,"open_pr_count":5,"open_issue_count":4,"freeze_minutes":0}
+JSON
+  assert_contains "$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")" "7/4" "test_healthy_state_shows_actual_floor"
+}
+
+test_below_floor_shows_warning_icon() {
+  setup_repo
+  write_snapshot <<'JSON'
+{"actual":2,"expected":5,"floor":4,"p0_streak":0,"open_pr_count":5,"open_issue_count":4,"freeze_minutes":0}
+JSON
+  assert_contains "$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")" "⚠" "test_below_floor_shows_warning_icon"
+}
+
+test_freeze_minutes_over_10_shows_stuck() {
+  setup_repo
+  write_snapshot <<'JSON'
+{"actual":7,"expected":5,"floor":4,"p0_streak":0,"open_pr_count":5,"open_issue_count":4,"freeze_minutes":15}
+JSON
+  assert_contains "$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")" "[STUCK 15m]" "test_freeze_minutes_over_10_shows_stuck"
+}
+
+test_statusline_runs_under_200ms
+test_no_snapshot_returns_placeholder
+test_healthy_state_shows_actual_floor
+test_below_floor_shows_warning_icon
+test_freeze_minutes_over_10_shows_stuck
+
+echo "statusline tests ok"


### PR DESCRIPTION
## Summary

依 issue #51 r3 **`META_JUDGE_DONE:consensus:C-minimal-statusline-via-concurrency_monitor-snapshot`**(3/3 unanimous C 框架):

- 扩 `concurrency_monitor.py`:每 tick 原子写 `.refactor-loop/state/statusline-snapshot.json`(reuse 现有 daemon,**无新 daemon**)
- 新 `statusline.sh`:fast (<200ms) bash+jq 读 snapshot,单行 ANSI(⚙ healthy / ⚠ below floor / 🔴 freeze / [STUCK Nm])
- 新 8 行为测试(5 statusline + 3 snapshot)
- SKILL.md 加 named exception 段 + install one-liner(host 手动 settings.json,**无** installer script)
- REFERENCE.md 加 snapshot schema
- source-regression `AutoLoopStatuslineContractTests` 守护"无新 daemon / 无 installer / 无自动 settings.json 修改"

## 边界

- host-agnostic + no lifecycle authority
- 不动 peek.sh(两者并存定位不同)
- 不动 host CLAUDE.md / AGENTS.md(Phase 9 deep consensus)
- 不加新 daemon / installer.sh / 自动改 settings.json(per 共识硬约束)

依 r3 judge artifact `.refactor-loop/runs/phase9-issue51-r3-judge.md`(3/3 unanimous C)。

## Test plan

- [x] 8 新测试 + 162 existing 全绿
- [ ] CI lint + 全套
- [ ] Phase 8 reviewer 3 lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⟦AI:AUTO-LOOP⟧
