### PR TITLE
feat(skill): statusline 扩 daemon health

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -111,11 +111,11 @@ Named exception: this autonomous release gate is host-agnostic and has no lifecy
 
 ## Claude Code statusline(per #51 consensus)
 
-`skills/codex-refactor-loop/scripts/statusline.sh` 是 fast (<200ms) read-only Claude Code statusline reader,显示本仓库 loop 实时状态(codex 计数、PR/issue 数、P0 streak、freeze 指示)。
+`skills/codex-refactor-loop/scripts/statusline.sh` 是 fast (<200ms) read-only Claude Code statusline reader,显示本仓库 loop 实时状态(codex 计数、PR/issue 数、daemon 健康、P0 streak、freeze 指示)。
 
-**Producer**:`concurrency_monitor.py` 每 tick 末尾原子写 `.refactor-loop/state/statusline-snapshot.json`(reuse 现有 daemon,**无新 daemon**)。
+**Producer**:`concurrency_monitor.py` 每 tick 末尾原子写 `.refactor-loop/state/statusline-snapshot.json`(reuse 现有 daemon,**无新 daemon**)。Snapshot 包含 `daemons` map(扫 `.refactor-loop/heartbeats/*.ts` 动态发现,每条记 `age_seconds` + `stale`,stale 阈值 90s)+ 汇总 `daemons_healthy` / `daemons_total`。
 
-**Consumer**:`statusline.sh` 读 snapshot,bash + jq < 200ms。
+**Consumer**:`statusline.sh` 读 snapshot,bash + jq < 200ms。任一 daemon stale → ⚠ 红色。显示形如 `⚙ 5/10 PR:1 issue:9 d:5/5`。
 
 **Install**(host project,**手动一行,无 installer script**):
 
