### PR TITLE
fix(#112): delete residual host-specific prompt/reference vocabulary

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -63,7 +63,7 @@ Narrow allowlist: run `check_skill_degradation.py`, write `.refactor-loop/.degra
 
 ### Daemon 启动(强制 pattern — 必须注入 host.env)
 
-**禁止** 裸 `nohup python3 <daemon> &`(拿不到 host 配置)与 `nohup env $(grep ... host.env) <daemon> &`(`BUILD_CMD="cargo build --workspace"` 含空格 → `env` 把 `build` 当命令崩)。**唯一正确**:用 `bash -c 'source host.env && exec'` 注入后再 exec:
+**禁止** 裸 `nohup python3 <daemon> &`(拿不到 host 配置)与 `nohup env $(grep ... host.env) <daemon> &`(`BUILD_CMD` 含空格时 `env` 会把后续 token 当命令崩)。**唯一正确**:用 `bash -c 'source host.env && exec'` 注入后再 exec:
 ```bash
 nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scripts/<daemon>.py' \
   >> .refactor-loop/logs/<daemon>.log 2>&1 & disown
@@ -160,9 +160,9 @@ codex 常把 prompt 里的 marker 模板原样回显到 log(如 prompt 写 `SOLV
 
 `gh` CLI 把 **`GH_REPO`** 当 `--repo` 默认值且要求 `OWNER/REPO` 格式。host.env 禁止导出 `GH_REPO=<repo-name>`。统一用 `GH_REPO_SLUG=OWNER/REPO`,脚本兼容 `GH_OWNER/GH_REPO_NAME`,所有脚本内 `gh issue/pr ...` 必带 `--repo "$GH_REPO_SLUG"`,所有 `gh api repos/...` 必用 `repos/$GH_REPO_SLUG/...`。旧 host 若只有 `GH_OWNER/GH_REPO` 且 `GH_REPO` 是 repo 名,脚本会拼成 slug,但新配置不再使用裸 `GH_REPO`。
 
-### Rust 测试节奏(host 适配)
+### Host 测试节奏(host 适配)
 
-`cargo test` 必带 `--test-threads=1`(permit 池 / cwd 等共享 fs 状态,并行会 race 出假失败);测试读源码文件用 `CARGO_MANIFEST_DIR` 锚定路径,勿用相对路径(被其它测试 chdir 污染)。
+测试命令由 host.env 的 `$TEST_CMD` 注入。若 host 测试共享 permit 池、cwd 或其他 filesystem 状态,必须在 host 项目的 `$PROJECT_RULES` / `$CI_GUARDS` 中声明串行化或稳定性约束;skill prompt 不推断具体测试框架或语言默认值。
 
 <a id="sentinel-and-comment-filters"></a>
 ## ⭐ 核心原则:GitHub 是系统状态唯一显示面(强制)
@@ -582,7 +582,7 @@ the work-unit fields documented in `REFERENCE.md` (`work_unit_id`, `kind`, `prod
   and `verification_hints`. It must not fabricate `cluster_id` or `legacy_cluster_id`.
 
 - Two clusters that touch the same `$BUILD_CMD 目标/工程文件` or share a file path go in different batches.
-- Two clusters that touch the same proto file → different batches.
+- Two clusters that touch the same schema/protocol file → different batches.
 
 ### requires_design clusters → open GitHub issue, do NOT auto-implement
 
@@ -595,7 +595,7 @@ For every cluster with `requires_design: true`:
      --label "refactor-design-needed,auto-loop" \
      --body "$(envsubst < <skill-root>/prompts/design-issue-body.md)"
    ```
-   The body template at `prompts/design-issue-body.md` includes: the cluster's YAML block from audit, full evidence section, the audit's `Fix boundary` paragraph, and an explicit "decision needed" checklist (proto schema? new contract? backward-compat strategy? whether to split into multiple PRs?).
+   The body template at `prompts/design-issue-body.md` includes: the cluster's YAML block from audit, full evidence section, the audit's `Fix boundary` paragraph, and an explicit "decision needed" checklist (schema/protocol change? new contract? backward-compat strategy? whether to split into multiple PRs?).
 2. Record in state.json:
    ```json
    "design_pending": [
@@ -1429,7 +1429,7 @@ fi
 4. meta-judge 仲裁 → 3/3 unanimous → 才能进 implement
 5. 不允许跳过 3 solver round 直接 implement(哪怕 maintainer 觉得方向很明显)
 
-理由:maintainer 直觉常常对,但 concrete 落地的细节(新 actor 边界 / proto 字段 / 命名 / 迁移路径)需要 3 个独立角度验证,避免单 codex 把 "明显方向" 误读成 "明显方案"。consensus 这步就是 catch 误读用的。
+理由:maintainer 直觉常常对,但 concrete 落地的细节(新 actor 边界 / schema 字段 / 命名 / 迁移路径)需要 3 个独立角度验证,避免单 codex 把 "明显方向" 误读成 "明显方案"。consensus 这步就是 catch 误读用的。
 
 ### Maintainer-reply-resets-the-round (mandatory)
 
@@ -2091,8 +2091,8 @@ Policy: **源文件内部 English-only;源文件之外的 user-facing artifact �
 | **代码内 doc comment / xmldoc / 其他注释** | **英文** |
 | **代码内 log / error / panic 字符串** | **英文** |
 | **代码内构造的 commit-body 模板字符串** | **英文** |
-| 代码 identifier / 类名 / 方法名 / 字段 | 英文(原 .NET / 项目惯例) |
-| proto / yaml 结构 | 英文 |
+| 代码 identifier / 类名 / 方法名 / 字段 | 英文(遵循 host / 项目惯例) |
+| schema / data 结构 | 英文 |
 | CLI 命令 / 文件路径 / SHA / URL | 英文 |
 | CLAUDE/AGENTS 条款 verbatim 引用 / error message / test name / 第三方英文 quote | 引用原文,不翻译 |
 
@@ -2368,7 +2368,7 @@ Goal: parallel safety. Two clusters can be in the same batch **only if** all fou
 
 1. `scope_paths` file overlap = 0.
 2. They touch different `$BUILD_CMD 目标/工程文件` files (compile-time isolation).
-3. They touch different proto files.
+3. They touch different schema/protocol files.
 4. Their `dependencies:` lists don't reference each other.
 
 Greedy bin-packing:

--- a/skills/codex-refactor-loop/prompts/_github-post-rules.md
+++ b/skills/codex-refactor-loop/prompts/_github-post-rules.md
@@ -34,7 +34,7 @@ escalation / consensus pick **必须**给清晰"方案 1/2/3"表格,cell 一行�
 ## 硬约束
 
 - **第一行 `## 🤖 ` 开头**:本 skill 的 `scripts/comment-monitor.sh` 据此识别 controller-post 跳过 👀 react。漏 🤖 → monitor 会把你的 post 当成 maintainer 评论 react 自己 → 误循环。
-- **中文 only**:per [SKILL.md 工作语言规则],不要平行 EN section。Code identifier / file path / proto 字段名保留原英文。CLAUDE/AGENTS 条款引用 verbatim 不翻译。
+- **中文 only**:per [SKILL.md 工作语言规则],不要平行 EN section。Code identifier / file path / schema field names 保留原英文。CLAUDE/AGENTS 条款引用 verbatim 不翻译。
 - **TL;DR ≤ 6 行**(3 bullet + 可选 cc 行)。
 - **raw artifact 必折叠**:不要让 TL;DR 之后立刻出现 raw YAML / verbatim spec dump。先用人话讲,raw 都进 `<details>`。
 - **No jargon dumps**:每个技术词(如 `IActorDispatchPort`)首次出现要一句话解释("actor 之间发命令的标准通道")。

--- a/skills/codex-refactor-loop/prompts/audit.md
+++ b/skills/codex-refactor-loop/prompts/audit.md
@@ -59,7 +59,7 @@ rg -n "<stringly typed identity / routing / subscription patterns>" $SOURCE_GLOB
 - **边界可控**：单 cluster 改动 ≤ 30 文件（小重构 ≤ 15）。
 - **不新增功能**：只清理违反位置；禁扩 scope。
 - **明确归因**：清楚 old/new pattern，后者直接写进代码注释。
-- **设计违规允许大 cluster**：如果是"需先定协议 / actor 化 / proto 迁移"的深层违规，**不要因为 >30 文件就拒绝**，标 `requires_design` 让 controller 决定是否拆。
+- **设计违规允许大 cluster**：如果是"需先定协议 / actor 化 / schema 迁移"的深层违规，**不要因为 >30 文件就拒绝**，标 `requires_design` 让 controller 决定是否拆。
 
 每个 cluster 输出含：
 

--- a/skills/codex-refactor-loop/prompts/design-issue-body.md
+++ b/skills/codex-refactor-loop/prompts/design-issue-body.md
@@ -1,6 +1,6 @@
 # ${PROBLEM_TITLE}
 
-<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+<!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 > 请用中文回复。Code identifier、file path、错误消息和条款引用可以保留原文。
 
@@ -36,7 +36,7 @@ ${WHY_NEEDS_DESIGN}
 
 - [ ] **模式选择**：${DESIGN_QUESTION}
 - [ ] **Schema 影响**：若 `${HOST_PROTO_POLICY}` 非空,按该 host schema/protocol 策略回答。如需新增 typed field 或 schema/protocol 变更,按 host 约定列出；无变更请明确说明。
-- [ ] **向后兼容**：现有持久态如何处理？（reserved 字段号 / type alias / schema migration / 可接受的重置）
+- [ ] **向后兼容**：现有持久态如何处理？（reserved identifier / compatibility alias / schema migration / 可接受的重置）
 - [ ] **Scope 拆分**：保留单 cluster 还是拆 N 个 PR？拆则给出 cluster id 草案。
 - [ ] **测试面**：除了下方 cluster spec 里 `verification_hints` 之外，**必须**被测试的行为？
 - [ ] **越界禁地**：implement codex **不应**碰的地方？

--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -1,6 +1,6 @@
 # 任务：实施 ${WORK_UNIT_ID}
 
-<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+<!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 你以无人值守模式在 worktree `${WORKTREE_PATH}` 中工作，对应分支 `${BRANCH}`。
 当前 v1 audit-backed work unit 的兼容 cluster alias 是 `${CLUSTER_ID}`；审计段查找、既有 artifact 文件名、分支/worktree 名和 marker 仍使用该 alias。

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -56,7 +56,7 @@ If a solver emits `escalate:no-plan:<reason>`, treat it like an `abstain` with s
 
 Take the 3 solvers' `verdict` + their `Recommended framing` summary:
 
-- **3/3 propose AND framings agree** (same boundary, same files, ≤30% LOC delta variance, no contradictory choices on naming / proto / migration, including any philosophy/CLAUDE.md/SPEC/Tier edits): **CONSENSUS REACHED** → go to Step 4.
+- **3/3 propose AND framings agree** (same boundary, same files, ≤30% LOC delta variance, no contradictory choices on naming / schema / migration, including any philosophy/CLAUDE.md/SPEC/Tier edits): **CONSENSUS REACHED** → go to Step 4.
 - **Mixed propose/abstain/escalate:no-plan (e.g., 2 propose + 1 abstain) AND the 2 proposers' framings agree**: **NOT unanimous**; go to Step 4 convergence OR escalate based on Step 4 logic.
 - **3/3 propose but framings disagree** (different files / different abstractions / different cost profiles): split — go to Step 4 convergence.
 - **3/3 abstain**: cluster is not solvable as scoped yet; converge with a narrower question unless the stall trigger already applies.

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -43,7 +43,7 @@ Categorize each demand into one of:
 For each fix:
 - Open the file fully (not just the hunk) to make a context-aware change.
 - Preserve refactor self-doc comment style: when fixing a refactored type/method, the `// Refactor (iterN/cluster-XXX):` block must remain (or be added if missing).
-- New test files: name `*Tests.cs`, single behavior per test, no `sleep/delay`, no `[Skip]`, no mock-only assertions.
+- New test files: follow existing host test naming conventions, single behavior per test, no `sleep/delay`, no `[Skip]`, no mock-only assertions.
 - New non-test code stays minimal and reuses existing patterns.
 
 ### Step 3 — Local verification

--- a/skills/codex-refactor-loop/prompts/reviewer-architect.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-architect.md
@@ -1,6 +1,6 @@
 # Role: Architect reviewer (CLAUDE.md compliance angle)
 
-<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+<!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 You are reviewing PR **${PR_NUMBER}** (`${PR_TITLE}`) against `${BASE_BRANCH}` from an **architecture compliance** perspective.
 

--- a/skills/codex-refactor-loop/prompts/reviewer-tests.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-tests.md
@@ -1,6 +1,6 @@
 # Role: Tests reviewer (test coverage + test quality angle)
 
-<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+<!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 You are reviewing PR **${PR_NUMBER}** (`${PR_TITLE}`) against `${BASE_BRANCH}` from a **test quality** perspective.
 

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -49,7 +49,7 @@ verdict: propose | abstain | escalate
 - Files: <list with intended action per file>
 - LOC delta: ~+N / -M
 - Tests to add/modify: <list>
-- Philosophy/PROJECT_RULES/SPEC/Tier change (if any): <exact file/clause + from X to Y + why worth it + why consensus can hold, OR "none">
+- Governance/ruleset change (if any): <exact file/clause + from X to Y + why worth it + why consensus can hold, OR "none">
 - Migration path: <single-step; "no migration needed" is also valid>
 
 ## Risks

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -55,8 +55,8 @@ verdict: propose | abstain | escalate
 - Files: <list with intended action per file>
 - LOC delta: ~+N / -M
 - Tests to add: <list with what behavior each asserts>
-- proto changes (if any): <field name + number + .proto file>
-- Philosophy/PROJECT_RULES/SPEC/Tier changes (if any): <exact file/clause + from X to Y + why worth it + why consensus can hold, OR "none">
+- Schema/protocol changes (if any): <identifier + compatibility impact + schema/protocol file>
+- Governance/ruleset changes (if any): <exact file/clause + from X to Y + why worth it + why consensus can hold, OR "none">
 - Runtime cost: <latency estimate, allocation estimate>
 
 ## Risks

--- a/skills/codex-refactor-loop/prompts/test-add.md
+++ b/skills/codex-refactor-loop/prompts/test-add.md
@@ -1,6 +1,6 @@
 # 任务：补测试覆盖重构引入的未覆盖代码 — ${CLUSTER_ID}
 
-<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+<!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 worktree: `${WORKTREE_PATH}`，分支 `${BRANCH}`。
 

--- a/skills/codex-refactor-loop/prompts/verify.md
+++ b/skills/codex-refactor-loop/prompts/verify.md
@@ -1,6 +1,6 @@
 # 任务：验证 ${WORK_UNIT_ID} 的实施改动
 
-<!-- Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识) -->
+<!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 你以无人值守模式在 worktree `${WORKTREE_PATH}` 中工作。前一个 codex 已完成实施，改动在工作树未提交。
 当前 v1 audit-backed work unit 的兼容 cluster alias 是 `${CLUSTER_ID}`；既有实施摘要、artifact 文件名和 marker 仍使用该 alias。

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -3026,6 +3026,51 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
             with self.subTest(alias=alias):
                 self.assertNotIn(alias, combined)
 
+    def test_cross_platform_prompts_and_reference_have_no_host_specific_defaults(self) -> None:
+        checked = self.rel_paths(
+            "skills/codex-refactor-loop/prompts/*.md",
+            "skills/codex-refactor-loop/REFERENCE.md",
+        )
+        forbidden_literals = (
+            "C#",
+            ".NET",
+            "protobuf",
+            "Protobuf",
+            "proto changes",
+            "proto /",
+            ".proto",
+            "Tier-N",
+            "SPEC-N",
+            "cargo",
+            "Rust",
+            ".csproj",
+            ".fsproj",
+            "test/**/*.cs",
+            "*Tests.cs",
+            "<TypeName>Tests.cs",
+            "```csharp",
+            "Directory.Packages.props",
+            "NuGet",
+            "如改 proto，必须本地重生成",
+            "if the diff touches `.proto`",
+            "Pure DTO / record proto fields exempt",
+        )
+        forbidden_patterns = (
+            r"\bTier [0-9]+\b",
+            r"\bSPEC-[0-9]+\b",
+            r"(?<!HOST_)\bproto\b",
+        )
+
+        for path in checked:
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            text = path.read_text(encoding="utf-8")
+            for literal in forbidden_literals:
+                with self.subTest(path=rel, literal=literal):
+                    self.assertNotIn(literal, text)
+            for pattern in forbidden_patterns:
+                with self.subTest(path=rel, pattern=pattern):
+                    self.assertIsNone(re.search(pattern, text))
+
     def test_host_language_policy_replaces_old_prompt_defaults(self) -> None:
         scoped_prompts = {
             "test-add.md": ("HOST_TEST_FILE_GLOBS", "HOST_TEST_NAMING_RULE", "HOST_COMMENT_RULE", "HOST_CODE_FENCE_LANG"),
@@ -3049,7 +3094,7 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
             "if the diff touches `.proto`",
             "Pure DTO / record proto fields exempt",
         )
-        host_comment = "Refactor (iter3/skill-host-language-policy): Old: 写死 C#/.NET/proto 默认  New: 6 个 HOST_* 可选空默认,host.env 注入(#20 structural 共识)"
+        host_comment = "Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus)"
 
         for prompt_name, required_names in scoped_prompts.items():
             text = (SKILL_ROOT / "prompts" / prompt_name).read_text(encoding="utf-8")


### PR DESCRIPTION
## 共识来源

- 设计 issue: #112
- Phase 9 r3: META_JUDGE_DONE:consensus:delete(framing: `delete residual host defaults and expand existing table-driven source-regression`)
- artifact: `.refactor-loop/runs/phase9-issue112-r3-judge.md`

## 改动概览

Phase 9 r3 三 solver 一致选 `propose`:不新增 `PromptHostPolicyProjection`,不改 CLAUDE.md/SKILL.md 同义不变量,只在 active prompts 和 REFERENCE 哲学段把残留 host-specific 字面词(`.proto`/`Tier`/`SPEC`/C# 风格示例等)替换为现有 6 个 `HOST_*` 字段 + `$PROJECT_RULES` + `$SOURCE_GLOBS` + diff evidence 的引用。

- 13 prompt 文件:替换残留 host 默认 → `${HOST_*}` 占位
- `REFERENCE.md`:对齐 language policy details 段
- `test_ensure_project_rules_fixed_points.py`:新增 `test_cross_platform_prompts_and_reference_have_no_host_specific_defaults` table-driven source-regression
- 23 host-specific lines 删除,349 tests passing

## 验证

```bash
cd skills/codex-refactor-loop && python3 -m unittest discover -s scripts -p 'test_*.py' 2>&1 | tail -5
```

## scope

仅 `skills/codex-refactor-loop/prompts/` + `REFERENCE.md` + `scripts/test_ensure_project_rules_fixed_points.py`。无 SKILL.md / CLAUDE.md / runtime 行为变更。

⟦AI:AUTO-LOOP⟧