### PR TITLE
feat(skill): #79 implement WORK_UNIT_SOURCE_REF + DESIGN_DECISION_PATH(r8 consensus)

### DIFF
--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -4,11 +4,13 @@
 
 你以无人值守模式在 worktree `${WORKTREE_PATH}` 中工作，对应分支 `${BRANCH}`。
 当前 v1 audit-backed work unit 的兼容 cluster alias 是 `${CLUSTER_ID}`；审计段查找、既有 artifact 文件名、分支/worktree 名和 marker 仍使用该 alias。
+实现上下文事实源是 `${WORK_UNIT_SOURCE_REF}`。audit-backed work unit 指向 `$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md`；design-issue work unit 指向已达成共识的 decision artifact。
+`${DESIGN_DECISION_PATH}` 非空时走 design-issue pathway，读取该 consensus artifact；为空时走 audit-backed legacy pathway，读取 `${WORK_UNIT_SOURCE_REF}` 中的 "${CLUSTER_ID}" 一节。
 
 ## 必读上下文
 
 1. 主仓库 `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 全部强制条款。
-2. 完整审计：`$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md` 中 "${CLUSTER_ID}" 一节。
+2. 实现上下文：若 `${DESIGN_DECISION_PATH}` 非空，读取 `$REPO_ROOT/${DESIGN_DECISION_PATH}`；否则读取 `${WORK_UNIT_SOURCE_REF}` 中 "${CLUSTER_ID}" 一节。
 3. `$REPO_ROOT 的架构/词汇文档(若有)` 下相关权威文档。
 
 ## 错误模式 / 设计原则
@@ -36,7 +38,7 @@ ${SCOPE_PATHS}
 
 ## 流程
 
-1. 读 audit 段、读所有 `scope_paths` 文件。
+1. 按 `${DESIGN_DECISION_PATH}` 选择 design-issue consensus artifact 或 audit 段，读所有 `scope_paths` 文件。
 2. 打印 `PLAN:` 前缀的具体改动计划（一行一项）。
 3. 实施。
 4. 编译：`$BUILD_CMD`，失败时修复，最多 5 次迭代。

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -780,6 +780,9 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
     # Refactor (iter2/cluster-007-work-unit-contract-schema):
     #   Old pattern: work-unit state contract existed only as prose, so migration/envelope terms could re-enter the skill unnoticed
     #   New principle: source-regression coverage keeps WorkUnitV1 v1 containers authoritative and blocks premature work_units_* migration surface
+    # Refactor (iter9/issue79-design-implementation-intake):
+    #   Old pattern: implement prompt could only name audit-iter-N as its context source.
+    #   New principle: WORK_UNIT_SOURCE_REF plus optional DESIGN_DECISION_PATH selects the authoritative intake artifact without adding a prompt fork.
     def render_work_unit_template(self, *, work_unit_id: str | None, cluster_id: str) -> str:
         with tempfile.TemporaryDirectory() as tmp:
             template = Path(tmp) / "template.md"
@@ -811,6 +814,48 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             result = subprocess.run(
                 ["bash", "-lc", script],
                 env={**env, "TEMPLATE": str(template), "OUTPUT": str(output)},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return output.read_text(encoding="utf-8")
+
+    def render_implement_prompt(
+        self,
+        *,
+        cluster_id: str = "cluster-079",
+        work_unit_source_ref: str,
+        design_decision_path: str,
+    ) -> str:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "implement-rendered.md"
+            env = os.environ.copy()
+            env.update(
+                {
+                    "REPO_ROOT": str(REPO_ROOT),
+                    "PROJECT_RULES": "AGENTS.md",
+                    "CLUSTER_ID": cluster_id,
+                    "WORK_UNIT_ID": cluster_id,
+                    "WORK_UNIT_SOURCE_REF": work_unit_source_ref,
+                    "DESIGN_DECISION_PATH": design_decision_path,
+                    "ITERATION": "9",
+                    "WORKTREE_PATH": "/tmp/worktree",
+                    "BRANCH": "refactor/iter9-cluster-079",
+                    "OLD_PATTERN": "single-source implementation context",
+                    "NEW_PRINCIPLE": "consensus artifact drives implementation",
+                    "SCOPE_PATHS": "skills/codex-refactor-loop/prompts/implement.md\nskills/codex-refactor-loop/scripts/test_*.py",
+                    "VERIFICATION_HINTS": "python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'",
+                    "HOST_COMMENT_RULE": "source files English-only; refactor self-documentation required",
+                    "HOST_PROTO_POLICY": "",
+                }
+            )
+
+            script = f'source "{SKILL_ROOT / "scripts" / "controller_lib.sh"}"; render_template "$TEMPLATE" "$OUTPUT"'
+            result = subprocess.run(
+                ["bash", "-lc", script],
+                env={**env, "TEMPLATE": str(SKILL_ROOT / "prompts" / "implement.md"), "OUTPUT": str(output)},
                 capture_output=True,
                 text=True,
                 check=False,
@@ -938,6 +983,57 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
         for marker in ("producer: audit", "WorkUnitV1", "manual-issue"):
             with self.subTest(marker=marker):
                 self.assertNotIn(marker, audit_prompt)
+
+    def test_implement_prompt_audit_dispatch_reads_work_unit_source_ref(self) -> None:
+        source_ref = "$REPO_ROOT/.refactor-loop/runs/audit-iter-9.md"
+        rendered = self.render_implement_prompt(
+            work_unit_source_ref=source_ref,
+            design_decision_path="",
+        )
+
+        required = (
+            f"实现上下文事实源是 `{source_ref}`",
+            "为空时走 audit-backed legacy pathway",
+            f"否则读取 `{source_ref}` 中 \"cluster-079\" 一节",
+            "skills/codex-refactor-loop/prompts/implement.md",
+            "skills/codex-refactor-loop/scripts/test_*.py",
+            "禁止 `git commit` / `git push` / `git checkout <branch>`",
+            "source files English-only; refactor self-documentation required",
+            "⟦AI:AUTO-LOOP⟧",
+        )
+
+        for marker in required:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, rendered)
+
+    def test_implement_prompt_design_dispatch_reads_consensus_artifact(self) -> None:
+        decision_path = ".refactor-loop/runs/phase9-issue79-r8-judge.md"
+        rendered = self.render_implement_prompt(
+            work_unit_source_ref=decision_path,
+            design_decision_path=decision_path,
+        )
+
+        required = (
+            f"`{decision_path}` 非空时走 design-issue pathway",
+            f"读取 `{REPO_ROOT / decision_path}`",
+            "design-issue consensus artifact",
+            "skills/codex-refactor-loop/prompts/implement.md",
+            "skills/codex-refactor-loop/scripts/test_*.py",
+            "禁止 `git commit` / `git push` / `git checkout <branch>`",
+            "source files English-only; refactor self-documentation required",
+            "⟦AI:AUTO-LOOP⟧",
+        )
+
+        for marker in required:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, rendered)
+
+    def test_implement_prompt_declares_design_intake_env_vars(self) -> None:
+        implement_prompt = (SKILL_ROOT / "prompts" / "implement.md").read_text(encoding="utf-8")
+
+        for marker in ("${WORK_UNIT_SOURCE_REF}", "${DESIGN_DECISION_PATH}"):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, implement_prompt)
 
     def test_v1_operational_tokens_are_stable_and_not_renamed(self) -> None:
         # Refactor (iter2/cluster-009-marker-label-compat-migration):

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -639,6 +639,33 @@ class ProjectRulesPromptContractTests(unittest.TestCase):
                 self.assertIn("AI 内容标识符", text)
                 self.assertIn("⟦AI:AUTO-LOOP⟧", text)
 
+    # Refactor (issue79/r8-consensus-no-implementation-helper-fork):
+    #   Old pattern: implement-from-design could grow a second intake/helper prompt or producer registry abstraction.
+    #   New principle: implementation stays on the existing implement prompt path; no helper/fork/intake abstraction tokens.
+    def test_issue79_consensus_no_helper_or_fork_intake_abstraction(self) -> None:
+        prompts_root = SKILL_ROOT / "prompts"
+        prompt_paths = sorted(prompts_root.glob("*implement*.md"))
+        prompt_names = {path.name for path in prompt_paths}
+        forbidden_prompt_names = {"implement-from-design-issue.md"}
+        forbidden_tokens = (
+            "ImplementationIntakeV1",
+            "implementation_intake",
+            "implement_intake",
+            "normalizer helper",
+            "producer registry",
+        )
+
+        self.assertIn(prompts_root / "implement.md", prompt_paths)
+        for prompt_name in forbidden_prompt_names:
+            with self.subTest(prompt_name=prompt_name):
+                self.assertNotIn(prompt_name, prompt_names)
+
+        for path in prompt_paths:
+            text = path.read_text(encoding="utf-8")
+            for token in forbidden_tokens:
+                with self.subTest(prompt=path.name, token=token):
+                    self.assertNotIn(token, text, f"r8 consensus(#79) forbids {token} in {path.name}")
+
     # Refactor (iter213/cluster-213-006-delete-solver-defer-escape):
     #   Old pattern: delete solver forbids defer, then defines Deferrable and asks for a tracking issue creation suggestion(prompt 内部矛盾,且 gh issue create 后被禁)
     #   New principle: delete solver 单 terminal vocabulary:delete/collapse/abstain/escalate;无 deferred side-channel、无 issue-create 命令建议;'not now' map 到 abstain/false-positive,lifecycle 决策归 controller/maintainer。


### PR DESCRIPTION
## Summary
- #79 Phase 9 r4/r7/r8 三轮 3/3 consensus `delete` framing 实现
- 加 `\${WORK_UNIT_SOURCE_REF}` + `\${DESIGN_DECISION_PATH}` 双 env var pathway 到 `implement.md`
- 保留 `\${CLUSTER_ID}` audit-backed legacy alias 不变
- 加 source-regression test 验证两 env var 存在

## Test plan
- [x] `python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` — 292 tests pass(local)
- [ ] Phase 8 multi-reviewer(architect/tests/quality)consensus
- [ ] CI green

## Unblocks
解锁 8 个 consensus-reached design issue 进入 implement pipeline:
- #53 codex 直接操作 git/gh
- #65 auto-refact-dev → develop rollup
- #66 skills 规范化防退化
- #70 codex max_output_tokens + cluster dedup
- #84 prompt marker allowlist
- #85 reflector rule #4 强化
- #86 audit producer chain 切换
- #87 peek.sh tail-only

## 授权来源
Phase 9 r8 judge artifact: `.refactor-loop/runs/phase9-issue79-r8-judge.md`(3/3 consensus:delete:no helper/fork)
Maintainer-directive 2026-05-27 cron #60:"提 issues 走流程改"

Closes #79

⟦AI:AUTO-LOOP⟧