### PR TITLE
feat(skill): #87 peek.sh tail-only status lens — 删 generic marker projector

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -226,13 +226,11 @@ gh issue view <N> --json comments --jq '
 减少人工 grep / parse 错误。一眼看全:
 - 活跃 codex 数(只数本 loop:命令行含 `.refactor-loop/logs/` 或 `.refactor-loop/prompts/`)
 - Open auto-loop PR 的 CI + state
-- Merge readiness reviewer truth table status
-- Daemon health / monitor zero_streak 当前 / max
-- Phase 9 router ledger 近 10 行
-- Pending events 近 10 行
+- Merge readiness / daemon health / monitor zero_streak 摘要
+- Phase 9 router ledger + pending events 近 10 行
 - Open auto-loop issue + phase label
 
-`peek.sh` 是 observability-only status lens,不显示 generic marker-to-route recommendation。Route authority remains SKILL Phase Routing + controller clean-exit log-tail sweep + `phase9_router_daemon.py`。
+`peek.sh` 是 observability-only status lens,只读展示 ledger / pending / readiness / health,不显示 generic marker-to-route recommendation。Route authority remains SKILL Phase Routing + controller clean-exit log-tail sweep + `phase9_router_daemon.py`。
 
 <a id="wake-source-rules"></a>
 ## Wake source rules and no-gap details

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -225,12 +225,14 @@ gh issue view <N> --json comments --jq '
 
 减少人工 grep / parse 错误。一眼看全:
 - 活跃 codex 数(只数本 loop:命令行含 `.refactor-loop/logs/` 或 `.refactor-loop/prompts/`)
-- 最近 60 min 完成 codex marker + 推荐下一步(按 SKILL route table)
 - Open auto-loop PR 的 CI + state
-- Monitor zero_streak 当前 / max
+- Merge readiness reviewer truth table status
+- Daemon health / monitor zero_streak 当前 / max
+- Phase 9 router ledger 近 10 行
+- Pending events 近 10 行
 - Open auto-loop issue + phase label
 
-输出格式稳定,易于直接判断派什么。
+`peek.sh` 是 observability-only status lens,不显示 generic marker-to-route recommendation。Route authority remains SKILL Phase Routing + controller clean-exit log-tail sweep + `phase9_router_daemon.py`。
 
 <a id="wake-source-rules"></a>
 ## Wake source rules and no-gap details

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -175,6 +175,8 @@ launchd host template:
 
 Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event wakeup follows this skeleton. Daemon pending-event wakeups are valid only through a mounted persistent Monitor or equivalent harness bridge; daemon alone is not a wake source. The Phase 9 router daemon may replace controller dispatch for SOLVER_DONE triplets, converge, and valid stalled continuation; controller fallback sweep remains authoritative for every other marker.
 
+`peek.sh` is a status lens, not routing authority; route actions still come from Phase Routing, clean-exit sweep, and the Phase 9 router daemon.
+
 1. Run `bash <skill-root>/scripts/peek.sh | tail -80` first.
 2. Load host config with `source .refactor-loop/host.env`; if missing or malformed, fail closed and post a status explaining the blocked bootstrap.
 3. Before pending-event sweep, marker parsing, concurrency-floor handling, or dispatch/spawn, read daemon heartbeats(`.refactor-loop/heartbeats/*.ts`);任 stale/missing/malformed `>90s` → 调 `bash <skill-root>/scripts/restart-daemons.sh`;无 progress >10 min(检 `.refactor-loop/runs/` + `.refactor-loop/logs/` mtime)→ 写 `STALE_CONTROLLER:freeze_minutes=N` 到 `.refactor-loop/.controller-pending-events.log`(no lifecycle authority,仅 alert).

--- a/skills/codex-refactor-loop/scripts/peek.sh
+++ b/skills/codex-refactor-loop/scripts/peek.sh
@@ -104,6 +104,10 @@ if [ "$n" -gt 0 ]; then
   list_loop_codex | sed -E 's/.*--log [^ ]*\/([^ ]+)\.log.*/  • \1/' | sort
 fi
 
