### PR TITLE
refactor(#118): posting-mode prompt 自声明,删除漂移 roster

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -1115,13 +1115,14 @@ The controller's only inline composition allowed for GitHub:
 EVERYTHING ELSE(reviewer verdict、fix-done body、consensus 公告、escalation rationale、design issue body、cross-post 通知、PR description 包括 rollup PR)由**正在跑的那个 codex 自己 post**,**不需要专门的 writer-codex 中介**:
 
 <!--
-# Refactor (iter3/skill-github-post-contract):
-#   Old: 宽泛 all-prompts direct-post 主张
-#   New: 两组明确 roster + 可枚举行为测试(#13 structural 共识)
+Refactor (iter6/issue-118):
+  Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
+  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
 -->
 
-- Direct-post prompts: `solver-minimal.md`, `solver-structural.md`, `solver-delete.md`, `meta-judge.md`, `reviewer-architect.md`, `reviewer-quality.md`, `reviewer-tests.md`, `review-fix.md`, `design-issue-reply.md`, `triage-external-issue.md`. Only these prompts must contain a `## GitHub post` section referencing `prompts/_github-post-rules.md`.
-- Marker/artifact-only prompts: `audit.md`, `design-issue-body.md`, `implement.md`, `verify.md`, `remote-ci-fix.md`, `test-add.md`. They keep the AI sentinel plus their marker/body contract, are surfaced by controller / PR / CI status, and must not claim direct posting.
+- A prompt is direct-post only when its own body contains a `## GitHub post` section referencing `prompts/_github-post-rules.md`; prompts without that self-declaration are marker/artifact-only.
+- `SKILL.md` / `REFERENCE.md` 不维护 posting-mode prompt filename roster,也不引入 JSON manifest 或 helper contract; inventory coverage 由 prompt body + tests 承担。
+- Direct-post prompts keep to GitHub comments, PR body edits, reactions, and temp files. Lifecycle/label/create/close/merge/push/release authority remains controller-owned.
 - body 必须 `## 🤖 <headline>` 开头(comment-monitor.sh 据此识别 controller-post 跳 react)
 - 中文 only / TL;DR ≤ 6 行 / raw artifact 折叠 `<details>` / 若 situation 给 `original_authors:` 加 `📢 cc`
 - codex 自己抓 gh 输出的 URL,打 `POSTED:<role>:<N>:<URL>:<headline>` 或 `POST_FAILED:...`

--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -1117,7 +1117,7 @@ EVERYTHING ELSE(reviewer verdict、fix-done body、consensus 公告、escalation
 <!--
 Refactor (iter6/issue-118):
   Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
-  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
 -->
 
 - A prompt is direct-post only when its own body contains a `## GitHub post` section referencing `prompts/_github-post-rules.md`; prompts without that self-declaration are marker/artifact-only.

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -762,7 +762,7 @@ Recovery rules:
 <!--
 Refactor (iter6/issue-118):
   Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
-  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
 -->
 
 Posting rules:

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -759,37 +759,22 @@ Recovery rules:
 
 ## GitHub Posting Contract
 
-Direct-post prompts:
-
-- `design-issue-body.md`
-- `design-issue-reply.md`
-- `_github-post-rules.md` inclusions where the prompt explicitly posts to GitHub
-
-Marker/artifact-only prompts:
-
-- `audit.md`
-- `implement.md`
-- `verify.md`
-- `remote-ci-fix.md`
-- `review-fix.md`
-- `reviewer-architect.md`
-- `reviewer-tests.md`
-- `reviewer-quality.md`
-- `solver-minimal.md`
-- `solver-structural.md`
-- `solver-delete.md`
-- `meta-judge.md`
-- `test-add.md`
-- `triage-external-issue.md`
+<!--
+Refactor (iter6/issue-118):
+  Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
+  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+-->
 
 Posting rules:
 
 1. Controller posts lifecycle banners directly.
-2. Worker prompts post only when their prompt explicitly owns a GitHub reply/body.
+2. A worker prompt is direct-post only when its own body contains `## GitHub post` and references `prompts/_github-post-rules.md`.
 3. Every GitHub body uses the sentinel final line.
 4. Avoid plain-text unverified human names or handles.
-5. Whitelisted mentions come from `$MAINTAINER_WHITELIST`.
-6. Label changes require a banner explaining the reason.
+5. `SKILL.md` and `REFERENCE.md` must not maintain a posting-mode prompt filename roster; inventory tests derive posting mode from prompt bodies.
+6. Direct-post permission is limited to GitHub comments, PR body edits, reactions, and temp files; lifecycle, labels, create/close/merge, push, and release stay controller-owned.
+7. Whitelisted mentions come from `$MAINTAINER_WHITELIST`.
+8. Label changes require a banner explaining the reason.
 
 ## Anchor Read Policy
 

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -134,9 +134,15 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## Hard rules
 
+<!--
+Refactor (iter6/issue-118):
+  Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
+  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+-->
+
 - You do NOT propose a solution; you ARBITRATE between proposals.
 - You do NOT dispatch other codexes; controller does.
-- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below). controller does.
+- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below).
 - Be willing to converge on philosophy. Fundamental philosophy gaps are not human escalation by themselves; ask the solvers for exact clause/Tier/SPEC changes until consensus or true stall.
 - Treat deep consensus as sufficient authorization. Never require post-consensus human approval, physical GPG ratification, or Tier I reinstall ratification.
 - Do not invent a 4th hybrid framing not present in any solver — that means you're solving, not judging. If no solver covers the right framing → converge with "no solver covers correct framing; propose exact framing" unless the stall trigger already applies.

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -137,7 +137,7 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 <!--
 Refactor (iter6/issue-118):
   Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
