### PR TITLE
fix(#113): release.yml step 命名跟随职责(去 issue 编号)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/github-script@v7
-        name: Verify required checks from issue 31
+        name: Verify required release checks
         with:
           script: |
             const required = ["contract-tests", "manifest-version-sync", "skill-degradation"];


### PR DESCRIPTION
## Summary
- `Verify required checks from issue 31` → `Verify required release checks`
- 单文件 `.github/workflows/release.yml` 1 行
- 不改 required check 名字、不改 release 行为

Closes #113

## Test plan
- [x] CI 跑过:release.yml 触发条件不变,step 行为不变
- [x] manifest-version-sync 不受影响