### PR TITLE
feat(detection): replace NL-literal anchors with protocol tokens per #106

### DIFF
--- a/.github/workflows/consensus-rnd-ci.yml
+++ b/.github/workflows/consensus-rnd-ci.yml
@@ -25,6 +25,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch source-regression base
+        run: git fetch origin auto-refact-dev
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -37,6 +37,11 @@ CANONICAL_HUMAN_LABELS = {"🤖 human:auto-推进", "👤 human:需-maintainer-�
 NON_AUTO_HUMAN_LABEL = "👤 human:需-maintainer-决策"  # refactor helper, no behavior change
 REMOVED_HUMAN_LABELS = {"🆘 human:卡死", "🆘 human:卡死-需-rework"}  # refactor helper, no behavior change
 
+DENIAL_OR_CONTROLLER_OWNER_RE = re.compile(
+    r"禁止|不可调|不得|不能|不要|不写|Forbidden|forbidden|Do NOT|do not|must not|"
+    r"not allowed|without|lifecycle / label .*controller|controller[^.\n]*(owns|owner|拥有|归|创 PR)"
+)
+
 PROMPTS_WITH_MANDATORY_PROJECT_RULES_INPUT = (
     "audit.md",
     "design-issue-reply.md",
@@ -51,6 +56,14 @@ PROMPTS_WITH_MANDATORY_PROJECT_RULES_INPUT = (
     "triage-external-issue.md",
     "verify.md",
 )
+
+
+def assert_denial_or_controller_owner_context(testcase: unittest.TestCase, line: str, *, token: str) -> None:
+    testcase.assertRegex(
+        line,
+        DENIAL_OR_CONTROLLER_OWNER_RE,
+        f"`{token}` must appear in an explicit denial or controller-owner context, got: {line}",
+    )
 
 
 class ScriptHygieneBehaviorTests(unittest.TestCase):
@@ -1418,6 +1431,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
 
     def test_manual_issue_reshape_requires_work_unit_v1_fields_without_audit_aliases(self) -> None:
         triage_prompt = (SKILL_ROOT / "prompts" / "triage-external-issue.md").read_text(encoding="utf-8")
+        accept_section = triage_prompt.split("### Step 2A", 1)[1].split("### Step 2B", 1)[0]
 
         required_markers = (
             "work_unit_id: issue-${ISSUE_NUMBER}",
@@ -1427,13 +1441,20 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             "scope_paths",
             "problem / invariant text",
             "verification_hints",
-            "`cluster_id`",
-            "`legacy_cluster_id`",
         )
 
         for marker in required_markers:
             with self.subTest(marker=marker):
-                self.assertIn(marker, triage_prompt)
+                self.assertIn(marker, accept_section)
+
+        for token in ("`cluster_id`", "`legacy_cluster_id`"):
+            matching_lines = [line for line in triage_prompt.splitlines() if token in line]
+            self.assertTrue(matching_lines, f"missing manual-issue alias boundary for {token}")
+            for line in matching_lines:
+                with self.subTest(token=token, line=line):
+                    self.assertIn("### Step 2A", triage_prompt[: triage_prompt.index(line)])
+                    self.assertNotIn("### Step 2B", triage_prompt[: triage_prompt.index(line)])
+                    assert_denial_or_controller_owner_context(self, line, token=token)
 
     def test_triage_external_issue_uses_artifact_only_lifecycle_handoff(self) -> None:
         triage_prompt = (SKILL_ROOT / "prompts" / "triage-external-issue.md").read_text(encoding="utf-8")
@@ -1492,6 +1513,13 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
         for marker in required:
             with self.subTest(marker=marker):
                 self.assertIn(marker, rendered)
+        redline_section = rendered.split("## 红线", 1)[1].split("## 附录", 1)[0]
+        for token in ("git commit", "git push", "git checkout"):
+            matching_lines = [line for line in redline_section.splitlines() if token in line]
+            self.assertTrue(matching_lines, f"missing redline boundary for {token}")
+            for line in matching_lines:
+                with self.subTest(token=token, line=line):
+                    assert_denial_or_controller_owner_context(self, line, token=token)
 
     def test_implement_prompt_design_dispatch_reads_consensus_artifact(self) -> None:
         decision_path = ".refactor-loop/runs/phase9-issue79-r8-judge.md"
@@ -1516,6 +1544,13 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
         for marker in required:
             with self.subTest(marker=marker):
                 self.assertIn(marker, rendered)
+        redline_section = rendered.split("## 红线", 1)[1].split("## 附录", 1)[0]
+        for token in ("git commit", "git push", "git checkout"):
+            matching_lines = [line for line in redline_section.splitlines() if token in line]
+            self.assertTrue(matching_lines, f"missing redline boundary for {token}")
+            for line in matching_lines:
+                with self.subTest(token=token, line=line):
+                    assert_denial_or_controller_owner_context(self, line, token=token)
 
     def test_implement_prompt_declares_design_intake_env_vars(self) -> None:
         implement_prompt = (SKILL_ROOT / "prompts" / "implement.md").read_text(encoding="utf-8")
@@ -2664,8 +2699,18 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
             with self.subTest(daemon=daemon):
                 self.assertIn(daemon, skill_text)
                 self.assertIn(daemon, reference_text)
-        self.assertIn("`nohup python3 <daemon> &`", reference_text)
-        self.assertIn("`env $(grep ... host.env)`", host_env_text)
+        startup_section = reference_text.split("### Daemon 启动", 1)[1].split("### Controller 主链路", 1)[0]
+        unsafe_examples = (
+            ("reference", startup_section, "`nohup python3 <daemon> &`"),
+            ("reference", startup_section, "env $(grep ... host.env)"),
+            ("host-env", host_env_text, "`env $(grep ... host.env)`"),
+        )
+        for source_name, source_text, token in unsafe_examples:
+            matching_lines = [line for line in source_text.splitlines() if token in line]
+            self.assertTrue(matching_lines, f"{source_name} missing unsafe startup anti-pattern `{token}`")
+            for line in matching_lines:
+                with self.subTest(source=source_name, token=token, line=line):
+                    assert_denial_or_controller_owner_context(self, line, token=token)
 
     # Refactor (iter215/cluster-215-controller-process-selftest):
     #   Old pattern: Controller runbook(REFERENCE.md)still instructs ps|grep/pgrep liveness checks,与 SKILL.md canonical CLI 与 CLAUDE.md daemon-counts-authority 子句矛盾。
@@ -2856,13 +2901,7 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
                     if token not in line:
                         continue
                     with self.subTest(prompt=path.name, token=token, line=line):
-                        before_line = body[: body.index(line)]
-                        self.assertTrue(
-                            "## GitHub post" in before_line
-                            or "## codex " in before_line
-                            or "## 红线" in before_line
-                            or "## Marker emission allowlist" in before_line
-                        )
+                        assert_denial_or_controller_owner_context(self, line, token=token)
 
     def test_disabled_test_escape_hatches_are_not_recommended(self) -> None:
         checked = self.rel_paths("skills/codex-refactor-loop/prompts/*.md", "skills/codex-refactor-loop/SKILL.md")

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -942,10 +942,11 @@ class ProjectRulesPromptContractTests(unittest.TestCase):
 
     def test_phase0_runtime_contract_names_resolved_project_rules_target(self) -> None:
         skill_text = (REPO_ROOT / "skills" / "codex-refactor-loop" / "SKILL.md").read_text(encoding="utf-8")
+        phase0 = skill_text.split("## Phase 0", 1)[1].split("## Phase Routing", 1)[0]
 
-        self.assertIn("ProjectRulesFixedPointEnsurer(强制,先于任何 actor 派发)", skill_text)
-        self.assertIn("$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}", skill_text)
-        self.assertIn("helper 退出非 0 → bootstrap fail closed", skill_text)
+        self.assertIn("ProjectRulesFixedPointEnsurer", phase0)
+        self.assertIn("$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}", phase0)
+        self.assertIn("fail closed", phase0)
 
     # Refactor (iter3/skill-github-post-contract):
     #   Old: 宽泛 all-prompts direct-post 主张
@@ -992,7 +993,6 @@ class ProjectRulesPromptContractTests(unittest.TestCase):
             text = (prompts_root / prompt_name).read_text(encoding="utf-8")
             with self.subTest(prompt=prompt_name, contract="marker-only"):
                 self.assertNotIn("## GitHub post", text)
-                self.assertIn("AI 内容标识符", text)
                 self.assertIn("⟦AI:AUTO-LOOP⟧", text)
 
     # Refactor (issue79/r8-consensus-no-implementation-helper-fork):
@@ -1414,7 +1414,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             with self.subTest(token=token):
                 for line in combined.splitlines():
                     if token in line:
-                        self.assertRegex(line, r"(Forbidden|forbidden|no |No |rejecting|rejects|rejected|without|FORBIDDEN|禁止|拒绝)")
+                        self.assertRegex(line, r"(Forbidden|forbidden|no |No |rejecting|rejects|rejected|without|FORBIDDEN)")
 
     def test_manual_issue_reshape_requires_work_unit_v1_fields_without_audit_aliases(self) -> None:
         triage_prompt = (SKILL_ROOT / "prompts" / "triage-external-issue.md").read_text(encoding="utf-8")
@@ -1427,7 +1427,8 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             "scope_paths",
             "problem / invariant text",
             "verification_hints",
-            "\u4e0d\u5199 `cluster_id` \u6216 `legacy_cluster_id`",
+            "`cluster_id`",
+            "`legacy_cluster_id`",
         )
 
         for marker in required_markers:
@@ -1481,7 +1482,9 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             f"否则读取 `{source_ref}` 中 \"cluster-079\" 一节",
             "skills/codex-refactor-loop/prompts/implement.md",
             "skills/codex-refactor-loop/scripts/test_*.py",
-            "禁止 `git commit` / `git push` / `git checkout <branch>`",
+            "git commit",
+            "git push",
+            "git checkout",
             "source files English-only; refactor self-documentation required",
             "⟦AI:AUTO-LOOP⟧",
         )
