### PR TITLE
fix(skill): phase9_router converge guard(judge-only source + 单调 round)

### DIFF
--- a/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
@@ -225,10 +225,23 @@ class Phase9Router:
                 ledger.add(key)
 
     def _dispatch_meta_judge_routes(self, markers: list[Marker], ledger: set[str]) -> None:
+        # Refactor (iter5/skill-converge-source-and-monotonic-guard):
+        #   Old pattern: any log with `META_JUDGE_DONE:converge:round-N` marker
+        #   could trigger solver dispatch, and `target_round` was accepted even
+        #   if it equaled or preceded the source log's round. Result: solver
+        #   logs echoing prompt-body marker examples plus judge-self-referential
+        #   verdicts spawned cascading r3..r8 solver rounds with judge gaps.
+        #   New principle: only judge-role source logs may authorize a converge
+        #   dispatch (JUDGE markers come from JUDGE logs), and `target_round`
+        #   must be strictly greater than the source round (monotonic).
         for marker in markers:
             if marker.marker.startswith("META_JUDGE_DONE:converge:round-"):
+                if marker.role != "judge":
+                    continue
                 target_round = self._round_from_converge(marker.marker)
                 if target_round is None:
+                    continue
+                if target_round <= marker.round:
                     continue
                 for role in ROLES:
                     key = self._key(marker.issue, target_round, role)
@@ -247,6 +260,8 @@ class Phase9Router:
                 continue
 
             if marker.marker.startswith("META_JUDGE_DONE:escalate:stalled:"):
+                if marker.role != "judge":
+                    continue
                 key = self._key(marker.issue, marker.round, "reflector")
                 log_path = self._log_path(marker.issue, marker.round, "reflector")
                 if key in ledger or self._in_flight(log_path):
@@ -277,9 +292,15 @@ class Phase9Router:
 
     def _directly_handled(self, marker: Marker, ledger: set[str]) -> bool:
         if marker.marker.startswith("META_JUDGE_DONE:converge:round-"):
+            if marker.role != "judge":
+                return False
             target_round = self._round_from_converge(marker.marker)
-            return target_round is not None and all(self._key(marker.issue, target_round, role) in ledger for role in ROLES)
+            if target_round is None or target_round <= marker.round:
+                return False
+            return all(self._key(marker.issue, target_round, role) in ledger for role in ROLES)
         if marker.marker.startswith("META_JUDGE_DONE:escalate:stalled:"):
+            if marker.role != "judge":
+                return False
             return self._key(marker.issue, marker.round, "reflector") in ledger
         return False
 

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -2511,5 +2511,36 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
         self.assertIsNone(re.search(r"\.proto\b", prompt_text))
 
 
+class Phase9RouterConvergeGuardSourceRegressionTests(unittest.TestCase):
+    """Phase 9 router daemon must enforce judge-only source + monotonic round on converge dispatch."""
+
+    DAEMON_PATH = SKILL_ROOT / "scripts" / "phase9_router_daemon.py"
+
+    def test_dispatch_meta_judge_routes_requires_judge_role_and_monotonic_round(self) -> None:
+        src = self.DAEMON_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "Refactor (iter5/skill-converge-source-and-monotonic-guard)",
+            src,
+            "refactor self-documentation must remain attached to converge guard",
+        )
+        self.assertIn('if marker.role != "judge":', src,
+                      "converge dispatch must require judge-role source log")
+        self.assertIn("if target_round <= marker.round:", src,
+                      "converge dispatch must require strictly greater target round")
+
+    def test_directly_handled_mirrors_converge_guards(self) -> None:
+        src = self.DAEMON_PATH.read_text(encoding="utf-8")
+        self.assertGreaterEqual(
+            src.count('if marker.role != "judge":'),
+            2,
+            "judge-role guard must apply in both _dispatch_meta_judge_routes and _directly_handled",
+        )
+        self.assertGreaterEqual(
+            src.count("target_round <= marker.round"),
+            2,
+            "monotonic round guard must apply in both _dispatch_meta_judge_routes and _directly_handled",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -158,6 +158,86 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             ["37-5-delete", "37-5-minimal", "37-5-structural"],
         )
 
