### PR TITLE
refactor(docs): #107 stage-1 strip V1/V2 schema-version suffixes(docs only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@
 - **边界清晰,职责分层**:本文件承载**跨 skill 边界**与**仓库级宪法约束**;单个 skill 的工作流细则、术语定义、当前状态归该 skill 自维护,不复制回本文件。
 - **事实源唯一**:同一约束禁止在多处平行声明。版本号 → `.version-bump.json`;host 运行时事实 → `host.env`;skill 行为 → 该 skill 的 SKILL.md 与 `scripts/test_*.py`。
 - **抽象优先,行为契约**:skill 间通过 `host.env` + 文件 artifact + GitHub API 等稳定边界协作,不耦合彼此内部脚本;命名跟随职责,不泄露 runtime / 内部实现细节。
-- **强类型边界,窄扩展点**:任何 controller-runtime 例外必须 narrow allowlist + no lifecycle authority by default;授权来源必须 durable artifact + 仓库级文档双重锚定。#53 唯一 carveout 是 `IntegrationSyncDaemonV1` 在专用 integration worktree 内的 integration-branch git allowlist(`git fetch` / `rev-list` / `rev-parse` / `merge-base` / `reset --hard` / `rebase --rebase-merges` / `merge --ff-only|--no-ff` / `push HEAD:$INTEGRATION_BRANCH` / force-with-lease adoption),不得 commit worker diff、create/merge/close PR、开关 issue/PR/label、tag/release,不得作为 generic lifecycle actor;通用授权、escape hatch、宽口径修宪一律视为设计未完成。
+- **强类型边界,窄扩展点**:任何 controller-runtime 例外必须 narrow allowlist + no lifecycle authority by default;授权来源必须 durable artifact + 仓库级文档双重锚定。#53 唯一 carveout 是 `integration sync daemon` 在专用 integration worktree 内的 integration-branch git allowlist(`git fetch` / `rev-list` / `rev-parse` / `merge-base` / `reset --hard` / `rebase --rebase-merges` / `merge --ff-only|--no-ff` / `push HEAD:$INTEGRATION_BRANCH` / force-with-lease adoption),不得 commit worker diff、create/merge/close PR、开关 issue/PR/label、tag/release,不得作为 generic lifecycle actor;通用授权、escape hatch、宽口径修宪一律视为设计未完成。
 - **抽象一旦能被滥用即设计未完成**:允许绕过审查边界、merge gate、CLAUDE.md 修宪门槛的通用机制必须继续收窄。
 - **删除优先**:废弃 skill、deprecated wrapper、`*.bak/*.old/*.deprecated` 直接删除,不保留兼容空壳;历史由 git 与 CHANGELOG 保留。
 - **变更必须可验证**:行为约束必须落到机械验证手段(behavior test / source-regression test / 段落 lint);仅靠"agent 应该记得"承载的约束视为未落地。
@@ -57,7 +57,7 @@
 - **maintainer(人)**:产品/战略决策、治理级非可编码变更的授权、罕见手工 merge。
 - **agent(controller LLM)**:纯编排;长跑中读 daemon 维护的 counts / state / artifact,不重新自测。
 - **agent worker**(被派发的 codex / 其他 CLI 实例):承担所有思考密集工作 —— 实现、验证、修复、review、design solving。每个 worker 在隔离 worktree 内运行。
-- **daemon(`scripts/` 后台)**:可机械、状态确定的 controller 工作的实现载体。Daemon 是经共识授权的 narrow allowlist 例外,默认**不**持 lifecycle authority(不开关 issue/PR/label、不 commit/push/merge/tag/release publish);仅 #53 授权 `IntegrationSyncDaemonV1` 在专用 integration worktree 内执行 integration-branch git allowlist。Implement/fix worker 仍不得 commit、push、open PR、merge、close issue/PR。
+- **daemon(`scripts/` 后台)**:可机械、状态确定的 controller 工作的实现载体。Daemon 是经共识授权的 narrow allowlist 例外,默认**不**持 lifecycle authority(不开关 issue/PR/label、不 commit/push/merge/tag/release publish);仅 #53 授权 `integration sync daemon` 在专用 integration worktree 内执行 integration-branch git allowlist。Implement/fix worker 仍不得 commit、push、open PR、merge、close issue/PR。
 - **host 项目**:消费 skill 的下游项目。skill **无 host 项目改动权**:不修改 host 的 `.git` 配置 / CI 配置 / policy 文档;只在 `host.env` 暴露的 surface 上工作。host opt-in 缺失或为假时,所有相关 surface 静默 noop(`exit 0` + reason)。
 
 ## 新增 / 修改 skill

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -457,7 +457,7 @@ You are the **Controller**. You never edit production code yourself. You orchest
 1. **state + integration 分支**:`mkdir -p .refactor-loop/{...}` + 写 `state.json` + idempotent 建/推 `$INTEGRATION_BRANCH`(下方细节)。
 2. **建全套 labels**:跑「Label 系统」节的 Bootstrap —— 9 个 phase label + 2 个 human label 创建循环。**漏建 = 后续 phase transition 无 label 可挂、comment-monitor 查 `--label auto-loop` 漏掉 PR**。
 3. **起并挂载全部 5 个 daemon**:按「Host 运行编排 → Daemon 启动」节的 `bash -c 'source host.env && exec'` pattern 起齐 `concurrency_monitor.py` / `codex-progress-reporter.sh` / `comment-monitor.sh` / `dev_sync_daemon.py` / `phase9_router_daemon.py`。随后运行 `bash <skill-root>/scripts/restart-daemons.sh` 规范化 heartbeat-managed daemon,再读 `.refactor-loop/heartbeats/*.ts` / `.refactor-loop/state/statusline-snapshot.json` / `bash <skill-root>/scripts/peek.sh | tail -80` 确认健康面可见;Phase 9 router 读其 lock/ledger/log/fallback event surface。**首轮就必须把 5 个全起起来——它不是「以后某次 wakeup 才做的 liveness 检查」**。
-4. **派默认 v1 work-unit producer**(Phase 1,默认 audit,`spawn-codex.sh` + Bash `run_in_background:true`)+ ScheduleWakeup 兜底 + end turn。
+4. **派默认 work-unit producer**(Phase 1,默认 audit,`spawn-codex.sh` + Bash `run_in_background:true`)+ ScheduleWakeup 兜底 + end turn。
 
 每步做完才进下一步。3 漏起任一 daemon、2 漏建 labels = bootstrap 失败,下次 wakeup 第一件事补齐。
 