@@ -1503,7 +1506,9 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             "design-issue consensus artifact",
             "skills/codex-refactor-loop/prompts/implement.md",
             "skills/codex-refactor-loop/scripts/test_*.py",
-            "禁止 `git commit` / `git push` / `git checkout <branch>`",
+            "git commit",
+            "git push",
+            "git checkout",
             "source files English-only; refactor self-documentation required",
             "⟦AI:AUTO-LOOP⟧",
         )
@@ -1827,11 +1832,9 @@ class HumanLabelSemanticsTests(unittest.TestCase):
         for token in (
             "Apply only when",
             "DO NOT apply when",
-            "禁止",
             "architect/quality reviewer",
             "needs Phase 9 artifact",
             "maintainer-directive",
-            "绕路工具",
         ):
             with self.subTest(token=token):
                 self.assertIn(token, skill)
@@ -2661,8 +2664,8 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
             with self.subTest(daemon=daemon):
                 self.assertIn(daemon, skill_text)
                 self.assertIn(daemon, reference_text)
-        self.assertIn("禁止** 裸 `nohup python3 <daemon> &`", reference_text)
-        self.assertIn("不能用 `env $(grep ... host.env)`", host_env_text)
+        self.assertIn("`nohup python3 <daemon> &`", reference_text)
+        self.assertIn("`env $(grep ... host.env)`", host_env_text)
 
     # Refactor (iter215/cluster-215-controller-process-selftest):
     #   Old pattern: Controller runbook(REFERENCE.md)still instructs ps|grep/pgrep liveness checks,与 SKILL.md canonical CLI 与 CLAUDE.md daemon-counts-authority 子句矛盾。
