### PR TITLE
fix(#115): peek.sh + daemon 单例 cross-host scope

### DIFF
--- a/skills/codex-refactor-loop/scripts/peek.sh
+++ b/skills/codex-refactor-loop/scripts/peek.sh
@@ -15,23 +15,25 @@
 # ⟦AI:AUTO-LOOP⟧
 
 set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SKILL_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
 if [ -z "${REPO_ROOT:-}" ]; then
   echo "FATAL: REPO_ROOT is unset and git rev-parse --show-toplevel failed" >&2
   exit 2
 fi
+export REPO_ROOT
 cd "$REPO_ROOT"
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/repo_slug.sh"
+source "$SCRIPT_DIR/repo_slug.sh"
 set_gh_repo_args 0 0 || exit $?
 git fetch origin --quiet 2>/dev/null
 
 list_loop_codex() {
-  # Scope to THIS repo by absolute REPO_ROOT, not the relative `.refactor-loop/`
-  # substring (which two loops on one machine share -> cross-host over-count).
-  # Requires callers to pass an absolute --cd so REPO_ROOT is in the cmdline.
-  # Exclude ` -c ` lines: each codex yields a real `bash spawn-codex.sh` supervisor
-  # AND a shell `-c` wrapper that echoes the command; count only the supervisor.
-  ps -eo command= | awk -v repo="$REPO_ROOT" 'repo != "" && /spawn-codex[.]sh/ && index($0, repo) && index($0, " -c ")==0 { print }'
+  python3 "$SKILL_ROOT/scripts/concurrency_monitor.py" --list-codex
+}
+
+count_loop_codex() {
+  python3 "$SKILL_ROOT/scripts/concurrency_monitor.py" --count-only
 }
 
 REVIEW_MARKER_TAIL_LINES=30
@@ -97,7 +99,7 @@ print(f'  {flag} [{author}] ${num} ${kind} ({delta_h:.1f}h ago): {body}')
 done
 
 # 1. Active codex
-n=$(list_loop_codex | wc -l | tr -d ' ')
+n=$(count_loop_codex)
 echo ""
 echo "▍活跃 codex: ${n}"
 if [ "$n" -gt 0 ]; then

--- a/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
+++ b/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
@@ -210,6 +210,14 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
         self.assertIn("MERGE_READY approve=2 comment=1 reject=0", result.stdout)
         self.assertNotIn("MERGE_READY approve=3 comment=0 reject=0", result.stdout)
 
+    def test_peek_counts_codex_via_canonical_monitor_cli(self) -> None:
+        text = PEEK.read_text(encoding="utf-8")
+
+        self.assertIn("concurrency_monitor.py\" --count-only", text)
+        self.assertIn("concurrency_monitor.py\" --list-codex", text)
+        self.assertNotIn("ps -ef | awk", text)
+        self.assertNotIn("ps -eo command= | awk", text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- peek.sh 用 canonical CLI(`concurrency_monitor.py --count-only`)取活跃 codex 数
- daemon 单例 pgrep 加 $REPO_ROOT 匹配
- 解决跨 host 计数混乱

Closes #115。