### PR TITLE
chore(skill): 5 个 marker-only prompts 补 gh 操作禁止段(prompt-gh-ban-marker-only)

### DIFF
--- a/skills/codex-refactor-loop/prompts/audit.md
+++ b/skills/codex-refactor-loop/prompts/audit.md
@@ -147,6 +147,16 @@ human_brief:
 - 禁止改任何代码
 - 禁止把"想加的功能"伪装成 cluster
 
+## codex 工具边界(强制)
+
+<!-- Refactor (iter5/prompt-gh-ban-marker-only): Old pattern: marker-only prompt(audit/implement/verify/remote-ci-fix/test-add)缺 gh 禁止段,codex 可自由调 gh issue create/pr merge/issue close/label edit。 New principle: 复用 reviewer/solver "可调/不可调" 模式,统一禁 lifecycle 类 gh 操作;controller 拥有 PR create/merge/close + issue create/close + label。(2026-05-26 maintainer-directive 等价 Phase 9 共识) -->
+
+本 prompt 是 marker/artifact-only,**默认不需要任何 gh 操作**。
+
+不可调:`git commit/push/checkout/merge/reset/rebase`、`gh pr create`、`gh pr merge`、`gh pr close`、`gh issue create`、`gh issue close`、`gh issue edit --add-label`、`gh issue edit --remove-label`、`gh pr edit --add-label`、`gh pr edit --remove-label`。lifecycle / label 决策归 controller,worker 不得越线。
+
+可调(仅当本 prompt 明示要 post 时):`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`。本 prompt 未明示 → 不要调任何 gh。
+
 开始执行。
 
 ---

--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -65,6 +65,16 @@ ${SCOPE_PATHS}
 
 ${VERIFICATION_HINTS}
 
+## codex 工具边界(强制)
+
+<!-- Refactor (iter5/prompt-gh-ban-marker-only): Old pattern: marker-only prompt(audit/implement/verify/remote-ci-fix/test-add)缺 gh 禁止段,codex 可自由调 gh issue create/pr merge/issue close/label edit。 New principle: 复用 reviewer/solver "可调/不可调" 模式,统一禁 lifecycle 类 gh 操作;controller 拥有 PR create/merge/close + issue create/close + label。(2026-05-26 maintainer-directive 等价 Phase 9 共识) -->
+
+本 prompt 是 marker/artifact-only,**默认不需要任何 gh 操作**。
+
+不可调:`git commit/push/checkout/merge/reset/rebase`、`gh pr create`、`gh pr merge`、`gh pr close`、`gh issue create`、`gh issue close`、`gh issue edit --add-label`、`gh issue edit --remove-label`、`gh pr edit --add-label`、`gh pr edit --remove-label`。lifecycle / label 决策归 controller,worker 不得越线。
+
+可调(仅当本 prompt 明示要 post 时):`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`。本 prompt 未明示 → 不要调任何 gh。
+
 开始执行。
 
 ---

--- a/skills/codex-refactor-loop/prompts/remote-ci-fix.md
+++ b/skills/codex-refactor-loop/prompts/remote-ci-fix.md
@@ -56,6 +56,16 @@ PR: `${PR_NUMBER}`，失败 check: `${CHECK_NAME}`，run url: `${RUN_URL}`。
 - 禁止 hypothetical 修复——必须本地复现后再改
 - 禁止扩 scope 到失败 test 直接相关之外的代码
 
+## codex 工具边界(强制)
+
+<!-- Refactor (iter5/prompt-gh-ban-marker-only): Old pattern: marker-only prompt(audit/implement/verify/remote-ci-fix/test-add)缺 gh 禁止段,codex 可自由调 gh issue create/pr merge/issue close/label edit。 New principle: 复用 reviewer/solver "可调/不可调" 模式,统一禁 lifecycle 类 gh 操作;controller 拥有 PR create/merge/close + issue create/close + label。(2026-05-26 maintainer-directive 等价 Phase 9 共识) -->
+
+本 prompt 是 marker/artifact-only,**默认不需要任何 gh 操作**。
+
+不可调:`git commit/push/checkout/merge/reset/rebase`、`gh pr create`、`gh pr merge`、`gh pr close`、`gh issue create`、`gh issue close`、`gh issue edit --add-label`、`gh issue edit --remove-label`、`gh pr edit --add-label`、`gh pr edit --remove-label`。lifecycle / label 决策归 controller,worker 不得越线。
+
+可调(仅当本 prompt 明示要 post 时):`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`。本 prompt 未明示 → 不要调任何 gh。
+
 开始执行。
 
 ---