@@ -2738,7 +2741,6 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
         ))
         self.assertIn("post_banner.py", active_docs)
         self.assertIn("spawn-codex.sh", active_docs)
-        self.assertIn("反模式", active_docs)
         self.assertNotIn("spawn_with_banner.py", active_docs)
         self.assertNotIn("Historical tombstone", active_docs)
 
@@ -2754,8 +2756,8 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
                     self.assertNotIn(pattern, text)
 
         skill_text = self.read_rel("skills/codex-refactor-loop/SKILL.md")
-        self.assertIn("Source files are English-only; external user-facing artifacts are 中文 by default", skill_text)
-        self.assertIn("No mandatory parallel English section", skill_text)
+        self.assertIn("[language policy details](REFERENCE.md#language-policy-details)", skill_text)
+        self.assertIn("[historical bilingual notes](REFERENCE.md#historical-bilingual-notes)", skill_text)
 
     def test_no_active_github_post_writer_reference_remains(self) -> None:
         checked = self.rel_paths("skills/codex-refactor-loop/SKILL.md", "skills/codex-refactor-loop/prompts/*.md")
@@ -2847,13 +2849,20 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
         for path in sorted((SKILL_ROOT / "prompts").glob("*.md")):
             if path.name in controller_owned:
                 continue
-            lines = path.read_text(encoding="utf-8").splitlines()
+            body = path.read_text(encoding="utf-8")
+            lines = body.splitlines()
             for token in forbidden:
                 for line in lines:
                     if token not in line:
                         continue
                     with self.subTest(prompt=path.name, token=token, line=line):
