### PR TITLE
feat(skill): #65 IntegrationSyncDaemonV1 release-rollup pending-event

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -818,12 +818,7 @@ For each `pass` cluster, serially:
       - Re-run local CI in worktree; on conflict, mark cluster `rework` and re-dispatch implement codex with conflict diff.
       - Force-push the cluster branch: `git push --force-with-lease origin refactor/iterN-<cluster-id>`.
 9b. Goto Phase 5 (remote CI watch on the cluster's PR).
-10b. After **all** iteration clusters have their PRs merged into `integration_branch`, ensure exactly one rollup PR exists from `integration_branch` to `review_base_branch`:
-     ```bash
-     gh pr list --head "<integration_branch>" --base "<review_base_branch>" --json number --jq '.[0].number'
-     # If empty, gh pr create --base "<review_base_branch>" --head "<integration_branch>" --title "Refactor iter<N>: rollup" --body <scorecard.md>
-     ```
-
+10b. After **all** iteration clusters have merged into `integration_branch`, Phase 6 may emit `DEV_SYNC_PENDING:release-rollup-needed:<json>`. Controller re-checks exactly one open `$INTEGRATION_BRANCH -> $REVIEW_BASE_BRANCH` rollup PR and, only when none exists, creates it through `open_release_rollup_pr_from_pending_event <event-json> <body-file>`. Daemon only detects/writes the event; PR create, labels, review gate, CI, and merge policy stay controller-owned.
 After merge of the cluster branch into its target → `git worktree remove "$REPO_ROOT/.worktrees/<cluster-id>"`. **Do NOT** delete the cluster branch yet under `stacked` mode — downstream PRs may still reference it as base; let GitHub auto-delete on merge.
 
 If no clusters left in current batch → start next batch (Phase 2 again). If no batches left → start next iteration (Phase 1 again) or **start Phase 5 if there is an open PR for the trunk/cluster branches**.
@@ -931,7 +926,7 @@ Daemon 工作流由 `IntegrationSyncDaemonV1` 命名状态机表达:
 5. `ADOPT_MERGED_ROLLUP`: if a merged rollup PR from `$INTEGRATION_BRANCH` to `$REVIEW_BASE_BRANCH` is provable, capture the old rollup head and current expected remote SHA, reset/replay onto `origin/$REVIEW_BASE_BRANCH`, then push only with exact `--force-with-lease=refs/heads/$INTEGRATION_BRANCH:<expected_remote_sha>`.
 6. `RESET_TO_REMOTE`: reset to `origin/$INTEGRATION_BRANCH` only after local-ahead preservation and rollup adoption checks.
 7. `FORWARD_SYNC`: merge `origin/$REVIEW_BASE_BRANCH` into integration using ff-only first, then no-ff merge; push with ordinary `git push origin HEAD:$INTEGRATION_BRANCH`.
-
+8. `DETECT_RELEASE_ROLLUP_NEEDED`: if `origin/$INTEGRATION_BRANCH` is ahead of `origin/$REVIEW_BASE_BRANCH` by at least `RELEASE_ROLLUP_MIN_COMMITS` and no open `$INTEGRATION_BRANCH -> $REVIEW_BASE_BRANCH` PR exists, append `DEV_SYNC_PENDING:release-rollup-needed:<json>` with branch names, SHAs, ahead count, timestamp, and reason. Cooldown only suppresses duplicate same-SHA events; it grants no lifecycle authority.
 Ambiguous rollup metadata, failed local-ahead push, or adoption conflicts append `.refactor-loop/.controller-pending-events.log` and do not guess. Controller reads pending events and posts the visible GitHub card when action is needed.
 
 ### Phase 9 router daemon command body
@@ -953,8 +948,7 @@ bash <skill-root>/scripts/peek.sh | tail -80
 tail -10 .refactor-loop/logs/dev_sync_daemon.log | grep -E "(DEV_SYNC_BLOCKED|FAIL|FATAL)" | tail -3
 ```
 若 heartbeat stale/missing/malformed → 由 `restart-daemons.sh` 按 canonical wrapper 重启。
-若发现 `DEV_SYNC_BLOCKED` → controller post 卡片到 rollup PR / 通知 maintainer。
-
+若发现 `DEV_SYNC_BLOCKED` → controller post 卡片到 rollup PR / 通知 maintainer。若发现 `DEV_SYNC_PENDING:release-rollup-needed:<json>` → controller 重新查 open `$INTEGRATION_BRANCH -> $REVIEW_BASE_BRANCH` PR;已存在则 ledger/suppress,否则生成中文 body 并调用 `open_release_rollup_pr_from_pending_event <event-json> <body-file>`。该 PR 进入既有 Phase 8 review gate 与 CI/merge policy。
 ### 反面(❌ 禁止)
 
 - ❌ controller 自己跑 `git merge dev` 同步(daemon 已做,会 race / 冲突)
@@ -1388,6 +1382,12 @@ new_events=$(( cur_offset - prev_offset ))
 if (( new_events > 0 )); then
   # 有 daemon detect 但未 controller-process 的 events
   sed -n "$((prev_offset+1)),$((cur_offset))p" "$PENDING" | while read -r line; do
+    if [[ "$line" == DEV_SYNC_PENDING:release-rollup-needed:* ]]; then
+      event_json="${line#DEV_SYNC_PENDING:release-rollup-needed:}"
+      # Re-check open head/base PR; suppress if present, else open through helper.
+      process_release_rollup_needed "$event_json"
+      continue
+    fi
     # 解析 issue / author / comment_id,触发 maintainer-reply-resets-the-round
     process_maintainer_reply "$line"
   done

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -103,12 +103,13 @@ Stability requires all signals green and fail-closed handling on missing or red 
 
 The release lifecycle surface consumes the decision-artifact-only output. A scheduled/on-demand controller may read `.refactor-loop/state/release-candidate.json`, re-check `$RELEASE_AUTO_ENABLE=true`, then call the existing version bump command, commit/push the mapped manifest changes, and let `release.yml` publish. Alternatively, `release.yml` may read `.refactor-loop/state/release-decision.json` directly, re-check the same host opt-in, bump/publish through its own guarded jobs, and record the result.
 
-In both integrations, `auto_release_gate.py` remains the decider only. The controller or workflow owns lifecycle operations and must re-validate the host opt-in before mutating git state or publishing.
-
-Forbidden: do not add per-release maintainer emoji ratification, approval-ticket gating, or release-candidate JSON authorization. The host opt-in is durable until removed from `host.env`.
+In both integrations, `auto_release_gate.py` remains the decider only. The controller or workflow owns lifecycle operations and must re-validate the host opt-in before mutating git state or publishing. Forbidden: do not add per-release maintainer emoji ratification, approval-ticket gating, or release-candidate JSON authorization. The host opt-in is durable until removed from `host.env`.
 
 Named exception: this autonomous release gate is host-agnostic and has no lifecycle authority. It only reads repo state/GitHub evidence, computes stability, and writes durable decision/candidate artifacts; it does not run `git`, bump mapped release manifests, commit, push, tag, publish, open, close, label, approve, merge, or otherwise lifecycle-manage issues or PRs.
 
+## Named runtime exception — IntegrationSyncDaemonV1(per #65)
+The r7 judge artifact `.refactor-loop/runs/phase9-issue65-r7-judge.md` authorizes the existing-review-base pending-event boundary. **Narrow allowlist**: release-rollup detection and existing-format pending-event emission only; event facts include `integration_branch`, `review_base_branch`, `integration_sha`, `review_base_sha`, `ahead_count`, `detected_at`, and `reason`.
+**No lifecycle authority**: the daemon must not run `gh pr create`; it must not create PRs, edit PRs, label PRs, close PRs, approve PRs, merge PRs, or push directly to `$REVIEW_BASE_BRANCH`. Controller pending-event sweep re-checks open head/base PRs, writes the Chinese PR body, and calls `open_release_rollup_pr_from_pending_event`, which delegates to `open_pr_with_label`. Behavior/source-regression tests cover event emission, suppression, cooldown, and forbidden daemon lifecycle tokens.
 ## Claude Code statusline(per #51 consensus)
 
 `skills/codex-refactor-loop/scripts/statusline.sh` 是 fast (<200ms) read-only Claude Code statusline reader,显示本仓库 loop 实时状态(codex 计数、PR/issue 数、daemon 健康、P0 streak、freeze 指示)。
@@ -708,7 +709,7 @@ Phase 6 guardrails:
 4. Sync failures must be visible on GitHub.
 5. Daemon command details live in [daemon command bodies](REFERENCE.md#daemon-command-bodies).
 
-Named exception: `IntegrationSyncDaemonV1` owns integration branch auto-sync, resolver continuation push, and merged-rollup adoption. The controller verifies singleton health, reads pending events, fetches after daemon pushes, and does not run checkout/merge/push sync while the daemon is healthy. Resolver codexes resolve conflicts only; they never push, reset, or abort.
+Named exception: `IntegrationSyncDaemonV1` owns integration branch auto-sync, resolver continuation push, merged-rollup adoption, and release-rollup pending-event detection. The controller verifies singleton health, reads pending events, fetches after daemon pushes, and does not run checkout/merge/push sync while the daemon is healthy. Resolver codexes resolve conflicts only; they never push, reset, or abort. Release-rollup pending events do not grant daemon PR lifecycle authority.
 
 Phase 7 guardrails:
 

--- a/skills/codex-refactor-loop/host.env.example
+++ b/skills/codex-refactor-loop/host.env.example
@@ -41,6 +41,13 @@ export INTEGRATION_BRANCH="auto-refact-dev"
 # review 基线分支(rollup PR 的目标;日常人审从这里看)。
 export REVIEW_BASE_BRANCH="dev"
 
+# release rollup pending-event detector: minimum integration-ahead commits before
+# dev_sync_daemon writes DEV_SYNC_PENDING:release-rollup-needed. Cooldown only
+# suppresses duplicate pending events for the same integration SHA; controller
+# still owns PR create/label/review/merge lifecycle.
+export RELEASE_ROLLUP_MIN_COMMITS="1"
+export RELEASE_ROLLUP_COOLDOWN_SECONDS="21600"
+
 # audit / review codex 读的规则文档(违反它的地方就是工作单元的种子)。
 # Phase 0 会在此文件中维护 consensus-rnd foundational invariant managed block;无 opt-out。
 export PROJECT_RULES="CLAUDE.md"

--- a/skills/codex-refactor-loop/scripts/controller_lib.sh
+++ b/skills/codex-refactor-loop/scripts/controller_lib.sh
@@ -127,6 +127,111 @@ open_pr_with_label() {
   export PR_NUM
 }
 
+# Open the release rollup PR from a daemon pending event.
+# Usage: open_release_rollup_pr_from_pending_event <event-json> <body-file>
+# Validates the event is exactly $INTEGRATION_BRANCH -> $REVIEW_BASE_BRANCH
+# with non-empty SHA/ahead facts, then delegates lifecycle creation to
+# open_pr_with_label. This helper belongs to the controller lifecycle surface;
+# dev_sync_daemon.py must only emit the pending event.
+open_release_rollup_pr_from_pending_event() {
+  local event_json="$1" body_file="$2"
+  if [ -z "$event_json" ]; then
+    echo "open_release_rollup_pr_from_pending_event: missing event json" >&2
+    return 2
+  fi
+  if [ -z "$body_file" ] || [ ! -f "$body_file" ]; then
+    echo "open_release_rollup_pr_from_pending_event: missing body file" >&2
+    return 2
+  fi
+
+  local parsed head base integration_sha review_base_sha ahead_count reason
+  parsed=$(EVENT_JSON="$event_json" python3 - <<'PY'
+import json
+import os
+import sys
+
+try:
+    event = json.loads(os.environ["EVENT_JSON"])
+except Exception:
+    print("invalid json", file=sys.stderr)
+    sys.exit(2)
+
+fields = [
+    "integration_branch",
+    "review_base_branch",
+    "integration_sha",
+    "review_base_sha",
+    "ahead_count",
+]
+missing = [field for field in fields if event.get(field) in ("", None)]
+if missing:
+    print("missing facts: " + ",".join(missing), file=sys.stderr)
+    sys.exit(3)
+
+try:
+    ahead = int(event["ahead_count"])
+except Exception:
+    print("ahead_count must be an integer", file=sys.stderr)
+    sys.exit(3)
+
+if ahead <= 0:
+    print("ahead_count must be positive", file=sys.stderr)
+    sys.exit(3)
+
+values = [
+    event["integration_branch"],
+    event["review_base_branch"],
+    event["integration_sha"],
+    event["review_base_sha"],
+    str(ahead),
+    event.get("reason", "release-rollup-needed"),
+]
+print("\t".join(str(value) for value in values))
+PY
+  ) || {
+    local status=$?
+    echo "open_release_rollup_pr_from_pending_event: invalid event" >&2
+    return "$status"
+  }
+
+  IFS=$'\t' read -r head base integration_sha review_base_sha ahead_count reason <<< "$parsed"
+  if [ -z "$head" ] || [ -z "$base" ]; then
+    echo "open_release_rollup_pr_from_pending_event: head/base required" >&2
+    return 2
+  fi
+  if [ "$head" = "$base" ]; then
+    echo "open_release_rollup_pr_from_pending_event: head and base must differ" >&2
+    return 2
+  fi
+  if [ "$head" != "$INTEGRATION_BRANCH" ]; then
+    echo "open_release_rollup_pr_from_pending_event: head must equal INTEGRATION_BRANCH" >&2
+    return 2
+  fi
+  if [ "$base" != "$REVIEW_BASE_BRANCH" ]; then
+    echo "open_release_rollup_pr_from_pending_event: base must equal REVIEW_BASE_BRANCH" >&2
+    return 2
+  fi
+  if [ -z "$integration_sha" ] || [ -z "$review_base_sha" ] || [ -z "$ahead_count" ]; then
+    echo "open_release_rollup_pr_from_pending_event: sha and ahead facts required" >&2
+    return 2
+  fi
+
+  local existing
+  existing=$(gh pr list "${gh_repo_args[@]}" --state open --head "$head" --base "$base" --limit 1 --json number --jq '.[0].number // ""' 2>/dev/null || true)
+  if [ -n "$existing" ]; then
+    PR_NUM="$existing"
+    export PR_NUM
+    echo "release-rollup PR already exists: #$existing"
+    return 0
+  fi
+
+  RELEASE_ROLLUP_REASON="$reason" \
+  RELEASE_ROLLUP_INTEGRATION_SHA="$integration_sha" \
+  RELEASE_ROLLUP_REVIEW_BASE_SHA="$review_base_sha" \
+  RELEASE_ROLLUP_AHEAD_COUNT="$ahead_count" \
+    open_pr_with_label "Release rollup: ${head} to ${base}" "$body_file" "$base" "$head"
+}
+
 # Refactor (iter4/human-label-semantics-guard): Old pattern: label 当 architect reject workaround. New principle: 严语义 + reflector self-check + controller helper guard + source-regression test.
 # Apply the maintainer-decision label only after checking maintainer-directive artifacts.
 # Usage: apply_human_label_or_skip <pr-number> <reason-or-topic>

--- a/skills/codex-refactor-loop/scripts/controller_lib.sh
+++ b/skills/codex-refactor-loop/scripts/controller_lib.sh
@@ -127,24 +127,14 @@ open_pr_with_label() {
   export PR_NUM
 }
 
-# Open the release rollup PR from a daemon pending event.
-# Usage: open_release_rollup_pr_from_pending_event <event-json> <body-file>
-# Validates the event is exactly $INTEGRATION_BRANCH -> $REVIEW_BASE_BRANCH
-# with non-empty SHA/ahead facts, then delegates lifecycle creation to
-# open_pr_with_label. This helper belongs to the controller lifecycle surface;
-# dev_sync_daemon.py must only emit the pending event.
-open_release_rollup_pr_from_pending_event() {
-  local event_json="$1" body_file="$2"
+_parse_release_rollup_pending_event() {
+  local event_json="$1"
   if [ -z "$event_json" ]; then
     echo "open_release_rollup_pr_from_pending_event: missing event json" >&2
     return 2
   fi
-  if [ -z "$body_file" ] || [ ! -f "$body_file" ]; then
-    echo "open_release_rollup_pr_from_pending_event: missing body file" >&2
-    return 2
-  fi
 
-  local parsed head base integration_sha review_base_sha ahead_count reason
+  local parsed
   parsed=$(EVENT_JSON="$event_json" python3 - <<'PY'
 import json
 import os
@@ -166,17 +156,17 @@ fields = [
 missing = [field for field in fields if event.get(field) in ("", None)]
 if missing:
     print("missing facts: " + ",".join(missing), file=sys.stderr)
-    sys.exit(3)
+    sys.exit(2)
 
 try:
     ahead = int(event["ahead_count"])
 except Exception:
     print("ahead_count must be an integer", file=sys.stderr)
-    sys.exit(3)
+    sys.exit(2)
 
 if ahead <= 0:
     print("ahead_count must be positive", file=sys.stderr)
-    sys.exit(3)
+    sys.exit(2)
 
 values = [
     event["integration_branch"],
@@ -194,42 +184,66 @@ PY
     return "$status"
   }
 
-  IFS=$'\t' read -r head base integration_sha review_base_sha ahead_count reason <<< "$parsed"
-  if [ -z "$head" ] || [ -z "$base" ]; then
+  IFS=$'\t' read -r RELEASE_ROLLUP_HEAD RELEASE_ROLLUP_BASE RELEASE_ROLLUP_INTEGRATION_SHA_VALUE RELEASE_ROLLUP_REVIEW_BASE_SHA_VALUE RELEASE_ROLLUP_AHEAD_COUNT_VALUE RELEASE_ROLLUP_REASON_VALUE <<< "$parsed"
+  if [ -z "$RELEASE_ROLLUP_HEAD" ] || [ -z "$RELEASE_ROLLUP_BASE" ]; then
     echo "open_release_rollup_pr_from_pending_event: head/base required" >&2
     return 2
   fi
-  if [ "$head" = "$base" ]; then
+  if [ "$RELEASE_ROLLUP_HEAD" = "$RELEASE_ROLLUP_BASE" ]; then
     echo "open_release_rollup_pr_from_pending_event: head and base must differ" >&2
     return 2
   fi
-  if [ "$head" != "$INTEGRATION_BRANCH" ]; then
+  if [ "$RELEASE_ROLLUP_HEAD" != "$INTEGRATION_BRANCH" ]; then
     echo "open_release_rollup_pr_from_pending_event: head must equal INTEGRATION_BRANCH" >&2
     return 2
   fi
-  if [ "$base" != "$REVIEW_BASE_BRANCH" ]; then
+  if [ "$RELEASE_ROLLUP_BASE" != "$REVIEW_BASE_BRANCH" ]; then
     echo "open_release_rollup_pr_from_pending_event: base must equal REVIEW_BASE_BRANCH" >&2
     return 2
   fi
-  if [ -z "$integration_sha" ] || [ -z "$review_base_sha" ] || [ -z "$ahead_count" ]; then
+  if [ -z "$RELEASE_ROLLUP_INTEGRATION_SHA_VALUE" ] || [ -z "$RELEASE_ROLLUP_REVIEW_BASE_SHA_VALUE" ] || [ -z "$RELEASE_ROLLUP_AHEAD_COUNT_VALUE" ]; then
     echo "open_release_rollup_pr_from_pending_event: sha and ahead facts required" >&2
     return 2
   fi
+}
+
+_release_rollup_pr_exists() {
+  local head="$1" base="$2"
+  gh pr list "${gh_repo_args[@]}" --state open --head "$head" --base "$base" --limit 1 --json number --jq '.[0].number // ""' 2>/dev/null || true
+}
+
+# Refactor (iter5/issue-65-release-rollup-pending-event):
+#   Old pattern: release-rollup event parsing, duplicate-open check, and PR creation were packed into one large controller helper.
+#   New principle: keep the public lifecycle helper as orchestration; isolate event parsing and existing-rollup lookup behind narrow helpers.
+# Open the release rollup PR from a daemon pending event.
+# Usage: open_release_rollup_pr_from_pending_event <event-json> <body-file>
+# Validates the event is exactly $INTEGRATION_BRANCH -> $REVIEW_BASE_BRANCH
+# with non-empty SHA/ahead facts, then delegates lifecycle creation to
+# open_pr_with_label. This helper belongs to the controller lifecycle surface;
+# dev_sync_daemon.py must only emit the pending event.
+open_release_rollup_pr_from_pending_event() {
+  local event_json="$1" body_file="$2"
+  if [ -z "$body_file" ] || [ ! -f "$body_file" ]; then
+    echo "open_release_rollup_pr_from_pending_event: missing body file" >&2
+    return 2
+  fi
+
+  _parse_release_rollup_pending_event "$event_json" || return "$?"
 
   local existing
-  existing=$(gh pr list "${gh_repo_args[@]}" --state open --head "$head" --base "$base" --limit 1 --json number --jq '.[0].number // ""' 2>/dev/null || true)
-  if [ -n "$existing" ]; then
+  existing=$(_release_rollup_pr_exists "$RELEASE_ROLLUP_HEAD" "$RELEASE_ROLLUP_BASE")
+  if [[ -n "$existing" && "$existing" =~ ^[0-9]+$ ]]; then
     PR_NUM="$existing"
     export PR_NUM
     echo "release-rollup PR already exists: #$existing"
     return 0
   fi
 
-  RELEASE_ROLLUP_REASON="$reason" \
-  RELEASE_ROLLUP_INTEGRATION_SHA="$integration_sha" \
-  RELEASE_ROLLUP_REVIEW_BASE_SHA="$review_base_sha" \
-  RELEASE_ROLLUP_AHEAD_COUNT="$ahead_count" \
-    open_pr_with_label "Release rollup: ${head} to ${base}" "$body_file" "$base" "$head"
+  RELEASE_ROLLUP_REASON="$RELEASE_ROLLUP_REASON_VALUE" \
+  RELEASE_ROLLUP_INTEGRATION_SHA="$RELEASE_ROLLUP_INTEGRATION_SHA_VALUE" \
+  RELEASE_ROLLUP_REVIEW_BASE_SHA="$RELEASE_ROLLUP_REVIEW_BASE_SHA_VALUE" \
+  RELEASE_ROLLUP_AHEAD_COUNT="$RELEASE_ROLLUP_AHEAD_COUNT_VALUE" \
+    open_pr_with_label "Release rollup: ${RELEASE_ROLLUP_HEAD} to ${RELEASE_ROLLUP_BASE}" "$body_file" "$RELEASE_ROLLUP_BASE" "$RELEASE_ROLLUP_HEAD"
 }
 
 # Refactor (iter4/human-label-semantics-guard): Old pattern: label 当 architect reject workaround. New principle: 严语义 + reflector self-check + controller helper guard + source-regression test.

--- a/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
+++ b/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
@@ -375,6 +375,9 @@ class IntegrationSyncDaemonV1:
                 return True
         return False
 
+    # Refactor (iter5/issue-65-release-rollup-pending-event):
+    #   Old pattern: no release-rollup detection when integration was ahead of the review base without an open PR.
+    #   New principle: detect ahead + no open PR, then emit DEV_SYNC_PENDING:release-rollup-needed:<json>.
     def detect_release_rollup_needed(self, cwd: Path) -> bool:
         if self.release_rollup_min_commits <= 0:
             return False

--- a/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
+++ b/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
@@ -78,6 +78,8 @@ REVIEW_BASE = os.environ.get("REVIEW_BASE_BRANCH") or os.environ.get("REVIEW_BAS
 SPAWN_CODEX = SKILL_ROOT / "scripts" / "spawn-codex.sh"
 LOCK_FILE = MAIN_REPO / ".refactor-loop" / "dev-sync-daemon.lock"
 PENDING_EVENTS_FILE = MAIN_REPO / ".refactor-loop" / ".controller-pending-events.log"
+RELEASE_ROLLUP_MIN_COMMITS = int(os.environ.get("RELEASE_ROLLUP_MIN_COMMITS", "1"))
+RELEASE_ROLLUP_COOLDOWN_SECONDS = int(os.environ.get("RELEASE_ROLLUP_COOLDOWN_SECONDS", "21600"))
 
 
 def log(msg: str) -> None:
@@ -259,6 +261,9 @@ class IntegrationSyncDaemonV1:
         dirty_detector=working_tree_dirty,
         resolver_in_flight=codex_resolve_in_flight,
         resolver_dispatcher=dispatch_codex_resolve,
+        release_rollup_min_commits: int = RELEASE_ROLLUP_MIN_COMMITS,
+        release_rollup_cooldown_seconds: int = RELEASE_ROLLUP_COOLDOWN_SECONDS,
+        now_provider=None,
     ) -> None:
         self.worktree = worktree
         self.main_repo = main_repo
@@ -272,6 +277,9 @@ class IntegrationSyncDaemonV1:
         self.codex_resolve_in_flight = resolver_in_flight
         self.dispatch_codex_resolve = resolver_dispatcher
         self.pending_events_file = main_repo / ".refactor-loop" / ".controller-pending-events.log"
+        self.release_rollup_min_commits = release_rollup_min_commits
+        self.release_rollup_cooldown_seconds = release_rollup_cooldown_seconds
+        self.now_provider = now_provider or (lambda: datetime.now(timezone.utc))
 
     def append_pending_event(self, reason: str, detail: str) -> None:
         self.pending_events_file.parent.mkdir(parents=True, exist_ok=True)
@@ -295,6 +303,109 @@ class IntegrationSyncDaemonV1:
             self.append_pending_event("remote-sha-unknown", result.stderr.strip()[:160])
             return None
         return result.stdout.strip()
+
+    def remote_branch_sha(self, cwd: Path, branch: str) -> str | None:
+        result = self.run(["git", "rev-parse", f"origin/{branch}"], cwd=cwd)
+        if result.returncode != 0:
+            self.log(f"skip release-rollup detector: origin/{branch} sha unavailable")
+            return None
+        return result.stdout.strip()
+
+    def release_rollup_ahead_count(self, cwd: Path) -> int:
+        result = self.run(
+            ["git", "rev-list", "--count", f"origin/{self.review_base}..origin/{self.integration}"],
+            cwd=cwd,
+        )
+        try:
+            return int(result.stdout.strip())
+        except ValueError:
+            self.log("skip release-rollup detector: ahead count unavailable")
+            return 0
+
+    def has_open_release_rollup_pr(self) -> bool:
+        result = self.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--head",
+                self.integration,
+                "--base",
+                self.review_base,
+                "--limit",
+                "1",
+                "--json",
+                "number,headRefName,baseRefName",
+            ],
+            cwd=self.main_repo,
+        )
+        if result.returncode != 0:
+            self.log("skip release-rollup detector: open PR query failed")
+            return True
+        try:
+            rows = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError:
+            self.log("skip release-rollup detector: open PR query returned invalid JSON")
+            return True
+        return bool(rows)
+
+    def release_rollup_event_recently_emitted(self, integration_sha: str, now: datetime) -> bool:
+        if self.release_rollup_cooldown_seconds <= 0 or not self.pending_events_file.exists():
+            return False
+        for line in self.pending_events_file.read_text(encoding="utf-8", errors="replace").splitlines():
+            prefix = "DEV_SYNC_PENDING:release-rollup-needed:"
+            if not line.startswith(prefix):
+                continue
+            try:
+                event = json.loads(line[len(prefix):])
+            except json.JSONDecodeError:
+                continue
+            if event.get("integration_sha") != integration_sha:
+                continue
+            detected_at = event.get("detected_at")
+            if not detected_at:
+                return True
+            try:
+                prior = datetime.fromisoformat(detected_at.replace("Z", "+00:00"))
+            except ValueError:
+                return True
+            if (now - prior).total_seconds() <= self.release_rollup_cooldown_seconds:
+                return True
+        return False
+
+    def detect_release_rollup_needed(self, cwd: Path) -> bool:
+        if self.release_rollup_min_commits <= 0:
+            return False
+        ahead_count = self.release_rollup_ahead_count(cwd)
+        if ahead_count < self.release_rollup_min_commits:
+            return False
+
+        integration_sha = self.remote_branch_sha(cwd, self.integration)
+        review_base_sha = self.remote_branch_sha(cwd, self.review_base)
+        if not integration_sha or not review_base_sha:
+            return False
+
+        if self.has_open_release_rollup_pr():
+            return False
+
+        now = self.now_provider()
+        if self.release_rollup_event_recently_emitted(integration_sha, now):
+            self.log(f"release-rollup pending event already emitted for {integration_sha}")
+            return False
+
+        event = {
+            "integration_branch": self.integration,
+            "review_base_branch": self.review_base,
+            "integration_sha": integration_sha,
+            "review_base_sha": review_base_sha,
+            "ahead_count": ahead_count,
+            "detected_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "reason": "integration-ahead-review-base-without-open-rollup-pr",
+        }
+        self.append_pending_event("release-rollup-needed", json.dumps(event, sort_keys=True))
+        return True
 
     def push_clean_local_ahead_before_reset(self, cwd: Path) -> bool:
         ahead_n = self.local_ahead_count(cwd)
@@ -433,6 +544,7 @@ class IntegrationSyncDaemonV1:
             behind_n = 0
 
         if behind_n == 0:
+            self.detect_release_rollup_needed(cwd)
             self.log(f"up-to-date with origin/{self.review_base}")
             return
 

--- a/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
+++ b/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -31,16 +32,21 @@ class FakeGit:
         self,
         *,
         ahead: int = 0,
+        release_ahead: int = 0,
         behind: int = 0,
         remote_sha: str = "remote-sha",
+        review_base_sha: str = "review-base-sha",
         ahead_stdout: str | None = None,
+        release_ahead_stdout: str | None = None,
         behind_stdout: str | None = None,
         replay_count: int = 0,
         replay_count_stdout: str | None = None,
         remote_sha_returncode: int = 0,
         remote_sha_stderr: str = "",
         gh_rows: list[dict] | None = None,
+        open_gh_rows: list[dict] | None = None,
         gh_stdout: str | None = None,
+        open_gh_stdout: str | None = None,
         gh_returncode: int = 0,
         gh_stderr: str = "",
         merge_base_adopted: bool = False,
@@ -60,15 +66,19 @@ class FakeGit:
         push_stderr: str = "",
     ) -> None:
         self.ahead = ahead
+        self.release_ahead = release_ahead
         self.behind = behind
         self.remote_sha = remote_sha
+        self.review_base_sha = review_base_sha
         self.ahead_stdout = ahead_stdout
+        self.release_ahead_stdout = release_ahead_stdout
         self.behind_stdout = behind_stdout
         self.replay_count = replay_count
         self.replay_count_stdout = replay_count_stdout
         self.remote_sha_returncode = remote_sha_returncode
         self.remote_sha_stderr = remote_sha_stderr
         self.gh_stdout = gh_stdout
+        self.open_gh_stdout = open_gh_stdout
         self.gh_returncode = gh_returncode
         self.gh_stderr = gh_stderr
         self.merge_base_adopted = merge_base_adopted
@@ -88,6 +98,7 @@ class FakeGit:
         self.push_stderr = push_stderr
         self.commands: list[list[str]] = []
         self.gh_rows: list[dict] = gh_rows or []
+        self.open_gh_rows: list[dict] = open_gh_rows or []
 
     def __call__(self, cmd: list[str], cwd: Path | None = None, check: bool = False) -> subprocess.CompletedProcess:
         self.commands.append(cmd)
@@ -100,6 +111,8 @@ class FakeGit:
             spec = cmd[3]
             if spec.startswith("origin/auto-refact-dev..HEAD"):
                 stdout = self.ahead_stdout if self.ahead_stdout is not None else f"{self.ahead}\n"
+            elif spec.startswith("origin/dev..origin/auto-refact-dev"):
+                stdout = self.release_ahead_stdout if self.release_ahead_stdout is not None else f"{self.release_ahead}\n"
             elif spec.startswith("HEAD..origin/dev"):
                 stdout = self.behind_stdout if self.behind_stdout is not None else f"{self.behind}\n"
             elif spec.startswith("old-head..origin/auto-refact-dev"):
@@ -110,6 +123,8 @@ class FakeGit:
             returncode = self.remote_sha_returncode
             stdout = f"{self.remote_sha}\n" if returncode == 0 else ""
             stderr = self.remote_sha_stderr
+        elif cmd[:3] == ["git", "rev-parse", "origin/dev"]:
+            stdout = f"{self.review_base_sha}\n"
         elif cmd[:3] == ["git", "merge-base", "--is-ancestor"]:
             if cmd[3] == "origin/dev":
                 returncode = 0 if self.merge_base_adopted else 1
@@ -117,7 +132,10 @@ class FakeGit:
                 returncode = 0 if self.old_head_is_ancestor else 1
         elif cmd[:3] == ["gh", "pr", "list"]:
             returncode = self.gh_returncode
-            stdout = self.gh_stdout if self.gh_stdout is not None else json.dumps(self.gh_rows)
+            if "--state" in cmd and cmd[cmd.index("--state") + 1] == "open":
+                stdout = self.open_gh_stdout if self.open_gh_stdout is not None else json.dumps(self.open_gh_rows)
+            else:
+                stdout = self.gh_stdout if self.gh_stdout is not None else json.dumps(self.gh_rows)
             stderr = self.gh_stderr
         elif cmd[:3] == ["git", "merge", "--ff-only"]:
             returncode = self.ff_returncode if self.ff_returncode is not None else 0
@@ -167,6 +185,9 @@ class IntegrationSyncDaemonV1BehaviorTests(unittest.TestCase):
             dirty_detector=overrides.get("dirty_detector", lambda _cwd: False),
             resolver_in_flight=overrides.get("resolver_in_flight", lambda: False),
             resolver_dispatcher=overrides.get("resolver_dispatcher", lambda: None),
+            release_rollup_min_commits=overrides.get("release_rollup_min_commits", 0),
+            release_rollup_cooldown_seconds=overrides.get("release_rollup_cooldown_seconds", 21600),
+            now_provider=overrides.get("now_provider", lambda: datetime(2026, 5, 27, 0, 0, 0, tzinfo=timezone.utc)),
         )
 
     def command_index(self, fake: FakeGit, needle: list[str]) -> int:
@@ -180,6 +201,14 @@ class IntegrationSyncDaemonV1BehaviorTests(unittest.TestCase):
         if not path.exists():
             return []
         return path.read_text(encoding="utf-8").splitlines()
+
+    def release_rollup_events(self) -> list[dict]:
+        events = []
+        prefix = "DEV_SYNC_PENDING:release-rollup-needed:"
+        for line in self.pending_events():
+            if line.startswith(prefix):
+                events.append(json.loads(line[len(prefix):]))
+        return events
 
     def test_clean_local_ahead_is_pushed_before_reset(self) -> None:
         fake = FakeGit(ahead=2)
@@ -702,6 +731,51 @@ class IntegrationSyncDaemonV1BehaviorTests(unittest.TestCase):
             ],
         )
 
+    def test_release_rollup_needed_emits_pending_event_when_integration_ahead_without_open_pr(self) -> None:
+        fake = FakeGit(merge_base_adopted=True, release_ahead=3, remote_sha="integration-sha", review_base_sha="base-sha")
+
+        self.daemon(fake, release_rollup_min_commits=1).tick()
+
+        events = self.release_rollup_events()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["integration_branch"], "auto-refact-dev")
+        self.assertEqual(events[0]["review_base_branch"], "dev")
+        self.assertEqual(events[0]["integration_sha"], "integration-sha")
+        self.assertEqual(events[0]["review_base_sha"], "base-sha")
+        self.assertEqual(events[0]["ahead_count"], 3)
+        self.assertEqual(events[0]["reason"], "integration-ahead-review-base-without-open-rollup-pr")
+
+    def test_release_rollup_needed_does_not_emit_when_open_rollup_pr_exists(self) -> None:
+        fake = FakeGit(
+            merge_base_adopted=True,
+            release_ahead=3,
+            open_gh_rows=[{"number": 77, "headRefName": "auto-refact-dev", "baseRefName": "dev"}],
+        )
+
+        self.daemon(fake, release_rollup_min_commits=1).tick()
+
+        self.assertEqual(self.release_rollup_events(), [])
+
+    def test_release_rollup_needed_does_not_emit_below_threshold_or_without_ahead(self) -> None:
+        for release_ahead, threshold in ((0, 1), (1, 2)):
+            with self.subTest(release_ahead=release_ahead, threshold=threshold):
+                self.tearDown()
+                self.setUp()
+                fake = FakeGit(merge_base_adopted=True, release_ahead=release_ahead)
+
+                self.daemon(fake, release_rollup_min_commits=threshold).tick()
+
+                self.assertEqual(self.release_rollup_events(), [])
+
+    def test_release_rollup_needed_cooldown_emits_same_integration_sha_once(self) -> None:
+        fake = FakeGit(merge_base_adopted=True, release_ahead=2, remote_sha="same-sha", review_base_sha="base-sha")
+        daemon = self.daemon(fake, release_rollup_min_commits=1, release_rollup_cooldown_seconds=3600)
+
+        daemon.tick()
+        daemon.tick()
+
+        self.assertEqual(len(self.release_rollup_events()), 1)
+
 
 class IntegrationSyncDaemonV1SourceRegressionTests(unittest.TestCase):
     def test_skill_phase6_names_integration_sync_daemon_v1(self) -> None:
@@ -758,6 +832,19 @@ class IntegrationSyncDaemonV1SourceRegressionTests(unittest.TestCase):
         ):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, src)
+
+    def test_dev_sync_daemon_has_no_pr_lifecycle_or_direct_review_base_push(self) -> None:
+        src = DEV_SYNC.read_text(encoding="utf-8")
+        forbidden_tokens = (
+            "gh pr create",
+            "gh pr edit",
+            "gh pr merge",
+            "HEAD:$REVIEW_BASE_BRANCH",
+            "HEAD:{self.review_base}",
+        )
+        for token in forbidden_tokens:
+            with self.subTest(token=token):
+                self.assertNotIn(token, src)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
+++ b/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
@@ -756,6 +756,29 @@ class IntegrationSyncDaemonV1BehaviorTests(unittest.TestCase):
 
         self.assertEqual(self.release_rollup_events(), [])
 
+    def test_release_rollup_detector_skips_on_gh_pr_list_nonzero_returncode(self) -> None:
+        fake = FakeGit(
+            merge_base_adopted=True,
+            release_ahead=3,
+            gh_returncode=1,
+            gh_stderr="gh unavailable",
+        )
+
+        self.daemon(fake, release_rollup_min_commits=1).tick()
+
+        self.assertEqual(self.release_rollup_events(), [])
+
+    def test_release_rollup_detector_skips_on_malformed_gh_pr_list_stdout(self) -> None:
+        fake = FakeGit(
+            merge_base_adopted=True,
+            release_ahead=3,
+            open_gh_stdout="{not json",
+        )
+
+        self.daemon(fake, release_rollup_min_commits=1).tick()
+
+        self.assertEqual(self.release_rollup_events(), [])
+
     def test_release_rollup_needed_does_not_emit_below_threshold_or_without_ahead(self) -> None:
         for release_ahead, threshold in ((0, 1), (1, 2)):
             with self.subTest(release_ahead=release_ahead, threshold=threshold):

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -297,6 +297,33 @@ class ScriptHygieneBehaviorTests(unittest.TestCase):
         self.assertIn("ahead_count must be positive", result.stderr)
         self.assertNotIn("unexpected open", result.stdout)
 
+    def test_release_rollup_controller_helper_rejects_branch_mismatch(self) -> None:
+        cases = [
+            (
+                "integration_branch_mismatch",
+                '{"integration_branch":"other-integration","review_base_branch":"dev",'
+                '"integration_sha":"i","review_base_sha":"b","ahead_count":1}',
+                "head must equal INTEGRATION_BRANCH",
+            ),
+            (
+                "review_base_branch_mismatch",
+                '{"integration_branch":"auto-refact-dev","review_base_branch":"main",'
+                '"integration_sha":"i","review_base_sha":"b","ahead_count":1}',
+                "base must equal REVIEW_BASE_BRANCH",
+            ),
+        ]
+
+        for name, event_json, expected_stderr in cases:
+            with self.subTest(case=name):
+                result = self.run_controller_lib_harness(
+                    f"open_release_rollup_pr_from_pending_event '{event_json}' \"$BODY_FILE\"",
+                    prelude='open_pr_with_label() { echo "unexpected open"; return 99; }',
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_stderr, result.stderr)
+                self.assertNotIn("unexpected open", result.stdout)
+
     def test_release_rollup_controller_helper_skips_open_pr_with_label_when_existing_rollup_exists(self) -> None:
         event_json = (
             '{"integration_branch":"auto-refact-dev","review_base_branch":"dev",'

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -267,6 +267,55 @@ class ScriptHygieneBehaviorTests(unittest.TestCase):
                 self.assertNotEqual(result.returncode, 0)
                 self.assertNotIn("unexpected open", result.stdout)
 
+    def test_release_rollup_controller_helper_rejects_non_integer_ahead_count(self) -> None:
+        event_json = (
+            '{"integration_branch":"auto-refact-dev","review_base_branch":"dev",'
+            '"integration_sha":"i","review_base_sha":"b","ahead_count":"bad"}'
+        )
+
+        result = self.run_controller_lib_harness(
+            f"open_release_rollup_pr_from_pending_event '{event_json}' \"$BODY_FILE\"",
+            prelude='open_pr_with_label() { echo "unexpected open"; return 99; }',
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("ahead_count must be an integer", result.stderr)
+        self.assertNotIn("unexpected open", result.stdout)
+
+    def test_release_rollup_controller_helper_rejects_zero_ahead_count(self) -> None:
+        event_json = (
+            '{"integration_branch":"auto-refact-dev","review_base_branch":"dev",'
+            '"integration_sha":"i","review_base_sha":"b","ahead_count":0}'
+        )
+
+        result = self.run_controller_lib_harness(
+            f"open_release_rollup_pr_from_pending_event '{event_json}' \"$BODY_FILE\"",
+            prelude='open_pr_with_label() { echo "unexpected open"; return 99; }',
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("ahead_count must be positive", result.stderr)
+        self.assertNotIn("unexpected open", result.stdout)
+
+    def test_release_rollup_controller_helper_skips_open_pr_with_label_when_existing_rollup_exists(self) -> None:
+        event_json = (
+            '{"integration_branch":"auto-refact-dev","review_base_branch":"dev",'
+            '"integration_sha":"i","review_base_sha":"b","ahead_count":2,'
+            '"reason":"integration-ahead-review-base-without-open-rollup-pr"}'
+        )
+
+        result = self.run_controller_lib_harness(
+            f"gh() {{ if [[ \"$1 $2\" == \"pr list\" ]]; then printf '94\\n'; return 0; fi; command gh \"$@\"; }}; "
+            f"open_release_rollup_pr_from_pending_event '{event_json}' \"$BODY_FILE\"; "
+            'printf "PR_NUM=%s\\n" "$PR_NUM"',
+            prelude='open_pr_with_label() { echo "unexpected open"; return 99; }',
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("release-rollup PR already exists: #94", result.stdout)
+        self.assertIn("PR_NUM=94", result.stdout)
+        self.assertNotIn("unexpected open", result.stdout)
+
     def test_release_rollup_controller_helper_accepts_valid_event_and_delegates_to_open_pr_with_label(self) -> None:
         event_json = (
             '{"integration_branch":"auto-refact-dev","review_base_branch":"dev",'

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -117,6 +117,57 @@ class ScriptHygieneBehaviorTests(unittest.TestCase):
                 check=False,
             )
 
+    def run_controller_lib_harness(
+        self,
+        command: str,
+        *,
+        env_updates: dict[str, str] | None = None,
+        prelude: str = "",
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fakebin = root / "fakebin"
+            fakebin.mkdir()
+            gh = fakebin / "gh"
+            gh.write_text(
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$*\" >> \"$GH_CALLS\"\n"
+                "if [[ \"$1 $2\" == \"pr list\" ]]; then printf '[]\\n'; exit 0; fi\n"
+                "if [[ \"$1 $2 $3\" == \"repo view --json\" ]]; then printf 'owner/repo\\n'; exit 0; fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
+            body = root / "body.md"
+            body.write_text("body\n", encoding="utf-8")
+            calls = root / "gh-calls.log"
+            env = os.environ.copy()
+            env.update(
+                {
+                    "REPO_ROOT": str(root),
+                    "GH_REPO_SLUG": "owner/repo",
+                    "GH_CALLS": str(calls),
+                    "PATH": f"{fakebin}{os.pathsep}{env.get('PATH', '')}",
+                    "INTEGRATION_BRANCH": "auto-refact-dev",
+                    "REVIEW_BASE_BRANCH": "dev",
+                    "BODY_FILE": str(body),
+                }
+            )
+            if env_updates:
+                env.update(env_updates)
+            script = (
+                f'source "{SKILL_ROOT / "scripts" / "controller_lib.sh"}"; '
+                f"{prelude}\n"
+                f"{command}"
+            )
+            return subprocess.run(
+                ["bash", "-lc", script],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
     def test_resolve_github_repo_slug_env_branches(self) -> None:
         cases = [
             ("explicit_slug", {"GH_REPO_SLUG": "owner/repo"}, 0, "owner/repo\n", ""),
@@ -196,6 +247,69 @@ class ScriptHygieneBehaviorTests(unittest.TestCase):
 
         self.assertEqual(fallback.returncode, 0, fallback.stderr)
         self.assertEqual(fallback.stdout.splitlines(), ["slug=fallback/slug", "argc=2", "arg=--repo", "arg=fallback/slug"])
+
+    def test_release_rollup_controller_helper_rejects_invalid_head_base_or_facts(self) -> None:
+        cases = [
+            ("empty_head", '{"integration_branch":"","review_base_branch":"dev","integration_sha":"i","review_base_sha":"b","ahead_count":1}'),
+            ("empty_base", '{"integration_branch":"auto-refact-dev","review_base_branch":"","integration_sha":"i","review_base_sha":"b","ahead_count":1}'),
+            ("same_head_base", '{"integration_branch":"auto-refact-dev","review_base_branch":"auto-refact-dev","integration_sha":"i","review_base_sha":"b","ahead_count":1}'),
+            ("missing_sha", '{"integration_branch":"auto-refact-dev","review_base_branch":"dev","integration_sha":"","review_base_sha":"b","ahead_count":1}'),
+            ("missing_ahead", '{"integration_branch":"auto-refact-dev","review_base_branch":"dev","integration_sha":"i","review_base_sha":"b"}'),
+        ]
+
+        for name, event_json in cases:
+            with self.subTest(case=name):
+                result = self.run_controller_lib_harness(
+                    f"open_release_rollup_pr_from_pending_event '{event_json}' \"$BODY_FILE\"",
+                    prelude='open_pr_with_label() { echo "unexpected open"; return 99; }',
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn("unexpected open", result.stdout)
+
+    def test_release_rollup_controller_helper_accepts_valid_event_and_delegates_to_open_pr_with_label(self) -> None:
+        event_json = (
+            '{"integration_branch":"auto-refact-dev","review_base_branch":"dev",'
+            '"integration_sha":"i","review_base_sha":"b","ahead_count":2,'
+            '"reason":"integration-ahead-review-base-without-open-rollup-pr"}'
+        )
+
+        result = self.run_controller_lib_harness(
+            f"open_release_rollup_pr_from_pending_event '{event_json}' \"$BODY_FILE\"",
+            prelude=(
+                'open_pr_with_label() { '
+                'printf "title=%s\\nbody=%s\\nbase=%s\\nhead=%s\\n" "$1" "$2" "$3" "$4"; '
+                '}'
+            ),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("title=Release rollup: auto-refact-dev to dev", result.stdout)
+        self.assertIn("base=dev", result.stdout)
+        self.assertIn("head=auto-refact-dev", result.stdout)
+
+    def test_integration_sync_daemon_v1_release_rollup_exception_contract(self) -> None:
+        skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        reference = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+        daemon = (SKILL_ROOT / "scripts" / "dev_sync_daemon.py").read_text(encoding="utf-8")
+        host_env = (SKILL_ROOT / "host.env.example").read_text(encoding="utf-8")
+        combined = "\n".join([skill, reference, daemon, host_env])
+
+        self.assertIn("## Named runtime exception — IntegrationSyncDaemonV1(per #65)", skill)
+        self.assertIn("phase9-issue65-r7-judge.md", skill)
+        self.assertIn("DEV_SYNC_PENDING:release-rollup-needed", combined)
+        self.assertIn("release-rollup detection and existing-format pending-event emission only", skill)
+        self.assertIn("must not create PRs, edit PRs, label PRs, close PRs, approve PRs, merge PRs", skill)
+        self.assertIn("must not run `gh pr create`", skill)
+        self.assertIn("push directly to `$REVIEW_BASE_BRANCH`", skill)
+        self.assertIn("open_release_rollup_pr_from_pending_event", reference)
+        self.assertIn("RELEASE_ROLLUP_MIN_COMMITS", host_env)
+        self.assertIn("RELEASE_ROLLUP_COOLDOWN_SECONDS", host_env)
+
+        for forbidden in ("$RELEASE_BRANCH", "RELEASE_BRANCH", "ReleaseRollupRequestV1"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, combined)
+        self.assertNotIn("gh pr create", daemon)
 
     def test_python_github_repo_slug_env_branches(self) -> None:
         from repo_config import github_repo_slug


### PR DESCRIPTION
## Summary

按 Phase 9 r7 3/3 consensus(\`.refactor-loop/runs/phase9-issue65-r7-judge.md\`,existing-review-base pending-event boundary)实施:

- **dev_sync_daemon.py**: IntegrationSyncDaemonV1 加 release-rollup detector;原 \`origin/\$INTEGRATION_BRANCH\` ahead \`origin/\$REVIEW_BASE_BRANCH\` 且无 open head/base rollup PR 时 write \`DEV_SYNC_PENDING:release-rollup-needed:<json>\` 到 \`.refactor-loop/.controller-pending-events.log\`。
- **controller_lib.sh**: 新 helper \`open_release_rollup_pr_from_pending_event <event-json> <body-file>\` 严格校验 + 委托既有 \`open_pr_with_label\`。
- **SKILL.md**: \`Named runtime exception — IntegrationSyncDaemonV1(per #65)\` narrow allowlist + no PR lifecycle authority。
- **REFERENCE.md**: Phase 4b/Phase 6 同步 daemon emit + controller consume 分工。
- **host.env.example**: \`RELEASE_ROLLUP_MIN_COMMITS\` + cooldown defaults。
- **Tests**: behavior + source-regression — detector emit/suppress/cooldown,daemon 无 gh pr lifecycle / push review base,无 \$RELEASE_BRANCH / ReleaseRollupRequestV1 envelope。

无改 CLAUDE.md / AGENTS.md / Tier / SPEC。

## Test plan

- [x] tests pass(per implement-issue-65.md verification)
- [ ] Phase 8 reviewers(architect / tests / quality)
- [ ] CI(contract-tests / manifest-version-sync / lint-advisory)

## Authorization

\`.refactor-loop/runs/phase9-issue65-r7-judge.md\`(r7 3/3 consensus on existing-review-base pending-event boundary)。

Closes #65。

⟦AI:AUTO-LOOP⟧