--- a/skills/codex-refactor-loop/prompts/test-add.md
+++ b/skills/codex-refactor-loop/prompts/test-add.md
@@ -74,6 +74,16 @@ ${UNCOVERED_LINES}
 - 禁止 `sleep/delay` 测试节奏。
 - 禁止"mock everything"式测试（每个测试至少有一条真业务断言；纯 mock 验证调用次数的测试不算覆盖）。
 
+## codex 工具边界(强制)
+
+<!-- Refactor (iter5/prompt-gh-ban-marker-only): Old pattern: marker-only prompt(audit/implement/verify/remote-ci-fix/test-add)缺 gh 禁止段,codex 可自由调 gh issue create/pr merge/issue close/label edit。 New principle: 复用 reviewer/solver "可调/不可调" 模式,统一禁 lifecycle 类 gh 操作;controller 拥有 PR create/merge/close + issue create/close + label。(2026-05-26 maintainer-directive 等价 Phase 9 共识) -->
+
+本 prompt 是 marker/artifact-only,**默认不需要任何 gh 操作**。
+
+不可调:`git commit/push/checkout/merge/reset/rebase`、`gh pr create`、`gh pr merge`、`gh pr close`、`gh issue create`、`gh issue close`、`gh issue edit --add-label`、`gh issue edit --remove-label`、`gh pr edit --add-label`、`gh pr edit --remove-label`。lifecycle / label 决策归 controller,worker 不得越线。
+
+可调(仅当本 prompt 明示要 post 时):`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`。本 prompt 未明示 → 不要调任何 gh。
+
 开始执行。
 
 ---

--- a/skills/codex-refactor-loop/prompts/verify.md
+++ b/skills/codex-refactor-loop/prompts/verify.md
@@ -100,6 +100,16 @@ verified_at: <ISO8601>
 - 禁止 `git commit` / `git push` / `git checkout`。
 - 验证宽松度倾向严格而非宽松：怀疑 → 标 rework，不要妥协给 pass。
 
+## codex 工具边界(强制)
+
+<!-- Refactor (iter5/prompt-gh-ban-marker-only): Old pattern: marker-only prompt(audit/implement/verify/remote-ci-fix/test-add)缺 gh 禁止段,codex 可自由调 gh issue create/pr merge/issue close/label edit。 New principle: 复用 reviewer/solver "可调/不可调" 模式,统一禁 lifecycle 类 gh 操作;controller 拥有 PR create/merge/close + issue create/close + label。(2026-05-26 maintainer-directive 等价 Phase 9 共识) -->
+
+本 prompt 是 marker/artifact-only,**默认不需要任何 gh 操作**。
+
+不可调:`git commit/push/checkout/merge/reset/rebase`、`gh pr create`、`gh pr merge`、`gh pr close`、`gh issue create`、`gh issue close`、`gh issue edit --add-label`、`gh issue edit --remove-label`、`gh pr edit --add-label`、`gh pr edit --remove-label`。lifecycle / label 决策归 controller,worker 不得越线。
+
+可调(仅当本 prompt 明示要 post 时):`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`。本 prompt 未明示 → 不要调任何 gh。
+
 开始执行。
 
 ---

