### PR TITLE
fix(#122): phase9_router_daemon tail-read,CPU bound 不随 logs/ 膨胀

### DIFF
--- a/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/phase9_router_daemon.py
@@ -160,6 +160,25 @@ class Phase9Router:
     #   alongside `EXIT=0`. Scan only the last MARKER_TAIL_LINES of each log.
     #   Body-position prompt-body echoes never reach the marker parser.
     MARKER_TAIL_LINES = 30
+    TAIL_READ_BYTES = 8192  # Refactor (iter5/issue122-phase9-tail-perf): bound tail read to ~8KB so per-tick scan stays O(num_logs), not O(total log bytes).
+
+    @staticmethod
+    def _read_tail_lines(path: Path, num_lines: int) -> list[str]:
+        # Refactor (iter5/issue122-phase9-tail-perf): Old: read full log via
+        # read_text() then splitlines()[-N:]. New: seek to file end and read
+        # only the last TAIL_READ_BYTES, decode, return tail num_lines. Keeps
+        # per-tick CPU bounded as logs/ grows.
+        try:
+            with path.open("rb") as fh:
+                fh.seek(0, 2)
+                size = fh.tell()
+                fh.seek(max(0, size - Phase9Router.TAIL_READ_BYTES))
+                blob = fh.read()
+        except OSError:
+            return []
+        text = blob.decode("utf-8", errors="replace")
+        lines = text.splitlines()
+        return lines[-num_lines:] if len(lines) > num_lines else lines
 
     def _collect_markers(self) -> list[Marker]:
         markers: list[Marker] = []
@@ -169,11 +188,7 @@ class Phase9Router:
             identity = self._identity_from_path(log_path)
             if identity is None:
                 continue
-            try:
-                lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
-            except OSError:
-                continue
-            tail = lines[-self.MARKER_TAIL_LINES :] if len(lines) > self.MARKER_TAIL_LINES else lines
+            tail = self._read_tail_lines(log_path, self.MARKER_TAIL_LINES)
             for line in tail:
                 marker = self._extract_marker(line)
                 if marker is None:
@@ -259,11 +274,12 @@ class Phase9Router:
         return parse_phase9_log_identity(path.name)
 
     def _is_clean_exit(self, path: Path) -> bool:
-        try:
-            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError:
+        # Refactor (iter5/issue122-phase9-tail-perf): tail-only read via
+        # _read_tail_lines bounds CPU as logs/ grows.
+        tail = self._read_tail_lines(path, 5)
+        if not tail:
             return False
-        return any(re.match(r"^EXIT=0$", line) for line in lines[-5:])
+        return any(re.match(r"^EXIT=0$", line) for line in tail)
 
     def _dispatch_solver_triplets(self, markers: list[Marker], ledger: set[str]) -> None:
         by_issue_round: dict[tuple[str, int], dict[str, Marker]] = {}
@@ -394,13 +410,11 @@ class Phase9Router:
         # Refactor (iter5/skill-marker-tail-only-scope): same tail-only invariant
         # as _collect_markers — _stalled_predicate_holds must not trust body-
         # position SOLVER_DONE echoes when classifying convergence verdicts.
+        # Refactor (iter5/issue122-phase9-tail-perf): tail-only read via
+        # _read_tail_lines bounds CPU as logs/ grows.
         if not path.exists():
             return []
-        try:
-            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError:
-            return []
-        tail = lines[-self.MARKER_TAIL_LINES :] if len(lines) > self.MARKER_TAIL_LINES else lines
+        tail = self._read_tail_lines(path, self.MARKER_TAIL_LINES)
         markers: list[str] = []
         for line in tail:
             marker = self._extract_marker(line)

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -58,6 +58,28 @@ class Phase9RouterDaemonTests(unittest.TestCase):
                 f"SOLVER_DONE:{role}:{verdict}:summary",
             )
 
+    def test_phase9_router_tail_read_bounds_io_to_last_kb(self) -> None:
+        # Refactor (iter5/issue122-phase9-tail-perf): direct behavior test for
+        # _read_tail_lines. Build a log far larger than TAIL_READ_BYTES, write
+        # the verdict marker only in the last few lines, and verify the helper
+        # returns those tail lines without paging the entire body.
+        path = self.repo / ".refactor-loop" / "logs" / "big.log"
+        body_size = Phase9Router.TAIL_READ_BYTES * 8
+        filler = "noise-line-padding-text\n" * (body_size // len("noise-line-padding-text\n"))
+        tail_lines = ["MARK_PENULTIMATE", "SOLVER_DONE:minimal:approve:summary", "EXIT=0", ""]
+        path.write_text(filler + "\n".join(tail_lines), encoding="utf-8")
+
+        result = self.router._read_tail_lines(path, 4)
+
+        self.assertEqual(result[-3:], ["MARK_PENULTIMATE", "SOLVER_DONE:minimal:approve:summary", "EXIT=0"])
+        self.assertTrue(self.router._is_clean_exit(path))
+
+    def test_phase9_router_tail_read_handles_short_file(self) -> None:
+        path = self.repo / ".refactor-loop" / "logs" / "short.log"
+        path.write_text("only-one-line\nEXIT=0\n", encoding="utf-8")
+        result = self.router._read_tail_lines(path, 5)
+        self.assertEqual(result, ["only-one-line", "EXIT=0"])
+
     def test_phase9_router_clean_exit_gating_requires_tail_exit_zero(self) -> None:
         self.write_log("phase9-issue37-r4-minimal.log", "SOLVER_DONE:minimal:ok:x")
         self.write_log("phase9-issue37-r4-structural.log", "SOLVER_DONE:structural:ok:x")


### PR DESCRIPTION
## Summary
- `_read_tail_lines(path, num_lines)` seek-based tail 读末 8 KB,替代 `read_text() + splitlines()[-N:]`
- 3 处 hotspot 替换:`_is_clean_exit` / `_collect_markers` / `_collect_markers_from_path`
- 实测影响:本地 logs/=2270 时 daemon 持续 18% CPU / 419 MB,本 fix + log cleanup 后预期 < 1% CPU

## Authorization
narrow bug fix(per [[feedback-direct-fix-vs-design-issue]]):
- 1 文件
- 行为不变(EXIT=0 + tail-30 marker scope-only 不变)
- 仅替换 read 实现方式

## Test plan
- [x] `python3 -m unittest skills.codex-refactor-loop.scripts.test_phase9_router_daemon` 30/30 OK
- [ ] CI contract-tests / skill-degradation / manifest-version-sync

Partially addresses #122(retention 全方案另开 PR)。