@@ -129,10 +129,10 @@ Named exception: this autonomous release gate is host-agnostic and has no lifecy
 **Uninstall**:删 `statusLine` 字段即可。
 
 **Named runtime exception(per #51 consensus)**:
-- **Narrow allowlist**:concurrency_monitor 加一行 snapshot write;不增其他 producer 职责;不引入新 daemon。
-- **Host-agnostic**:snapshot schema 不含 host fact;statusline.sh 不假设 host repo 结构(只依赖 $REPO_ROOT)。
+- **Narrow allowlist**:concurrency_monitor 写 snapshot + 顺手 stat `heartbeats/*.ts` 汇总 daemon 健康;不引入新 daemon、不持 lifecycle authority、不读 prompt body。
+- **Host-agnostic**:snapshot schema 不含 host fact;daemon 发现按 heartbeat 文件 glob,无 hard-coded daemon 列表;statusline.sh 不假设 host repo 结构(只依赖 $REPO_ROOT)。
 - **No lifecycle authority**:statusline 只 read,不写 GitHub / git / file lifecycle。
-- **Behavior tests**:`test_statusline.sh` < 200ms + 各 state icon + freeze 指示。
+- **Behavior tests**:`test_statusline.sh` < 200ms + 各 state icon + freeze 指示 + daemon health 显示;`test_concurrency_monitor.py::StatuslineDaemonHealthTests` 覆盖 fresh / stale / malformed / missing-dir / 动态发现 / snapshot 字段。
 - **Source-regression**:本段 + Named exception 子段 + install one-liner。
 
 授权来源:`.refactor-loop/runs/phase9-issue51-r3-judge.md`(Phase 9 r3 3/3 unanimous consensus on C framing)。

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -132,7 +132,7 @@ Named exception: this autonomous release gate is host-agnostic and has no lifecy
 - **Narrow allowlist**:concurrency_monitor 写 snapshot + 顺手 stat `heartbeats/*.ts` 汇总 daemon 健康;不引入新 daemon、不持 lifecycle authority、不读 prompt body。
 - **Host-agnostic**:snapshot schema 不含 host fact;daemon 发现按 heartbeat 文件 glob,无 hard-coded daemon 列表;statusline.sh 不假设 host repo 结构(只依赖 $REPO_ROOT)。
 - **No lifecycle authority**:statusline 只 read,不写 GitHub / git / file lifecycle。
-- **Behavior tests**:`test_statusline.sh` < 200ms + 各 state icon + freeze 指示 + daemon health 显示;`test_concurrency_monitor.py::StatuslineDaemonHealthTests` 覆盖 fresh / stale / malformed / missing-dir / 动态发现 / snapshot 字段。
+- **Behavior tests**:`test_statusline.sh` < 200ms + 各 state icon + freeze 指示 + daemon health 显示;`test_concurrency_monitor.py::SnapshotDaemonHealthFieldTests` 覆盖 fresh / stale / malformed / missing-dir / 动态发现 / snapshot 字段。
 - **Source-regression**:本段 + Named exception 子段 + install one-liner。
 
 授权来源:`.refactor-loop/runs/phase9-issue51-r3-judge.md`(Phase 9 r3 3/3 unanimous consensus on C framing)。

--- a/skills/codex-refactor-loop/scripts/concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/concurrency_monitor.py
@@ -68,6 +68,8 @@ GH_REPO_SLUG = github_repo_slug()
 ALERT_LOG = REPO_ROOT / ".refactor-loop" / ".concurrency-alert.log"
 PENDING_EVENTS = REPO_ROOT / ".refactor-loop" / ".controller-pending-events.log"
 STATUSLINE_SNAPSHOT = REPO_ROOT / ".refactor-loop" / "state" / "statusline-snapshot.json"
+HEARTBEATS_DIR = REPO_ROOT / ".refactor-loop" / "heartbeats"
+HEARTBEAT_STALE_SECONDS = 90
 PROGRESS_MARKER_RE = re.compile(r"\b(PHASE|REVIEW|FIX|META)[A-Z_]*:")
 DISPATCH_QUEUE = REPO_ROOT / ".refactor-loop" / "dispatch-queue"
 DISPATCH_DISPATCHED = REPO_ROOT / ".refactor-loop" / "dispatch-dispatched"
@@ -163,6 +165,32 @@ def freeze_minutes(now: float | None = None) -> int:
     return max(0, int((now - marker_at) / 60))
 
 
+def read_daemon_heartbeats(now: float | None = None) -> dict[str, dict]:
+    """Discover heartbeat files and report age/stale per daemon.
+
+    Each `.ts` file under HEARTBEATS_DIR is treated as one daemon. The file name
+    minus `.ts` is the daemon key. A missing/malformed/empty file is reported
+    as `stale=True` with `age_seconds=None`. Discovery is dynamic so adding a
+    new daemon that writes a heartbeat is automatically surfaced; no caller
+    list to keep in sync.
+    """
+    if now is None:
+        now = time.time()
+    result: dict[str, dict] = {}
+    if not HEARTBEATS_DIR.exists():
+        return result
+    for hb in sorted(HEARTBEATS_DIR.glob("*.ts")):
+        name = hb.stem
+        try:
+            raw = hb.read_text(encoding="utf-8").strip()
+            ts = int(raw)
+            age = max(0, int(now - ts))
+            result[name] = {"age_seconds": age, "stale": age >= HEARTBEAT_STALE_SECONDS}
+        except (OSError, ValueError):
+            result[name] = {"age_seconds": None, "stale": True}
+    return result
+
+
 def write_statusline_snapshot(
     *,
     actual: int,
@@ -171,11 +199,15 @@ def write_statusline_snapshot(
     last_p0_at: str | None,
     open_pr_count: int,
     open_issue_count: int,
+    daemons: dict[str, dict] | None = None,
     now: datetime | None = None,
 ) -> None:
     """Write the Claude Code statusline snapshot atomically."""
     if now is None:
         now = datetime.now(timezone.utc)
+    if daemons is None:
+        daemons = read_daemon_heartbeats(now=now.timestamp())
+    healthy = sum(1 for d in daemons.values() if not d["stale"])
     payload = {
         "ts": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "actual": actual,
@@ -186,6 +218,9 @@ def write_statusline_snapshot(
         "freeze_minutes": freeze_minutes(now.timestamp()),
         "open_pr_count": open_pr_count,
         "open_issue_count": open_issue_count,
+        "daemons": daemons,
+        "daemons_healthy": healthy,
+        "daemons_total": len(daemons),
     }
     STATUSLINE_SNAPSHOT.parent.mkdir(parents=True, exist_ok=True)
     tmp = STATUSLINE_SNAPSHOT.with_name(f".{STATUSLINE_SNAPSHOT.name}.tmp.{os.getpid()}")

--- a/skills/codex-refactor-loop/scripts/statusline.sh
+++ b/skills/codex-refactor-loop/scripts/statusline.sh
@@ -28,10 +28,16 @@ p0=$(jq -r '.p0_streak' "$SNAPSHOT")
 prs=$(jq -r '.open_pr_count' "$SNAPSHOT")
 issues=$(jq -r '.open_issue_count' "$SNAPSHOT")
 freeze=$(jq -r '.freeze_minutes' "$SNAPSHOT")
+d_healthy=$(jq -r '.daemons_healthy // 0' "$SNAPSHOT")
+d_total=$(jq -r '.daemons_total // 0' "$SNAPSHOT")
 
 icon="⚙"
 color=""
 if [ "$actual" -lt "$floor" ]; then
+  icon="⚠"
+  color="\033[31m"
+fi
+if [ "$d_total" -gt 0 ] && [ "$d_healthy" -lt "$d_total" ]; then
   icon="⚠"
   color="\033[31m"
 fi
@@ -49,5 +55,9 @@ p0_seg=""
 if [ "$p0" -gt 2 ]; then
   p0_seg=" P0×${p0}"
 fi
+d_seg=""
+if [ "$d_total" -gt 0 ]; then
+  d_seg=" d:${d_healthy}/${d_total}"
+fi
 
-printf "${color}${icon} ${actual}/${floor} PR:${prs} issue:${issues}${p0_seg}${freeze_seg}${reset}\n"
+printf "${color}${icon} ${actual}/${floor} PR:${prs} issue:${issues}${d_seg}${p0_seg}${freeze_seg}${reset}\n"

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
@@ -295,7 +295,7 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
             self.assertNotIn(" -c ", line)
 
 
-class StatuslineDaemonHealthTests(unittest.TestCase):
+class SnapshotDaemonHealthFieldTests(unittest.TestCase):
     """Producer side of the statusline daemon-health extension.
 
     Daemon heartbeat staleness is collected by concurrency_monitor and surfaced

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
@@ -295,5 +295,119 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
             self.assertNotIn(" -c ", line)
 
 
+class StatuslineDaemonHealthTests(unittest.TestCase):
+    """Producer side of the statusline daemon-health extension.
+
+    Daemon heartbeat staleness is collected by concurrency_monitor and surfaced
+    in the snapshot, so the consumer (statusline.sh) does not need to enumerate
+    daemons itself. Discovery is dynamic via heartbeat file presence.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.old_env = os.environ.copy()
+        os.environ["REPO_ROOT"] = str(self.repo)
+        os.environ["CODEX_FLOOR"] = "2"
+        sys.path.insert(0, str(SCRIPT_DIR))
+        import concurrency_monitor
+
+        self.monitor = importlib.reload(concurrency_monitor)
+        self.heartbeats = self.repo / ".refactor-loop" / "heartbeats"
+        self.heartbeats.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self.old_env)
+        try:
+            sys.path.remove(str(SCRIPT_DIR))
+        except ValueError:
+            pass
+        self.tmp.cleanup()
+
+    def _write_heartbeat(self, name: str, age_seconds: int, now: float) -> None:
+        (self.heartbeats / f"{name}.ts").write_text(str(int(now - age_seconds)))
+
+    def test_read_daemon_heartbeats_fresh_is_not_stale(self) -> None:
+        now = 1_000_000.0
+        self._write_heartbeat("concurrency_monitor", 10, now)
+        result = self.monitor.read_daemon_heartbeats(now=now)
+        self.assertEqual(result["concurrency_monitor"]["age_seconds"], 10)
+        self.assertFalse(result["concurrency_monitor"]["stale"])
+
+    def test_read_daemon_heartbeats_old_is_stale(self) -> None:
+        now = 1_000_000.0
+        self._write_heartbeat("dev_sync_daemon", 200, now)
+        result = self.monitor.read_daemon_heartbeats(now=now)
+        self.assertTrue(result["dev_sync_daemon"]["stale"])
+        self.assertEqual(result["dev_sync_daemon"]["age_seconds"], 200)
+
+    def test_read_daemon_heartbeats_malformed_is_stale(self) -> None:
+        (self.heartbeats / "comment-monitor.ts").write_text("not-a-number\n")
+        result = self.monitor.read_daemon_heartbeats(now=1_000_000.0)
+        self.assertTrue(result["comment-monitor"]["stale"])
+        self.assertIsNone(result["comment-monitor"]["age_seconds"])
+
+    def test_read_daemon_heartbeats_missing_dir_returns_empty(self) -> None:
+        # Wipe heartbeats dir; ensure no crash and empty result.
+        import shutil
+
+        shutil.rmtree(self.heartbeats)
+        self.assertEqual(self.monitor.read_daemon_heartbeats(now=1_000_000.0), {})
+
+    def test_read_daemon_heartbeats_discovers_dynamically(self) -> None:
+        # New daemon name not in any hard-coded list should appear automatically.
+        now = 1_000_000.0
+        self._write_heartbeat("future_daemon", 5, now)
+        result = self.monitor.read_daemon_heartbeats(now=now)
+        self.assertIn("future_daemon", result)
+
+    def test_snapshot_includes_daemons_map_and_counts(self) -> None:
+        from datetime import datetime, timezone
+
+        now_dt = datetime(2026, 5, 26, 19, 0, 0, tzinfo=timezone.utc)
+        now_ts = now_dt.timestamp()
+        self._write_heartbeat("concurrency_monitor", 5, now_ts)
+        self._write_heartbeat("comment-monitor", 5, now_ts)
+        self._write_heartbeat("dev_sync_daemon", 300, now_ts)  # stale
+        self.monitor.write_statusline_snapshot(
+            actual=7,
+            expected=5,
+            p0_streak=0,
+            last_p0_at=None,
+            open_pr_count=2,
+            open_issue_count=4,
+            now=now_dt,
+        )
+        snap_path = self.repo / ".refactor-loop" / "state" / "statusline-snapshot.json"
+        payload = json.loads(snap_path.read_text())
+        self.assertEqual(payload["daemons_total"], 3)
+        self.assertEqual(payload["daemons_healthy"], 2)
+        self.assertIn("daemons", payload)
+        self.assertTrue(payload["daemons"]["dev_sync_daemon"]["stale"])
+        self.assertFalse(payload["daemons"]["concurrency_monitor"]["stale"])
+
+    def test_snapshot_with_no_heartbeats_writes_empty_daemons(self) -> None:
+        from datetime import datetime, timezone
+
+        # Ensure no heartbeats present.
+        for hb in self.heartbeats.glob("*.ts"):
+            hb.unlink()
+        self.monitor.write_statusline_snapshot(
+            actual=3,
+            expected=3,
+            p0_streak=0,
+            last_p0_at=None,
+            open_pr_count=0,
+            open_issue_count=0,
+            now=datetime(2026, 5, 26, 19, 0, 0, tzinfo=timezone.utc),
+        )
+        snap_path = self.repo / ".refactor-loop" / "state" / "statusline-snapshot.json"
+        payload = json.loads(snap_path.read_text())
+        self.assertEqual(payload["daemons"], {})
+        self.assertEqual(payload["daemons_total"], 0)
+        self.assertEqual(payload["daemons_healthy"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_statusline.sh
+++ b/skills/codex-refactor-loop/scripts/test_statusline.sh
@@ -97,11 +97,52 @@ JSON
   assert_contains "$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")" "P0×3" "test_p0_streak_over_2_shows_highlight"
 }
 
+test_all_daemons_healthy_shows_full_count() {
+  setup_repo
+  write_snapshot <<'JSON'
+{"actual":7,"expected":5,"floor":4,"p0_streak":0,"open_pr_count":5,"open_issue_count":4,"freeze_minutes":0,"daemons_healthy":5,"daemons_total":5}
+JSON
+  local out
+  out="$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")"
+  assert_contains "$out" "d:5/5" "test_all_daemons_healthy_shows_full_count"
+  if [[ "$out" == *"⚠"* ]]; then
+    echo "FAIL test_all_daemons_healthy_shows_full_count: warning icon present when healthy: $out" >&2
+    exit 1
+  fi
+}
+
+test_stale_daemon_shows_warning_icon() {
+  setup_repo
+  write_snapshot <<'JSON'
+{"actual":7,"expected":5,"floor":4,"p0_streak":0,"open_pr_count":5,"open_issue_count":4,"freeze_minutes":0,"daemons_healthy":3,"daemons_total":5}
+JSON
+  local out
+  out="$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")"
+  assert_contains "$out" "d:3/5" "test_stale_daemon_shows_warning_icon (count)"
+  assert_contains "$out" "⚠" "test_stale_daemon_shows_warning_icon (icon)"
+}
+
+test_no_daemons_field_omits_segment() {
+  setup_repo
+  write_snapshot <<'JSON'
+{"actual":7,"expected":5,"floor":4,"p0_streak":0,"open_pr_count":5,"open_issue_count":4,"freeze_minutes":0}
+JSON
+  local out
+  out="$(REPO_ROOT="$TMP_DIR" bash "$STATUSLINE")"
+  if [[ "$out" == *" d:"* ]]; then
+    echo "FAIL test_no_daemons_field_omits_segment: daemon segment shown when fields absent: $out" >&2
+    exit 1
+  fi
+}
+
 test_statusline_runs_under_200ms
 test_no_snapshot_returns_placeholder
 test_healthy_state_shows_actual_floor
 test_below_floor_shows_warning_icon
 test_freeze_minutes_over_10_shows_stuck
 test_p0_streak_over_2_shows_highlight
