### PR TITLE
fix(skill): solver-delete 单 terminal vocabulary(删 Deferrable 内部矛盾)

### DIFF
--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -1,5 +1,9 @@
 # Role: Solver — delete framing(no defer)
 
+<!-- Refactor (iter213/cluster-213-006-delete-solver-defer-escape):
+  Old pattern: delete solver forbids defer, then defines Deferrable and asks for a tracking issue creation suggestion(prompt 内部矛盾,且 gh issue create 后被禁)
+  New principle: delete solver 单 terminal vocabulary:delete/collapse/abstain/escalate;无 deferred side-channel、无 issue-create 命令建议;'not now' map 到 abstain/false-positive,lifecycle 决策归 controller/maintainer。 -->
+
 You are **one of 3 independent design solvers** evaluating issue **${ISSUE_NUMBER}** (cluster `${CLUSTER_ID}`). You see only the issue + repo, NOT the other solvers' outputs.
 
 Your bias: **question the necessity**. Before any code change, ask:
@@ -7,7 +11,7 @@ Your bias: **question the necessity**. Before any code change, ask:
 - Can it be deleted entirely?
 - Can it be merged into an existing simpler abstraction?
 
-**Do NOT propose "defer to a later iteration"**: this loop is fully automated and unlimited-compute; nothing waits on human bandwidth. Either delete now, or accept it must stay (abstain / let minimal/structural propose). "defer" is not a valid verdict.
+**Do NOT propose "defer to a later iteration"**: this loop is fully automated and unlimited-compute; nothing waits on human bandwidth. Either delete/collapse now, or accept it must stay (abstain / false-positive / let minimal/structural propose). "defer" is not a valid verdict.
 
 You explicitly resist adding code. If after honest evaluation the feature must stay, abstain and let `solver-minimal` or `solver-structural` win.
 
@@ -36,8 +40,7 @@ You explicitly resist adding code. If after honest evaluation the feature must s
    - **(b) Orphan feature** — has callers but capability is unused/disabled (feature flag off, old endpoint not in routes, etc.). → propose deletion + remove unused entry points.
    - **(c) Replaceable with existing** — there's already another code path doing the same job. → propose deletion + redirect.
    - **(d) Genuinely needed but over-built** — feature is real but uses 5 abstractions when 1 would do. → propose collapse-and-delete.
-   - **(e) Genuinely needed and right-sized** → ABSTAIN, defer to other solvers.
-   - **(f) Deferrable** — needed eventually but no current dependency forces it now. → propose moving cluster to "deferred" with a tracking issue.
+   - **(e) Genuinely needed and right-sized, or "not now" / no current dependency** → ABSTAIN or `SOLVER_DONE:delete:false-positive:<reason>` with evidence. Lifecycle decisions stay with controller/maintainer.
 3. **If the best deletion/collapse plan changes philosophy or Tier boundaries**, include exact file/clause, current invariant, proposed invariant/text, why deletion makes that change worth it, and why deep consensus should be reachable. Do NOT emit `escalate` or `abstain` merely because an existing philosophy/Tier boundary would change.
 4. **Escalate only for real exits**:
    - `ESCALATE_REASON:gpg-ratification:<short>` — consensus plan would require physical human GPG signing for Tier II files (`SPEC.md`, `conformance/`, `trusted_base.lock`) or physical Tier I supervisor reinstall/swap.
@@ -56,10 +59,10 @@ verdict: propose | abstain | escalate
 ---
 
 ## Classification
-<one of a/b/c/d/e/f from procedure step 2>
+<one of a/b/c/d/e from procedure step 2>
 
 ## Recommended action
-<one paragraph 中文: delete what, redirect callers to where, or defer to which future iteration with what tracking>
+<one paragraph 中文: delete what, redirect callers to where, collapse what, abstain with evidence, or mark false-positive with evidence>
 
 ## Concrete plan (if propose)
 - Files to delete: <list>
@@ -67,7 +70,6 @@ verdict: propose | abstain | escalate
 - Tests to delete: <list of test files no longer needed>
 - LOC delta: -N (deletion-positive number)
 - Philosophy/CLAUDE.md/SPEC/Tier changes (if any): <exact file/clause + from X to Y + why worth it + why consensus can hold, OR "none">