-  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
 -->
 
 - You do NOT propose a solution; you ARBITRATE between proposals.

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -91,7 +91,7 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 <!--
 Refactor (iter6/issue-118):
   Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
-  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
 -->
 
 - You do NOT write code; you propose a plan.

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -88,9 +88,15 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## Hard rules
 
+<!--
+Refactor (iter6/issue-118):
+  Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
+  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+-->
+
 - You do NOT write code; you propose a plan.
 - You do NOT commit / push / open PRs.
-- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below).(controller posts).
+- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below).
 - You do NOT dispatch other codexes.
 - "Minimal" means smallest code change; it does NOT mean "ignore architectural correctness". If the minimum is still wrong, abstain.
 - Philosophy is evolvable: touching CLAUDE.md/L0/L1/L2, Tier boundaries, SPEC, or architecture vocabulary is allowed when it is the minimum viable fix and is written as a concrete plan.

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -972,53 +972,76 @@ class ProjectRulesPromptContractTests(unittest.TestCase):
         self.assertIn("$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}", phase0)
         self.assertIn("fail closed", phase0)
 
-    # Refactor (iter3/skill-github-post-contract):
-    #   Old: broad all-prompts direct-post claim.
-    #   New: two explicit rosters plus enumerable behavior tests
-    #   (#13 structural consensus).
-    def test_github_post_contract_matches_prompt_roster(self) -> None:
+    # Refactor (iter6/issue-118):
+    #   Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
+    #   New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+    def test_github_post_contract_is_prompt_self_declared(self) -> None:
         prompts_root = SKILL_ROOT / "prompts"
         skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
-        direct_post_prompts = {
-            "solver-minimal.md",
-            "solver-structural.md",
-            "solver-delete.md",
-            "meta-judge.md",
-            "reviewer-architect.md",
-            "reviewer-quality.md",
-            "reviewer-tests.md",
-            "review-fix.md",
-            "design-issue-reply.md",
-            "triage-external-issue.md",
-        }
-        marker_only_prompts = {
-            "audit.md",
-            "design-issue-body.md",
-            "implement.md",
-            "meta-reflector-stalled.md",
-            "verify.md",
-            "remote-ci-fix.md",
-            "test-add.md",
-        }
-        prompt_inventory = {path.name for path in prompts_root.glob("*.md")} - {"_github-post-rules.md"}
+        reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+        prompt_paths = sorted(path for path in prompts_root.glob("*.md") if path.name != "_github-post-rules.md")
 