+test_all_daemons_healthy_shows_full_count
+test_stale_daemon_shows_warning_icon
+test_no_daemons_field_omits_segment
 
 echo "statusline tests ok"

--- a/skills/codex-refactor-loop/scripts/test_statusline_daemon_health_regression.py
+++ b/skills/codex-refactor-loop/scripts/test_statusline_daemon_health_regression.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Source-regression tests for the statusline daemon-health extension.
+
+These assertions lock the SKILL.md narrow-allowlist wording, the producer
+function name, and the consumer display format so that doc and implementation
+cannot drift apart. They use plain substring grep on the file text, not the
+shared paragraph helper, because the helper currently fails on an unrelated
+pre-existing CLAUDE.md drift (commit 634a608 rewrote CLAUDE.md to
+philosophy-only but did not retire the corresponding paragraph tests).
+"""
+
+import unittest
+from pathlib import Path
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SKILL_MD = SKILL_ROOT / "SKILL.md"
+STATUSLINE_SH = SKILL_ROOT / "scripts" / "statusline.sh"
+CONCURRENCY_MONITOR = SKILL_ROOT / "scripts" / "concurrency_monitor.py"
+
+
+class StatuslineDaemonHealthSourceRegressionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill_md = SKILL_MD.read_text(encoding="utf-8")
+        self.statusline_sh = STATUSLINE_SH.read_text(encoding="utf-8")
+        self.monitor_py = CONCURRENCY_MONITOR.read_text(encoding="utf-8")
+
+    def test_skill_md_documents_daemon_health_in_statusline_section(self) -> None:
+        self.assertIn("Claude Code statusline", self.skill_md)
+        self.assertIn("daemon 健康", self.skill_md)
+        self.assertIn("daemons_healthy", self.skill_md)
+        self.assertIn("daemons_total", self.skill_md)
+        self.assertIn("heartbeats/*.ts", self.skill_md)
+        # Display format example must match what statusline.sh prints so future
+        # readers do not invent a different schema.
+        self.assertIn("d:5/5", self.skill_md)
+
+    def test_skill_md_locks_narrow_allowlist_for_extension(self) -> None:
+        # The exception must stay narrow: no new daemon, no lifecycle authority,
+        # no prompt-body reading. These are the same invariants #51 r3 set;
+        # this PR only widens the producer to also stat heartbeats.
+        self.assertIn("不引入新 daemon", self.skill_md)
+        self.assertIn("不持 lifecycle authority", self.skill_md)
+        self.assertIn("不读 prompt body", self.skill_md)
+        self.assertIn("无 hard-coded daemon 列表", self.skill_md)
+
+    def test_producer_function_name_present(self) -> None:
+        self.assertIn("def read_daemon_heartbeats(", self.monitor_py)
+        self.assertIn("HEARTBEATS_DIR", self.monitor_py)
+        self.assertIn("HEARTBEAT_STALE_SECONDS = 90", self.monitor_py)
+
+    def test_consumer_reads_daemon_fields(self) -> None:
+        self.assertIn(".daemons_healthy", self.statusline_sh)
+        self.assertIn(".daemons_total", self.statusline_sh)
+        # Display segment format and warning behavior are locked.
+        self.assertIn(' d:${d_healthy}/${d_total}', self.statusline_sh)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Producer adds daemons map + healthy/total to snapshot; consumer shows d:N/M, stale 转红. heartbeats/*.ts dynamic discovery. tests: 22+9+9+4 全过. ⟦AI:AUTO-LOOP⟧