### PR TITLE
chore(skill): SKILL.md 澄清 in-flight 不算 actionable marker(floor-fill-not-optional)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -233,13 +233,16 @@ Controller non-duties:
 
 The floor is local because it prevents loop stalls.
 
+<!-- Refactor (iter4/skill-floor-fill-not-optional): Old pattern: "If below floor and no higher-priority actionable marker exists, dispatch audit" left "actionable marker" undefined,导致 controller 拿 in-flight codex 当 actionable marker rationalize defer top-up。New principle: actionable marker 必须 EXIT=0 / maintainer comment / CI red / no-gap;in-flight codex (没 EXIT=0) 不算;floor 不足时 default action = envsubst 下一 iteration audit + harness background task spawn,不等 maintainer 反问触发。(2026-05-26 maintainer-directive 等价 Phase 9 共识) -->
+
 - `$CODEX_FLOOR` defaults to 5 and has a hard minimum of 2.
 - Use `FLOOR=$(( ${CODEX_FLOOR:-5} < 2 ? 2 : ${CODEX_FLOOR:-5} ))`.
 - Count only this repository's loop codexes: command line contains `spawn-codex.sh` and the absolute `$REPO_ROOT`.
 - Exclude shell ` -c ` wrapper rows so each real codex counts once.
 - `concurrency_monitor.py` 只做 no-gap sentinel; the controller owns top-up.
 - controller 每次 wakeup 的 step 1.5 checks the count and 必须在任何 `ScheduleWakeup` 之前执行.
-- If below floor and no higher-priority actionable marker exists, dispatch audit/self-audit/retrospective-compatible work per current phase.
+- If below floor and no higher-priority actionable marker exists, dispatch audit/self-audit/retrospective-compatible work per current phase. "Actionable marker" 限定为:log tail `EXIT=0` 后的完成 verdict (FIX_DONE / REVIEW_DONE / IMPLEMENT_DONE / SOLVER_DONE / META_JUDGE_DONE / TEST_ADD_DONE / AUDIT_DONE / VERIFY_DONE),或新 maintainer comment、CI red、no-gap violation。in-flight codex (没 EXIT=0) 不是 actionable marker——以"等 cascade / fix 完会派 reviewers"为由 defer floor top-up 是绕规则。
+- floor 不足时 default action(无 maintainer 反问触发的前提下):envsubst 下一 iteration `prompts/audit.md` 到 `.refactor-loop/prompts/audit-iter-N.md` → `spawn-codex.sh` 用 harness background task 启动。"派 audit 重 / daemon target stale / 等 cascade / 和已有工作冲突" 都不接受作为 defer 理由;实际成本 = 2 行 envsubst + 1 个 background task。
 
 More detail is in [concurrency floor details](REFERENCE.md#concurrency-floor-details).
 

--- a/skills/codex-refactor-loop/scripts/test_skill_floor_fill_not_optional.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_floor_fill_not_optional.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Source-regression: SKILL.md Concurrency Floor 段必须明文 in-flight 不算 actionable marker."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__)
+SKILL_ROOT = SCRIPT_PATH.parents[1]
+SKILL_MD = SKILL_ROOT / "SKILL.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class FloorFillNotOptionalTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill = read(SKILL_MD)
+        match = re.search(
+            r"## Concurrency Floor\s*\n(?P<body>.*?)\n## ",
+            self.skill,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(match, "Concurrency Floor section missing")
+        self.section = match.group("body")
+
+    def test_refactor_self_doc_block_present(self) -> None:
+        self.assertIn(
+            "Refactor (iter4/skill-floor-fill-not-optional)",
+            self.section,
+            "Refactor self-doc block missing — 2026-05-26 maintainer-directive 落地需保留",
+        )
+
+    def test_actionable_marker_bounded_by_exit_zero(self) -> None:
+        self.assertRegex(
+            self.section,
+            r"Actionable marker.*EXIT=0",
+            "Concurrency Floor 段必须把 actionable marker 绑到 EXIT=0,防止 in-flight 被误当 actionable",
+        )
+
+    def test_in_flight_codex_explicitly_not_actionable(self) -> None:
+        self.assertIn("in-flight codex", self.section)
+        self.assertIn("不是 actionable marker", self.section)
+
+    def test_default_action_envsubst_audit(self) -> None:
+        for required in ("envsubst", "audit-iter-N", "harness background task"):
+            with self.subTest(required=required):
+                self.assertIn(required, self.section)
+
+    def test_rationalization_wording_blocked(self) -> None:
+        # 维护者实证识别的 typical defer wording 必须显式列入禁止集
+        for phrase in ("派 audit 重", "target stale", "等 cascade", "和已有工作冲突"):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, self.section, f"防御 wording 缺失: {phrase}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动

`SKILL.md` 「Concurrency Floor」段:
- 把 "actionable marker" 限定为 `EXIT=0` 后的完成 verdict / 新 maintainer comment / CI red / no-gap violation
- 明文 "in-flight codex (没 EXIT=0) 不是 actionable marker——以等 cascade 为由 defer floor top-up 是绕规则"
- 加 default action 步骤化:envsubst 下一 iteration `prompts/audit.md` → `spawn-codex.sh` harness background task
- 列禁 rationalization wording("派 audit 重 / target stale / 等 cascade / 和已有工作冲突")

配套:`scripts/test_skill_floor_fill_not_optional.py` 5 个 source-regression test。

## 为什么

session 实证:floor=4 actual=1,fix-pr63 in-flight,controller rationalize "等 cascade 会自然补",连续噪音 alert 5 分钟没动作,直到 maintainer 反问"那为什么你没自动派?"才动手。SKILL.md 原文已说低于 floor 必派 audit,本 PR 只是把 "actionable marker" 边界 + default action 明文化,防止后续 controller 复发同样 rationalization。

## 与 concurrency-auto-topup directive 关系

- `2026-05-26-concurrency-auto-topup.md` directive 改 daemon (`concurrency_monitor.py` 加 `_try_topup` 消费 dispatch queue):daemon 侧自动派,减少 controller wake 延迟
- 本 PR 改 controller 侧(`SKILL.md`):wake 时强制派,防止 rationalize defer
- 两者互补,不冲突

## Phase 9 等价证明

依 `CLAUDE.md` maintainer-directive equivalence 子句(PR #48 merged f2854db):
- audit-derived: SKILL.md 现有 floor rule 的边界澄清,非新规则
- requires_design=false: 机械型明文化
- host-agnostic: SKILL.md 不含具体 host 事实
- 配套行为测试 + source-regression test(5 个 pass)
- 保留 Refactor self-doc 块
- artifact: `.refactor-loop/runs/maintainer-directives/2026-05-26-floor-fill-not-optional.md`

## 测试

\`\`\`
$ python3 -m unittest skills.codex-refactor-loop.scripts.test_skill_floor_fill_not_optional
.....
Ran 5 tests in 0.001s
OK
\`\`\`

⟦AI:AUTO-LOOP⟧