### PR TITLE
fix(skill): phase9_router marker tail-only(避 body echo 误派)

### DIFF
--- a/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
@@ -103,6 +103,17 @@ class Phase9Router:
             lock.flush()
             yield
 
+    # Refactor (iter5/skill-marker-tail-only-scope):
+    #   Old pattern: scan entire log body for markers; codex worker logs that
+    #   happen to echo prompt-body / test-fixture / grep-output marker text
+    #   (e.g. `META_JUDGE_DONE:converge:round-3:echoed-from-prompt-body` from
+    #   test_phase9_router_daemon.py source listing) were classified as real
+    #   verdicts and triggered cascading dispatches.
+    #   New principle: real worker verdict markers always appear in the tail
+    #   alongside `EXIT=0`. Scan only the last MARKER_TAIL_LINES of each log.
+    #   Body-position prompt-body echoes never reach the marker parser.
+    MARKER_TAIL_LINES = 30
+
     def _collect_markers(self) -> list[Marker]:
         markers: list[Marker] = []
         for log_path in sorted(self.logs_dir.glob("*.log")):
@@ -111,7 +122,12 @@ class Phase9Router:
             issue, round_no, role_hint = self._identity_from_path(log_path)
             if issue is None or round_no is None:
                 continue
-            for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            try:
+                lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+            except OSError:
+                continue
+            tail = lines[-self.MARKER_TAIL_LINES :] if len(lines) > self.MARKER_TAIL_LINES else lines
+            for line in tail:
                 marker = self._extract_marker(line)
                 if marker is None:
                     continue

--- a/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
@@ -343,10 +343,18 @@ class Phase9Router:
         return recent[0] == recent[1] == recent[2]
 
     def _collect_markers_from_path(self, path: Path) -> list[str]:
+        # Refactor (iter5/skill-marker-tail-only-scope): same tail-only invariant
+        # as _collect_markers — _stalled_predicate_holds must not trust body-
+        # position SOLVER_DONE echoes when classifying convergence verdicts.
         if not path.exists():
             return []
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            return []
+        tail = lines[-self.MARKER_TAIL_LINES :] if len(lines) > self.MARKER_TAIL_LINES else lines
         markers: list[str] = []
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        for line in tail:
             marker = self._extract_marker(line)
             if marker:
                 markers.append(marker)

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -2562,12 +2562,22 @@ class Phase9RouterMarkerTailOnlySourceRegressionTests(unittest.TestCase):
         )
         self.assertIn("MARKER_TAIL_LINES", src,
                       "tail-only constant must remain named")
-        self.assertIn("self.MARKER_TAIL_LINES", src,
-                      "tail-only slice must use the named constant")
+        # Both marker-parsing helpers must slice to tail (_collect_markers AND
+        # _collect_markers_from_path, the latter feeding _stalled_predicate_holds).
+        self.assertGreaterEqual(
+            src.count("self.MARKER_TAIL_LINES"),
+            2,
+            "tail-only slice must apply to both _collect_markers and _collect_markers_from_path",
+        )
         self.assertNotIn(
             'for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():',
             src,
             "_collect_markers must not iterate the entire log body",
+        )
+        self.assertNotIn(
+            'for line in path.read_text(encoding="utf-8", errors="replace").splitlines():',
+            src,
+            "_collect_markers_from_path must not iterate the entire log body",
         )
 
 

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -2548,6 +2548,29 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
         self.assertIsNone(re.search(r"\.proto\b", prompt_text))
 
 
+class Phase9RouterMarkerTailOnlySourceRegressionTests(unittest.TestCase):
+    """Phase 9 router daemon must scope marker parsing to log tail only."""
+
+    DAEMON_PATH = SKILL_ROOT / "scripts" / "phase9_router_daemon.py"
+
+    def test_collect_markers_uses_tail_only_with_constant(self) -> None:
+        src = self.DAEMON_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "Refactor (iter5/skill-marker-tail-only-scope)",
+            src,
+            "tail-only refactor self-documentation must remain attached",
+        )
+        self.assertIn("MARKER_TAIL_LINES", src,
+                      "tail-only constant must remain named")
+        self.assertIn("self.MARKER_TAIL_LINES", src,
+                      "tail-only slice must use the named constant")
+        self.assertNotIn(
+            'for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():',
+            src,
+            "_collect_markers must not iterate the entire log body",
+        )
+
+
 class Phase9RouterConvergeGuardSourceRegressionTests(unittest.TestCase):
     """Phase 9 router daemon must enforce judge-only source + monotonic round on converge dispatch."""
 

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -158,6 +158,36 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             ["37-5-delete", "37-5-minimal", "37-5-structural"],
         )
 