--- a/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Source-regression: marker-only prompts must explicitly ban lifecycle gh operations."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__)
+PROMPTS_DIR = SCRIPT_PATH.parents[1] / "prompts"
+
+MARKER_ONLY_PROMPTS = (
+    "audit.md",
+    "implement.md",
+    "verify.md",
+    "remote-ci-fix.md",
+    "test-add.md",
+)
+
+REQUIRED_BAN_SUBSTRINGS = (
+    "## codex 工具边界(强制)",
+    "iter5/prompt-gh-ban-marker-only",
+    "marker/artifact-only",
+    "gh pr create",
+    "gh pr merge",
+    "gh pr close",
+    "gh issue create",
+    "gh issue close",
+    "gh issue edit --add-label",
+    "gh issue edit --remove-label",
+    "gh pr edit --add-label",
+    "gh pr edit --remove-label",
+    "lifecycle / label 决策归 controller",
+)
+
+
+class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
+    def test_each_marker_only_prompt_has_complete_ban_section(self) -> None:
+        for filename in MARKER_ONLY_PROMPTS:
+            with self.subTest(prompt=filename):
+                path = PROMPTS_DIR / filename
+                self.assertTrue(path.exists(), f"missing prompt: {filename}")
+                body = path.read_text(encoding="utf-8")
+                for needle in REQUIRED_BAN_SUBSTRINGS:
+                    self.assertIn(
+                        needle,
+                        body,
+                        f"{filename} 缺少必备字面 `{needle}`(iter5 ban section regression)",
+                    )
+
+    def test_refactor_self_doc_block_present(self) -> None:
+        for filename in MARKER_ONLY_PROMPTS:
+            with self.subTest(prompt=filename):
+                body = (PROMPTS_DIR / filename).read_text(encoding="utf-8")
+                self.assertIn(
+                    "Refactor (iter5/prompt-gh-ban-marker-only)",
+                    body,
+                    f"{filename} 缺少 Refactor self-doc 块",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动

`audit.md` / `implement.md` / `verify.md` / `remote-ci-fix.md` / `test-add.md` 5 个 marker-only prompts 末尾(在"开始执行。"前)追加「## codex 工具边界(强制)」段:
- **不可调**: \`git commit/push/checkout/merge/reset/rebase\`、\`gh pr create\`、\`gh pr merge\`、\`gh pr close\`、\`gh issue create\`、\`gh issue close\`、\`gh issue edit --add-label\`、\`gh issue edit --remove-label\`、\`gh pr edit --add-label\`、\`gh pr edit --remove-label\`
- **可调**(仅当 prompt 明示要 post): \`gh issue/pr comment\`、\`gh pr edit --body-file\`、\`gh api .../reactions\`、\`mktemp\`
- 每段含 Refactor self-doc 块 \`iter5/prompt-gh-ban-marker-only\`

配套:`scripts/test_marker_only_prompts_gh_ban.py` 2 个 source-regression test,5 prompt × 13 substring 断言,跑通(\`Ran 2 tests in 0.001s, OK\`)。

## 漏洞实证(2026-05-26 session maintainer 提问)

session 实证:reviewer-architect / reviewer-tests / reviewer-quality / review-fix / solver-{minimal,structural,delete} / meta-judge / design-issue-reply / triage-external-issue 9 个 prompts 都有"可调/不可调"段; audit / implement / verify / remote-ci-fix / test-add 5 个 marker-only prompts 都**没**该段。理论后果:codex 拿这些 prompt 可自由 lifecycle 操作 GitHub,违反 SKILL.md "Controller owns ...PR create/merge/close + label"。audit.md 还顺带缺 \`git commit/push/checkout\` 显式禁。

## Phase 9 等价证明

依 \`CLAUDE.md\` maintainer-directive equivalence 子句(PR #48 merged):
- audit-derived: reviewer/solver prompts 已有该模式,本批扩到 marker-only,非新设计
- requires_design=false: 机械复制
- host-agnostic: gh 命令通用,不含 host fact
- 配套行为测试 + source-regression test(已 pass)
- 保留 Refactor self-doc 块(\`iter5/prompt-gh-ban-marker-only\`)
- 不放宽 merge gate / CI / lifecycle authority / Tier I/II 边界
- artifact: \`.refactor-loop/runs/maintainer-directives/2026-05-26-prompt-gh-ban-marker-only.md\`

## Related

- 既有"可调/不可调"模式来源:reviewer-architect.md / solver-*.md / meta-judge.md 等(merged earlier)
- 现存 design issue #53:"codex 直接操作 git/gh 减少 controller 中转" — 本 PR 与 #53 方向相反(收紧而非放开),#53 后续如有 expand 必须在这 5 prompt 修改 ban list

⟦AI:AUTO-LOOP⟧