+    def test_phase9_router_converge_ignores_non_judge_source_logs(self) -> None:
+        # Refactor (iter5/skill-converge-source-and-monotonic-guard):
+        # solver logs echoing a converge marker (e.g. from prompt body or codex
+        # brainstorming) must not authorize daemon to dispatch next-round
+        # solvers. Only judge-role logs may carry an authoritative converge
+        # verdict.
+        for role in ("minimal", "structural", "delete"):
+            self.write_log(
+                f"phase9-issue79-r2-{role}.log",
+                f"SOLVER_DONE:{role}:propose:settle",
+                "META_JUDGE_DONE:converge:round-3:echoed-from-prompt-body",
+            )
+
+        self.router.tick()
+
+        for command in self.commands:
+            joined = " ".join(command)
+            self.assertNotIn("phase9-issue79-r3-", joined,
+                             "solver-log converge marker must not spawn next round")
+        ledger_keys = [entry["key"] for entry in self.ledger_entries()]
+        for forbidden in ("79-3-minimal", "79-3-structural", "79-3-delete"):
+            self.assertNotIn(forbidden, ledger_keys)
+
+    def test_phase9_router_converge_requires_strictly_greater_target_round(self) -> None:
+        # Refactor (iter5/skill-converge-source-and-monotonic-guard):
+        # judge emitting converge:round-N where N <= source round (e.g. r2 judge
+        # emitting converge:round-2 self-reference, or a smaller round number)
+        # must be treated as noop — otherwise daemon enters spawn loops over
+        # past rounds.
+        self.write_log(
+            "phase9-issue79-r2-judge.log",
+            "META_JUDGE_DONE:converge:round-2:self-reference-bug",
+        )
+        self.write_log(
+            "phase9-issue79-r5-judge.log",
+            "META_JUDGE_DONE:converge:round-4:backward-reference-bug",
+        )
+
+        self.router.tick()
+
+        for command in self.commands:
+            joined = " ".join(command)
+            self.assertNotIn("phase9-issue79-r2-minimal.log", joined)
+            self.assertNotIn("phase9-issue79-r2-structural.log", joined)
+            self.assertNotIn("phase9-issue79-r2-delete.log", joined)
+            self.assertNotIn("phase9-issue79-r4-minimal.log", joined)
+        ledger_keys = [entry["key"] for entry in self.ledger_entries()]
+        for forbidden in ("79-2-minimal", "79-2-structural", "79-2-delete",
+                          "79-4-minimal", "79-4-structural", "79-4-delete"):
+            self.assertNotIn(forbidden, ledger_keys)
+
+    def test_phase9_router_converge_valid_judge_marker_still_spawns_next_round(self) -> None:
+        # Confirm the source/monotonic guards do not break the happy path:
+        # r4 judge emitting converge:round-5 must still spawn r5 solver triplet.
+        self.write_log(
+            "phase9-issue80-r4-judge.log",
+            "META_JUDGE_DONE:converge:round-5:legitimate-next-round",
+        )
+
+        self.router.tick()
+
+        logs = " ".join(" ".join(command) for command in self.commands)
+        self.assertIn("phase9-issue80-r5-minimal.log", logs)
+        self.assertIn("phase9-issue80-r5-structural.log", logs)
+        self.assertIn("phase9-issue80-r5-delete.log", logs)
+
+    def test_phase9_router_stalled_ignores_non_judge_source_logs(self) -> None:
+        # Solver log emitting an escalate:stalled marker (echo/brainstorm)
+        # must not spawn reflector.
+        self.write_log(
+            "phase9-issue81-r3-minimal.log",
+            "SOLVER_DONE:minimal:ok:summary",
+            "META_JUDGE_DONE:escalate:stalled:echoed-from-prompt",
+        )
+
+        self.router.tick()
+
+        self.assertFalse(any("reflector" in " ".join(command) for command in self.commands))
+        self.assertNotIn("81-3-reflector", [entry["key"] for entry in self.ledger_entries()])
+
     def test_phase9_router_stalled_requires_valid_predicate(self) -> None:
         self.write_log("phase9-issue37-r2-judge.log", "META_JUDGE_DONE:escalate:stalled:no-change")
         self.router.tick()


### PR DESCRIPTION
## 实证

cron #59 发现 phase9_router_daemon 在 issue #79 处理中 over-spawn:floor 涨至 19,daemon 一次性派 r3, r4, r5, r6, r7, r8 全部 solver triplet,judge 全漏。

## 根因

1. r2 judge codex 误 emit \`META_JUDGE_DONE:converge:round-2\`(指向自身 round)
2. \`_dispatch_meta_judge_routes\` 接受任何 log 中的 converge marker(包括 solver log echo prompt body 的 marker)
3. 无 \`target_round > source_round\` 校验

→ daemon 把 solver log 里 echo 的 \`META_JUDGE_DONE:converge:round-N\` 当真 marker,且循环派往各 round。

## Fix(两条窄约束)

\`_dispatch_meta_judge_routes\` + \`_directly_handled\` 同时加:
- \`marker.role != 'judge'\` → 跳过(只信 judge 源 log)
- \`target_round <= marker.round\` → 跳过(round 单调)

stalled 路径同样加 judge-role 约束。

## 授权

maintainer-directive \"有bug及时修\"(本会话直接修,等价 Phase 9 共识)。

## 测试

- behavior(+4):
  - \`test_phase9_router_converge_ignores_non_judge_source_logs\`
  - \`test_phase9_router_converge_requires_strictly_greater_target_round\`
  - \`test_phase9_router_converge_valid_judge_marker_still_spawns_next_round\`(happy-path 不破)
  - \`test_phase9_router_stalled_ignores_non_judge_source_logs\`
- source-regression(+1 class with 2 tests):
  - \`Phase9RouterConvergeGuardSourceRegressionTests\` 字面断言 daemon 含 refactor comment + 两条 guard 字面 + 各出现 ≥2 次(覆盖 dispatch + directly_handled)
- \`python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'\` → **285 OK**

## scope

- \`skills/codex-refactor-loop/scripts/phase9_router_daemon.py\` (+22/-1)
- \`skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py\` (+80)
- \`skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py\` (+31)

⟦AI:AUTO-LOOP⟧