-        self.assertEqual(prompt_inventory, direct_post_prompts | marker_only_prompts)
-        self.assertFalse(direct_post_prompts & marker_only_prompts)
-        self.assertIn("Direct-post prompts", skill_text)
-        self.assertIn("Marker/artifact-only prompts", skill_text)
+        self.assertGreater(len(prompt_paths), 0)
         self.assertNotIn("所有 prompts 末尾都有 `## GitHub post (强制)`", skill_text)
 
-        for prompt_name in sorted(direct_post_prompts):
-            text = (prompts_root / prompt_name).read_text(encoding="utf-8")
-            with self.subTest(prompt=prompt_name, contract="direct-post"):
-                self.assertIn("## GitHub post", text)
-                self.assertIn("_github-post-rules.md", text)
+        direct_post_prompts = []
+        marker_only_prompts = []
+        for prompt_path in prompt_paths:
+            text = prompt_path.read_text(encoding="utf-8")
+            if re.search(r"(?m)^## GitHub post", text):
+                direct_post_prompts.append(prompt_path)
+            else:
+                marker_only_prompts.append(prompt_path)
 
-        for prompt_name in sorted(marker_only_prompts):
-            text = (prompts_root / prompt_name).read_text(encoding="utf-8")
-            with self.subTest(prompt=prompt_name, contract="marker-only"):
+        self.assertGreater(len(direct_post_prompts), 0)
+        self.assertGreater(len(marker_only_prompts), 0)
+
+        for prompt_path in direct_post_prompts:
+            text = prompt_path.read_text(encoding="utf-8")
+            with self.subTest(prompt=prompt_path.name, contract="direct-post"):
+                self.assertIn("## GitHub post", text)
+                self.assertIn("prompts/_github-post-rules.md", text)
+                self.assertIn("⟦AI:AUTO-LOOP⟧", text)
+                self.assertTrue(
+                    "POSTED:" in text or "遵循 `prompts/_github-post-rules.md`" in text,
+                    f"{prompt_path.name} must either spell out post flow or delegate to shared post rules",
+                )
+                for token in ("gh pr create", "gh pr merge", "gh issue create", "gh issue close", "git commit", "git push", "git checkout"):
+                    lines = [
+                        line
+                        for line in text.splitlines()
+                        if token in line and "Old pattern:" not in line
+                    ]
+                    for line in lines:
+                        assert_denial_or_controller_owner_context(self, line, token=token)
+
+        for prompt_path in marker_only_prompts:
+            text = prompt_path.read_text(encoding="utf-8")
+            with self.subTest(prompt=prompt_path.name, contract="marker-only"):
                 self.assertNotIn("## GitHub post", text)
                 self.assertIn("⟦AI:AUTO-LOOP⟧", text)
+                self.assertNotIn("You DO post to GitHub directly", text)
+                self.assertNotIn("自己调 `gh` post", text)
+                self.assertNotIn("Post 后打印 `POSTED:", text)
+
+        for source_name, source_text in (("SKILL.md", skill_text), ("REFERENCE.md", reference_text)):
+            with self.subTest(source=source_name, contract="no-roster"):
+                self.assertNotIn("Direct-post prompts:", source_text)
+                self.assertNotIn("Marker/artifact-only prompts:", source_text)
+                self.assertIn("prompt body", source_text)
+                self.assertIn("## GitHub post", source_text)
+
+        for forbidden in (
+            SKILL_ROOT / "prompts" / "posting-contract.json",
+            SKILL_ROOT / "scripts" / "prompt_posting_contract.py",
+        ):
+            with self.subTest(forbidden_path=forbidden.name):
+                self.assertFalse(forbidden.exists())
+
+        for text in (skill_text, reference_text):
+            self.assertNotIn("PromptGitHubPostingContract", text)
+            self.assertNotIn("posting-contract.json", text)
+            self.assertNotIn("prompt_posting_contract.py", text)
 
     # Refactor (issue79/r8-consensus-no-implementation-helper-fork):
     #   Old pattern: implement-from-design could grow a second intake/helper prompt or producer registry abstraction.

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -974,7 +974,7 @@ class ProjectRulesPromptContractTests(unittest.TestCase):
 
     # Refactor (iter6/issue-118):
     #   Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
