### PR TITLE
chore: 扩 CLAUDE.md exception 子句到 scoped Phase 9 named-surface authorization(#60 r1 consensus)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,13 @@
 
 ## 当前状态
 
-- `skills/codex-refactor-loop/` 为 host 项目移植,**verbatim**,仍带"重构"外壳与少量 host 主张。泛化路线见 `README.md` 的「泛化路线」。脱壳 / 重命名前不要改它的正文逻辑；例外：经 Phase 9 deep consensus 明确授权的 host-agnostic bootstrap / policy 注入修正可先落地，但不得引入具体 host 事实，且必须配套行为测试。
+- `skills/codex-refactor-loop/` 为 host 项目移植,**verbatim**,仍带"重构"外壳与少量 host 主张。泛化路线见 `README.md` 的「泛化路线」。脱壳 / 重命名前不要改它的正文逻辑；例外：经 Phase 9 deep consensus 明确授权的 host-agnostic bootstrap / policy 注入修正可先落地，但不得引入具体 host 事实，必须 narrow allowlist、no lifecycle authority，且必须配套行为测试与 source-regression test。
 
-**该例外同时覆盖** Phase 9 共识授权的**确定性 controller-runtime 路由 daemon**(例如 narrow allowlist phase router):必须 host-agnostic、必须 narrow allowlist 不引入 lifecycle authority、必须配套行为测试与 source-regression test、必须在 SKILL.md 加 named exception 段。这是为了把可机械的 controller 工作从长跑 LLM 搬到脚本(维护者明示 "LLM 长时间运行会退化,但是脚本不会"，见 issue #37 共识)。
+**该例外同时覆盖** Phase 9 deep consensus 共识授权的**任何 named runtime surface**(narrow allowlist deterministic controller-runtime daemon、observability surface、release/lifecycle decision-artifact surface,等):必须 **host-agnostic** + **narrow allowlist 不引入 lifecycle authority** + 必须配套**行为测试/behavior tests**与 **source-regression test** + 必须在 SKILL.md 加 **named exception 段**(标题含 `## Named runtime exception — <surface-name>(per #<issue>)`)+ 必须有 Phase 9 r<N> consensus 的 judge artifact 引用。每个 named surface 都必须:
+- **host-agnostic**:目录路径相对 `$REPO_ROOT`,无 host fact 注入
+- **no lifecycle authority**:不开关 issue/PR/label,不 commit/push/merge,不 tag,不 release publish。**release/lifecycle surface 仅产出 durable decision/candidate artifact**,真 commit/push/tag/release/merge/close 仍由既有 controller 或 release pipeline 在 host opt-in + 有效 artifact 同时成立后执行
+- **narrow allowlist**:每段必须明确列举该 surface 允许做的事;**不**给 surface 通用授权或 escape hatch
+**不放宽**:merge gate、CI/release policy、语言 policy、Tier I/II 边界、版本同步规则、任意 CLAUDE.md 修宪授权、独立 PR 自我放行权。
+这是为了把可机械的 controller 工作从长跑 LLM 搬到脚本(维护者明示 "LLM 长时间运行会退化,但是脚本不会",见 issue #37 共识),同时让后续 Phase 9 授权的 named surface(如 observability per #51 + release decision-artifact per #56)能 mechanical 落地,不需每次都修宪。
 
 **该例外也可由 maintainer-directive artifact 等价证明**:仅限 audit-derived、`requires_design=false` 的机械型 hygiene 批次;当维护者在 `.refactor-loop/runs/maintainer-directives/<date>-<topic>.md` 明示授权该批次时,该 artifact 可视为 Phase 9 deep consensus 等价证明。该等价证明不新增独立 PR 自我放行权,也不放宽 merge gate、CI/release policy、语言 policy、lifecycle authority 或 Tier I/II 边界,不得作为任意 `CLAUDE.md` 修宪授权;覆盖项仍必须 host-agnostic、不得引入具体 host 事实、必须配套行为测试与源回归测试/source-regression test、必须保留 `Refactor (iterN/cluster): Old pattern: ... New principle: ...` 自文档块,并在 FIX_REPORT 逐项标 fixed / already addressed / blocked。

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -1960,6 +1960,64 @@ class MaintainerDirectiveEquivalenceParagraphTests(unittest.TestCase):
                     self.assertNotIn(forbidden, p, f"独立 audit-derived 段不可含 {forbidden}")
 
 
+class ScopedNamedSurfaceAuthorizationParagraphTests(unittest.TestCase):
+    """#60 r1 consensus 守护 Phase 9 named runtime surface 授权不被偷扩。"""
+
+    @staticmethod
+    def _paragraph_containing(needle: str) -> str:
+        text = (REPO_ROOT / "CLAUDE.md").read_text()
+        paragraphs = re.split(r"\n\s*\n", text)
+        return next(p for p in paragraphs if needle in p)
+
+    def test_scoped_named_surface_paragraph_has_required_keywords(self):
+        p = self._paragraph_containing("named runtime surface")
+        for term in ("deep consensus", "named runtime surface", "host-agnostic",
+                     "narrow allowlist", "no lifecycle authority", "behavior tests",
+                     "source-regression"):
+            self.assertIn(term, p)
+
+    def test_scoped_named_surface_paragraph_has_negative_boundaries(self):
+        p = self._paragraph_containing("named runtime surface")
+        for term in ("不放宽", "merge gate", "CI/release policy", "语言 policy",
+                     "Tier I/II", "CLAUDE.md 修宪", "独立 PR 自我放行权"):
+            self.assertIn(term, p)
+
+    def test_scoped_named_surface_paragraph_has_lifecycle_authority_carveout(self):
+        p = self._paragraph_containing("named runtime surface")
+        for term in ("release/lifecycle surface 仅产出 durable decision/candidate artifact",
+                     "controller 或 release pipeline", "host opt-in + 有效 artifact"):
+            self.assertIn(term, p)
+
+    def test_no_generic_phase9_authorization_paragraph_exists(self):
+        text = (REPO_ROOT / "CLAUDE.md").read_text()
+        paragraphs = re.split(r"\n\s*\n", text)
+        for p in paragraphs:
+            lowered = p.lower()
+            if ".refactor-loop/runs/maintainer-directives/" in p:
+                continue
+            if "phase 9" in lowered and "授权" in p:
+                with self.subTest(paragraph=p[:80]):
+                    self.assertIn("host-agnostic", p)
+                    self.assertIn("no lifecycle authority", p)
+                    self.assertIn("narrow allowlist", p)
+
+    def test_no_maintainer_directive_used_as_pr_release_or_observability_authorization(self):
+        p = self._paragraph_containing(".refactor-loop/runs/maintainer-directives/")
+        forbidden_terms = (
+            "release/lifecycle surface",
+            "release decision-artifact",
+            "release-readiness",
+            "observability surface",
+            "observability per #51",
+            "release decision-artifact per #56",
+            "PR #58",
+            "PR #59",
+        )
+        for term in forbidden_terms:
+            with self.subTest(term=term):
+                self.assertNotIn(term, p)
+
+
 # Refactor (iter3/skill-contract-test-suite):
 #   Old pattern: skill contract regressions were documented in prompts/SKILL text but not enforced by the host TEST_CMD.
 #   New principle: a contiguous source-regression suite makes those contracts fail under the dogfood TEST_CMD without adding a new runner or scanner abstraction.


### PR DESCRIPTION
## Summary

依 issue #60 r1 **`META_JUDGE_DONE:consensus:D-scoped-Phase9-named-surface-authorization`**(3/3 倾向 generalize)。

扩 `CLAUDE.md` line 41 narrow daemon clause 为 **D scoped Phase 9 named-surface authorization**:

- 覆盖 Phase 9 deep consensus 共识授权的**任何 named runtime surface**(narrow allowlist deterministic controller-runtime daemon、observability surface、release/lifecycle decision-artifact surface,等)
- 必须:host-agnostic + narrow allowlist 不引入 lifecycle authority + 行为测试 + source-regression test + SKILL.md 加 named exception 段 + Phase 9 judge artifact 引用
- **release/lifecycle surface 仅产出 durable decision/candidate artifact**;真 commit/push/tag/release/merge/close 仍由既有 controller 或 release pipeline 在 host opt-in + 有效 artifact 同时成立后执行
- **不放宽**:merge gate / CI/release policy / 语言 policy / Tier I/II / 版本同步规则 / 任意 CLAUDE.md 修宪授权 / 独立 PR 自我放行权

加 5 paragraph-anchored source-regression 测试守护(`ScopedNamedSurfaceAuthorizationParagraphTests`):
- required keywords / negative boundaries / lifecycle authority carveout / no-generic-phase9-paragraph / no-maintainer-directive-used-as-pr-release-or-observability-authorization

## 解锁串联

本 PR merge 后:
- **PR #58**(autonomous release):architect 可 re-review,fix-r3 cite 本 amendment;若 detector/decider 当前直接 bump/push,redesign 为 decision-artifact-only(per judge artifact)
- **PR #59**(statusline):architect 可 re-review,fix-r3 cite 本 amendment

## Test plan

- [x] 5 新 paragraph-anchored test 全绿
- [ ] CI lint + 全套
- [ ] Phase 8 reviewer 3 lane

依 r1 judge artifact `.refactor-loop/runs/phase9-issue60-r1-judge.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⟦AI:AUTO-LOOP⟧