+# Refactor (iter5/issue-87-peek-status-lens):
+# Old pattern: generic marker projector plus 60-minute route-hint table in peek output.
+# New principle: observability-only status lens reads Phase 9 ledger/pending events as facts,
+# while merge readiness remains tail-only REVIEW_DONE consensus below.
 # 2. Phase 9 router ledger and pending events. Facts only; routing authority
 # remains Phase Routing, clean-exit log-tail sweep, and phase9_router_daemon.py.
 echo ""

--- a/skills/codex-refactor-loop/scripts/peek.sh
+++ b/skills/codex-refactor-loop/scripts/peek.sh
@@ -6,9 +6,9 @@
 #
 # 输出:
 #   1. 活跃 codex 数 + 每个的 log 名(harness-tracked vs detached 分别标)
-#   2. 完成 markers + 推荐下一步路由(per skill route table)
-#   3. 每个 open auto-loop PR 的 CI + reviewer 状态
-#   4. monitor zero_streak 最大值(过去 10 tick)
+#   2. Open auto-loop PR CI + reviewer status
+#   3. Monitor zero_streak max over the last 10 ticks
+#   4. Phase 9 router ledger + pending events as facts only
 #
 # Usage: bash .claude/skills/codex-refactor-loop/scripts/peek.sh
 #
@@ -34,15 +34,15 @@ list_loop_codex() {
   ps -eo command= | awk -v repo="$REPO_ROOT" 'repo != "" && /spawn-codex[.]sh/ && index($0, repo) && index($0, " -c ")==0 { print }'
 }
 