+    def test_phase9_router_marker_tail_only_ignores_body_echo(self) -> None:
+        # Refactor (iter5/skill-marker-tail-only-scope):
+        # codex worker logs that echo prompt-body / grep-output / test-fixture
+        # marker text in the body (not tail) must NOT trigger dispatch.
+        path = self.repo / ".refactor-loop" / "logs" / "phase9-issue90-r2-judge.log"
+        body_pad = "\n".join(f"discussion line {i}" for i in range(60))
+        body_echo = (
+            "skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py:171: "
+            '"META_JUDGE_DONE:converge:round-3:body-echo-from-test-fixture",'
+        )
+        actual_tail = "META_JUDGE_DONE:converge:round-3:real-tail-verdict"
+        path.write_text(
+            "\n".join([body_pad, body_echo, body_pad, actual_tail, "EXIT=0", ""]),
+            encoding="utf-8",
+        )
+
+        self.router.tick()
+
+        ledger_markers = [entry.get("marker", "") for entry in self.ledger_entries()]
+        for entry_marker in ledger_markers:
+            self.assertNotIn("body-echo-from-test-fixture", entry_marker,
+                             "body-position marker echo must not be classified as verdict")
+        for command in self.commands:
+            joined = " ".join(command)
+            self.assertNotIn("body-echo-from-test-fixture", joined)
+        ledger_keys = [entry["key"] for entry in self.ledger_entries()]
+        for key in ("90-3-minimal", "90-3-structural", "90-3-delete"):
+            self.assertIn(key, ledger_keys,
+                          "real tail verdict must still spawn next round")
+
     def test_phase9_router_converge_ignores_non_judge_source_logs(self) -> None:
         # Refactor (iter5/skill-converge-source-and-monotonic-guard):
         # solver logs echoing a converge marker (e.g. from prompt body or codex

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -162,11 +162,14 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         # Refactor (iter5/skill-marker-tail-only-scope):
         # codex worker logs that echo prompt-body / grep-output / test-fixture
         # marker text in the body (not tail) must NOT trigger dispatch.