-- Tracking issue (if defer): <gh issue create command suggestion>
 
 ## Reverse-evidence (why this is safe to delete)
 - No public API breaks (verified by `git grep` on public surface)
@@ -89,8 +91,8 @@ verdict: propose | abstain | escalate
 ```
 
 End with EXACTLY ONE marker line:
-- `SOLVER_DONE:delete:propose:<summary>` — concrete deletion / deferral plan
-- `SOLVER_DONE:delete:abstain:<reason>` — feature genuinely needed, defer to other solvers (this is a NORMAL outcome; do not feel obligated to find something to delete)
+- `SOLVER_DONE:delete:propose:<summary>` — concrete deletion / collapse plan
+- `SOLVER_DONE:delete:abstain:<reason>` — feature genuinely needed or no current deletion/collapse is justified (this is a NORMAL outcome; do not feel obligated to find something to delete)
 - `SOLVER_DONE:delete:escalate:gpg-ratification:<reason>` — concrete plan exists and only physical Tier II GPG signing or Tier I reinstall/swap blocks landing
 - `SOLVER_DONE:delete:escalate:no-plan:<reason>` — no deletion/collapse/abstain classification can be produced
 - `SOLVER_DONE:delete:false-positive:<reason>`

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -639,6 +639,32 @@ class ProjectRulesPromptContractTests(unittest.TestCase):
                 self.assertIn("AI 内容标识符", text)
                 self.assertIn("⟦AI:AUTO-LOOP⟧", text)
 
+    # Refactor (iter213/cluster-213-006-delete-solver-defer-escape):
+    #   Old pattern: delete solver forbids defer, then defines Deferrable and asks for a tracking issue creation suggestion(prompt 内部矛盾,且 gh issue create 后被禁)
+    #   New principle: delete solver 单 terminal vocabulary:delete/collapse/abstain/escalate;无 deferred side-channel、无 issue-create 命令建议;'not now' map 到 abstain/false-positive,lifecycle 决策归 controller/maintainer。
+    def test_delete_solver_has_no_defer_side_channel_or_issue_create_suggestion(self) -> None:
+        solver_delete = (SKILL_ROOT / "prompts" / "solver-delete.md").read_text(encoding="utf-8")
+        scan_text = "\n".join(
+            line
+            for line in solver_delete.splitlines()
+            if "Refactor (iter213/cluster-213-006-delete-solver-defer-escape)" not in line
+            and "Old pattern:" not in line
+            and "New principle:" not in line
+        )
+
+        forbidden_tokens = (
+            "Deferrable",
+            "Tracking issue (if defer)",
+            "tracking issue creation suggestion",
+            "gh issue create command suggestion",
+            "moving cluster to \"deferred\"",
+        )
+        for token in forbidden_tokens:
+            with self.subTest(token=token):
+                self.assertNotIn(token, scan_text)
+        self.assertIn("Either delete/collapse now", scan_text)
+        self.assertIn("Lifecycle decisions stay with controller/maintainer.", scan_text)
+
 
 class ContributingDocSourceRegressionTests(unittest.TestCase):
     def read_contributing(self) -> str:


### PR DESCRIPTION
## 动机

audit-iter-213 cluster-006(R02-SINGLE-MAINLINE / R08-DELETION-FIRST / R14-CONTROLLER-OWNS-LIFECYCLE)direct-implement。

solver-delete.md 内部矛盾:先禁 defer,后定义 Deferrable + 教 solver 生成 gh issue create 命令建议,而 prompt 后段 lifecycle gh 又被禁。

## 变更

- 删 Deferrable 分类 + tracking-issue 命令建议段。
- 'not now' map 到 abstain/false-positive 配 evidence,lifecycle 决策归 controller/maintainer。
- 加 source-regression 锁住 Deferrable / Tracking issue (if defer) tokens 不再出现。

## 验证

- 282 tests pass(281+1)。
- 2 files changed, 36+/8-。

auto-loop

⟦AI:AUTO-LOOP⟧