-    #   New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+    #   New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
     def test_github_post_contract_is_prompt_self_declared(self) -> None:
         prompts_root = SKILL_ROOT / "prompts"
         skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
@@ -1030,6 +1030,33 @@ class ProjectRulesPromptContractTests(unittest.TestCase):
                 self.assertNotIn("Marker/artifact-only prompts:", source_text)
                 self.assertIn("prompt body", source_text)
                 self.assertIn("## GitHub post", source_text)
+
+        skill_posting_contract = skill_text.split("## GitHub Posting Contract", 1)[1].split("## Anchor Read Policy", 1)[0]
+        reference_traceability = reference_text.split("### GitHub traceability", 1)[1].split("**@-mention rule:**", 1)[0]
+        former_roster_tokens = (
+            "solver-minimal.md",
+            "solver-structural.md",
+            "solver-delete.md",
+            "meta-judge.md",
+            "reviewer-tests.md",
+            "reviewer-quality.md",
+            "reviewer-architect.md",
+            "review-fix.md",
+            "design-issue-reply.md",
+            "triage-external-issue.md",
+            "audit.md",
+            "implement.md",
+            "verify.md",
+            "remote-ci-fix.md",
+            "test-add.md",
+        )
+        for source_name, posting_section in (
+            ("SKILL.md GitHub Posting Contract", skill_posting_contract),
+            ("REFERENCE.md GitHub traceability", reference_traceability),
+        ):
+            for token in former_roster_tokens:
+                with self.subTest(source=source_name, forbidden_roster_token=token):
+                    self.assertNotIn(token, posting_section)
 
         for forbidden in (
             SKILL_ROOT / "prompts" / "posting-contract.json",

--- a/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
@@ -74,7 +74,7 @@ def prompts_with_marker_only_ban() -> list[Path]:
 class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
     # Refactor (iter6/issue-118):
     #   Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
-    #   New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+    #   New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
     def test_marker_only_prompts_with_ban_block_have_complete_lifecycle_ban(self) -> None:
         paths = prompts_with_marker_only_ban()
         self.assertGreater(len(paths), 0)

--- a/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
@@ -16,14 +16,6 @@ DENIAL_OR_CONTROLLER_OWNER_RE = re.compile(
     r"not allowed|marker/artifact-only|lifecycle / label .*controller|controller[^.\n]*(owns|owner|拥有|归|创 PR)"
 )
 
-MARKER_ONLY_PROMPTS = (
-    "audit.md",
-    "implement.md",
-    "verify.md",
-    "remote-ci-fix.md",
-    "test-add.md",
-)
-
 REQUIRED_BAN_SUBSTRINGS = (
     "## codex ",
     "iter5/prompt-gh-ban-marker-only",
@@ -55,43 +47,69 @@ FORBIDDEN_DIRECT_LIFECYCLE_SNIPPETS = (
     "git rebase",
 )
 
+AFFIRMATIVE_DIRECT_POST_SNIPPETS = (
+    "You DO post to GitHub directly",
+    "自己调 `gh` post",
+    "Post 后打印 `POSTED:",
+)
+
+
+def prompt_paths() -> list[Path]:
+    return sorted(path for path in PROMPTS_DIR.glob("*.md") if path.name != "_github-post-rules.md")
+
+
+def marker_only_prompt_paths() -> list[Path]:
+    return [path for path in prompt_paths() if not re.search(r"(?m)^## GitHub post", path.read_text(encoding="utf-8"))]
+
+
+def prompts_with_marker_only_ban() -> list[Path]:
+    paths = []
+    for path in marker_only_prompt_paths():
+        body = path.read_text(encoding="utf-8")
+        if "## codex " in body or "marker/artifact-only" in body:
+            paths.append(path)
+    return paths
+
 
 class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
-    def test_each_marker_only_prompt_has_complete_ban_section(self) -> None:
-        for filename in MARKER_ONLY_PROMPTS:
-            with self.subTest(prompt=filename):
-                path = PROMPTS_DIR / filename
-                self.assertTrue(path.exists(), f"missing prompt: {filename}")
+    # Refactor (iter6/issue-118):
+    #   Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
+    #   New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 DESIGN_DECISION_PATH
+    def test_marker_only_prompts_with_ban_block_have_complete_lifecycle_ban(self) -> None:
+        paths = prompts_with_marker_only_ban()
+        self.assertGreater(len(paths), 0)
+        for path in paths:
+            with self.subTest(prompt=path.name):
                 body = path.read_text(encoding="utf-8")
                 for needle in REQUIRED_BAN_SUBSTRINGS:
                     self.assertIn(
                         needle,
                         body,
-                        f"{filename} missing required ban-section token `{needle}`",
+                        f"{path.name} missing required ban-section token `{needle}`",
                     )
                 self.assertRegex(body, r"(?m)^## codex .+$")
 
     def test_refactor_self_doc_block_present(self) -> None:
-        for filename in MARKER_ONLY_PROMPTS:
-            with self.subTest(prompt=filename):
-                body = (PROMPTS_DIR / filename).read_text(encoding="utf-8")
+        for path in prompts_with_marker_only_ban():
+            with self.subTest(prompt=path.name):
+                body = path.read_text(encoding="utf-8")
                 self.assertIn(
                     "Refactor (iter5/prompt-gh-ban-marker-only)",
                     body,
-                    f"{filename} missing Refactor self-doc block",
+                    f"{path.name} missing Refactor self-doc block",
                 )
 
     def test_lifecycle_tokens_only_appear_in_ban_lines(self) -> None:
-        for filename in MARKER_ONLY_PROMPTS:
-            body = (PROMPTS_DIR / filename).read_text(encoding="utf-8")
+        for path in prompts_with_marker_only_ban():
+            body = path.read_text(encoding="utf-8")
             ban_section_match = re.search(r"(?ms)^## codex .+?(?=^## |\Z)", body)
-            self.assertIsNotNone(ban_section_match, filename)
+            self.assertIsNotNone(ban_section_match, path.name)
             ban_section = ban_section_match.group(0)
             for token in FORBIDDEN_DIRECT_LIFECYCLE_SNIPPETS:
                 for line in ban_section.splitlines():
                     if token not in line:
                         continue
-                    with self.subTest(prompt=filename, token=token, line=line):
+                    with self.subTest(prompt=path.name, token=token, line=line):
                         self.assertRegex(line, DENIAL_OR_CONTROLLER_OWNER_RE)
                 affirmative_lines = [
                     line
@@ -101,8 +119,19 @@ class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
                 self.assertEqual(
                     affirmative_lines,
                     [],
-                    f"{filename} mentions forbidden lifecycle token `{token}` outside denial/controller-owner context",
+                    f"{path.name} mentions forbidden lifecycle token `{token}` outside denial/controller-owner context",
                 )
+
+    def test_all_marker_only_prompts_forbid_affirmative_direct_post_wording(self) -> None:
+        paths = marker_only_prompt_paths()
+        self.assertGreater(len(paths), 0)
+        for path in paths:
+            body = path.read_text(encoding="utf-8")
+            with self.subTest(prompt=path.name):
+                self.assertNotIn("## GitHub post", body)
+                self.assertIn("⟦AI:AUTO-LOOP⟧", body)
+                for snippet in AFFIRMATIVE_DIRECT_POST_SNIPPETS:
+                    self.assertNotIn(snippet, body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 共识来源
- 设计 issue: #118
- Phase 9 r3: `META_JUDGE_DONE:consensus:prompt-self-declaration`
- artifact: `.refactor-loop/runs/phase9-issue118-r3-judge.md`

## 改动
删除 SKILL.md/REFERENCE.md 中漂移的 posting-mode prompt filename roster;posting mode 由 prompt body 自声明(`## GitHub post` + 引用 `_github-post-rules.md`),inventory tests 扫 `prompts/*.md` 派生强制。不新增 JSON manifest / contract 脚本。

## 验证
`python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → 359 OK

⟦AI:AUTO-LOOP⟧