+        # Negative path: body echo targets round-9 (distinct from tail's
+        # round-3). On the old broken implementation this would dispatch
+        # 90-9-* solvers; on the fixed implementation only 90-3-* appear.
         path = self.repo / ".refactor-loop" / "logs" / "phase9-issue90-r2-judge.log"
         body_pad = "\n".join(f"discussion line {i}" for i in range(60))
         body_echo = (
             "skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py:171: "
-            '"META_JUDGE_DONE:converge:round-3:body-echo-from-test-fixture",'
+            '"META_JUDGE_DONE:converge:round-9:body-echo-from-test-fixture",'
         )
         actual_tail = "META_JUDGE_DONE:converge:round-3:real-tail-verdict"
         path.write_text(
@@ -176,17 +179,53 @@ class Phase9RouterDaemonTests(unittest.TestCase):
 
         self.router.tick()
 
-        ledger_markers = [entry.get("marker", "") for entry in self.ledger_entries()]
-        for entry_marker in ledger_markers:
-            self.assertNotIn("body-echo-from-test-fixture", entry_marker,
-                             "body-position marker echo must not be classified as verdict")
+        ledger_keys = [entry["key"] for entry in self.ledger_entries()]
+        for forbidden_key in ("90-9-minimal", "90-9-structural", "90-9-delete"):
+            self.assertNotIn(forbidden_key, ledger_keys,
+                             "body-position round-9 echo must not dispatch round-9 solvers")
         for command in self.commands:
             joined = " ".join(command)
+            self.assertNotIn("phase9-issue90-r9-", joined,
+                             "no command may target round-9 (body echo)")
             self.assertNotIn("body-echo-from-test-fixture", joined)
-        ledger_keys = [entry["key"] for entry in self.ledger_entries()]
         for key in ("90-3-minimal", "90-3-structural", "90-3-delete"):
             self.assertIn(key, ledger_keys,
-                          "real tail verdict must still spawn next round")
+                          "real tail verdict (round-3) must still spawn next round")
+
+    def test_phase9_router_stalled_predicate_uses_tail_only(self) -> None:
+        # Refactor (iter5/skill-marker-tail-only-scope):
+        # _stalled_predicate_holds must also scope to log tail so body-only
+        # SOLVER_DONE echoes cannot satisfy the stalled predicate.
+        body_pad_lines = [f"discussion line {i}" for i in range(60)]
+        for round_no in (1, 2, 3):
+            for role in ("minimal", "structural", "delete"):
+                body_echo = (
+                    "skills/codex-refactor-loop/scripts/grep_output_quote.txt: "
+                    f"SOLVER_DONE:{role}:same:body-echo-not-real-verdict"
+                )
+                self.write_log(
+                    f"phase9-issue91-r{round_no}-{role}.log",
+                    *body_pad_lines,
+                    body_echo,
+                    *body_pad_lines,
+                    "non-verdict tail line",
+                )
+        self.write_ledger_key("91-1-judge")
+        self.write_ledger_key("91-2-judge")
+        self.write_log(
+            "phase9-issue91-r3-judge.log",
+            "META_JUDGE_DONE:escalate:stalled:no-change",
+        )
+
+        self.router.tick()
+
+        reflector_commands = [
+            command for command in self.commands if "phase9-issue91-r3-reflector.log" in " ".join(command)
+        ]
+        self.assertEqual(reflector_commands, [],
+                         "body-only SOLVER_DONE echoes must not satisfy stalled predicate")
+        ledger_keys = [entry["key"] for entry in self.ledger_entries()]
+        self.assertNotIn("91-3-reflector", ledger_keys)
 
     def test_phase9_router_converge_ignores_non_judge_source_logs(self) -> None:
         # Refactor (iter5/skill-converge-source-and-monotonic-guard):


### PR DESCRIPTION
## 实证

cron #66 发现 PR #80 fix 后 daemon **仍 over-spawn**:ledger 派 \`81-3-structural\` + \`81-4-{minimal,structural,delete}\` from markers \`META_JUDGE_DONE:converge:round-3:echoed-from-prompt-body\` 和 \`converge:round-4:backward-reference-bug\` — 这些是 **PR #80 自己加的 test fixture 字面**,被 codex worker grep/列出到 production log body,daemon scan 整个 log 当真 marker。

## 根因

\`_collect_markers\` 扫 log 全 body:
\`\`\`python
for line in log_path.read_text(...).splitlines():
    marker = self._extract_marker(line)
\`\`\`

codex worker 在工作中常 grep 源码 / 引用 test fixture,这些 lines 含合法 marker 文本(VALID_MARKER_PAYLOAD pass)→ daemon 当真 verdict。

## Fix(narrow)

\`_collect_markers\` 只扫 log tail(\`MARKER_TAIL_LINES=30\`):
- 真 verdict marker 都靠近 \`EXIT=0\`(tail 几行)
- body 位置的 prompt-body/grep-output/test-fixture echo 永不到达 marker parser

## 授权

Same narrow bug-fix path as PR #80(maintainer-directive 等价 Phase 9 共识,本会话 cron #59)。

## 测试

- behavior(+1):
  - \`test_phase9_router_marker_tail_only_ignores_body_echo\` — body 含 fixture echo + tail 真 verdict → 只 tail 触发 dispatch
- source-regression(+1):
  - \`Phase9RouterMarkerTailOnlySourceRegressionTests::test_collect_markers_uses_tail_only_with_constant\` — 字面断言 refactor comment、\`MARKER_TAIL_LINES\` constant、\`self.MARKER_TAIL_LINES\` slice、无 entire-body iteration
- \`python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'\` → **288 OK**(285 + 2 behavior + 1 source-regression)

## scope

- \`skills/codex-refactor-loop/scripts/phase9_router_daemon.py\` (+15/-1)
- \`skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py\` (+30)
- \`skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py\` (+22)

⟦AI:AUTO-LOOP⟧