-                        self.assertRegex(line, r"禁止|不可调|Do NOT|do not")
+                        before_line = body[: body.index(line)]
+                        self.assertTrue(
+                            "## GitHub post" in before_line
+                            or "## codex " in before_line
+                            or "## 红线" in before_line
+                            or "## Marker emission allowlist" in before_line
+                        )
 
     def test_disabled_test_escape_hatches_are_not_recommended(self) -> None:
         checked = self.rel_paths("skills/codex-refactor-loop/prompts/*.md", "skills/codex-refactor-loop/SKILL.md")

--- a/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
@@ -11,6 +11,11 @@ from pathlib import Path
 SCRIPT_PATH = Path(__file__)
 PROMPTS_DIR = SCRIPT_PATH.parents[1] / "prompts"
 
+DENIAL_OR_CONTROLLER_OWNER_RE = re.compile(
+    r"禁止|不可调|不得|不能|不要|Forbidden|forbidden|Do NOT|do not|must not|"
+    r"not allowed|marker/artifact-only|lifecycle / label .*controller|controller[^.\n]*(owns|owner|拥有|归|创 PR)"
+)
+
 MARKER_ONLY_PROMPTS = (
     "audit.md",
     "implement.md",
@@ -83,15 +88,21 @@ class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
             self.assertIsNotNone(ban_section_match, filename)
             ban_section = ban_section_match.group(0)
             for token in FORBIDDEN_DIRECT_LIFECYCLE_SNIPPETS:
-                for line in body.splitlines():
+                for line in ban_section.splitlines():
                     if token not in line:
                         continue
                     with self.subTest(prompt=filename, token=token, line=line):
-                        self.assertTrue(
-                            line in ban_section
-                            or "## 红线" in body[: body.index(line)]
-                            or "## Marker emission allowlist" in body[: body.index(line)]
-                        )
+                        self.assertRegex(line, DENIAL_OR_CONTROLLER_OWNER_RE)
+                affirmative_lines = [
+                    line
+                    for line in body.splitlines()
+                    if token in line and not DENIAL_OR_CONTROLLER_OWNER_RE.search(line)
+                ]
+                self.assertEqual(
+                    affirmative_lines,
+                    [],
+                    f"{filename} mentions forbidden lifecycle token `{token}` outside denial/controller-owner context",
+                )
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import unittest
+import re
 from pathlib import Path
 
 
@@ -19,7 +20,7 @@ MARKER_ONLY_PROMPTS = (
 )
 
 REQUIRED_BAN_SUBSTRINGS = (
-    "## codex 工具边界(强制)",
+    "## codex ",
     "iter5/prompt-gh-ban-marker-only",
     "marker/artifact-only",
     "gh pr create",
@@ -32,7 +33,8 @@ REQUIRED_BAN_SUBSTRINGS = (
     "gh pr edit --add-label",
     "gh pr edit --remove-label",
     "git commit/push/checkout/merge/reset/rebase",
-    "lifecycle / label 决策归 controller",
+    "lifecycle / label ",
+    "controller",
 )
 
 FORBIDDEN_DIRECT_LIFECYCLE_SNIPPETS = (
@@ -60,8 +62,9 @@ class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
                     self.assertIn(
                         needle,
                         body,
-                        f"{filename} 缺少必备字面 `{needle}`(iter5 ban section regression)",
+                        f"{filename} missing required ban-section token `{needle}`",
                     )
+                self.assertRegex(body, r"(?m)^## codex .+$")
 
     def test_refactor_self_doc_block_present(self) -> None:
         for filename in MARKER_ONLY_PROMPTS:
@@ -70,18 +73,25 @@ class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
                 self.assertIn(
                     "Refactor (iter5/prompt-gh-ban-marker-only)",
                     body,
-                    f"{filename} 缺少 Refactor self-doc 块",
+                    f"{filename} missing Refactor self-doc block",
                 )
 
     def test_lifecycle_tokens_only_appear_in_ban_lines(self) -> None:
         for filename in MARKER_ONLY_PROMPTS:
             body = (PROMPTS_DIR / filename).read_text(encoding="utf-8")
+            ban_section_match = re.search(r"(?ms)^## codex .+?(?=^## |\Z)", body)
+            self.assertIsNotNone(ban_section_match, filename)
+            ban_section = ban_section_match.group(0)
             for token in FORBIDDEN_DIRECT_LIFECYCLE_SNIPPETS:
                 for line in body.splitlines():
                     if token not in line:
                         continue
                     with self.subTest(prompt=filename, token=token, line=line):
-                        self.assertRegex(line, r"不可调|禁止|不得|marker/artifact-only|controller")
+                        self.assertTrue(
+                            line in ban_section
+                            or "## 红线" in body[: body.index(line)]
+                            or "## Marker emission allowlist" in body[: body.index(line)]
+                        )
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_no_new_prose_detection.py
+++ b/skills/codex-refactor-loop/scripts/test_no_new_prose_detection.py
@@ -12,6 +12,11 @@ SCRIPT_PATH = Path(__file__)
 REPO_ROOT = SCRIPT_PATH.parents[3]
 BASE_REF = "origin/auto-refact-dev"
 
+# Refactor (issue106/nl-prose-detector-anchors):
+#   Old pattern: source-regression tests used localized prose literals as detector anchors, so
+#   normal wording edits or language cleanup could break machine checks and encourage brittle text pinning.
+#   New principle: detector tests must key on protocol tokens, sentinels, heading ids, and structured
+#   context; this guard prevents newly changed tests from adding back localized prose detector tokens.
 FORBIDDEN_NEW_TEST_TOKENS = (
     "事实源唯一",
     "GitHub 是系统状态唯一显示面",

--- a/skills/codex-refactor-loop/scripts/test_no_new_prose_detection.py
+++ b/skills/codex-refactor-loop/scripts/test_no_new_prose_detection.py
@@ -48,8 +48,12 @@ def changed_test_files() -> list[Path]:
         text=True,
         check=False,
     )
-    if diff_result.returncode != 0 or untracked_result.returncode != 0:
-        return []
+    if diff_result.returncode != 0:
+        raise AssertionError(
+            f"failed to compute changed test files against {BASE_REF}: {diff_result.stderr.strip()}"
+        )
+    if untracked_result.returncode != 0:
+        raise AssertionError(f"failed to compute untracked test files: {untracked_result.stderr.strip()}")
     paths = set(diff_result.stdout.splitlines()) | set(untracked_result.stdout.splitlines())
     return [REPO_ROOT / line for line in sorted(paths) if line]
 
@@ -57,7 +61,14 @@ def changed_test_files() -> list[Path]:
 class NoNewProseDetectionTests(unittest.TestCase):
     def test_new_or_modified_tests_do_not_add_prose_detection_tokens(self) -> None:
         offenders: list[str] = []
-        for path in changed_test_files():
+        changed_paths = changed_test_files()
+        if SCRIPT_PATH in changed_paths:
+            self.assertGreater(
+                len([path for path in changed_paths if path != SCRIPT_PATH]),
+                0,
+                "this PR changed the prose-detector guard but scanned no other changed test files",
+            )
+        for path in changed_paths:
             if not path.exists():
                 continue
             if path.name == SCRIPT_PATH.name:

--- a/skills/codex-refactor-loop/scripts/test_no_new_prose_detection.py
+++ b/skills/codex-refactor-loop/scripts/test_no_new_prose_detection.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Source-regression: new tests must not add localized prose detectors."""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__)
+REPO_ROOT = SCRIPT_PATH.parents[3]
+BASE_REF = "origin/auto-refact-dev"
+
+FORBIDDEN_NEW_TEST_TOKENS = (
+    "事实源唯一",
+    "GitHub 是系统状态唯一显示面",
+    "ensure all 5 daemons",
+    "ensure all 5 restart-helper-managed daemons",
+    "AI 内容标识符",
+    "缺少必备字面",
+    "缺少 Refactor self-doc",
+    "历史 bilingual 规则的位置",
+    "不能用 `env $(grep ... host.env)`",
+    "禁止** 裸 `nohup python3 <daemon> &`",
+    "Source files are English-only; external user-facing artifacts are 中文 by default",
+    "No mandatory parallel English section",
+)
+
+
+def changed_test_files() -> list[Path]:
+    diff_result = subprocess.run(
+        ["git", "diff", "--name-only", BASE_REF, "--", "skills/codex-refactor-loop/scripts/test_*.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    untracked_result = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard", "--", "skills/codex-refactor-loop/scripts/test_*.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if diff_result.returncode != 0 or untracked_result.returncode != 0:
+        return []
+    paths = set(diff_result.stdout.splitlines()) | set(untracked_result.stdout.splitlines())
+    return [REPO_ROOT / line for line in sorted(paths) if line]
+
+
+class NoNewProseDetectionTests(unittest.TestCase):
+    def test_new_or_modified_tests_do_not_add_prose_detection_tokens(self) -> None:
+        offenders: list[str] = []
+        for path in changed_test_files():
+            if not path.exists():
+                continue
+            if path.name == SCRIPT_PATH.name:
+                continue
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            text = path.read_text(encoding="utf-8")
+            for token in FORBIDDEN_NEW_TEST_TOKENS:
+                if token in text:
+                    offenders.append(f"{rel}: {token}")
+
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -18,6 +18,19 @@ def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def markdown_headings(text: str, level: int = 2) -> list[str]:
+    prefix = "#" * level
+    return [line for line in text.splitlines() if line.startswith(f"{prefix} ")]
+
+
+def section_between(text: str, start_heading_re: str, end_heading_re: str) -> str:
+    start = re.search(start_heading_re, text, flags=re.MULTILINE)
+    end = re.search(end_heading_re, text[start.end() :] if start else "", flags=re.MULTILINE)
+    if not start or not end:
+        return ""
+    return text[start.end() : start.end() + end.start()]
+
+
 class SkillEntrypointContractTests(unittest.TestCase):
     def setUp(self) -> None:
         self.skill = read(SKILL_MD)
@@ -36,29 +49,30 @@ class SkillEntrypointContractTests(unittest.TestCase):
 
     def test_entrypoint_line_budget_and_controller_contract_headings(self) -> None:
         line_count = len(self.skill.splitlines())
+        headings = set(markdown_headings(self.skill))
 
         self.assertGreaterEqual(line_count, 600)
         self.assertLessEqual(line_count, 850)
-        for heading in (
-            "## Controller Contract Index",
-            "## Host 配置(通用化注入点)",
-            "## Phase Index",
-            "## Phase 0 — Bootstrap (first wakeup only)",
-            "## Loop control",
-            "## Label 系统 — 强制",
-            "## Hard rules (controller-level, propagated into every codex prompt)",
-            "## 工作语言规则(源码内英文,源码外中文)",
-            "## Files",
+        for pattern in (
+            r"^## Controller Contract Index$",
+            r"^## Host .+$",
+            r"^## Phase Index$",
+            r"^## Phase 0 .+Bootstrap .+$",
+            r"^## Loop control$",
+            r"^## Label .+$",
+            r"^## Hard rules .+$",
+            r"^## .+language.+$|^## .+语言.+$",
+            r"^## Files$",
         ):
-            with self.subTest(heading=heading):
-                self.assertIn(heading, self.skill)
+            with self.subTest(pattern=pattern):
+                self.assertTrue(any(re.match(pattern, heading) for heading in headings))
 
     def test_mandatory_local_invariants_remain_in_entrypoint(self) -> None:
         required = (
             "⟦AI:AUTO-LOOP⟧",
-            "GitHub 是系统状态唯一显示面",
+            "REFERENCE.md#status-and-escalation-templates",
             "Controller = pure orchestration",
-            "first wakeup",
+            "REFERENCE.md#phase-0-details",
             "Phase 0",
             "phase routing",
             "3/3",
@@ -67,16 +81,20 @@ class SkillEntrypointContractTests(unittest.TestCase):
             "label",
             "spawn",
             "Hard rules",
-            "Source files are English-only; external user-facing artifacts are 中文 by default",
-            "No mandatory parallel English section",
+            "REFERENCE.md#language-policy-details",
+            "REFERENCE.md#historical-bilingual-notes",
         )
         for needle in required:
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.skill)
 
     def test_first_wakeup_bootstrap_obligations_are_ordered_in_skill_alone(self) -> None:
-        phase0 = self.skill.split("## Phase 0 — Bootstrap (first wakeup only)", 1)[1]
-        phase0 = phase0.split("## Phase Routing", 1)[0]
+        phase0 = section_between(
+            self.skill,
+            r"^## Phase 0 .+Bootstrap .+$",
+            r"^## Phase Routing$",
+        )
+        self.assertTrue(phase0)
         obligations = (
             "source .refactor-loop/host.env",
             "fail closed",
@@ -84,7 +102,7 @@ class SkillEntrypointContractTests(unittest.TestCase):
             "initialize state",
             "integration branch",
             "ensure labels",
-            "ensure all 5 restart-helper-managed daemons",
+            "restart-helper-managed daemons",
             "arm persistent daemon-event Monitor",
             "dispatch producer",
             "confirm a wake source",
@@ -96,29 +114,41 @@ class SkillEntrypointContractTests(unittest.TestCase):
                 self.assertNotEqual(index, -1)
                 self.assertGreater(index, cursor)
             cursor = index
+        for daemon in (
+            "concurrency_monitor.py",
+            "codex-progress-reporter.sh",
+            "comment-monitor.sh",
+            "dev_sync_daemon.py",
+            "phase9_router_daemon.py",
+        ):
+            with self.subTest(daemon=daemon):
+                self.assertIn(daemon, phase0)
 
     def test_wake_source_contract_names_three_lanes(self) -> None:
-        self.assertIn("active daemon-event Monitor bridge", self.skill)
-        self.assertIn("in-flight codex task-notification", self.skill)
-        self.assertIn("confirmed ScheduleWakeup", self.skill)
-        self.assertIn("daemon alone is not a wake source", self.skill)
+        wake_row = next(line for line in self.skill.splitlines() if line.startswith("| Wake source |"))
+        for token in ("daemon-event Monitor bridge", "codex task-notification", "ScheduleWakeup"):
+            with self.subTest(token=token):
+                self.assertIn(token, wake_row)
+        self.assertIn("REFERENCE.md#wake-source-rules", wake_row)
 
     def test_heavy_reference_material_is_not_in_entrypoint(self) -> None:
-        heavy_markers = (
-            "## 📊 当前状态 — <phase>",
-            "## 🆘 状态卡片 — 共识机制无法继续收敛",
-            '"schema_version": 1',
-            "## WorkUnitV1 contract",
-            "## Batching heuristics",
-            "## Recovery playbook",
-            "gh label create",
-            "Poll every 60s; emit one event per failed check",
-            "历史 bilingual 规则的位置",
+        reference_only_anchors = (
+            "workunitv1-contract",
+            "batching-heuristics",
+            "recovery-playbook",
+            "label-bootstrap-loops",
+            "historical-bilingual-notes",
         )
-        for marker in heavy_markers:
-            with self.subTest(marker=marker):
-                self.assertNotIn(marker, self.skill)
-                self.assertIn(marker, self.reference)
+        for anchor in reference_only_anchors:
+            with self.subTest(anchor=anchor):
+                self.assertIn(f"(REFERENCE.md#{anchor})", self.skill)
+                self.assertIn(anchor, self.reference)
+        self.assertNotIn('"schema_version": 1', self.skill)
+        self.assertIn('"schema_version": 1', self.reference)
+        for emoji_heading in ("📊", "🆘"):
+            with self.subTest(emoji_heading=emoji_heading):
+                self.assertNotRegex(self.skill, rf"(?m)^## {emoji_heading} ")
+                self.assertRegex(self.reference, rf"(?m)^## {emoji_heading} ")
 
     def test_entrypoint_uses_lazy_reference_links_only(self) -> None:
         self.assertNotIn("@REFERENCE.md", self.skill)


### PR DESCRIPTION
## TL;DR
Phase 9 #106 r2 consensus → 48 NL-literal detection anchors → protocol tokens / sentinel / emoji / heading-id。No registry introduced。349/349 tests pass。4 files,新增 `test_no_new_prose_detection.py` source-regression guard。

Closes #106

授权:`.refactor-loop/logs/meta-judge-issue106-r2.log` → `META_JUDGE_DONE:consensus:structural:no DetectionInvariantV1`

⟦AI:AUTO-LOOP⟧