@@ -479,8 +479,6 @@ Write initial `state.json`:
 
 ```json
 {
-  "schema_version": 1,
-  "work_unit_schema_version": 1,
   "trunk_branch": "auto-refact-dev",
   "integration_branch": "auto-refact-dev",
   "review_base_branch": "dev",
@@ -527,8 +525,8 @@ Create top-level TaskCreate items: audit / dispatch / merge.
 <a id="phase-routing-details"></a>
 ## Phase 1 — Work-unit production (audit default)
 
-The default v1 work-unit producer is `audit`. Producer normalization is documented in
-[REFERENCE.md](REFERENCE.md): v1 accepts only `producer: audit` and `producer: manual-issue`.
+The default work-unit producer is `audit`. Producer normalization is documented in
+[REFERENCE.md](REFERENCE.md): accepts only `producer: audit` and `producer: manual-issue`.
 `audit` is the raw artifact producer for this phase; `manual-issue` enters through Phase 7
 triage and must already be reshaped before Phase 9.
 
@@ -2253,8 +2251,6 @@ Fields:
 
 ```json
 {
-  "schema_version": 1,
-  "work_unit_schema_version": 1,
   "loop_started_at": "<ISO8601>",
   "trunk_branch": "<branch the loop integrates into; same as integration_branch>",
   "integration_branch": "<branch all clusters land on>",

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -686,7 +686,7 @@ For each cluster whose implement finished `ok`:
 
 1. Materialize `prompts/verify.md` → `.refactor-loop/prompts/verify-<cluster-id>.md`. For current
    audit-backed units, export `WORK_UNIT_ID=$CLUSTER_ID`; `WORK_UNIT_ID` is the canonical prompt
-   identity, while `CLUSTER_ID` remains the v1 compatibility alias for markers and artifacts.
+   identity, while `CLUSTER_ID` remains the compatibility alias for markers and artifacts.
 2. Dispatch in the same worktree (verify reads `git diff HEAD`, runs full test/guard suite, gates merge):
 
    ```bash
@@ -2164,7 +2164,7 @@ Audit compatibility:
 Stable operational tokens:
 
 - Current markers, GitHub labels, issue title prefixes, branch prefixes, artifact paths, prompt
-  markers, log markers, and audit section lookups are stable v1 operational names.
+  markers, log markers, and audit section lookups are stable operational names.
 - `cluster-009-marker-label-compat-migration` does not rename, dual-write, or add aliases for
   these names. Keep existing `refactor`, `cluster`, `auto-loop`, and `*_DONE` spellings as the
   public routing surface while `WORK_UNIT_ID=$CLUSTER_ID` is the compatibility bridge.
@@ -2194,7 +2194,7 @@ the work-unit contract before adding it to `clusters_planned`:
 - `kind: audit-cluster`
 - `producer: audit`
 - `source_ref: .refactor-loop/runs/audit-iter-N.md#<cluster-id>`
-- `legacy_cluster_id: <cluster-id>` optional but recommended during v1 compatibility
+- `legacy_cluster_id: <cluster-id>` optional but recommended during compatibility window
 
 Audit-backed units may keep using `<cluster-id>` for branch names, worktree paths, artifact
 filenames, markers, and audit section lookup while `WORK_UNIT_ID=$CLUSTER_ID` remains the compatibility alias.

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -52,7 +52,7 @@ dogfood 运行中固化的操作经验。host 注入的配置集中放 `$REPO_RO
 
 <a id="skill-degradation-watch-details"></a>
 ### Skill degradation watch details
-`SkillDegradationWatchV1(per #66)` is authorized by `.refactor-loop/runs/phase9-issue66-r8-judge.md` and is intentionally delete-framed: no standalone watchdog, no seventh daemon, no `DegradationCheck` protocol, no plugin registry, no new event envelope, no auto-clean, no auto-fix, no GitHub lifecycle mutation, and no codex dispatch path.
+The skill degradation watch(per #66) is authorized by `.refactor-loop/runs/phase9-issue66-r8-judge.md` and is intentionally delete-framed: no standalone watchdog, no seventh daemon, no `DegradationCheck` protocol, no plugin registry, no new event envelope, no auto-clean, no auto-fix, no GitHub lifecycle mutation, and no codex dispatch path.
 Static checker: `python3 skills/codex-refactor-loop/scripts/check_skill_degradation.py --static`; CI job `.github/workflows/consensus-rnd-ci.yml` `skill-degradation`; release gate `auto_release_gate.py:required_checks_recent_green` requires `skill-degradation` beside `contract-tests` and `manifest-version-sync`, mirrored by `release.yml`. The checker is read-only and returns nonzero on missing named exception text, CI/release wiring, forbidden runtime files, forbidden expansion surfaces, or missing runtime hook markers.
 Runtime hook: existing `concurrency_monitor.py`, no standalone daemon. `$DEGRADATION_WATCH_INTERVAL_SECONDS` controls throttle; unset or `0` disables and `host.env.example` opts in with `1800`. `$DEGRADATION_WATCH_TIMEOUT_SECONDS` defaults to `30`. Passing writes nothing; failing writes `.refactor-loop/.degradation-alert.log` and appends an existing-format pending event to `.refactor-loop/.controller-pending-events.log`.
 Alert formats: pending event `<UTC> skill-degradation-alert returncode=N log=.refactor-loop/.degradation-alert.log` or `<UTC> skill-degradation-alert checker-error log=.refactor-loop/.degradation-alert.log`; alert log `[UTC] skill-degradation-alert <summary> | detail=<json>` with `returncode`, `stdout_tail`, `stderr_tail`, or `error`. `DEGRADATION_ALERT_TAIL_LINES` controls `peek.sh` display count for `.refactor-loop/.degradation-alert.log`, default `10`.
@@ -68,7 +68,7 @@ Narrow allowlist: run `check_skill_degradation.py`, write `.refactor-loop/.degra
 nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scripts/<daemon>.py' \
   >> .refactor-loop/logs/<daemon>.log 2>&1 & disown
 ```
-Integration sync requests use `IntegrationSyncRequestV1`; controller sweep consumes `DEV_SYNC_REQUEST:<path>` and applies it through `<skill-root>/scripts/apply_integration_sync_request.py` after live-state validation.
+Integration sync requests use integration sync request artifacts; controller sweep consumes `DEV_SYNC_REQUEST:<path>` and applies it through `<skill-root>/scripts/apply_integration_sync_request.py` after live-state validation.
 **5 个长跑 daemon 全部要起**(监控面 = 这 5 个):`concurrency_monitor.py`(60s codex 并发)、`codex-progress-reporter.sh`(600s 进度回贴)、`comment-monitor.sh`(30s maintainer 评论 eyes-react)、`dev_sync_daemon.py`(600s integration sync detection/request)、`phase9_router_daemon.py`(30s narrow Phase 9 deterministic routing)。
 <!-- Refactor (iter215/cluster-215-controller-process-selftest):
   Old pattern: Controller runbook(REFERENCE.md)still instructs ps|grep/pgrep liveness checks,与 SKILL.md canonical CLI 与 CLAUDE.md daemon-counts-authority 子句矛盾。
@@ -495,12 +495,11 @@ Write initial `state.json`:
 }
 ```
 
-`work_unit_schema_version: 1` means `clusters_planned`, `clusters_active`, `clusters_done`, and
-`clusters_failed` are the authoritative v1 queue containers, but each item is a WorkUnitV1 record
-as specified in [REFERENCE.md](REFERENCE.md). If an existing state file lacks
-`work_unit_schema_version`, read it as v1 legacy state: derive `work_unit_id` from each item's
-`id`, treat audit clusters as `kind="audit-cluster"` and `producer="audit"`, and continue without
-migration.
+`clusters_planned`, `clusters_active`, `clusters_done`, and `clusters_failed` are the
+authoritative queue containers, but each item is a work-unit contract record as specified in
+[REFERENCE.md](REFERENCE.md). If an existing state file lacks the work-unit schema marker, read it
+as legacy state: derive `work_unit_id` from each item's `id`, treat audit clusters as
+`kind="audit-cluster"` and `producer="audit"`, and continue without migration.
 
 **Default integration branch**: `auto-refact-dev`. This is the long-lived branch where all auto-refactor cluster PRs land before rolling up to `dev`. On a fresh loop:
 
@@ -563,23 +562,23 @@ When task notification fires → **controller validation** before accepting the 
 Anti-anchoring: **do not** include phrases like "prefer 0", "loop saturated", "healthy signal" in the audit prompt body. These bias codex toward terminating instead of digging. Use the mechanical thresholds in `prompts/audit.md` as the only stop criteria.
 
 After validation: read `audit-iter-N.md`; the controller projects each accepted audit cluster into
-the WorkUnitV1 fields documented in `REFERENCE.md` (`work_unit_id`, `kind`, `producer`,
-`source_ref`, and v1 audit compatibility aliases), populate `clusters_planned`, split into batches
+the work-unit fields documented in `REFERENCE.md` (`work_unit_id`, `kind`, `producer`,
+`source_ref`, and audit compatibility aliases), populate `clusters_planned`, split into batches
 (max `max_parallel_clusters` per batch) by
 **file/project disjointness**:
 
 - Current audit-backed units set `work_unit_id == id == cluster_id == legacy_cluster_id`,
   `kind="audit-cluster"`, `producer="audit"`, and `source_ref="audit-iter-N.md#<cluster-id>"`.
 - Preserve existing cluster fields for audit section lookup, markers, artifact filenames, branch
-  names, and GitHub issue routing during v1 compatibility.
-- Stable v1 operational tokens are public routing tokens, not names to migrate in this contract:
+  names, and GitHub issue routing during compatibility.
+- Stable operational tokens are public routing tokens, not names to migrate in this contract:
   `[refactor-design]`, `refactor-design-needed`, `auto-loop`, `phase9-auto-solve`,
   `auto-loop-resume`, `refactor/iterN-<cluster-id>`, `.refactor-loop/.../<cluster-id>`,
   `IMPLEMENT_DONE:${CLUSTER_ID}`, `VERIFY_DONE:${CLUSTER_ID}`, `SOLVER_DONE`, and
   `META_JUDGE_DONE`.
 - Do not rename, dual-write, alias, or replace those tokens with `work-unit-*` forms; do not add
-  a named operational-policy abstraction for v1 compatibility.
-- Phase 7 `manual-issue` intake may write WorkUnitV1 items into `clusters_planned` only after the
+  a named operational-policy abstraction for compatibility.
+- Phase 7 `manual-issue` intake may write work-unit contract items into `clusters_planned` only after the
   accepted GitHub issue has been reshaped with `kind="manual-work-unit"`,
   `producer="manual-issue"`, `source_ref="gh-issue-<N>"`, `scope_paths`, problem/invariant text,
   and `verification_hints`. It must not fabricate `cluster_id` or `legacy_cluster_id`.
@@ -669,7 +668,7 @@ For each cluster in the current batch:
 
 3. Dispatch via `spawn-codex.sh --cd <worktree>` with `--stall 5400` (5400s no-output stall window).
 
-4. Update `clusters_active` with the WorkUnitV1 identity/provenance fields plus `bg_task` id.
+4. Update `clusters_active` with the work-unit identity/provenance fields plus `bg_task` id.
 
 After all parallel dispatches, schedule wakeup 1800s safety net. **End turn.**
 
@@ -919,14 +918,14 @@ nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scrip
 disown
 ```
 
-Daemon 工作流由 `IntegrationSyncDaemonV1` 命名状态机表达:
+Daemon 工作流由 `integration sync daemon` 命名状态机表达:
 1. `FETCH`: fetch origin in the daemon worktree.
 2. `CHECK_MERGE`: if a merge is in progress, observe or dispatch exactly one resolver codex. Resolver codexes resolve files and run `git merge --continue`; they never push, reset, or abort.
 3. `CHECK_DIRTY`: dirty non-merge worktrees skip without reset.
-4. `PRESERVE_LOCAL_AHEAD`: before any controller-side alignment, compute `local_ahead_count` with `git rev-list --count origin/$INTEGRATION_BRANCH..HEAD`; if the daemon worktree is clean and ahead, emit an `IntegrationSyncRequestV1` artifact plus `DEV_SYNC_REQUEST:<path>` marker for the controller apply helper. This preserves resolver continuation commits without daemon-side git lifecycle authority.
-5. `ADOPT_MERGED_ROLLUP`: if a merged rollup PR from `$INTEGRATION_BRANCH` to `$REVIEW_BASE_BRANCH` is provable, capture the old rollup head and current expected remote SHA, then emit an `IntegrationSyncRequestV1` artifact plus `DEV_SYNC_REQUEST:<path>` marker for controller-side adoption. The controller helper re-checks ancestry and live SHAs before applying.
-6. `RESET_TO_REMOTE`: after local-ahead preservation and rollup adoption checks, emit an `IntegrationSyncRequestV1` artifact plus `DEV_SYNC_REQUEST:<path>` marker for controller-side remote alignment.
-7. `FORWARD_SYNC`: when review base needs to be incorporated into integration, emit an `IntegrationSyncRequestV1` artifact plus `DEV_SYNC_REQUEST:<path>` marker for controller-side forward sync. The controller helper owns branch update mechanics and re-checks live state before applying.
+4. `PRESERVE_LOCAL_AHEAD`: before any controller-side alignment, compute `local_ahead_count` with `git rev-list --count origin/$INTEGRATION_BRANCH..HEAD`; if the daemon worktree is clean and ahead, emit an integration sync request artifact plus `DEV_SYNC_REQUEST:<path>` marker for the controller apply helper. This preserves resolver continuation commits without daemon-side git lifecycle authority.
+5. `ADOPT_MERGED_ROLLUP`: if a merged rollup PR from `$INTEGRATION_BRANCH` to `$REVIEW_BASE_BRANCH` is provable, capture the old rollup head and current expected remote SHA, then emit an integration sync request artifact plus `DEV_SYNC_REQUEST:<path>` marker for controller-side adoption. The controller helper re-checks ancestry and live SHAs before applying.
+6. `RESET_TO_REMOTE`: after local-ahead preservation and rollup adoption checks, emit an integration sync request artifact plus `DEV_SYNC_REQUEST:<path>` marker for controller-side remote alignment.
+7. `FORWARD_SYNC`: when review base needs to be incorporated into integration, emit an integration sync request artifact plus `DEV_SYNC_REQUEST:<path>` marker for controller-side forward sync. The controller helper owns branch update mechanics and re-checks live state before applying.
 8. `DETECT_RELEASE_ROLLUP_NEEDED`: if `origin/$INTEGRATION_BRANCH` is ahead of `origin/$REVIEW_BASE_BRANCH` by at least `RELEASE_ROLLUP_MIN_COMMITS` and no open `$INTEGRATION_BRANCH -> $REVIEW_BASE_BRANCH` PR exists, append `DEV_SYNC_PENDING:release-rollup-needed:<json>` with branch names, SHAs, ahead count, timestamp, and reason. Cooldown only suppresses duplicate same-SHA events; it grants no lifecycle authority.
 Ambiguous rollup metadata, failed request emission, or adoption conflicts append `.refactor-loop/.controller-pending-events.log` and do not guess. Controller reads pending events and posts the visible GitHub card when action is needed.
 
@@ -937,8 +936,8 @@ Allowlist(唯一 direct spawn authority):
 - `SOLVER_DONE:<minimal|structural|delete>:*` x3, same issue/round, clean `^EXIT=0`, non-placeholder, not ledgered, not in-flight → spawn same-round meta-judge.
 - `META_JUDGE_DONE:converge:round-<N>:*`, clean exit, not ledgered/in-flight → spawn round-N minimal/structural/delete solvers.
 - `META_JUDGE_DONE:escalate:stalled:*`, clean exit + stalled predicate(`round >= 3` and solver verdict text unchanged across 3 rounds) → spawn reflector with the full `prompts/meta-reflector-stalled.md` template plus the 3 recent rounds x 3 solver log path evidence; template read failure must fail closed in the spawned prompt, not fall back to a generic route.
-Input filename dialect allowlist:`phase9-issue<N>-r<R>-<minimal|structural|delete|judge|reflector>.log`,`solver-issue<N>-r<R>-<minimal|structural|delete>.log`,`meta-judge-issue<N>-r<R>.log`。issue/round 来自 filename identity,public marker payload remains role-local(`SOLVER_DONE:<role>:...`); must not introduce public marker aliases, WorkUnitV2, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority. daemon-owned output logs remain `phase9-issue...`;legacy input logs 只作为读取兼容面。daemon startup / first wakeup 文本必须与 `restart-daemons.sh` 的 5-daemon restart-helper-managed 面一致,包含 Phase 9 router; persistent daemon-event Monitor bridge 单独由 controller arm。
-Fallback/ledger/recovery: lifecycle/unknown markers append `.refactor-loop/.controller-pending-events.log`; no spawn beyond the allowlisted worker dispatches, no direct resolution, no git, no GitHub, no label, no lifecycle authority(no close/merge/release). Append-only `.refactor-loop/phase9-router-ledger.jsonl` records `{key, marker, log_path, dispatched_at}`; fallback events use prefix `phase9-router-fallback`. In-flight target logs or live `spawn-codex.sh --log <target>` suppress re-dispatch, `.refactor-loop/phase9-router.lock` enforces singleton, and duplicate ledger rows never delete logs. Staged expansion requires route-ledger evidence and must not introduce ControllerEvent, ControllerCommand, ControllerOrchestrator, WorkUnitV2, public marker aliases, or lifecycle authority.
+Input filename dialect allowlist:`phase9-issue<N>-r<R>-<minimal|structural|delete|judge|reflector>.log`,`solver-issue<N>-r<R>-<minimal|structural|delete>.log`,`meta-judge-issue<N>-r<R>.log`。issue/round 来自 filename identity,public marker payload remains role-local(`SOLVER_DONE:<role>:...`); must not introduce public marker aliases, migrated work-unit schema, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority. daemon-owned output logs remain `phase9-issue...`;legacy input logs 只作为读取兼容面。daemon startup / first wakeup 文本必须与 `restart-daemons.sh` 的 5-daemon restart-helper-managed 面一致,包含 Phase 9 router; persistent daemon-event Monitor bridge 单独由 controller arm。
+Fallback/ledger/recovery: lifecycle/unknown markers append `.refactor-loop/.controller-pending-events.log`; no spawn beyond the allowlisted worker dispatches, no direct resolution, no git, no GitHub, no label, no lifecycle authority(no close/merge/release). Append-only `.refactor-loop/phase9-router-ledger.jsonl` records `{key, marker, log_path, dispatched_at}`; fallback events use prefix `phase9-router-fallback`. In-flight target logs or live `spawn-codex.sh --log <target>` suppress re-dispatch, `.refactor-loop/phase9-router.lock` enforces singleton, and duplicate ledger rows never delete logs. Staged expansion requires route-ledger evidence and must not introduce ControllerEvent, ControllerCommand, ControllerOrchestrator, migrated work-unit schema, public marker aliases, or lifecycle authority.
 ### Daemon vs controller 分工
 dev sync stays with daemon; Phase 9 triplet/converge/valid-stalled continuation may use **phase9_router_daemon.py** narrow allowlist with controller fallback sweep retained; design/consensus/implement/review/fix/liveness/escalation stay with controller wakeups.
 ### Controller 每 wakeup 责任(只 verify daemon)
@@ -964,7 +963,7 @@ If a maintainer must repair the daemon worktree manually, stop the singleton `de
 
 ### Post-rollup adoption invariant
 
-After a rollup PR has merged into `review_base_branch`, `IntegrationSyncDaemonV1` must make `integration_branch` contain that merged review-base head before new forward sync work. Any post-rollup integration commits are replayed only after the proven old rollup head; if the old head or expected remote SHA cannot be proven, the daemon writes a pending event and does not force-push.
+After a rollup PR has merged into `review_base_branch`, `integration sync daemon` must make `integration_branch` contain that merged review-base head before new forward sync work. Any post-rollup integration commits are replayed only after the proven old rollup head; if the old head or expected remote SHA cannot be proven, the daemon writes a pending event and does not force-push.
 
 ### Why this matters
 
@@ -999,8 +998,8 @@ Controller 下次 wakeup sweep `gh issue list --label "auto-loop,phase9-auto-sol
 
 maintainer 只加 1 label:`auto-loop-triage`
 
-This path is the v1 `manual-issue` producer. The triage codex accepts only concrete repository
-work units suitable for consensus, reshapes the issue into a WorkUnitV1-backed design issue, and
+This path is the `manual-issue` producer. The triage codex accepts only concrete repository
+work units suitable for consensus, reshapes the issue into a work-unit-backed design issue, and
 then label-routes it to Phase 9. Accepted manual issues must contain `work_unit_id: issue-<N>`,
 `kind: manual-work-unit`, `producer: manual-issue`, `source_ref: gh-issue-<N>`, `scope_paths`,
 problem/invariant text, and `verification_hints`; they must not include fabricated `cluster_id` or
@@ -1008,7 +1007,7 @@ problem/invariant text, and `verification_hints`; they must not include fabricat
 
 **Daemon 自包含**:
 
-Controller wakeup sweep handles external `auto-loop-triage` issue intake; `triage-monitor.sh` is deleted. Triage workers emit `ManualIssueTriageDecisionV1` plus `TRIAGE_DECISION_DONE:<issue>:<accept|reject>:<path>`, and controller apply helpers re-read live labels before body/label lifecycle.
+Controller wakeup sweep handles external `auto-loop-triage` issue intake; `triage-monitor.sh` is deleted. Triage workers emit a manual issue triage decision artifact plus `TRIAGE_DECISION_DONE:<issue>:<accept|reject>:<path>`, and controller apply helpers re-read live labels before body/label lifecycle.
 
 
 ## Phase 8 details
@@ -1214,7 +1213,7 @@ A single reviewer codex would weigh all dimensions and might trade tests for arc
 
 ## Phase 9 — Multi-solver design consensus (sole authorization gate)
 
-Runs when a `state.design_pending[i]` WorkUnitV1 item needs a concrete implementation decision.
+Runs when a `state.design_pending[i]` work-unit item needs a concrete implementation decision.
 Current audit-backed items expose `WORK_UNIT_ID=$CLUSTER_ID` so Phase 9 can frame the decision as
 work-unit design while preserving `cluster_id` as legacy routing metadata. Goal: 3 independent
 solver codexes propose framings from different biases; a 4th meta-judge codex arbitrates; **3/3
@@ -2119,17 +2118,17 @@ Policy: **源文件内部 English-only;源文件之外的 user-facing artifact �
 
 `$REPO_ROOT 的架构/词汇文档(若有)` 与 `docs/adr/*.md` 在仓库内的文档仍按 [$REPO_ROOT 的架构/词汇文档(若有)architecture-vocabulary.md]($REPO_ROOT 的架构/词汇文档(若有)architecture-vocabulary.md) 既有惯例(混排,不归本规则管辖)。CLAUDE.md / AGENTS.md 仍是中英混排,不动。
 
-<a id="workunitv1-contract"></a>
+<a id="work-unit-contract"></a>
 
-## WorkUnitV1 contract
+## Work-unit contract
 
-`WorkUnitV1` is the v1 queue item contract stored inside the existing `clusters_planned`,
+The work-unit contract is the queue item contract stored inside the existing `clusters_planned`,
 `clusters_active`, `clusters_done`, and `clusters_failed` containers. The container names are
-historical but authoritative for state schema v1; do not add migrated queue containers, envelope
-wrappers, a normalizer helper, or a state-v2 migration for this contract.
+historical but authoritative; do not add migrated queue containers, envelope wrappers, a normalizer
+helper, or a state migration for this contract.
 
 Naming policy: this engine's public product identity is Consensus R&D, and `codex-refactor-loop`
-remains the stable installed skill entrypoint. In v1, `refactor` is a valid development/work-unit
+remains the stable installed skill entrypoint. `refactor` is a valid development/work-unit
 metaphor and compatibility intake, not a requirement to rename the skill, add an alias, or create a
 new identity contract.
 
@@ -2155,39 +2154,39 @@ Audit compatibility:
 - For current audit-backed units, `work_unit_id == id == cluster_id == legacy_cluster_id`.
 - For non-audit units, `work_unit_id` is not required to start with `cluster-`; omit
   `legacy_cluster_id` and do not fabricate `cluster_id`.
-- Old state without `work_unit_schema_version` is read as v1 legacy state. Derive
+- Old state without the work-unit schema marker is read as legacy state. Derive
   `work_unit_id` from each queue item's `id`, treat items as `kind="audit-cluster"` and
   `producer="audit"`, and use the audit section as `source_ref` when known.
 - Prompt dispatch for current audit-backed units exports `WORK_UNIT_ID=$CLUSTER_ID`. Existing
   markers, artifact names, branch names, and audit section lookups may continue to use
-  `CLUSTER_ID` during v1 compatibility.
+  `CLUSTER_ID` during compatibility.
 
-Stable v1 operational tokens:
+Stable operational tokens:
 
 - Current markers, GitHub labels, issue title prefixes, branch prefixes, artifact paths, prompt
   markers, log markers, and audit section lookups are stable v1 operational names.
 - `cluster-009-marker-label-compat-migration` does not rename, dual-write, or add aliases for
   these names. Keep existing `refactor`, `cluster`, `auto-loop`, and `*_DONE` spellings as the
-  v1 public routing surface while `WORK_UNIT_ID=$CLUSTER_ID` is the compatibility bridge.
+  public routing surface while `WORK_UNIT_ID=$CLUSTER_ID` is the compatibility bridge.
 
-## Producers in v1
+## Producers
 
-`WorkUnitV1` separates the queue item contract from the source that produced the item. The v1
-controller recognizes exactly these producer values:
+The work-unit contract separates the queue item contract from the source that produced the item.
+The controller recognizes exactly these producer values:
 
 - `audit`
 - `manual-issue`
 
 This is a documented normalization boundary, not a new producer framework. Do not add new
 producer abstractions, registry helpers, envelope wrappers, or migrated work-unit state containers
-for v1.
+for this contract.
 
 ### `audit` producer
 
 `audit` remains the default producer. It reads the raw artifact contract from
 `prompts/audit.md` and the resulting `.refactor-loop/runs/audit-iter-N.md` cluster sections.
 The controller leaves `prompts/audit.md` unchanged and projects each accepted audit cluster into
-`WorkUnitV1` before adding it to `clusters_planned`:
+the work-unit contract before adding it to `clusters_planned`:
 
 - `work_unit_id: <cluster-id>`
 - `id: <cluster-id>`
@@ -2198,12 +2197,12 @@ The controller leaves `prompts/audit.md` unchanged and projects each accepted au
 - `legacy_cluster_id: <cluster-id>` optional but recommended during v1 compatibility
 
 Audit-backed units may keep using `<cluster-id>` for branch names, worktree paths, artifact
-filenames, markers, and audit section lookup while `WORK_UNIT_ID=$CLUSTER_ID` remains the v1 alias.
+filenames, markers, and audit section lookup while `WORK_UNIT_ID=$CLUSTER_ID` remains the compatibility alias.
 
 ### `manual-issue` producer
 
 `manual-issue` is the Phase 7 `auto-loop-triage` intake path for maintainer-selected GitHub
-issues. Accepted issues must be reshaped into a `WorkUnitV1`-backed design issue before Phase 9
+issues. Accepted issues must be reshaped into a work-unit-backed design issue before Phase 9
 solver dispatch:
 
 - `work_unit_id: issue-<N>`

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -24,7 +24,7 @@ Read `REFERENCE.md` only when a phase needs the detailed body. Use normal Markdo
 <!-- Refactor (iter3/skill-monitor-wake-source): Old pattern: 2-lane wake source(harness task-notification + ScheduleWakeup). New principle: 3-lane wake source adds daemon-event Monitor lane(daemon writes event file -> mounted persistent Monitor bridge -> controller wakes immediately; daemon alone is not a wake source). -->
 | Wake source | Each turn must end with a confirmed future wake source. | Confirm one of three lanes before ending: active daemon-event Monitor bridge, in-flight codex task-notification, or confirmed ScheduleWakeup. | [wake source rules](REFERENCE.md#wake-source-rules) | Monitor bridge, harness Bash background tasks, ScheduleWakeup |
 | First wakeup | Phase 0 bootstrap is ordered and mandatory before any normal phase. | Run the Phase 0 checklist in this file, in order. | [daemon command bodies](REFERENCE.md#daemon-command-bodies) | scripts, `host.env` |
-| Work unit state | WorkUnitV1 is stable v1; do not rename, migrate, or wrap it. | Read and write existing v1 containers; export `WORK_UNIT_ID=$CLUSTER_ID` for audit-backed units. | [WorkUnitV1](REFERENCE.md#workunitv1-contract), [state schema](REFERENCE.md#state-schema) | `.refactor-loop/state.json` |
+| Work unit state | The work-unit contract is stable; do not rename, migrate, or wrap it. | Read and write existing containers; export `WORK_UNIT_ID=$CLUSTER_ID` for audit-backed units. | [work-unit contract](REFERENCE.md#work-unit-contract), [state schema](REFERENCE.md#state-schema) | `.refactor-loop/state.json` |
 | Phase routing | Markers route immediately to the next actor in the same wakeup. | Sweep `EXIT=0` logs, parse verdict markers only after clean exit, then spawn next work if actionable. | [phase routing details](REFERENCE.md#phase-routing-details) | logs, prompts |
 | 3/3 consensus | Concrete plans require Phase 9 multi-solver consensus and meta-judge consensus. | Dispatch minimal, structural, delete solvers; meta-judge may return only consensus, converge, or stalled-style escalation path. | [phase 9 details](REFERENCE.md#phase-9-details) | `solver-*.md`, `meta-judge.md` |
 | Floor | Keep `$CODEX_FLOOR` host-scoped codexes, default 5, hard lower bound 2. | Count only this loop's `spawn-codex.sh` processes containing absolute `$REPO_ROOT`; top up before ScheduleWakeup. | [concurrency floor details](REFERENCE.md#concurrency-floor-details) | `concurrency_monitor.py`, `peek.sh` |
@@ -105,17 +105,17 @@ The release lifecycle surface consumes decision-artifact-only output: a schedule
 ## Named runtime exception — autonomous-release-gate lifecycle boundary(per #56)
 Host-agnostic, no lifecycle authority: only read repo/GitHub evidence and write durable decision/candidate artifacts; do not run `git`, bump mapped manifests, commit, push, tag, publish, open, close, label, approve, merge, or otherwise lifecycle-manage issues or PRs.
 
-## Named runtime exception — IntegrationSyncDaemonV1(per #53)
-Authorization source: `.refactor-loop/runs/phase9-issue53-r7-judge.md`. **Narrow allowlist**: detect-and-emit only in the dedicated integration worktree. The daemon may fetch refs, compare ref counts and ancestry, detect conflicts, dispatch resolver workers, append pending events, and emit `IntegrationSyncRequestV1` artifacts. Controller apply helpers consume those artifacts, re-check live state, and own git apply lifecycle. **Forbidden**: no worker-diff commit, no PR create/merge/close/edit, no issue/PR/label lifecycle, no tag/release, no direct branch update, no generic lifecycle actor, and no lifecycle mutation verbs from the daemon. Implement/fix workers still never commit, push, or open PRs.
+## Named runtime exception — integration sync daemon(per #53)
+Authorization source: `.refactor-loop/runs/phase9-issue53-r7-judge.md`. **Narrow allowlist**: detect-and-emit only in the dedicated integration worktree. The daemon may fetch refs, compare ref counts and ancestry, detect conflicts, dispatch resolver workers, append pending events, and emit integration sync request artifacts. Controller apply helpers consume those artifacts, re-check live state, and own git apply lifecycle. **Forbidden**: no worker-diff commit, no PR create/merge/close/edit, no issue/PR/label lifecycle, no tag/release, no direct branch update, no generic lifecycle actor, and no lifecycle mutation verbs from the daemon. Implement/fix workers still never commit, push, or open PRs.
 
 ## Named runtime exception — observability-comment-writers(per #53)
-Authorization source: `.refactor-loop/runs/phase9-issue53-r7-judge.md`. **Narrow allowlist**: GitHub issue/PR comments, PR body edit, reactions, and deleting/updating own progress comments only. **Forbidden**: label mutation, issue/PR close/create/merge, release/tag, and git lifecycle. Triage accept/reject writes `ManualIssueTriageDecisionV1` artifacts for controller apply instead of mutating labels/body directly.
+Authorization source: `.refactor-loop/runs/phase9-issue53-r7-judge.md`. **Narrow allowlist**: GitHub issue/PR comments, PR body edit, reactions, and deleting/updating own progress comments only. **Forbidden**: label mutation, issue/PR close/create/merge, release/tag, and git lifecycle. Triage accept/reject writes manual issue triage decision artifacts for controller apply instead of mutating labels/body directly.
 
-## Named runtime exception — IntegrationSyncDaemonV1(per #65)
+## Named runtime exception — integration sync daemon(per #65)
 The r7 judge artifact `.refactor-loop/runs/phase9-issue65-r7-judge.md` authorizes the existing-review-base pending-event boundary. **Narrow allowlist**: release-rollup detection and existing-format pending-event emission only; event facts include `integration_branch`, `review_base_branch`, `integration_sha`, `review_base_sha`, `ahead_count`, `detected_at`, and `reason`.
 **No lifecycle authority**: the daemon must not run `gh pr create`; it must not create PRs, edit PRs, label PRs, close PRs, approve PRs, merge PRs, or push directly to `$REVIEW_BASE_BRANCH`. Controller pending-event sweep re-checks open head/base PRs, writes the Chinese PR body, and calls `open_release_rollup_pr_from_pending_event`, which delegates to `open_pr_with_label`. Behavior/source-regression tests cover event emission, suppression, cooldown, and forbidden daemon lifecycle tokens.
 
-## Named runtime exception — SkillDegradationWatchV1(per #66) — Authorization source: `.refactor-loop/runs/phase9-issue66-r8-judge.md`. Single-file checker/gates: `check_skill_degradation.py`; CI required `skill-degradation` runs `<skill-root>/scripts/check_skill_degradation.py --static`; `auto_release_gate.py` requires it beside `contract-tests` and `manifest-version-sync`. **Narrow allowlist**: run `check_skill_degradation.py`; write `.refactor-loop/.degradation-alert.log`; append existing-format pending events to `.refactor-loop/.controller-pending-events.log`; expose read-only `peek.sh` status. **Forbidden actions**: no source mutation; no git reset/rebase/merge/push; no GitHub issue/PR/body/label lifecycle mutation; no codex dispatch; no standalone daemon creation; no WorkUnit/schema/envelope changes; no protocol/plugin registry; no auto-clean root garbage; no auto-fix API. Runtime hook: `concurrency_monitor.py` may run the checker on `$DEGRADATION_WATCH_INTERVAL_SECONDS`; failures alert-only, passing writes nothing, and the hook must not mutate source, run git, call GitHub lifecycle APIs, spawn codex, create a daemon, or change WorkUnit/event schema; details: [skill degradation watch details](REFERENCE.md#skill-degradation-watch-details).
+## Named runtime exception — skill degradation watch(per #66) — Authorization source: `.refactor-loop/runs/phase9-issue66-r8-judge.md`. Single-file checker/gates: `check_skill_degradation.py`; CI required `skill-degradation` runs `<skill-root>/scripts/check_skill_degradation.py --static`; `auto_release_gate.py` requires it beside `contract-tests` and `manifest-version-sync`. **Narrow allowlist**: run `check_skill_degradation.py`; write `.refactor-loop/.degradation-alert.log`; append existing-format pending events to `.refactor-loop/.controller-pending-events.log`; expose read-only `peek.sh` status. **Forbidden actions**: no source mutation; no git reset/rebase/merge/push; no GitHub issue/PR/body/label lifecycle mutation; no codex dispatch; no standalone daemon creation; no WorkUnit/schema/envelope changes; no protocol/plugin registry; no auto-clean root garbage; no auto-fix API. Runtime hook: `concurrency_monitor.py` may run the checker on `$DEGRADATION_WATCH_INTERVAL_SECONDS`; failures alert-only, passing writes nothing, and the hook must not mutate source, run git, call GitHub lifecycle APIs, spawn codex, create a daemon, or change WorkUnit/event schema; details: [skill degradation watch details](REFERENCE.md#skill-degradation-watch-details).
 
 ## Claude Code statusline(per #51 consensus)
 `skills/codex-refactor-loop/scripts/statusline.sh` 是 fast (<200ms) read-only Claude Code statusline reader,显示本仓库 loop 实时状态(codex 计数、PR/issue 数、daemon 健康、P0 streak、freeze 指示)。
@@ -202,7 +202,7 @@ The phase index is the local routing map. It intentionally links to heavy detail
 | Phase | Local controller contract | Detail anchor |
 |---|---|---|
 | Phase 0 | First wakeup bootstrap. Must complete before normal routing. | [Phase 0 details](REFERENCE.md#phase-0-details) |
-| Phase 1 | Produce WorkUnitV1 items. Audit remains the default compatibility producer; manual issue intake is separate. | [WorkUnitV1](REFERENCE.md#workunitv1-contract), [batching heuristics](REFERENCE.md#batching-heuristics) |
+| Phase 1 | Produce work-unit items. Audit remains the default compatibility producer; manual issue intake is separate. | [work-unit contract](REFERENCE.md#work-unit-contract), [batching heuristics](REFERENCE.md#batching-heuristics) |
 | Phase 2 | Implement one codex per active work unit in the batch. Controller owns branch/worktree topology and prompt construction. | [phase routing details](REFERENCE.md#phase-routing-details) |
 | Phase 3 | Verify with a separate codex from the implementer. Verification may return ok, rework, partial, or blocked. | [recovery playbook](REFERENCE.md#recovery-playbook) |
 | Phase 4 | Controller commits, merges, pushes, and opens PRs. Workers never commit/push/checkout. | [merge and push details](REFERENCE.md#merge-and-push-details) |
@@ -220,7 +220,7 @@ Phase 0 is mandatory and ordered. Do not spawn normal actors before it completes
 2. Validate `REPO_ROOT`, `GH_REPO_SLUG`, `INTEGRATION_BRANCH`, `REVIEW_BASE_BRANCH`, `BUILD_CMD`, `TEST_CMD`, and `SOURCE_GLOBS` according to host policy.
 3. Run `ProjectRulesFixedPointEnsurer(强制,先于任何 actor 派发)` against `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}`.
 4. If the helper exits non-zero, helper 退出非 0 → bootstrap fail closed; post the failure and stop before actors.
-5. initialize state in `.refactor-loop/state.json` if missing, using WorkUnitV1 v1 containers only.
+5. initialize state in `.refactor-loop/state.json` if missing, using the existing work-unit containers only.
 6. Ensure the integration branch exists locally and remotely; create it from `$REVIEW_BASE_BRANCH` only when missing.
 7. ensure labels for the exact phase/human taxonomy; bootstrap command loops live in [label bootstrap loops](REFERENCE.md#label-bootstrap-loops).
 8. ensure all 5 restart-helper-managed daemons are alive as singletons: `concurrency_monitor.py`, `codex-progress-reporter.sh`, `comment-monitor.sh`, `dev_sync_daemon.py`, and `phase9_router_daemon.py`. The persistent daemon-event Monitor bridge is armed separately in step 9.
@@ -325,7 +325,7 @@ Controller non-duties:
 - Do not run reviewer, solver, implementer, or verifier reasoning inline when a codex role exists.
 - Do not fabricate consensus without Phase 9.
 - Do not hide status in local files only.
-- Do not create new runtime abstractions, event envelopes, state versions, or producer registries for this split, except the Phase 9-authorized phase9_router_daemon.py private ledger plus existing-format pending-event append for narrow deterministic Phase 9 dispatch; do not introduce WorkUnitV2, public marker aliases, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority.
+- Do not create new runtime abstractions, event envelopes, state versions, or producer registries for this split, except the Phase 9-authorized phase9_router_daemon.py private ledger plus existing-format pending-event append for narrow deterministic Phase 9 dispatch; do not introduce migrated work-unit schema, public marker aliases, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority.
 
 ## Concurrency Floor
 
@@ -505,7 +505,7 @@ Policy:the loop continues until an explicit stop condition or a visible `👤 hu
 6. No `[Skip]`, disabled tests, ignored tests, or manual category escapes to make CI green.
 7. No scope creep; workers must print `SCOPE_EXTEND: <file> <reason>` before touching outside authorized scope.
 8. Source files are English-only; external user-facing artifacts are 中文 by default. No mandatory parallel English section.
-9. Do not rename the skill, manifests, WorkUnitV1, public markers, branch prefixes, or labels during this split.
+9. Do not rename the skill, manifests, work-unit contract, public markers, branch prefixes, or labels during this split.
 10. Do not hardcode host facts into this cross-platform skill.
 
 Details are in [hard rules details](REFERENCE.md#hard-rules-details).
@@ -625,15 +625,14 @@ Authoritative surfaces:
 
 State rules:
 
-1. Keep `schema_version: 1` and `work_unit_schema_version: 1`.
-2. Use existing containers: `clusters_planned`, `clusters_active`, `clusters_done`, `clusters_failed`, `design_pending`, `remote_ci`.
-3. Do not add a state-v2 migration for this split.
-4. Do not add queue aliases, envelope wrappers, or normalizer helpers.
-5. For audit-backed work, keep `work_unit_id == id == cluster_id` during v1 compatibility.
-6. For manual issue work, do not fabricate `cluster_id`; use `work_unit_id: issue-<N>`.
-7. Prompt dispatch may keep `WORK_UNIT_ID=$CLUSTER_ID` for current audit-backed units.
-8. Public v1 operational names remain stable: `cluster`, `refactor`, `auto-loop`, `*_DONE`, branch prefixes, marker names, and label names.
-9. Full schema and examples live in [state schema](REFERENCE.md#state-schema).
+1. Use existing containers: `clusters_planned`, `clusters_active`, `clusters_done`, `clusters_failed`, `design_pending`, `remote_ci`.
+2. Do not add a state migration for this split.
+3. Do not add queue aliases, envelope wrappers, or normalizer helpers.
+4. For audit-backed work, keep `work_unit_id == id == cluster_id` during compatibility.
+5. For manual issue work, do not fabricate `cluster_id`; use `work_unit_id: issue-<N>`.
+6. Prompt dispatch may keep `WORK_UNIT_ID=$CLUSTER_ID` for current audit-backed units.
+7. Public operational names remain stable: `cluster`, `refactor`, `auto-loop`, `*_DONE`, branch prefixes, marker names, and label names.
+8. Full schema and examples live in [state schema](REFERENCE.md#state-schema).
 
 State write timing:
 
@@ -646,11 +645,11 @@ State write timing:
 
 ## Producer Contract
 
-The controller recognizes two v1 producers:
+The controller recognizes two producers:
 
 | Producer | Intake | Controller behavior |
 |---|---|---|
-| `audit` | Default compatibility audit/refactor intake. | Run audit prompt, project accepted clusters into WorkUnitV1, batch by dependencies/risk. |
+| `audit` | Default compatibility audit/refactor intake. | Run audit prompt, project accepted clusters into work-unit items, batch by dependencies/risk. |
 | `manual-issue` | Explicit GitHub issue intake via labels/triage. | Normalize problem and verification hints into a design issue, then use Phase 9. |
 
 Producer rules:
@@ -660,7 +659,7 @@ Producer rules:
 3. `requires_design` audit clusters open GitHub issues and do not auto-implement until Phase 9 consensus.
 4. Direct implementation is allowed only for clusters already authorized by policy and not requiring design.
 5. Batching should prefer independent, low-risk work and preserve dependency ordering.
-6. Detailed producer fields and batching heuristics live in [WorkUnitV1](REFERENCE.md#workunitv1-contract) and [batching heuristics](REFERENCE.md#batching-heuristics).
+6. Detailed producer fields and batching heuristics live in [work-unit contract](REFERENCE.md#work-unit-contract) and [batching heuristics](REFERENCE.md#batching-heuristics).
 
 ## Phase Guardrails
 
@@ -668,7 +667,7 @@ Phase 1 guardrails:
 
 1. Run the producer with host-injected `$SOURCE_GLOBS`.
 2. Write audit output to `.refactor-loop/runs/audit-iter-N.md`.
-3. Convert accepted units into WorkUnitV1 before dispatch.
+3. Convert accepted units into work-unit items before dispatch.
 4. Clean stale worktrees before audit pollution can affect decisions.
 5. For `requires_design`, open or update GitHub design issues and label them `🔍 phase:design-solving` plus `🤖 human:auto-推进`.
 
@@ -704,17 +703,17 @@ Phase 5 guardrails:
 4. Codecov patch failures route to test-add work.
 5. Repeated same-check failure routes through meta-layer policy before human escalation.
 
-Phase 6 guardrails: integration sync is daemon-owned detect-and-emit plus controller-owned git apply. The daemon emits `IntegrationSyncRequestV1` and `DEV_SYNC_REQUEST:<path>`; controller apply helpers consume `IntegrationSyncRequestV1` artifacts and re-check live state before git lifecycle. Daemon command details live in [daemon command bodies](REFERENCE.md#daemon-command-bodies).
+Phase 6 guardrails: integration sync is daemon-owned detect-and-emit plus controller-owned git apply. The daemon emits integration sync request artifacts and `DEV_SYNC_REQUEST:<path>`; controller apply helpers consume those artifacts and re-check live state before git lifecycle. Daemon command details live in [daemon command bodies](REFERENCE.md#daemon-command-bodies).
 
-## Named runtime exception — IntegrationSyncDaemonV1 phase-6 controller boundary
-`IntegrationSyncDaemonV1` owns read-only detection, conflict detection, resolver dispatch, heartbeat, pending-event append, and `IntegrationSyncRequestV1` artifact emission only. Controller helpers own git apply and must reject stale SHA, branch mismatch, dirty non-merge worktrees, invalid rollup ancestry, malformed, or already-applied requests. Resolver codexes resolve conflicts only; they never push, reset, or abort.
+## Named runtime exception — integration sync daemon phase-6 controller boundary
+The integration sync daemon owns read-only detection, conflict detection, resolver dispatch, heartbeat, pending-event append, and integration sync request artifact emission only. Controller helpers own git apply and must reject stale SHA, branch mismatch, dirty non-merge worktrees, invalid rollup ancestry, malformed, or already-applied requests. Resolver codexes resolve conflicts only; they never push, reset, or abort.
 
 Phase 7 guardrails:
 
 1. Sweep design issues every wakeup.
 2. Maintainer replies that materially change framing reset the Phase 9 round.
 3. Bot comments and AI sentinel comments do not count as maintainer input.
-4. External issues require explicit opt-in labels; controller wakeup sweep dispatches triage and applies `ManualIssueTriageDecisionV1` artifacts.
+4. External issues require explicit opt-in labels; controller wakeup sweep dispatches triage and applies manual issue triage decision artifacts.
 5. Do not auto-implement from a free-form issue without Phase 9 consensus.
 
 Phase 8 guardrails:
@@ -798,7 +797,7 @@ The entrypoint is intentionally enough for controller routing. Open reference an
 When to read an anchor:
 
 1. Before writing a full status or escalation banner, read [status and escalation templates](REFERENCE.md#status-and-escalation-templates).
-2. Before editing state shape or producer normalization, read [WorkUnitV1](REFERENCE.md#workunitv1-contract) and [state schema](REFERENCE.md#state-schema).
+2. Before editing state shape or producer normalization, read [work-unit contract](REFERENCE.md#work-unit-contract) and [state schema](REFERENCE.md#state-schema).
 3. Before starting or repairing daemons, read [daemon command bodies](REFERENCE.md#daemon-command-bodies).
 4. Before changing label bootstrap or transition helpers, read [label bootstrap loops](REFERENCE.md#label-bootstrap-loops).
 5. Before handling repeated failure, stuck CI, merge conflicts, or stale worktrees, read [recovery playbook](REFERENCE.md#recovery-playbook).

--- a/skills/codex-refactor-loop/scripts/check_skill_degradation.py
+++ b/skills/codex-refactor-loop/scripts/check_skill_degradation.py
@@ -7,7 +7,7 @@
 # forbidden runtime/surface set explicit.
 """Static degradation checks for the codex-refactor-loop skill.
 
-SkillDegradationWatchV1 is intentionally a single read-only checker. It has no
+The skill degradation watch is intentionally a single read-only checker. It has no
 daemon lifecycle, no source mutation path, no GitHub lifecycle authority, and no
 worker dispatch API. Runtime monitoring is owned by concurrency_monitor.py,
 which may call this file and report failures as local alerts only.
@@ -83,7 +83,7 @@ DOC_FORBIDDEN_CONTEXT = (
 )
 
 REQUIRED_SKILL_MARKERS = (
-    "## Named runtime exception — SkillDegradationWatchV1(per #66)",
+    "## Named runtime exception — skill degradation watch(per #66)",
     JUDGE_ARTIFACT,
     "run `check_skill_degradation.py`",
     "write `.refactor-loop/.degradation-alert.log`",
@@ -100,7 +100,7 @@ REQUIRED_SKILL_MARKERS = (
 )
 
 REQUIRED_REFERENCE_MARKERS = (
-    "SkillDegradationWatchV1(per #66)",
+    "skill degradation watch(per #66)",
     JUDGE_ARTIFACT,
     ALERT_LOG,
     PENDING_EVENTS,

--- a/skills/codex-refactor-loop/scripts/test_check_skill_degradation.py
+++ b/skills/codex-refactor-loop/scripts/test_check_skill_degradation.py
@@ -70,7 +70,7 @@ class SkillDegradationCheckerBehaviorTests(unittest.TestCase):
             skill = repo / "skills/codex-refactor-loop/SKILL.md"
             skill.write_text(
                 skill.read_text(encoding="utf-8").replace(
-                    "## Named runtime exception — SkillDegradationWatchV1(per #66)",
+                    "## Named runtime exception — skill degradation watch(per #66)",
                     "## Removed heading",
                 ),
                 encoding="utf-8",
@@ -79,7 +79,7 @@ class SkillDegradationCheckerBehaviorTests(unittest.TestCase):
             findings = self.checker_module.SkillDriftChecker(repo).run_static()
 
         self.assertTrue(any(f.check == "skill-named-exception" for f in findings))
-        self.assertTrue(any("SkillDegradationWatchV1" in f.message for f in findings))
+        self.assertTrue(any("skill degradation watch" in f.message for f in findings))
 
     def test_checker_detects_forbidden_runtime_file(self) -> None:
         with copy_minimal_repo() as tmp:

--- a/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
+++ b/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
@@ -217,18 +217,18 @@ class IntegrationSyncRequestSchemaTests(unittest.TestCase):
             validate_request_dict(data)
 
 
-class IntegrationSyncDaemonV1SourceRegressionTests(unittest.TestCase):
+class IntegrationSyncDaemonSourceRegressionTests(unittest.TestCase):
     def test_skill_phase6_names_detector_and_controller_apply_boundary(self) -> None:
         text = SKILL_MD.read_text(encoding="utf-8")
-        self.assertIn("## Named runtime exception — IntegrationSyncDaemonV1 phase-6 controller boundary", text)
+        self.assertIn("## Named runtime exception — integration sync daemon phase-6 controller boundary", text)
         self.assertIn("daemon-owned detect-and-emit plus controller-owned git apply", text)
-        self.assertIn("IntegrationSyncRequestV1", text)
+        self.assertIn("integration sync request artifacts", text)
 
     def test_reference_has_no_active_controller_sync_procedure(self) -> None:
         text = REFERENCE_MD.read_text(encoding="utf-8")
         self.assertNotIn("### Sync procedure", text)
         self.assertNotIn("### Sync cadence", text)
-        self.assertIn("IntegrationSyncRequestV1", text)
+        self.assertIn("integration sync request artifact", text)
 
     def test_dev_sync_daemon_has_no_git_lifecycle_mutation_tokens(self) -> None:
         src = DEV_SYNC.read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -1573,7 +1573,7 @@ class WorkUnitSourceRegressionTests(unittest.TestCase):
 
         required_markers = (
             "Stable operational tokens",
-            "stable v1 operational names",
+            "stable operational names",
             "[refactor-design]",
             "refactor-design-needed",
             "auto-loop",

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -474,14 +474,14 @@ class ScriptHygieneBehaviorTests(unittest.TestCase):
         self.assertIn("sync-helper", result.stdout)
         self.assertIn(".refactor-loop/runs/integration-sync-request-x.json", result.stdout)
 
-    def test_integration_sync_daemon_v1_release_rollup_exception_contract(self) -> None:
+    def test_integration_sync_daemon_release_rollup_exception_contract(self) -> None:
         skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
         reference = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
         daemon = (SKILL_ROOT / "scripts" / "dev_sync_daemon.py").read_text(encoding="utf-8")
         host_env = (SKILL_ROOT / "host.env.example").read_text(encoding="utf-8")
         combined = "\n".join([skill, reference, daemon, host_env])
 
-        self.assertIn("## Named runtime exception — IntegrationSyncDaemonV1(per #65)", skill)
+        self.assertIn("## Named runtime exception — integration sync daemon(per #65)", skill)
         self.assertIn("phase9-issue65-r7-judge.md", skill)
         self.assertIn("DEV_SYNC_PENDING:release-rollup-needed", combined)
         self.assertIn("release-rollup detection and existing-format pending-event emission only", skill)
@@ -491,10 +491,15 @@ class ScriptHygieneBehaviorTests(unittest.TestCase):
         self.assertIn("open_release_rollup_pr_from_pending_event", reference)
         self.assertIn("RELEASE_ROLLUP_MIN_COMMITS", host_env)
         self.assertIn("RELEASE_ROLLUP_COOLDOWN_SECONDS", host_env)
-        for marker in ("## Named runtime exception — IntegrationSyncDaemonV1(per #53)", "phase9-issue53-r7-judge.md", "detect-and-emit", "IntegrationSyncRequestV1"):
+        for marker in (
+            "## Named runtime exception — integration sync daemon(per #53)",
+            "phase9-issue53-r7-judge.md",
+            "detect-and-emit",
+            "integration sync request artifacts",
+        ):
             self.assertIn(marker, skill)
         issue53_section = re.search(
-            r"## Named runtime exception — IntegrationSyncDaemonV1\(per #53\)(.*?)\n## Named runtime exception — observability-comment-writers",
+            r"## Named runtime exception — integration sync daemon\(per #53\)(.*?)\n## Named runtime exception — observability-comment-writers",
             skill,
             re.S,
         )
@@ -510,7 +515,7 @@ class ScriptHygieneBehaviorTests(unittest.TestCase):
 
     def test_integration_sync_daemon_command_body_is_detect_and_emit_only(self) -> None:
         reference = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
-        section = reference.split("Daemon 工作流由 `IntegrationSyncDaemonV1` 命名状态机表达:", 1)[1].split(
+        section = reference.split("Daemon 工作流由 `integration sync daemon` 命名状态机表达:", 1)[1].split(
             "### Phase 9 router daemon command body",
             1,
         )[0]
@@ -520,7 +525,7 @@ class ScriptHygieneBehaviorTests(unittest.TestCase):
             "`ADOPT_MERGED_ROLLUP`",
             "`RESET_TO_REMOTE`",
             "`FORWARD_SYNC`",
-            "`IntegrationSyncRequestV1`",
+            "integration sync request artifact",
             "`DEV_SYNC_REQUEST:<path>`",
             "controller helper",
         ):
@@ -549,7 +554,7 @@ class ScriptHygieneBehaviorTests(unittest.TestCase):
             with self.subTest(path=path.name):
                 self.assertIn("no lifecycle authority by default", text)
                 self.assertIn("#53 唯一 carveout", text)
-                self.assertIn("IntegrationSyncDaemonV1", text)
+                self.assertIn("integration sync daemon", text)
                 self.assertIn("Implement/fix worker 仍不得 commit、push、open PR", text)
 
         for forbidden in (
@@ -1172,7 +1177,7 @@ class Phase8MergePolicySourceRegressionTests(unittest.TestCase):
                 self.assertNotIn(forbidden, controller_lib)
 
 
-class WorkUnitV1SourceRegressionTests(unittest.TestCase):
+class WorkUnitSourceRegressionTests(unittest.TestCase):
     # Refactor (iter2/cluster-007-work-unit-contract-schema):
     #   Old pattern: work-unit state contract existed only as prose, so migration/envelope terms could re-enter the skill unnoticed
     #   New principle: source-regression coverage keeps WorkUnitV1 v1 containers authoritative and blocks premature work_units_* migration surface
@@ -1260,7 +1265,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             return output.read_text(encoding="utf-8")
 
-    def test_work_unit_v1_contract_markers_are_present(self) -> None:
+    def test_work_unit_contract_markers_are_present(self) -> None:
         reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
         skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
         implement_prompt = (SKILL_ROOT / "prompts" / "implement.md").read_text(encoding="utf-8")
@@ -1269,7 +1274,6 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
         combined = "\n".join([reference_text, skill_text, implement_prompt, verify_prompt, controller_lib])
 
         required_markers = (
-            "WorkUnitV1",
             "work_unit_schema_version",
             "work_unit_id == id == cluster_id == legacy_cluster_id",
             "WORK_UNIT_ID=$CLUSTER_ID",
@@ -1282,7 +1286,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             with self.subTest(marker=marker):
                 self.assertIn(marker, combined)
 
-    def test_work_unit_v1_forbidden_migration_surface_is_absent(self) -> None:
+    def test_work_unit_forbidden_migration_surface_is_absent(self) -> None:
         checked_paths = [
             SKILL_ROOT / "REFERENCE.md",
             SKILL_ROOT / "SKILL.md",
@@ -1317,14 +1321,14 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
         self.assertIn("primary=cluster-007", rendered)
         self.assertNotIn("{{work_unit_id}}", rendered)
 
-    def test_v1_producer_contract_markers_are_present(self) -> None:
+    def test_producer_contract_markers_are_present(self) -> None:
         reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
         skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
         triage_prompt = (SKILL_ROOT / "prompts" / "triage-external-issue.md").read_text(encoding="utf-8")
         combined = "\n".join([reference_text, skill_text, triage_prompt])
 
         required_markers = (
-            "Producers in v1",
+            "## Producers",
             "- `audit`",
             "- `manual-issue`",
             "kind: audit-cluster",
@@ -1341,14 +1345,14 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             with self.subTest(marker=marker):
                 self.assertIn(marker, combined)
 
-    def test_v1_producer_contract_remains_two_values(self) -> None:
+    def test_producer_contract_remains_two_values(self) -> None:
         reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
         match = re.search(
-            r"## Producers in v1\s*\n(?P<body>.*?)(?:\n### |\n## |\Z)",
+            r"## Producers\s*\n(?P<body>.*?)(?:\n### |\n## |\Z)",
             reference_text,
             flags=re.DOTALL,
         )
-        self.assertIsNotNone(match, "Producers in v1 section missing")
+        self.assertIsNotNone(match, "Producers section missing")
         producers = re.findall(r"^- `([^`]+)`$", match.group("body"), flags=re.MULTILINE)
 
         self.assertEqual(producers, ["audit", "manual-issue"])
@@ -1392,7 +1396,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
                         if token in line:
                             self.assertRegex(line, r"\b(do not|must not)\b")
 
-    def test_skill_degradation_watch_v1_named_exception_and_delete_boundary(self) -> None:
+    def test_skill_degradation_watch_named_exception_and_delete_boundary(self) -> None:
         skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
         reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
         checker_text = (SKILL_ROOT / "scripts" / "check_skill_degradation.py").read_text(encoding="utf-8")
@@ -1401,7 +1405,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
         combined = "\n".join([skill_text, reference_text, checker_text, monitor_text, host_env])
 
         required_markers = (
-            "## Named runtime exception — SkillDegradationWatchV1(per #66)",
+            "## Named runtime exception — skill degradation watch(per #66)",
             ".refactor-loop/runs/phase9-issue66-r8-judge.md",
             "check_skill_degradation.py --static",
             ".refactor-loop/.degradation-alert.log",
@@ -1486,7 +1490,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
     def test_audit_prompt_remains_raw_artifact_contract(self) -> None:
         audit_prompt = (SKILL_ROOT / "prompts" / "audit.md").read_text(encoding="utf-8")
 
-        for marker in ("producer: audit", "WorkUnitV1", "manual-issue"):
+        for marker in ("producer: audit", "work-unit contract", "manual-issue"):
             with self.subTest(marker=marker):
                 self.assertNotIn(marker, audit_prompt)
 
@@ -1559,7 +1563,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
             with self.subTest(marker=marker):
                 self.assertIn(marker, implement_prompt)
 
-    def test_v1_operational_tokens_are_stable_and_not_renamed(self) -> None:
+    def test_operational_tokens_are_stable_and_not_renamed(self) -> None:
         # Refactor (iter2/cluster-009-marker-label-compat-migration):
         #   Old pattern: marker/label 命名与 refactor 外壳耦合,无显式稳定契约
         #   New principle: minimal docs+test 固化 marker/label 为稳定 v1 operational tokens(保持现状,不重命名);不引入 OperationalNamePolicyV1(#5 structural 共识)
@@ -1568,7 +1572,7 @@ class WorkUnitV1SourceRegressionTests(unittest.TestCase):
         combined = "\n".join([reference_text, skill_text])
 
         required_markers = (
-            "Stable v1 operational tokens",
+            "Stable operational tokens",
             "stable v1 operational names",
             "[refactor-design]",
             "refactor-design-needed",
@@ -2183,7 +2187,7 @@ print(check(f"bash -c {repo}/.claude/skills/codex-refactor-loop/scripts/spawn-co
         self.assertFalse((SKILL_ROOT / "scripts" / "triage-monitor.sh").exists())
         skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
         reference = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
-        self.assertIn("ManualIssueTriageDecisionV1", skill + reference)
+        self.assertIn("manual issue triage decision artifact", skill + reference)
         self.assertIn("controller wakeup sweep", skill + reference)
         self.assertNotIn("triage-monitor-state.json", skill + reference)
 

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -1274,7 +1274,6 @@ class WorkUnitSourceRegressionTests(unittest.TestCase):
         combined = "\n".join([reference_text, skill_text, implement_prompt, verify_prompt, controller_lib])
 
         required_markers = (
-            "work_unit_schema_version",
             "work_unit_id == id == cluster_id == legacy_cluster_id",
             "WORK_UNIT_ID=$CLUSTER_ID",
             "must not fabricate `cluster_id` or",

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -133,7 +133,7 @@ class SkillEntrypointContractTests(unittest.TestCase):
 
     def test_heavy_reference_material_is_not_in_entrypoint(self) -> None:
         reference_only_anchors = (
-            "workunitv1-contract",
+            "work-unit-contract",
             "batching-heuristics",
             "recovery-playbook",
             "label-bootstrap-loops",
@@ -161,7 +161,7 @@ class SkillEntrypointContractTests(unittest.TestCase):
         self.assertIn("SOLVER_DONE", self.skill)
         self.assertIn("META_JUDGE_DONE:converge", self.skill)
         self.assertIn("META_JUDGE_DONE:escalate:stalled", self.skill)
-        self.assertIn("do not introduce WorkUnitV2, public marker aliases, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority", self.skill)
+        self.assertIn("do not introduce migrated work-unit schema, public marker aliases, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority", self.skill)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -144,7 +144,8 @@ class SkillEntrypointContractTests(unittest.TestCase):
                 self.assertIn(f"(REFERENCE.md#{anchor})", self.skill)
                 self.assertIn(anchor, self.reference)
         self.assertNotIn('"schema_version": 1', self.skill)
-        self.assertIn('"schema_version": 1', self.reference)
+        self.assertNotIn('"schema_version": 1', self.reference)
+        self.assertNotIn('"work_unit_schema_version": 1', self.reference)
         for emoji_heading in ("📊", "🆘"):
             with self.subTest(emoji_heading=emoji_heading):
                 self.assertNotRegex(self.skill, rf"(?m)^## {emoji_heading} ")

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -53,7 +53,7 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             "controller-contract-details",
             "host-runtime-details",
             "status-and-escalation-templates",
-            "workunitv1-contract",
+            "work-unit-contract",
             "state-schema",
             "batching-heuristics",
             "recovery-playbook",


### PR DESCRIPTION
## TL;DR
Phase 9 #107 staged 实现 — stage-1 仅哲学/SKILL/REFERENCE docs:44 V1 occurrences → 0,3 docs + 6 stale tests 更新,349/349 tests pass。

## 不在本 PR scope(stage-2/3/4)
- Python identifier rename(class/function/file)
- state.json schema 字段删除 + live migration
- 全 codebase source-regression guard

## 授权
- Consensus: `.refactor-loop/runs/meta-judge-issue107-r3.log` → `META_JUDGE_DONE:consensus:full-rename-one-shot`
- Maintainer directive: `.refactor-loop/runs/maintainer-directives/2026-05-28-no-version-in-code-either.md` → "代码中也禁止出现版本号,很傻"

部分实现 #107(完整 close 等 stage-2~4 land)

⟦AI:AUTO-LOOP⟧