-MARKER_RE="AUDIT_DONE|AUDIT_INCOMPLETE|IMPLEMENT_DONE|IMPLEMENT_BLOCKED|FIX_DONE|FIX_BLOCKED|REVIEW_DONE|SOLVER_DONE|META_JUDGE_DONE|META_RESOLVED|TEST_ADD_DONE"
-extract_terminal_marker() {
-  local f="$1"
-  awk '/^EXIT=/{exit} {print}' "$f" 2>/dev/null |
-    grep -E "(${MARKER_RE}):" |
-    sed -E 's/^[+[:space:]]+//; s/^.*(AUDIT_DONE:|AUDIT_INCOMPLETE:|IMPLEMENT_DONE:|IMPLEMENT_BLOCKED:|FIX_DONE:|FIX_BLOCKED:|REVIEW_DONE:|SOLVER_DONE:|META_JUDGE_DONE:|META_RESOLVED:|TEST_ADD_DONE:)/\1/' |
-    grep -vE '<reason>|<id>|<status>|<category>|<framing>|round-N|cluster-XXX' |
-    tail -1 |
-    head -c 100
+REVIEW_MARKER_TAIL_LINES=30
+extract_review_verdict_tail() {
+  local log_path="$1"
+  local pr_num="$2"
+  local role="$3"
+  tail -n "$REVIEW_MARKER_TAIL_LINES" "$log_path" 2>/dev/null |
+    grep -E "REVIEW_DONE:${pr_num}:${role}:(approve|comment|reject)" |
+    sed -E "s/^.*REVIEW_DONE:${pr_num}:${role}:(approve|comment|reject).*$/\1/" |
+    tail -1
 }
 
 echo "═══════════════ peek $(date -u +%H:%M:%SZ) ═══════════════"
@@ -104,48 +104,14 @@ if [ "$n" -gt 0 ]; then
   list_loop_codex | sed -E 's/.*--log [^ ]*\/([^ ]+)\.log.*/  • \1/' | sort
 fi
 
-# 2. Recently finished markers (last 60 min) + routing hint
-# Refactor (iter3/skill-human-label-taxonomy):
-#   Old: 四个 Human label(含两个 🆘),no-gap/escalation 判定散落
-#   New principle: 恰好两个 active Human label;causes 移到 reason surface(#15 structural 共识)
-# Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识)
+# 2. Phase 9 router ledger and pending events. Facts only; routing authority
+# remains Phase Routing, clean-exit log-tail sweep, and phase9_router_daemon.py.
 echo ""
-echo "▍最近 60 min 完成 codex(marker → 推荐下一步):"
-find .refactor-loop/logs -name "*.log" -mmin -60 -type f 2>/dev/null | while read f; do
-  base=$(basename "$f" .log)
-  # Skip in-progress (no EXIT line)
-  exit_line=$(grep "^EXIT=" "$f" 2>/dev/null | tail -1)
-  [ -z "$exit_line" ] && continue
-  marker=$(extract_terminal_marker "$f")
-  [ -z "$marker" ] && continue
-  # Routing hint
-  hint=""
-  case "$marker" in
-    IMPLEMENT_DONE:*:ok*)    hint="→ commit/push + open PR + 3 reviewer r1" ;;
-    IMPLEMENT_DONE:*:partial|IMPLEMENT_DONE:*:blocked) hint="→ inspect + re-prompt or escalate" ;;
-    IMPLEMENT_BLOCKED:*)     hint="→ inspect blocker + meta-reflect" ;;
-    FIX_DONE:*)              hint="→ commit/push + 3 reviewer r+1" ;;
-    FIX_BLOCKED:*)           hint="→ meta-reflect" ;;
-    REVIEW_DONE:*:approve)   hint="→ latest complete reviewer round: reject=0 + approve>=1 => merge; all-comment => WAIT_EXPLICIT_APPROVAL" ;;
-    REVIEW_DONE:*:comment)   hint="→ advisory; wait reviewers; all-comment => WAIT_EXPLICIT_APPROVAL, not fix" ;;
-    REVIEW_DONE:*:reject)    hint="→ wait other 2 reviewers,then fix r+1" ;;
-    SOLVER_DONE:*)           hint="→ wait other 2 solvers,then meta-judge" ;;
-    META_JUDGE_DONE:consensus:*) hint="→ implement codex (worktree + spawn)" ;;
-    META_JUDGE_DONE:converge:*)  hint="→ re-spawn 3 solver with convergence question" ;;
-    META_JUDGE_DONE:escalate:philosophy:*) hint="→ label escalate-human + ASCII problem banner" ;;
-    META_JUDGE_DONE:escalate:*)  hint="→ reflector codex" ;;
-    META_RESOLVED:retry-fix:*)   hint="→ implement codex(or fix r+1 if PR exists)" ;;
-    META_RESOLVED:re-design:*)   hint="→ close PR + Phase 9 fresh round" ;;
-    META_RESOLVED:re-cluster:*)  hint="→ close PR + audit re-split" ;;
-    META_RESOLVED:drop:*)        hint="→ close PR + close issue wontfix" ;;
-    META_RESOLVED:escalate-human:*) hint="→ label 👤 + reason banner + push notify" ;;
-    AUDIT_DONE:*)            hint="→ 验证 cluster evidence + 开 design issues + 派 implement" ;;
-    AUDIT_INCOMPLETE:*)      hint="→ re-dispatch audit with missing pieces" ;;
-    TEST_ADD_DONE:*)         hint="→ commit/push 等 CI" ;;
-  esac
-  echo "  • ${base}: ${marker}"
-  [ -n "$hint" ] && echo "    ${hint}"
-done
+echo "▍Phase 9 router / pending events:"
+echo "  ledger tail:"
+tail -10 .refactor-loop/phase9-router-ledger.jsonl 2>/dev/null | sed 's/^/    /' || true
+echo "  pending events tail:"
+tail -10 .refactor-loop/.controller-pending-events.log 2>/dev/null | sed 's/^/    /' || true
 
 # 3. Open auto-loop PRs + state
 echo ""
