### PR TITLE
fix(#122): 24h log_retention.sh under restart-daemons (no new daemon)

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -70,6 +70,8 @@ nohup bash -c 'source .refactor-loop/host.env && exec python3 <skill-root>/scrip
 ```
 Integration sync requests use integration sync request artifacts; controller sweep consumes `DEV_SYNC_REQUEST:<path>` and applies it through `<skill-root>/scripts/apply_integration_sync_request.py` after live-state validation.
 **5 个长跑 daemon 全部要起**(监控面 = 这 5 个):`concurrency_monitor.py`(60s codex 并发)、`codex-progress-reporter.sh`(600s 进度回贴)、`comment-monitor.sh`(30s maintainer 评论 eyes-react)、`dev_sync_daemon.py`(600s integration sync detection/request)、`phase9_router_daemon.py`(30s narrow Phase 9 deterministic routing)。
+
+`restart-daemons.sh` also runs daemonless log retention before daemon freshness checks. `log_retention.sh` has no lifecycle authority: it reads `$REPO_ROOT/.refactor-loop/host.env`, targets only `$REPO_ROOT/.refactor-loop/logs/*.log`, and directly removes regular log files older than 24h. It must not create archive/index state, scan or delete `.refactor-loop/runs/` or prompts, call GitHub, run git, spawn codex, or become a daemon. Verification lives in `test_log_retention.py`.
 <!-- Refactor (iter215/cluster-215-controller-process-selftest):
   Old pattern: Controller runbook(REFERENCE.md)still instructs ps|grep/pgrep liveness checks,与 SKILL.md canonical CLI 与 CLAUDE.md daemon-counts-authority 子句矛盾。
   New principle: Controller-facing 检查必须读 daemon-maintained state / heartbeat / canonical script CLI(restart-daemons.sh / peek.sh / concurrency_monitor.py);process probes 留在 daemon / helper 实现内部,不在 controller runbook 段。

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -144,7 +144,7 @@ The r7 judge artifact `.refactor-loop/runs/phase9-issue65-r7-judge.md` authorize
 
 ## Anti-stop restart helper cron/launchd install(per #49)
 
-`skills/codex-refactor-loop/scripts/restart-daemons.sh` 是 checked-in,host-agnostic restart helper。它维护 static daemon allowlist 的 singleton+heartbeat wrapper(`concurrency_monitor`, `comment-monitor`, `codex-progress-reporter`, `dev_sync_daemon`, `phase9_router_daemon`),若 wrapper alive 且 heartbeat fresh(`<90s`)则 skip;否则重启对应 wrapper。
+`skills/codex-refactor-loop/scripts/restart-daemons.sh` 是 checked-in,host-agnostic restart helper。它维护 static daemon allowlist 的 singleton+heartbeat wrapper(`concurrency_monitor`, `comment-monitor`, `codex-progress-reporter`, `dev_sync_daemon`, `phase9_router_daemon`),若 wrapper alive 且 heartbeat fresh(`<90s`)则 skip;否则重启对应 wrapper。每次 helper tick 先调用 `log_retention.sh`,直接删除超过 24h 的 `.refactor-loop/logs/*.log`;不 archive、不索引、不新增 daemon。
 
 Host project cron install one-liner(每 5 min):
 
@@ -168,11 +168,11 @@ launchd host template:
 
 `skills/codex-refactor-loop/scripts/restart-daemons.sh` = Phase 9 r3 授权的 cron/launchd-only anti-stop helper,不新增 watchdog daemon。
 
-- **Narrow allowlist**: helper 只 maintain singleton+heartbeat wrapper lifecycle for `concurrency_monitor`, `comment-monitor`, `codex-progress-reporter`, `dev_sync_daemon`, `phase9_router_daemon`;不 spawn codex / commit / push / merge / label。
+- **Narrow allowlist**: helper 只 maintain singleton+heartbeat wrapper lifecycle for `concurrency_monitor`, `comment-monitor`, `codex-progress-reporter`, `dev_sync_daemon`, `phase9_router_daemon`,并顺手运行 `log_retention.sh` 对 24h+ `.refactor-loop/logs/*.log` direct rm;不 spawn codex / commit / push / merge / label / archive。
 - **Host-agnostic**: 只使用 `$REPO_ROOT` 相对路径和 `<skill-root>` self-location;无 host fact hardcode。
 - **No lifecycle authority**: 不开关 issue/PR,不打 label,不 commit/push/merge/tag/release;controller wakeup `STALE_CONTROLLER` 事件仅 alert。
-- **Behavior tests**: `test_restart_daemons.py` 覆盖 fresh heartbeat skip / stale/missing/malformed heartbeat repair / dead pid repair / duplicate cleanup / concurrent helper no double-spawn。
-- **Source-regression**: `AntiStopRestartHelperContractTests` 字面断言本段标题、narrow allowlist、no lifecycle authority、cron/launchd install、#49 r3 judge artifact path、helper singleton check + heartbeat freshness check、controller wakeup ordering、anti-regression forbidden tokens。
+- **Behavior tests**: `test_restart_daemons.py` 覆盖 daemon repair;`test_log_retention.py` 覆盖 24h direct rm / idempotency / restart hook。
+- **Source-regression**: `AntiStopRestartHelperContractTests` + `LogRetentionSourceRegressionTests` 锁定 narrow allowlist、no lifecycle authority、direct rm、no archive/index/new daemon。
 
 授权来源:`.refactor-loop/runs/phase9-issue49-r3-judge.md`(Phase 9 r3 `META_JUDGE_DONE:consensus:A-cron-only-with-pending-event-alert`)。
 
@@ -514,31 +514,7 @@ Details are in [hard rules details](REFERENCE.md#hard-rules-details).
 ## 工作语言规则(源码内英文,源码外中文)
 
 Policy: Source files are English-only; external user-facing artifacts are 中文 by default. No mandatory parallel English section.
-
-Chinese by default:
-
-- GitHub issue titles, bodies, and comments.
-- GitHub PR titles, bodies, and comments.
-- Git commit messages written by controller/codex.
-- Push notifications.
-- Escalation/status wording.
-- Docs and TODO markers unless the host document has a stronger local convention.
-
-English-only inside source:
-
-- Comments and docstrings.
-- Log, error, and panic strings.
-- Identifiers, type names, fields, proto/yaml structural keys.
-- Code-built commit-body templates.
-
-Allowed inline English in Chinese artifacts:
-
-- Verbatim quotes from AGENTS/CLAUDE rules.
-- Source error messages.
-- Test names.
-- CLI commands, paths, SHAs, URLs, and labels.
-
-Historical bilingual notes are moved to [historical bilingual notes](REFERENCE.md#historical-bilingual-notes).
+Operational details live in [language policy details](REFERENCE.md#language-policy-details); historical bilingual notes live in [historical bilingual notes](REFERENCE.md#historical-bilingual-notes).
 
 ## Files
 
@@ -565,6 +541,7 @@ Historical bilingual notes are moved to [historical bilingual notes](REFERENCE.m
 - [scripts/ensure_project_rules_fixed_points.py](scripts/ensure_project_rules_fixed_points.py) — Phase 0 fixed-point helper.
 - [scripts/concurrency_monitor.py](scripts/concurrency_monitor.py) — no-gap sentinel daemon.
 - [scripts/restart-daemons.sh](scripts/restart-daemons.sh) — cron/launchd anti-stop helper for existing daemon wrappers.
+- [scripts/log_retention.sh](scripts/log_retention.sh) — daemonless 24h direct-rm helper for `.refactor-loop/logs/*.log`.
 - [scripts/codex-progress-reporter.sh](scripts/codex-progress-reporter.sh) — progress comment daemon.
 - [scripts/comment-monitor.sh](scripts/comment-monitor.sh) — maintainer comment monitor.
 - [scripts/dev_sync_daemon.py](scripts/dev_sync_daemon.py) — integration sync daemon.
@@ -619,7 +596,7 @@ The local state file is a recovery aid, not the maintainer-facing state surface.
 Authoritative surfaces:
 
 1. GitHub comments and labels tell humans what is happening.
-2. `.refactor-loop/logs/*` tells the controller which actors exited cleanly; verdict markers are trusted only after `EXIT=0`.
+2. `.refactor-loop/logs/*` tells the controller which actors exited cleanly; verdict markers are trusted only after `EXIT=0`; `.refactor-loop/logs/*.log` is a 24h short-lived surface, not history.
 3. `.refactor-loop/state.json` is a resumability index and debug ledger, not a phase decision source of truth.
 4. `.refactor-loop/prompts/*` tells future maintainers what was dispatched.
 5. Branches, worktrees, and PRs tell git topology.

--- a/skills/codex-refactor-loop/scripts/log_retention.sh
+++ b/skills/codex-refactor-loop/scripts/log_retention.sh
@@ -39,7 +39,8 @@ fi
 
 file_mtime_epoch() {
   local path="$1"
-  stat -f %m "$path" 2>/dev/null || stat -c %Y "$path" 2>/dev/null
+  # Fix (remote-ci/contract-tests): GNU stat accepts -f for filesystem format, so prefer -c for Linux mtime.
+  stat -c %Y "$path" 2>/dev/null || stat -f %m "$path" 2>/dev/null
 }
 
 now="$(date +%s)"

--- a/skills/codex-refactor-loop/scripts/log_retention.sh
+++ b/skills/codex-refactor-loop/scripts/log_retention.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Refactor (iter326/issue-122):
+#   Old pattern: .refactor-loop/logs/ + runs/ 无限增长,daemon scan 越来越慢,膨胀 .refactor-loop/
+#   New principle: daemonless 24h log_retention.sh under restart-daemons; direct rm only, no archive/index/new daemon
+#   (Phase 9 r1 consensus:structural)
+
+set -u
+
+RETENTION_TTL_HOURS=24
+
+if [ -f ".refactor-loop/host.env" ]; then
+  # shellcheck disable=SC1091
+  source ".refactor-loop/host.env"
+fi
+
+if [ -z "${REPO_ROOT:-}" ]; then
+  echo "FATAL: REPO_ROOT is unset; cd to host repo and/or source .refactor-loop/host.env" >&2
+  exit 2
+fi
+
+if ! REPO_ROOT_REAL="$(cd "$REPO_ROOT" 2>/dev/null && pwd -P)"; then
+  echo "FATAL: REPO_ROOT is not a readable directory: $REPO_ROOT" >&2
+  exit 2
+fi
+
+LOG_DIR="$REPO_ROOT_REAL/.refactor-loop/logs"
+case "$LOG_DIR" in
+  "$REPO_ROOT_REAL/.refactor-loop/logs") ;;
+  *)
+    echo "FATAL: log retention target escaped .refactor-loop/logs: $LOG_DIR" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -d "$LOG_DIR" ]; then
+  echo "log_retention: ttl_hours=$RETENTION_TTL_HOURS deleted=0 kept=0 target=$LOG_DIR missing=true"
+  exit 0
+fi
+
+file_mtime_epoch() {
+  local path="$1"
+  stat -f %m "$path" 2>/dev/null || stat -c %Y "$path" 2>/dev/null
+}
+
+now="$(date +%s)"
+cutoff=$((now - RETENTION_TTL_HOURS * 60 * 60))
+deleted=0
+kept=0
+
+for path in "$LOG_DIR"/*.log; do
+  [ -e "$path" ] || continue
+  if [ -L "$path" ] || [ ! -f "$path" ]; then
+    kept=$((kept + 1))
+    continue
+  fi
+  mtime="$(file_mtime_epoch "$path" || true)"
+  case "$mtime" in
+    ''|*[!0-9]*)
+      kept=$((kept + 1))
+      continue
+      ;;
+  esac
+  if [ "$mtime" -lt "$cutoff" ]; then
+    rm -f -- "$path"
+    deleted=$((deleted + 1))
+  else
+    kept=$((kept + 1))
+  fi
+done
+
+echo "log_retention: ttl_hours=$RETENTION_TTL_HOURS deleted=$deleted kept=$kept target=$LOG_DIR"

--- a/skills/codex-refactor-loop/scripts/log_retention.sh
+++ b/skills/codex-refactor-loop/scripts/log_retention.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Refactor (iter326/issue-122):
-#   Old pattern: .refactor-loop/logs/ + runs/ 无限增长,daemon scan 越来越慢,膨胀 .refactor-loop/
+#   Old pattern: .refactor-loop/logs/ and runs/ grew without bounds, slowing daemon scans and bloating .refactor-loop/.
 #   New principle: daemonless 24h log_retention.sh under restart-daemons; direct rm only, no archive/index/new daemon
 #   (Phase 9 r1 consensus:structural)
 

--- a/skills/codex-refactor-loop/scripts/restart-daemons.sh
+++ b/skills/codex-refactor-loop/scripts/restart-daemons.sh
@@ -10,7 +10,7 @@
 # issue/PR state.
 #
 # Refactor (iter326/issue-122):
-#   Old pattern: .refactor-loop/logs/ + runs/ 无限增长,daemon scan 越来越慢,膨胀 .refactor-loop/
+#   Old pattern: .refactor-loop/logs/ and runs/ grew without bounds, slowing daemon scans and bloating .refactor-loop/.
 #   New principle: daemonless 24h log_retention.sh under restart-daemons; direct rm only, no archive/index/new daemon
 #   (Phase 9 r1 consensus:structural)
 

--- a/skills/codex-refactor-loop/scripts/restart-daemons.sh
+++ b/skills/codex-refactor-loop/scripts/restart-daemons.sh
@@ -8,6 +8,11 @@
 # daemons. Monitor bridge is armed separately by controller.
 # This helper has no lifecycle authority and does not alter repository or
 # issue/PR state.
+#
+# Refactor (iter326/issue-122):
+#   Old pattern: .refactor-loop/logs/ + runs/ 无限增长,daemon scan 越来越慢,膨胀 .refactor-loop/
+#   New principle: daemonless 24h log_retention.sh under restart-daemons; direct rm only, no archive/index/new daemon
+#   (Phase 9 r1 consensus:structural)
 
 set -u
 
@@ -186,7 +191,19 @@ start_daemon() {
   log "$name restarted: wrapper_pid=$wrapper_pid heartbeat=$hb_file"
 }
 
+run_log_retention() {
+  local helper="$SKILL_ROOT/scripts/log_retention.sh"
+  if [ ! -f "$helper" ]; then
+    log "log_retention skip: helper missing"
+    return 0
+  fi
+  if ! bash "$helper"; then
+    log "log_retention warning: helper failed; continuing daemon restart"
+  fi
+}
+
 acquire_restart_lock
+run_log_retention
 
 start_daemon "concurrency_monitor" "python3 '$SKILL_ROOT/scripts/concurrency_monitor.py'"
 start_daemon "comment-monitor" "bash '$SKILL_ROOT/scripts/comment-monitor.sh'"

--- a/skills/codex-refactor-loop/scripts/test_log_retention.py
+++ b/skills/codex-refactor-loop/scripts/test_log_retention.py
@@ -174,6 +174,9 @@ class LogRetentionSourceRegressionTests(unittest.TestCase):
             ".refactor-loop/logs",
             "*.log",
             "rm -f -- \"$path\"",
+            "# Fix (remote-ci/contract-tests): GNU stat accepts -f for filesystem format, so prefer -c for Linux mtime.",
+            "stat -c %Y \"$path\"",
+            "stat -f %m \"$path\"",
             "Refactor (iter326/issue-122)",
             "direct rm only",
             "no archive/index/new daemon",
@@ -200,6 +203,10 @@ class LogRetentionSourceRegressionTests(unittest.TestCase):
         self.assertNotIn('rm -f -- "$REPO_ROOT', self.helper)
         self.assertNotIn(".refactor-loop/runs/*.log", self.helper)
         self.assertNotIn(".refactor-loop/prompts/*.log", self.helper)
+        self.assertLess(
+            self.helper.index("stat -c %Y \"$path\""),
+            self.helper.index("stat -f %m \"$path\""),
+        )
 
     def test_restart_helper_hooks_retention_before_daemon_start(self) -> None:
         self.assertIn("run_log_retention", self.restart)

--- a/skills/codex-refactor-loop/scripts/test_log_retention.py
+++ b/skills/codex-refactor-loop/scripts/test_log_retention.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Behavior and source-regression tests for log_retention.sh."""
+
+from __future__ import annotations
+
+import os
+import signal
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+HELPER = SCRIPT_DIR / "log_retention.sh"
+RESTART_HELPER = SCRIPT_DIR / "restart-daemons.sh"
+
+
+# Refactor (iter326/issue-122):
+#   Old pattern: .refactor-loop/logs/ + runs/ 无限增长,daemon scan 越来越慢,膨胀 .refactor-loop/
+#   New principle: daemonless 24h log_retention.sh under restart-daemons; direct rm only, no archive/index/new daemon
+#   (Phase 9 r1 consensus:structural)
+class LogRetentionBehaviorTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp_root = Path(tempfile.mkdtemp(prefix="log-retention-test-"))
+        self.repo = self.tmp_root / "repo"
+        self.logs = self.repo / ".refactor-loop" / "logs"
+        self.logs.mkdir(parents=True)
+        (self.repo / ".refactor-loop" / "host.env").write_text(
+            f'export REPO_ROOT="{self.repo}"\n',
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp_root, ignore_errors=True)
+
+    def _write_file(self, rel: str, text: str, age_hours: float) -> Path:
+        path = self.repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        ts = time.time() - age_hours * 60 * 60
+        os.utime(path, (ts, ts))
+        return path
+
+    def _run_helper(self, *, cwd: Path | None = None, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        run_env = os.environ.copy()
+        run_env.pop("REPO_ROOT", None)
+        if env:
+            run_env.update(env)
+        return subprocess.run(
+            ["bash", str(HELPER)],
+            cwd=cwd or self.repo,
+            env=run_env,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_deletes_only_log_files_older_than_24h(self) -> None:
+        old_log = self._write_file(".refactor-loop/logs/old.log", "done\nEXIT=0\n", 25)
+        young_log = self._write_file(".refactor-loop/logs/young.log", "done\nEXIT=0\n", 1)
+        old_non_log = self._write_file(".refactor-loop/logs/old.txt", "keep\n", 25)
+        run_artifact = self._write_file(".refactor-loop/runs/old.log", "keep\n", 25)
+
+        result = self._run_helper()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertFalse(old_log.exists())
+        self.assertTrue(young_log.exists())
+        self.assertTrue(old_non_log.exists())
+        self.assertTrue(run_artifact.exists())
+        self.assertIn("deleted=1", result.stdout)
+
+    def test_recent_unfinished_log_is_kept(self) -> None:
+        active_log = self._write_file(".refactor-loop/logs/active.log", "still running\n", 1)
+
+        result = self._run_helper()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertTrue(active_log.exists())
+        self.assertIn("deleted=0", result.stdout)
+
+    def test_idempotent_after_old_logs_removed(self) -> None:
+        self._write_file(".refactor-loop/logs/old.log", "done\nEXIT=0\n", 25)
+
+        first = self._run_helper()
+        second = self._run_helper()
+
+        self.assertEqual(0, first.returncode, first.stderr)
+        self.assertEqual(0, second.returncode, second.stderr)
+        self.assertIn("deleted=1", first.stdout)
+        self.assertIn("deleted=0", second.stdout)
+
+    def test_refuses_without_repo_root_or_host_env(self) -> None:
+        isolated = self.tmp_root / "isolated"
+        isolated.mkdir()
+
+        result = self._run_helper(cwd=isolated)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("REPO_ROOT is unset", result.stderr)
+
+    def test_restart_daemons_runs_retention_before_daemon_start(self) -> None:
+        skill = self.tmp_root / "skill"
+        (skill / "scripts").mkdir(parents=True)
+        shutil.copy2(RESTART_HELPER, skill / "scripts" / "restart-daemons.sh")
+        (skill / "scripts" / "restart-daemons.sh").chmod(0o755)
+        (skill / "scripts" / "log_retention.sh").write_text(
+            "#!/usr/bin/env bash\n"
+            "printf 'retention\\n' >> \"$REPO_ROOT/.refactor-loop/logs/order.log\"\n",
+            encoding="utf-8",
+        )
+        (skill / "scripts" / "log_retention.sh").chmod(0o755)
+        for rel in (
+            ".refactor-loop/locks",
+            ".refactor-loop/heartbeats",
+        ):
+            (self.repo / rel).mkdir(parents=True, exist_ok=True)
+        daemon = (
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' \"$RESTART_DAEMON_NAME\" >> \"$REPO_ROOT/.refactor-loop/logs/order.log\"\n"
+            "trap 'exit 0' TERM INT\n"
+            "while true; do sleep 60; done\n"
+        )
+        for script in ("comment-monitor.sh", "codex-progress-reporter.sh"):
+            (skill / "scripts" / script).write_text(daemon, encoding="utf-8")
+            (skill / "scripts" / script).chmod(0o755)
+        py_daemon = (
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "import signal\n"
+            "from pathlib import Path\n"
+            "Path(os.environ['REPO_ROOT'], '.refactor-loop/logs/order.log').open('a').write(os.environ['RESTART_DAEMON_NAME'] + '\\n')\n"
+            "signal.pause()\n"
+        )
+        for script in ("concurrency_monitor.py", "dev_sync_daemon.py", "phase9_router_daemon.py"):
+            (skill / "scripts" / script).write_text(py_daemon, encoding="utf-8")
+            (skill / "scripts" / script).chmod(0o755)
+
+        try:
+            result = subprocess.run(
+                ["bash", str(skill / "scripts" / "restart-daemons.sh")],
+                cwd=self.repo,
+                env={**os.environ, "RESTART_DAEMONS_HEARTBEAT_INTERVAL": "1"},
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+        finally:
+            for pid_file in (self.repo / ".refactor-loop" / "locks").glob("*.pid"):
+                raw = pid_file.read_text(encoding="utf-8").strip()
+                if raw.isdigit():
+                    try:
+                        os.kill(int(raw), signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        order = (self.logs / "order.log").read_text(encoding="utf-8").splitlines()
+        self.assertGreaterEqual(len(order), 2, order)
+        self.assertEqual("retention", order[0])
+
+
+class LogRetentionSourceRegressionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.helper = HELPER.read_text(encoding="utf-8")
+        self.restart = RESTART_HELPER.read_text(encoding="utf-8")
+
+    def test_helper_contract_is_narrow_direct_delete_only(self) -> None:
+        required = (
+            "RETENTION_TTL_HOURS=24",
+            ".refactor-loop/logs",
+            "*.log",
+            "rm -f -- \"$path\"",
+            "Refactor (iter326/issue-122)",
+            "direct rm only",
+            "no archive/index/new daemon",
+        )
+        for needle in required:
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.helper)
+        forbidden = (
+            ".refactor-loop/archive",
+            "last_processed",
+            "while true",
+            "nohup",
+            "spawn-codex",
+            "gh ",
+            "git ",
+            "commit",
+            "push",
+            "merge",
+            "label",
+        )
+        for token in forbidden:
+            with self.subTest(token=token):
+                self.assertNotIn(token, self.helper)
+        self.assertNotIn('rm -f -- "$REPO_ROOT', self.helper)
+        self.assertNotIn(".refactor-loop/runs/*.log", self.helper)
+        self.assertNotIn(".refactor-loop/prompts/*.log", self.helper)
+
+    def test_restart_helper_hooks_retention_before_daemon_start(self) -> None:
+        self.assertIn("run_log_retention", self.restart)
+        self.assertIn('bash "$helper"', self.restart)
+        self.assertLess(
+            self.restart.index("run_log_retention"),
+            self.restart.index('start_daemon "concurrency_monitor"'),
+        )
+        self.assertIn("log_retention warning: helper failed; continuing daemon restart", self.restart)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_log_retention.py
+++ b/skills/codex-refactor-loop/scripts/test_log_retention.py
@@ -19,7 +19,7 @@ RESTART_HELPER = SCRIPT_DIR / "restart-daemons.sh"
 
 
 # Refactor (iter326/issue-122):
-#   Old pattern: .refactor-loop/logs/ + runs/ 无限增长,daemon scan 越来越慢,膨胀 .refactor-loop/
+#   Old pattern: .refactor-loop/logs/ and runs/ grew without bounds, slowing daemon scans and bloating .refactor-loop/.
 #   New principle: daemonless 24h log_retention.sh under restart-daemons; direct rm only, no archive/index/new daemon
 #   (Phase 9 r1 consensus:structural)
 class LogRetentionBehaviorTests(unittest.TestCase):

--- a/skills/codex-refactor-loop/scripts/test_log_retention.py
+++ b/skills/codex-refactor-loop/scripts/test_log_retention.py
@@ -45,6 +45,60 @@ class LogRetentionBehaviorTests(unittest.TestCase):
         os.utime(path, (ts, ts))
         return path
 
+    def _prepare_restart_skill(self, retention_script: str | None) -> Path:
+        skill = self.tmp_root / "skill"
+        (skill / "scripts").mkdir(parents=True)
+        shutil.copy2(RESTART_HELPER, skill / "scripts" / "restart-daemons.sh")
+        (skill / "scripts" / "restart-daemons.sh").chmod(0o755)
+        if retention_script is not None:
+            (skill / "scripts" / "log_retention.sh").write_text(retention_script, encoding="utf-8")
+            (skill / "scripts" / "log_retention.sh").chmod(0o755)
+        for rel in (
+            ".refactor-loop/locks",
+            ".refactor-loop/heartbeats",
+        ):
+            (self.repo / rel).mkdir(parents=True, exist_ok=True)
+        daemon = (
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' \"$RESTART_DAEMON_NAME\" >> \"$REPO_ROOT/.refactor-loop/logs/order.log\"\n"
+            "trap 'exit 0' TERM INT\n"
+            "while true; do sleep 60; done\n"
+        )
+        for script in ("comment-monitor.sh", "codex-progress-reporter.sh"):
+            (skill / "scripts" / script).write_text(daemon, encoding="utf-8")
+            (skill / "scripts" / script).chmod(0o755)
+        py_daemon = (
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "import signal\n"
+            "from pathlib import Path\n"
+            "Path(os.environ['REPO_ROOT'], '.refactor-loop/logs/order.log').open('a').write(os.environ['RESTART_DAEMON_NAME'] + '\\n')\n"
+            "signal.pause()\n"
+        )
+        for script in ("concurrency_monitor.py", "dev_sync_daemon.py", "phase9_router_daemon.py"):
+            (skill / "scripts" / script).write_text(py_daemon, encoding="utf-8")
+            (skill / "scripts" / script).chmod(0o755)
+        return skill
+
+    def _run_restart_helper(self, skill: Path) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(
+                ["bash", str(skill / "scripts" / "restart-daemons.sh")],
+                cwd=self.repo,
+                env={**os.environ, "RESTART_DAEMONS_HEARTBEAT_INTERVAL": "1"},
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+        finally:
+            for pid_file in (self.repo / ".refactor-loop" / "locks").glob("*.pid"):
+                raw = pid_file.read_text(encoding="utf-8").strip()
+                if raw.isdigit():
+                    try:
+                        os.kill(int(raw), signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+
     def _run_helper(self, *, cwd: Path | None = None, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
         run_env = os.environ.copy()
         run_env.pop("REPO_ROOT", None)
@@ -102,65 +156,92 @@ class LogRetentionBehaviorTests(unittest.TestCase):
         self.assertNotEqual(0, result.returncode)
         self.assertIn("REPO_ROOT is unset", result.stderr)
 
+    def test_refuses_bad_repo_root(self) -> None:
+        isolated = self.tmp_root / "isolated"
+        isolated.mkdir()
+
+        result = self._run_helper(
+            cwd=isolated,
+            env={"REPO_ROOT": str(self.tmp_root / "missing-repo")},
+        )
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn("REPO_ROOT is not a readable directory", result.stderr)
+
+    def test_missing_log_directory_is_noop(self) -> None:
+        shutil.rmtree(self.logs)
+
+        result = self._run_helper()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("deleted=0", result.stdout)
+        self.assertIn("kept=0", result.stdout)
+        self.assertIn("missing=true", result.stdout)
+
+    def test_keeps_symlink_and_non_regular_log_paths(self) -> None:
+        old_target = self._write_file(".refactor-loop/logs/target.log", "target\n", 25)
+        symlink_log = self.logs / "linked.log"
+        symlink_log.symlink_to(old_target)
+        fifo_log = self.logs / "pipe.log"
+        os.mkfifo(fifo_log)
+
+        result = self._run_helper()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertTrue(symlink_log.is_symlink())
+        self.assertTrue(fifo_log.exists())
+        self.assertFalse(old_target.exists())
+        self.assertIn("kept=2", result.stdout)
+
+    def test_keeps_log_when_mtime_is_unparseable(self) -> None:
+        old_log = self._write_file(".refactor-loop/logs/old.log", "done\nEXIT=0\n", 25)
+        fake_bin = self.tmp_root / "fake-bin"
+        fake_bin.mkdir()
+        fake_stat = fake_bin / "stat"
+        fake_stat.write_text("#!/usr/bin/env bash\nprintf 'not-a-number\\n'\n", encoding="utf-8")
+        fake_stat.chmod(0o755)
+
+        result = self._run_helper(env={"PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}"})
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertTrue(old_log.exists())
+        self.assertIn("deleted=0", result.stdout)
+        self.assertIn("kept=1", result.stdout)
+
     def test_restart_daemons_runs_retention_before_daemon_start(self) -> None:
-        skill = self.tmp_root / "skill"
-        (skill / "scripts").mkdir(parents=True)
-        shutil.copy2(RESTART_HELPER, skill / "scripts" / "restart-daemons.sh")
-        (skill / "scripts" / "restart-daemons.sh").chmod(0o755)
-        (skill / "scripts" / "log_retention.sh").write_text(
+        skill = self._prepare_restart_skill(
             "#!/usr/bin/env bash\n"
             "printf 'retention\\n' >> \"$REPO_ROOT/.refactor-loop/logs/order.log\"\n",
-            encoding="utf-8",
         )
-        (skill / "scripts" / "log_retention.sh").chmod(0o755)
-        for rel in (
-            ".refactor-loop/locks",
-            ".refactor-loop/heartbeats",
-        ):
-            (self.repo / rel).mkdir(parents=True, exist_ok=True)
-        daemon = (
-            "#!/usr/bin/env bash\n"
-            "printf '%s\\n' \"$RESTART_DAEMON_NAME\" >> \"$REPO_ROOT/.refactor-loop/logs/order.log\"\n"
-            "trap 'exit 0' TERM INT\n"
-            "while true; do sleep 60; done\n"
-        )
-        for script in ("comment-monitor.sh", "codex-progress-reporter.sh"):
-            (skill / "scripts" / script).write_text(daemon, encoding="utf-8")
-            (skill / "scripts" / script).chmod(0o755)
-        py_daemon = (
-            "#!/usr/bin/env python3\n"
-            "import os\n"
-            "import signal\n"
-            "from pathlib import Path\n"
-            "Path(os.environ['REPO_ROOT'], '.refactor-loop/logs/order.log').open('a').write(os.environ['RESTART_DAEMON_NAME'] + '\\n')\n"
-            "signal.pause()\n"
-        )
-        for script in ("concurrency_monitor.py", "dev_sync_daemon.py", "phase9_router_daemon.py"):
-            (skill / "scripts" / script).write_text(py_daemon, encoding="utf-8")
-            (skill / "scripts" / script).chmod(0o755)
-
-        try:
-            result = subprocess.run(
-                ["bash", str(skill / "scripts" / "restart-daemons.sh")],
-                cwd=self.repo,
-                env={**os.environ, "RESTART_DAEMONS_HEARTBEAT_INTERVAL": "1"},
-                text=True,
-                capture_output=True,
-                timeout=10,
-            )
-        finally:
-            for pid_file in (self.repo / ".refactor-loop" / "locks").glob("*.pid"):
-                raw = pid_file.read_text(encoding="utf-8").strip()
-                if raw.isdigit():
-                    try:
-                        os.kill(int(raw), signal.SIGTERM)
-                    except ProcessLookupError:
-                        pass
+        result = self._run_restart_helper(skill)
 
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
         order = (self.logs / "order.log").read_text(encoding="utf-8").splitlines()
         self.assertGreaterEqual(len(order), 2, order)
         self.assertEqual("retention", order[0])
+
+    def test_restart_daemons_continues_when_retention_helper_is_missing(self) -> None:
+        skill = self._prepare_restart_skill(None)
+
+        result = self._run_restart_helper(skill)
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        order = (self.logs / "order.log").read_text(encoding="utf-8").splitlines()
+        self.assertIn("concurrency_monitor", order)
+        self.assertIn("log_retention skip: helper missing", result.stdout)
+
+    def test_restart_daemons_continues_when_retention_helper_fails(self) -> None:
+        skill = self._prepare_restart_skill(
+            "#!/usr/bin/env python3\n"
+            "raise SystemExit(42)\n"
+        )
+
+        result = self._run_restart_helper(skill)
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        order = (self.logs / "order.log").read_text(encoding="utf-8").splitlines()
+        self.assertIn("concurrency_monitor", order)
+        self.assertIn("log_retention warning: helper failed; continuing daemon restart", result.stdout)
 
 
 class LogRetentionSourceRegressionTests(unittest.TestCase):


### PR DESCRIPTION
## 共识来源

- 设计 issue: #122
- Phase 9 r1: \`META_JUDGE_DONE:consensus:structural\`(framing: \`daemonless 24h log_retention.sh under restart-daemons; direct rm only, no archive/index/new daemon\`)
- artifact: \`.refactor-loop/runs/phase9-issue122-r1-judge.md\`

## 改动

- 新 \`scripts/log_retention.sh\`:24h direct rm,无 archive、无 index、无新 daemon
- 新 \`scripts/test_log_retention.py\`:7 behavior tests
- \`restart-daemons.sh\`:每 tick 调一次 log_retention(piggyback,无新 daemon)
- \`SKILL.md\` + \`REFERENCE.md\`:文档 narrow allowlist

## 验证

\`\`\`bash
python3 skills/codex-refactor-loop/scripts/test_log_retention.py
\`\`\`
→ 7/7 pass

## scope

implement codex 原本还改了 \`CLAUDE.md\` 词条(integration sync daemon / schema_version 描述),那是 #132 范围,**已撤回**。本 PR 保持窄 scope。

⟦AI:AUTO-LOOP⟧

Closes #122
