### PR TITLE
fix(skill): peek.sh marker false-positive(EXIT=0 gate + placeholder filter)

### DIFF
--- a/skills/codex-refactor-loop/scripts/peek.sh
+++ b/skills/codex-refactor-loop/scripts/peek.sh
@@ -37,10 +37,11 @@ list_loop_codex() {
 MARKER_RE="AUDIT_DONE|AUDIT_INCOMPLETE|IMPLEMENT_DONE|IMPLEMENT_BLOCKED|FIX_DONE|FIX_BLOCKED|REVIEW_DONE|SOLVER_DONE|META_JUDGE_DONE|META_RESOLVED|TEST_ADD_DONE"
 extract_terminal_marker() {
   local f="$1"
-  awk '/^EXIT=/{exit} {print}' "$f" 2>/dev/null |
+  tail -200 "$f" 2>/dev/null |
+    awk '{ line[NR]=$0 } /^EXIT=/{ last_exit=NR } END { limit=last_exit ? last_exit : NR + 1; for (i=1; i<limit; i++) print line[i] }' |
     grep -E "(${MARKER_RE}):" |
     sed -E 's/^[+[:space:]]+//; s/^.*(AUDIT_DONE:|AUDIT_INCOMPLETE:|IMPLEMENT_DONE:|IMPLEMENT_BLOCKED:|FIX_DONE:|FIX_BLOCKED:|REVIEW_DONE:|SOLVER_DONE:|META_JUDGE_DONE:|META_RESOLVED:|TEST_ADD_DONE:)/\1/' |
-    grep -vE '<reason>|<id>|<status>|<category>|<framing>|round-N|cluster-XXX' |
+    grep -vE '<reason>|<id>|<status>|<category>|<framing>|<short>|<verdict>|<role>|<summary>|<question>|<kind>|\{role\}|round-N|cluster-XXX|AUDIT_DONE:none:|AUDIT_INCOMPLETE:\*\)|META_RESOLVED:<kind>' |
     tail -1 |
     head -c 100
 }
@@ -113,9 +114,9 @@ echo ""
 echo "▍最近 60 min 完成 codex(marker → 推荐下一步):"
 find .refactor-loop/logs -name "*.log" -mmin -60 -type f 2>/dev/null | while read f; do
   base=$(basename "$f" .log)
-  # Skip in-progress (no EXIT line)
-  exit_line=$(grep "^EXIT=" "$f" 2>/dev/null | tail -1)
-  [ -z "$exit_line" ] && continue
+  # Skip in-progress and failed runs; terminal status is authoritative only in the tail.
+  exit_line=$(tail -5 "$f" 2>/dev/null | grep -m1 "^EXIT=" || true)
+  [ "$exit_line" != "EXIT=0" ] && continue
   marker=$(extract_terminal_marker "$f")
   [ -z "$marker" ] && continue
   # Routing hint

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -769,6 +769,15 @@ class Phase8MergePolicySourceRegressionTests(unittest.TestCase):
         self.assertIn("WAIT_EXPLICIT_APPROVAL", peek)
         self.assertIn("do not merge", peek)
 
+    def test_peek_finished_marker_detection_is_tail_scoped(self) -> None:
+        peek = (SKILL_ROOT / "scripts" / "peek.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn('grep "^EXIT=" "$f"', peek)
+        self.assertIn('exit_line=$(tail -5 "$f" 2>/dev/null | grep -m1 "^EXIT=" || true)', peek)
+        self.assertIn('[ "$exit_line" != "EXIT=0" ] && continue', peek)
+        self.assertIn('tail -200 "$f"', peek)
+        self.assertNotIn("awk '/^EXIT=/{exit} {print}' \"$f\"", peek)
+
     def test_review_fix_blocks_only_on_reject(self) -> None:
         review_fix = (SKILL_ROOT / "prompts" / "review-fix.md").read_text(encoding="utf-8")
 

--- a/skills/codex-refactor-loop/scripts/test_peek_marker_extraction.sh
+++ b/skills/codex-refactor-loop/scripts/test_peek_marker_extraction.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PEEK="${SCRIPT_DIR}/peek.sh"
+TMP_DIR=""
+
+cleanup() {
+  if [ -n "${TMP_DIR:-}" ]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+setup_repo() {
+  TMP_DIR="$(mktemp -d)"
+  mkdir -p "$TMP_DIR/.refactor-loop/logs" "$TMP_DIR/fakebin"
+
+  cat > "$TMP_DIR/fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "--jq" ]; then
+    exit 0
+  fi
+done
+case "$1 $2" in
+  "issue list"|"pr list")
+    printf '[]\n'
+    ;;
+  "issue view"|"pr view")
+    printf '{"comments":[],"state":"OPEN"}\n'
+    ;;
+  *)
+    ;;
+esac
+SH
+  chmod +x "$TMP_DIR/fakebin/gh"
+
+  cat > "$TMP_DIR/fakebin/git" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  fetch)
+    exit 0
+    ;;
+  worktree)
+    if [ "$2" = "list" ]; then
+      printf 'worktree %s\n' "${REPO_ROOT:-$PWD}"
+    fi
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SH
+  chmod +x "$TMP_DIR/fakebin/git"
+}
+
+write_log() {
+  local name="$1"
+  shift
+  printf '%s\n' "$@" > "$TMP_DIR/.refactor-loop/logs/${name}.log"
+}
+
+run_peek() {
+  PATH="$TMP_DIR/fakebin:$PATH" REPO_ROOT="$TMP_DIR" GH_REPO_SLUG="" bash "$PEEK"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "FAIL ${label}: expected output to contain ${needle}" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "FAIL ${label}: expected output not to contain ${needle}" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+test_mid_log_exit_literal_without_exit_ok_is_not_finished() {
+  setup_repo
+  write_log "audit-mid-exit" \
+    "SPAWN: audit" \
+    'grep pattern source.sh' \
+    'EXIT=$?' \
+    "AUDIT_DONE:audit-iter-fake.md:9" \
+    "ERROR: command failed"
+
+  local out
+  out="$(run_peek)"
+
+  assert_not_contains "$out" "audit-mid-exit: AUDIT_DONE:audit-iter-fake.md:9" "${FUNCNAME[0]}"
+}
+
+test_tail_exit_one_is_not_finished() {
+  setup_repo
+  write_log "audit-exit-one" \
+    "SPAWN: audit" \
+    "AUDIT_DONE:audit-iter-fake.md:9" \
+    "EXIT=1"
+
+  local out
+  out="$(run_peek)"
+
+  assert_not_contains "$out" "audit-exit-one: AUDIT_DONE:audit-iter-fake.md:9" "${FUNCNAME[0]}"
+}
+
+test_exit_zero_with_real_audit_marker_is_finished() {
+  setup_repo
+  write_log "audit-real" \
+    "SPAWN: audit" \
+    "AUDIT_DONE:audit-iter-xxx.md:5" \
+    "EXIT=0"
+
+  local out
+  out="$(run_peek)"
+
+  assert_contains "$out" "audit-real: AUDIT_DONE:audit-iter-xxx.md:5" "${FUNCNAME[0]}"
+}
+
+test_exit_zero_with_audit_placeholder_is_filtered() {
+  setup_repo
+  write_log "audit-placeholder" \
+    "SPAWN: audit" \
+    "AUDIT_DONE:none:0" \
+    "EXIT=0"
+
+  local out
+  out="$(run_peek)"
+
+  assert_not_contains "$out" "audit-placeholder: AUDIT_DONE:none:0" "${FUNCNAME[0]}"
+}
+
+test_exit_zero_with_meta_short_placeholder_is_filtered() {
+  setup_repo
+  write_log "meta-placeholder" \
+    "SPAWN: judge" \
+    "META_JUDGE_DONE:escalate:stalled:<short>" \
+    "EXIT=0"
+
+  local out
+  out="$(run_peek)"
+
+  assert_not_contains "$out" "meta-placeholder: META_JUDGE_DONE:escalate:stalled:<short>" "${FUNCNAME[0]}"
+}
+
+test_exit_zero_with_real_meta_marker_is_finished() {
+  setup_repo
+  write_log "meta-real" \
+    "SPAWN: judge" \
+    "META_JUDGE_DONE:consensus:A-real-framing" \
+    "EXIT=0"
+
+  local out
+  out="$(run_peek)"
+
+  assert_contains "$out" "meta-real: META_JUDGE_DONE:consensus:A-real-framing" "${FUNCNAME[0]}"
+}
+
+test_mid_log_exit_literal_without_exit_ok_is_not_finished
+test_tail_exit_one_is_not_finished
+test_exit_zero_with_real_audit_marker_is_finished
+test_exit_zero_with_audit_placeholder_is_filtered
+test_exit_zero_with_meta_short_placeholder_is_filtered
+test_exit_zero_with_real_meta_marker_is_finished
+
+echo "peek marker extraction tests ok"


### PR DESCRIPTION
## Summary

`peek.sh` 在"最近 60 min 完成 codex"段误把以下当成真完成 marker:

1. **失败 codex(EXIT=1)** — `grep "^EXIT=" "$f"` 整 log 扫,匹配源码里 literal `EXIT=$?` / `EXIT=0` 引用(REFERENCE.md / scripts 字面),把失败的 audit/meta-judge 误报为完成
2. **prompt placeholder marker** — 模板里 `META_JUDGE_DONE:escalate:stalled:<short>` / `AUDIT_DONE:none:0` / `SOLVER_DONE:{role}:...` 等占位文本被当真 marker 显示

## 实际证据(本 session 实证)

- `meta-judge-issue100-r1-r3` EXIT=1(503 disconnect)但 peek 误报 `META_JUDGE_DONE:escalate:stalled:<short>`
- `audit-cron156-1` EXIT=1 但 peek 误报 `META_JUDGE_DONE:consensus:A-cron-only-with-pending-event-alert`(从 grep 输出的另一 log 字面)
- `audit-cron155-probe` EXIT=1 但 peek 误报 `AUDIT_DONE:none:0`

## 修复(只改 peek.sh + 加测试)

| 文件 | 改动 |
|---|---|
| `peek.sh:117` | `grep "^EXIT="` → `tail -5 ... grep -m1 "^EXIT="`,且严格 `== "EXIT=0"`;非 0 视为失败不报 marker |
| `peek.sh:40` | `awk '/^EXIT=/{exit}'` → tail-200 截断,避免源码中段 EXIT= 截断 |
| `peek.sh:43` | placeholder filter 扩展加 `<short>` / `<verdict>` / `<role>` / `{role}` / `AUDIT_DONE:none:` / `AUDIT_INCOMPLETE:\*\)` |
| `test_peek_marker_extraction.sh`(新) | 6 case behavior 测试(mid-log EXIT literal / EXIT=1 / 真 marker / 各类 placeholder) |
| `test_ensure_project_rules_fixed_points.py` | 加 source-regression 断言:peek.sh 不再含整 log scan,必含 tail-based pattern |

契约依据:REFERENCE.md:156 明确写 `❌ grep "^EXIT=" 全 log 判 finished → codex 中途 echo / cat 含 EXIT= 文件会误判。必须 tail -5。` peek.sh 违反自己的契约。

LOC: ~192 added / ~5 removed(主要新测试文件)

## Test plan

- [x] `bash skills/codex-refactor-loop/scripts/test_peek_marker_extraction.sh` 通过(6 case ok)
- [x] `python3 -m unittest skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py` 通过(114 tests ok)
- [x] 手工 sanity:`bash skills/codex-refactor-loop/scripts/peek.sh` 不再有 audit-cron156-* 假完成 marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⟦AI:AUTO-LOOP⟧