@@ -192,7 +158,7 @@ gh pr list "${gh_repo_args[@]}" --label "auto-loop" --state open --json number,t
   for role in architect tests quality; do
     f=".refactor-loop/logs/review-pr${pr_num}-${role}-r${max_round}.log"
     [ -f "$f" ] || continue
-    v=$(extract_terminal_marker "$f" | sed -E 's/.*:([a-z]+)\s*$/\1/')
+    v=$(extract_review_verdict_tail "$f" "$pr_num" "$role")
     case "$v" in
       approve) approve=$((approve+1)) ;;
       comment) comment=$((comment+1)) ;;

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -757,8 +757,8 @@ class Phase8MergePolicySourceRegressionTests(unittest.TestCase):
     def test_peek_uses_option_a_threshold(self) -> None:
         peek = (SKILL_ROOT / "scripts" / "peek.sh").read_text(encoding="utf-8")
 
-        self.assertIn('hint="→ latest complete reviewer round: reject=0 + approve>=1 => merge; all-comment => WAIT_EXPLICIT_APPROVAL"', peek)
         self.assertIn('if [ "$reject" = "0" ] && [ "$approve" -ge 1 ]; then', peek)
+        self.assertIn("MERGE_READY approve=${approve} comment=${comment} reject=0", peek)
         self.assertNotIn('"$approve" -ge 2', peek)
         self.assertNotIn("≥2 approve", peek)
 
@@ -1322,7 +1322,8 @@ class HumanLabelTaxonomySourceRegressionTests(unittest.TestCase):
     def test_peek_hints_do_not_recommend_emergency_human_label(self) -> None:
         peek = (SKILL_ROOT / "scripts" / "peek.sh").read_text(encoding="utf-8")
 
-        self.assertIn('META_RESOLVED:escalate-human:*) hint="→ label 👤 + reason banner + push notify" ;;', peek)
+        self.assertNotIn("META_RESOLVED:escalate-human:*)", peek)
+        self.assertNotIn("reason banner + push notify", peek)
         self.assertNotIn("label 🆘 + push notify", peek)
 
         for line in peek.splitlines():
@@ -1333,6 +1334,28 @@ class HumanLabelTaxonomySourceRegressionTests(unittest.TestCase):
                         or "lstrip().startswith(('## 📊', '## 🤖', '## ✅', '## 🆘'))" in line
                         or "Old: 四个 Human label(含两个 🆘)" in line
                     )
+
+    def test_peek_is_status_lens_not_generic_route_projector(self) -> None:
+        peek = (SKILL_ROOT / "scripts" / "peek.sh").read_text(encoding="utf-8")
+
+        for forbidden in (
+            "MARKER_RE=",
+            "extract_terminal_marker",
+            'case "$marker"',
+            "SOLVER_DONE:*)",
+            "META_JUDGE_DONE:*)",
+            "AUDIT_DONE:*)",
+            "IMPLEMENT_DONE:*)",
+            "FIX_DONE:*)",
+            "TEST_ADD_DONE:*)",
+            "META_RESOLVED:*)",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, peek)
+
+        self.assertIn("REVIEW_MARKER_TAIL_LINES=30", peek)
+        self.assertIn("extract_review_verdict_tail", peek)
+        self.assertIn("REVIEW_DONE:${pr_num}:${role}:(approve|comment|reject)", peek)
 
 
 class HumanLabelSemanticsTests(unittest.TestCase):

--- a/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
+++ b/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
@@ -1,0 +1,203 @@
+#!/bin/sh
+"exec" "python3" "$0" "$@"
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+SKILL_ROOT = SCRIPT_PATH.parents[1]
+REPO_ROOT = SCRIPT_PATH.parents[3]
+PEEK = SKILL_ROOT / "scripts" / "peek.sh"
+
+
+class PeekStatusLensBehaviorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.fakebin = self.root / "fakebin"
+        self.logs = self.root / ".refactor-loop" / "logs"
+        self.fakebin.mkdir(parents=True)
+        self.logs.mkdir(parents=True)
+        self.write_fake_git()
+        self.write_fake_gh()
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write_fake_git(self) -> None:
+        git = self.fakebin / "git"
+        git.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                case "$1" in
+                  fetch) exit 0 ;;
+                  worktree) exit 0 ;;
+                  rev-parse) printf '%s\\n' "$REPO_ROOT"; exit 0 ;;
+                  *) exit 0 ;;
+                esac
+                """
+            ),
+            encoding="utf-8",
+        )
+        git.chmod(0o755)
+
+    def write_fake_gh(self) -> None:
+        gh = self.fakebin / "gh"
+        gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                args="$*"
+                pr="${PEEK_TEST_PR:-}"
+                if [[ "$1 $2" == "issue list" ]]; then
+                  printf '[]\\n'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "issue view" ]]; then
+                  if [[ "$args" == *"--json state"* ]]; then
+                    printf 'OPEN\\n'
+                  else
+                    printf '{"comments":[]}\\n'
+                  fi
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr list" ]]; then
+                  if [[ -z "$pr" ]]; then
+                    if [[ "$args" == *"--jq"* ]]; then exit 0; fi
+                    printf '[]\\n'
+                    exit 0
+                  fi
+                  if [[ "$args" == *"--state merged"* ]]; then
+                    exit 0
+                  fi
+                  if [[ "$args" == *"--state closed"* ]]; then
+                    printf '[]\\n'
+                    exit 0
+                  fi
+                  if [[ "$args" == *"--jq .[].number"* || "$args" == *"--jq '.[].number'"* ]]; then
+                    printf '%s\\n' "$pr"
+                    exit 0
+                  fi
+                  if [[ "$args" == *"--jq .[]"* || "$args" == *"--jq '.[]'"* ]]; then
+                    printf '{"number":%s,"title":"stub PR"}\\n' "$pr"
+                    exit 0
+                  fi
+                  printf '[{"number":%s,"title":"stub PR","labels":[]}]\\n' "$pr"
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  if [[ "$args" == *'bucket=="fail"'* || "$args" == *'bucket==\\"fail\\"'* ]]; then printf '0\\n'; exit 0; fi
+                  if [[ "$args" == *'bucket=="pending"'* || "$args" == *'bucket==\\"pending\\"'* ]]; then printf '0\\n'; exit 0; fi
+                  if [[ "$args" == *'bucket=="pass"'* || "$args" == *'bucket==\\"pass\\"'* ]]; then printf '3\\n'; exit 0; fi
+                  printf '0\\n'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  if [[ "$args" == *"--json comments"* ]]; then
+                    printf '{"comments":[]}\\n'
+                  else
+                    printf 'CLEAN\\n'
+                  fi
+                  exit 0
+                fi
+                printf '[]\\n'
+                exit 0
+                """
+            ),
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+
+    def run_peek(self, *, pr: int | None = None) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "REPO_ROOT": str(self.root),
+                "PATH": f"{self.fakebin}{os.pathsep}{env.get('PATH', '')}",
+                "GH_REPO_SLUG": "owner/repo",
+            }
+        )
+        if pr is not None:
+            env["PEEK_TEST_PR"] = str(pr)
+        return subprocess.run(
+            ["bash", str(PEEK)],
+            cwd=self.root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_peek_does_not_surface_generic_body_echo_markers(self) -> None:
+        (self.logs / "phase9-issue87-r9-judge.log").write_text(
+            "prompt echo META_JUDGE_DONE:converge:round-9:body-echo\n"
+            "real work\n"
+            "META_JUDGE_DONE:consensus:structural:real\n"
+            "EXIT=0\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_peek()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("round-9:body-echo", result.stdout)
+        self.assertNotIn("marker → 推荐下一步", result.stdout)
+        self.assertNotIn("→ implement codex", result.stdout)
+        self.assertNotIn("→ re-spawn", result.stdout)
+
+    def test_peek_shows_phase9_ledger_and_pending_as_facts(self) -> None:
+        (self.root / ".refactor-loop" / "phase9-router-ledger.jsonl").write_text(
+            '{"key":"k1","marker":"SOLVER_DONE:minimal:propose","log_path":"a.log"}\n',
+            encoding="utf-8",
+        )
+        (self.root / ".refactor-loop" / ".controller-pending-events.log").write_text(
+            "phase9-router-fallback unknown marker fact\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_peek()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Phase 9 router / pending events", result.stdout)
+        self.assertIn('"key":"k1"', result.stdout)
+        self.assertIn("phase9-router-fallback unknown marker fact", result.stdout)
+        self.assertNotIn("推荐下一步", result.stdout)
+        self.assertNotIn("→ implement codex", result.stdout)
+
+    def test_peek_review_merge_readiness_uses_tail_only_review_done(self) -> None:
+        pr = 123
+        (self.logs / f"review-pr{pr}-architect-r1.log").write_text(
+            f"REVIEW_DONE:{pr}:architect:approve\nEXIT=0\n",
+            encoding="utf-8",
+        )
+        (self.logs / f"review-pr{pr}-tests-r1.log").write_text(
+            f"REVIEW_DONE:{pr}:tests:approve\nEXIT=0\n",
+            encoding="utf-8",
+        )
+        body_lines = "\n".join(f"body filler {i}" for i in range(40))
+        (self.logs / f"review-pr{pr}-quality-r1.log").write_text(
+            f"prompt echo REVIEW_DONE:{pr}:quality:approve\n"
+            f"{body_lines}\n"
+            f"REVIEW_DONE:{pr}:quality:comment\n"
+            "EXIT=0\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_peek(pr=pr)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("MERGE_READY approve=2 comment=1 reject=0", result.stdout)
+        self.assertNotIn("MERGE_READY approve=3 comment=0 reject=0", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

按 Phase 9 r4 3/3 consensus(`.refactor-loop/runs/phase9-issue87-r4-judge.md`,structural framing)实施:

- **peek.sh**: 删 `MARKER_RE` / `extract_terminal_marker()` / "Recently finished markers (last 60 min)" + `case "$marker"` route-hint 表;新增 "Phase 9 router / pending events" 只读摘要(ledger 近 10 行 + pending events 近 10 行,**无 route recommendation**);mergeable PR 改用 `extract_review_verdict_tail(log, pr, role)` + `REVIEW_MARKER_TAIL_LINES=30`,只接 `REVIEW_DONE:<pr>:<role>:<verdict>` tail。
- **REFERENCE.md**: Wakeup 第一动作 由 route-hint dashboard 改为 **observability-only status lens**;route authority 仍归 SKILL Phase Routing + clean-exit log-tail sweep + phase9_router_daemon.py。
- **SKILL.md**: Wakeup Skeleton 补一句 \`peek.sh\` is a status lens, not routing authority。
- **test_ensure_project_rules_fixed_points.py**: 重写 `test_peek_uses_option_a_threshold` + `test_peek_hints_do_not_recommend_emergency_human_label`;新增 `test_peek_is_status_lens_not_generic_route_projector`。
- **test_peek_status_lens.py(NEW,203 lines)**: 3 个 focused behavior tests:body echo marker 不展示 / ledger pending facts / review merge readiness tail-only。

无新通用 abstraction / marker contract / daemon / event envelope / public alias / lifecycle authority。

## Test plan

- [x] \`bash skills/codex-refactor-loop/scripts/test_peek_status_lens.py\`: 3 tests PASS
- [x] \`cd .worktrees/issue87 && python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py' -v\`: **300 tests PASS**
- [ ] Phase 8 reviewers(architect / tests / quality)
- [ ] CI(contract-tests / manifest-version-sync / lint-advisory)

## Authorization

\`.refactor-loop/runs/phase9-issue87-r4-judge.md\`(Phase 9 r4 3/3 consensus on structural framing)。

Closes #87。

⟦AI:AUTO-LOOP⟧