### PR TITLE
refactor(#133): dispatch queue mutable-prefix cwd guard

### DIFF
--- a/skills/codex-refactor-loop/REFERENCE.md
+++ b/skills/codex-refactor-loop/REFERENCE.md
@@ -134,10 +134,18 @@ Allowed priority directories are `p0/`, `p1/`, and `p2/`; the monitor always che
 
 Required fields are `cd`, `prompt`, and `log`; `task_id` defaults to the `.dispatch.json` filename stem if omitted, and `stall` defaults to `5400` if omitted. Paths must be absolute so floor counting can still scope by `$REPO_ROOT`.
 
+Dispatch cwd guard:
+- `MUTABLE_DISPATCH_PREFIXES`: `implement-`, `fix-pr`, `remote-ci-fix`, `test-add-`, `verify-`, and `hotfix-`.
+- `MAIN_READONLY_DISPATCH_PREFIXES`: `audit-`, `phase9-issue`, `solver-`, `meta-judge-`, `review-pr`, and `reviewer-pr`.
+- Queued mutable task prefixes must use `cd` under `$REPO_ROOT/.worktrees/<name>/`; `$REPO_ROOT`, relative paths, paths outside `$REPO_ROOT`, and `$REPO_ROOT/.worktrees/` itself fail closed.
+- Main-readonly prefixes are the explicit allowlist that may use `$REPO_ROOT` as `cd`.
+- This is a backward-compatible tightening of the existing dispatch queue protocol: no shared workspace policy, no `workspace_policy.py`, no `WorkUnitWorkspace`, and no required `actor/work_unit_id` migration.
+
 Auto-dispatch semantics:
 - On each tick, if `actual < CODEX_FLOOR` and the queue is non-empty, the monitor launches at most `CODEX_FLOOR - actual` tasks via `<skill-root>/scripts/spawn-codex.sh --cd <cd> --prompt <prompt> --log <log> --stall <stall>`.
 - After each launch, the monitor archives the consumed file to `.refactor-loop/dispatch-dispatched/<task-id>.json`, adding `dispatch_at`, `priority`, and `source_dispatch_file` for audit trail.
 - The monitor writes `DISPATCH_FIRED:<task-id>:<priority>:<reason>` to `.refactor-loop/.controller-pending-events.log`.
+- If a queued mutable task violates the cwd guard, the monitor moves it to `.refactor-loop/dispatch-rejected/<task-id>.json`, adding `rejected_at`, `reject_reason`, `priority`, and `source_dispatch_file`, writes `DISPATCH_REJECTED:<task-id>:<priority>:main-worktree-cd:<reason>`, and continues scanning for the next legal queued item.
 - If `actual < CODEX_FLOOR` and the queue is empty, the monitor writes `CONCURRENCY_LOW:actual=N expected=M queue=0` so the controller can enqueue real work when one of the floor refill routes below is valid.
 - This daemon path is a narrow exception for mechanical controller-runtime dispatch; it does not add lifecycle authority or change marker routing.
 

--- a/skills/codex-refactor-loop/scripts/concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/concurrency_monitor.py
@@ -85,8 +85,11 @@ HEARTBEAT_STALE_SECONDS = 90
 PROGRESS_MARKER_RE = re.compile(r"\b(PHASE|REVIEW|FIX|META)[A-Z_]*:")
 DISPATCH_QUEUE = REPO_ROOT / ".refactor-loop" / "dispatch-queue"
 DISPATCH_DISPATCHED = REPO_ROOT / ".refactor-loop" / "dispatch-dispatched"
+DISPATCH_REJECTED = REPO_ROOT / ".refactor-loop" / "dispatch-rejected"
 SPAWN_CODEX = Path(__file__).resolve().parent / "spawn-codex.sh"
 PRIORITIES = ("p0", "p1", "p2")
+MUTABLE_DISPATCH_PREFIXES = ("implement-", "fix-pr", "remote-ci-fix", "test-add-", "verify-", "hotfix-")
+MAIN_READONLY_DISPATCH_PREFIXES = ("audit-", "phase9-issue", "solver-", "meta-judge-", "review-pr", "reviewer-pr")
 
 # Phase label -> expected codex count per active issue/PR.
 PHASE_EXPECTED = {
@@ -457,6 +460,61 @@ def archive_dispatched(path: Path, payload: dict, task_id: str) -> Path:
     return archive
 
 
+# Refactor (iter6/issue-133):
+#   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+#   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+def validate_dispatch_cwd(payload: dict, task_id: str) -> tuple[bool, str]:
+    cd_raw = payload.get("cd")
+    if not cd_raw:
+        return False, "missing-cd"
+    cd = Path(str(cd_raw))
+    if not cd.is_absolute():
+        return False, "relative-cd"
+
+    repo_root = REPO_ROOT.resolve()
+    worktrees_root = (REPO_ROOT / ".worktrees").resolve()
+    cd_resolved = cd.resolve()
+
+    try:
+        cd_resolved.relative_to(repo_root)
+    except ValueError:
+        return False, "outside-repo"
+
+    if task_id.startswith(MAIN_READONLY_DISPATCH_PREFIXES):
+        return True, "main-readonly-prefix"
+
+    if task_id.startswith(MUTABLE_DISPATCH_PREFIXES):
+        pass
+
+    if cd_resolved == repo_root:
+        return False, "repo-root-cd"
+    try:
+        cd_resolved.relative_to(worktrees_root)
+    except ValueError:
+        return False, "outside-worktrees"
+    if cd_resolved == worktrees_root:
+        return False, "worktrees-root-cd"
+    return True, "worktrees-cd"
+
+
+# Refactor (iter6/issue-133):
+#   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+#   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+def archive_rejected(path: Path, payload: dict, task_id: str, priority: str, reason: str) -> Path:
+    DISPATCH_REJECTED.mkdir(parents=True, exist_ok=True)
+    payload["rejected_at"] = utc_ts()
+    payload["reject_reason"] = reason
+    payload["priority"] = priority
+    payload["source_dispatch_file"] = str(path)
+    archive = DISPATCH_REJECTED / f"{task_id}.json"
+    if archive.exists():
+        stamp = payload["rejected_at"].replace(":", "").replace("-", "")
+        archive = DISPATCH_REJECTED / f"{task_id}-{stamp}.json"
+    archive.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    path.unlink()
+    return archive
+
+
 def launch_dispatch(payload: dict) -> None:
     subprocess.Popen(
         [
@@ -477,24 +535,29 @@ def launch_dispatch(payload: dict) -> None:
     )
 
 
-# Refactor (iter4/concurrency-auto-topup):
-#   Old pattern: controller-only dispatch; monitor could report deficits but did not consume queued work.
-#   New principle: monitor may fire one queued dispatch from the narrow dispatch-queue allowlist and archive it.
+# Refactor (iter6/issue-133):
+#   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+#   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
 def dispatch_one_from_queue() -> tuple[str, str, str] | None:
-    next_file = next_dispatch_file()
-    if next_file is None:
-        return None
-    priority, path = next_file
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    task_id = str(payload.get("task_id") or path.name.removesuffix(".dispatch.json"))
-    reason = str(payload.get("reason", ""))
-    payload["task_id"] = task_id
-    payload["priority"] = priority
-    launch_dispatch(payload)
-    archive_dispatched(path, payload, task_id)
-    write_pending_event(f"DISPATCH_FIRED:{task_id}:{priority}:{reason}")
-    log(f"DISPATCH_FIRED:{task_id}:{priority}:{reason}")
-    return task_id, priority, reason
+    for priority, path in dispatch_queue_files():
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        task_id = str(payload.get("task_id") or path.name.removesuffix(".dispatch.json"))
+        reason = str(payload.get("reason", ""))
+        payload["task_id"] = task_id
+        payload["priority"] = priority
+        ok, reject_reason = validate_dispatch_cwd(payload, task_id)
+        if not ok:
+            archive_rejected(path, payload, task_id, priority, reject_reason)
+            event = f"DISPATCH_REJECTED:{task_id}:{priority}:main-worktree-cd:{reject_reason}"
+            write_pending_event(event)
+            log(event)
+            continue
+        launch_dispatch(payload)
+        archive_dispatched(path, payload, task_id)
+        write_pending_event(f"DISPATCH_FIRED:{task_id}:{priority}:{reason}")
+        log(f"DISPATCH_FIRED:{task_id}:{priority}:{reason}")
+        return task_id, priority, reason
+    return None
 
 
 # Refactor (iter4/concurrency-auto-topup):

--- a/skills/codex-refactor-loop/scripts/concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/concurrency_monitor.py
@@ -440,13 +440,6 @@ def dispatch_queue_empty() -> bool:
     return not dispatch_queue_files()
 
 
-def next_dispatch_file() -> tuple[str, Path] | None:
-    files = dispatch_queue_files()
-    if not files:
-        return None
-    return files[0]
-
-
 def archive_dispatched(path: Path, payload: dict, task_id: str) -> Path:
     DISPATCH_DISPATCHED.mkdir(parents=True, exist_ok=True)
     payload["dispatch_at"] = utc_ts()
@@ -462,7 +455,7 @@ def archive_dispatched(path: Path, payload: dict, task_id: str) -> Path:
 
 # Refactor (iter6/issue-133):
 #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
-#   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+#   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
 def validate_dispatch_cwd(payload: dict, task_id: str) -> tuple[bool, str]:
     cd_raw = payload.get("cd")
     if not cd_raw:
@@ -483,9 +476,8 @@ def validate_dispatch_cwd(payload: dict, task_id: str) -> tuple[bool, str]:
     if task_id.startswith(MAIN_READONLY_DISPATCH_PREFIXES):
         return True, "main-readonly-prefix"
 
-    if task_id.startswith(MUTABLE_DISPATCH_PREFIXES):
-        pass
-
+    # Unknown prefixes are treated as mutable by default: fail closed unless
+    # the queued dispatch runs inside this repo's isolated worktrees root.
     if cd_resolved == repo_root:
         return False, "repo-root-cd"
     try:
@@ -499,7 +491,7 @@ def validate_dispatch_cwd(payload: dict, task_id: str) -> tuple[bool, str]:
 
 # Refactor (iter6/issue-133):
 #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
-#   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+#   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
 def archive_rejected(path: Path, payload: dict, task_id: str, priority: str, reason: str) -> Path:
     DISPATCH_REJECTED.mkdir(parents=True, exist_ok=True)
     payload["rejected_at"] = utc_ts()
@@ -537,7 +529,7 @@ def launch_dispatch(payload: dict) -> None:
 
 # Refactor (iter6/issue-133):
 #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
-#   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+#   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
 def dispatch_one_from_queue() -> tuple[str, str, str] | None:
     for priority, path in dispatch_queue_files():
         payload = json.loads(path.read_text(encoding="utf-8"))

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
@@ -75,6 +75,18 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
 
         return _fake_popen
 
+    def assert_dispatch_rejected(self, task_id: str, reason: str, calls: list[list[str]]) -> None:
+        self.assertEqual(calls, [])
+        self.assertFalse((self.refactor_loop / "dispatch-queue" / "p0" / f"{task_id}.dispatch.json").exists())
+        rejected = self.refactor_loop / "dispatch-rejected" / f"{task_id}.json"
+        self.assertTrue(rejected.exists())
+        payload = json.loads(rejected.read_text(encoding="utf-8"))
+        self.assertEqual(payload["reject_reason"], reason)
+        self.assertEqual(payload["priority"], "p0")
+        self.assertIn("source_dispatch_file", payload)
+        events = (self.refactor_loop / ".controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertIn(f"DISPATCH_REJECTED:{task_id}:p0:main-worktree-cd:{reason}", events)
+
     def test_monitor_dispatches_from_queue_when_below_floor(self) -> None:
         self.write_dispatch("p1", "fix-pr44-round-3")
         self.write_dispatch("p1", "audit-iter-5")
@@ -91,7 +103,7 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
 
     # Refactor (iter6/issue-133):
     #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
-    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
     def test_rejects_mutable_dispatch_to_repo_root(self) -> None:
         self.write_dispatch("p0", "fix-pr44-round-3", cd=self.repo)
         calls: list[list[str]] = []
@@ -100,20 +112,80 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
             fired = self.monitor.dispatch_one_from_queue()
 
         self.assertIsNone(fired)
-        self.assertEqual(calls, [])
-        self.assertFalse((self.refactor_loop / "dispatch-queue" / "p0" / "fix-pr44-round-3.dispatch.json").exists())
-        rejected = self.refactor_loop / "dispatch-rejected" / "fix-pr44-round-3.json"
-        self.assertTrue(rejected.exists())
-        payload = json.loads(rejected.read_text(encoding="utf-8"))
-        self.assertEqual(payload["reject_reason"], "repo-root-cd")
-        self.assertEqual(payload["priority"], "p0")
-        self.assertIn("source_dispatch_file", payload)
-        events = (self.refactor_loop / ".controller-pending-events.log").read_text(encoding="utf-8")
-        self.assertIn("DISPATCH_REJECTED:fix-pr44-round-3:p0:main-worktree-cd:repo-root-cd", events)
+        self.assert_dispatch_rejected("fix-pr44-round-3", "repo-root-cd", calls)
 
     # Refactor (iter6/issue-133):
     #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
-    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
+    def test_rejects_dispatch_missing_cd(self) -> None:
+        path = self.write_dispatch("p0", "fix-pr44-round-3")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        del payload["cd"]
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        calls: list[list[str]] = []
+
+        with mock.patch.object(self.monitor.subprocess, "Popen", side_effect=self.fake_popen(calls)):
+            fired = self.monitor.dispatch_one_from_queue()
+
+        self.assertIsNone(fired)
+        self.assert_dispatch_rejected("fix-pr44-round-3", "missing-cd", calls)
+
+    # Refactor (iter6/issue-133):
+    #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
+    def test_rejects_dispatch_relative_cd(self) -> None:
+        self.write_dispatch("p0", "fix-pr44-round-3", cd=Path(".worktrees/fix-pr44-round-3"))
+        calls: list[list[str]] = []
+
+        with mock.patch.object(self.monitor.subprocess, "Popen", side_effect=self.fake_popen(calls)):
+            fired = self.monitor.dispatch_one_from_queue()
+
+        self.assertIsNone(fired)
+        self.assert_dispatch_rejected("fix-pr44-round-3", "relative-cd", calls)
+
+    # Refactor (iter6/issue-133):
+    #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
+    def test_rejects_dispatch_cd_outside_repo(self) -> None:
+        outside_repo = self.repo.parent / "outside-repo"
+        self.write_dispatch("p0", "fix-pr44-round-3", cd=outside_repo)
+        calls: list[list[str]] = []
+
+        with mock.patch.object(self.monitor.subprocess, "Popen", side_effect=self.fake_popen(calls)):
+            fired = self.monitor.dispatch_one_from_queue()
+
+        self.assertIsNone(fired)
+        self.assert_dispatch_rejected("fix-pr44-round-3", "outside-repo", calls)
+
+    # Refactor (iter6/issue-133):
+    #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
+    def test_rejects_mutable_dispatch_inside_repo_but_outside_worktrees(self) -> None:
+        self.write_dispatch("p0", "fix-pr44-round-3", cd=self.repo / "tmp" / "fix-pr44-round-3")
+        calls: list[list[str]] = []
+
+        with mock.patch.object(self.monitor.subprocess, "Popen", side_effect=self.fake_popen(calls)):
+            fired = self.monitor.dispatch_one_from_queue()
+
+        self.assertIsNone(fired)
+        self.assert_dispatch_rejected("fix-pr44-round-3", "outside-worktrees", calls)
+
+    # Refactor (iter6/issue-133):
+    #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
+    def test_rejects_mutable_dispatch_to_worktrees_root(self) -> None:
+        self.write_dispatch("p0", "fix-pr44-round-3", cd=self.repo / ".worktrees")
+        calls: list[list[str]] = []
+
+        with mock.patch.object(self.monitor.subprocess, "Popen", side_effect=self.fake_popen(calls)):
+            fired = self.monitor.dispatch_one_from_queue()
+
+        self.assertIsNone(fired)
+        self.assert_dispatch_rejected("fix-pr44-round-3", "worktrees-root-cd", calls)
+
+    # Refactor (iter6/issue-133):
+    #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
     def test_accepts_mutable_dispatch_inside_worktrees(self) -> None:
         worktree = self.repo / ".worktrees" / "fix-pr44-round-3"
         self.write_dispatch("p0", "fix-pr44-round-3", cd=worktree)
@@ -131,7 +203,7 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
 
     # Refactor (iter6/issue-133):
     #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
-    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
     def test_allows_main_readonly_dispatch_prefixes(self) -> None:
         task_ids = ("audit-iter-5", "phase9-issue133-r4-minimal", "review-pr44-tests")
 
@@ -149,7 +221,7 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
 
     # Refactor (iter6/issue-133):
     #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
-    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
     def test_rejected_dispatch_does_not_block_next_queue_item(self) -> None:
         self.write_dispatch("p0", "fix-pr44-round-3", cd=self.repo)
         self.write_dispatch("p0", "fix-pr44-round-4", cd=self.repo / ".worktrees" / "fix-pr44-round-4")

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
@@ -36,7 +36,15 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
             pass
         self.tmp.cleanup()
 
-    def write_dispatch(self, priority: str, task_id: str, reason: str | None = None, *, include_task_id: bool = True) -> Path:
+    def write_dispatch(
+        self,
+        priority: str,
+        task_id: str,
+        reason: str | None = None,
+        *,
+        include_task_id: bool = True,
+        cd: Path | None = None,
+    ) -> Path:
         priority_dir = self.refactor_loop / "dispatch-queue" / priority
         priority_dir.mkdir(parents=True, exist_ok=True)
         prompt = self.refactor_loop / "prompts" / f"{task_id}.md"
@@ -44,8 +52,10 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
         prompt.parent.mkdir(parents=True, exist_ok=True)
         log.parent.mkdir(parents=True, exist_ok=True)
         prompt.write_text("prompt\n", encoding="utf-8")
+        if cd is None:
+            cd = self.repo if task_id.startswith(self.monitor.MAIN_READONLY_DISPATCH_PREFIXES) else self.repo / ".worktrees" / task_id
         payload = {
-            "cd": str(self.repo),
+            "cd": str(cd),
             "prompt": str(prompt),
             "log": str(log),
             "stall": 5400,
@@ -78,6 +88,83 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
         self.assertEqual(list((self.refactor_loop / "dispatch-queue" / "p1").glob("*.dispatch.json")), [])
         archived = sorted((self.refactor_loop / "dispatch-dispatched").glob("*.json"))
         self.assertEqual([p.name for p in archived], ["audit-iter-5.json", "fix-pr44-round-3.json"])
+
+    # Refactor (iter6/issue-133):
+    #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+    def test_rejects_mutable_dispatch_to_repo_root(self) -> None:
+        self.write_dispatch("p0", "fix-pr44-round-3", cd=self.repo)
+        calls: list[list[str]] = []
+
+        with mock.patch.object(self.monitor.subprocess, "Popen", side_effect=self.fake_popen(calls)):
+            fired = self.monitor.dispatch_one_from_queue()
+
+        self.assertIsNone(fired)
+        self.assertEqual(calls, [])
+        self.assertFalse((self.refactor_loop / "dispatch-queue" / "p0" / "fix-pr44-round-3.dispatch.json").exists())
+        rejected = self.refactor_loop / "dispatch-rejected" / "fix-pr44-round-3.json"
+        self.assertTrue(rejected.exists())
+        payload = json.loads(rejected.read_text(encoding="utf-8"))
+        self.assertEqual(payload["reject_reason"], "repo-root-cd")
+        self.assertEqual(payload["priority"], "p0")
+        self.assertIn("source_dispatch_file", payload)
+        events = (self.refactor_loop / ".controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertIn("DISPATCH_REJECTED:fix-pr44-round-3:p0:main-worktree-cd:repo-root-cd", events)
+
+    # Refactor (iter6/issue-133):
+    #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+    def test_accepts_mutable_dispatch_inside_worktrees(self) -> None:
+        worktree = self.repo / ".worktrees" / "fix-pr44-round-3"
+        self.write_dispatch("p0", "fix-pr44-round-3", cd=worktree)
+        calls: list[list[str]] = []
+
+        with mock.patch.object(self.monitor.subprocess, "Popen", side_effect=self.fake_popen(calls)):
+            fired = self.monitor.dispatch_one_from_queue()
+
+        self.assertEqual(fired, ("fix-pr44-round-3", "p0", "fix-pr44-round-3 needed"))
+        self.assertEqual(len(calls), 1)
+        cd_index = calls[0].index("--cd")
+        self.assertEqual(calls[0][cd_index + 1], str(worktree))
+        self.assertTrue((self.refactor_loop / "dispatch-dispatched" / "fix-pr44-round-3.json").exists())
+        self.assertFalse((self.refactor_loop / "dispatch-rejected").exists())
+
+    # Refactor (iter6/issue-133):
+    #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+    def test_allows_main_readonly_dispatch_prefixes(self) -> None:
+        task_ids = ("audit-iter-5", "phase9-issue133-r4-minimal", "review-pr44-tests")
+
+        for task_id in task_ids:
+            with self.subTest(task_id=task_id):
+                self.write_dispatch("p0", task_id, cd=self.repo)
+                calls: list[list[str]] = []
+
+                with mock.patch.object(self.monitor.subprocess, "Popen", side_effect=self.fake_popen(calls)):
+                    fired = self.monitor.dispatch_one_from_queue()
+
+                self.assertEqual(fired, (task_id, "p0", f"{task_id} needed"))
+                self.assertEqual(len(calls), 1)
+                self.assertTrue((self.refactor_loop / "dispatch-dispatched" / f"{task_id}.json").exists())
+
+    # Refactor (iter6/issue-133):
+    #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+    def test_rejected_dispatch_does_not_block_next_queue_item(self) -> None:
+        self.write_dispatch("p0", "fix-pr44-round-3", cd=self.repo)
+        self.write_dispatch("p0", "fix-pr44-round-4", cd=self.repo / ".worktrees" / "fix-pr44-round-4")
+        calls: list[list[str]] = []
+
+        with mock.patch.object(self.monitor.subprocess, "Popen", side_effect=self.fake_popen(calls)):
+            fired = self.monitor.dispatch_one_from_queue()
+
+        self.assertEqual(fired, ("fix-pr44-round-4", "p0", "fix-pr44-round-4 needed"))
+        self.assertEqual(len(calls), 1)
+        self.assertTrue((self.refactor_loop / "dispatch-rejected" / "fix-pr44-round-3.json").exists())
+        self.assertTrue((self.refactor_loop / "dispatch-dispatched" / "fix-pr44-round-4.json").exists())
+        events = (self.refactor_loop / ".controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertIn("DISPATCH_REJECTED:fix-pr44-round-3:p0:main-worktree-cd:repo-root-cd", events)
+        self.assertIn("DISPATCH_FIRED:fix-pr44-round-4:p0:fix-pr44-round-4 needed", events)
 
     def test_monitor_respects_priority_order(self) -> None:
         self.write_dispatch("p2", "p2-task")

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -1698,6 +1698,37 @@ class ConcurrencyFloorSourceRegressionTests(unittest.TestCase):
         self.assertIn("CONCURRENCY_LOW:actual=N expected=M queue=0", reference_text)
         self.assertEqual(reference_text.count("**判定脚本**(controller wakeup step 1.5):"), 1)
 
+    # Refactor (iter6/issue-133):
+    #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+    def test_dispatch_queue_workspace_guard_is_documented_and_enforced(self) -> None:
+        monitor_text = (SKILL_ROOT / "scripts" / "concurrency_monitor.py").read_text(encoding="utf-8")
+        reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+        combined = monitor_text + "\n" + reference_text
+
+        for required in (
+            "MUTABLE_DISPATCH_PREFIXES",
+            "MAIN_READONLY_DISPATCH_PREFIXES",
+            "validate_dispatch_cwd",
+            "archive_rejected",
+            ".worktrees",
+            "dispatch-rejected",
+            "DISPATCH_REJECTED",
+            "main-worktree-cd",
+            "no shared workspace policy",
+            "no required `actor/work_unit_id` migration",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, combined)
+
+        for forbidden in (
+            "workspace_policy.py",
+            "WorkUnitWorkspace",
+            "ActorWorkspacePolicy",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, monitor_text)
+
     # Refactor (existing-issue-priority): Old pattern: controller dispatched
     # fresh audit whenever floor was deficit, even when open auto-loop issues
     # in design-solving / pr-open / fixing had 0 codex. New principle:

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -1700,7 +1700,7 @@ class ConcurrencyFloorSourceRegressionTests(unittest.TestCase):
 
     # Refactor (iter6/issue-133):
     #   Old pattern: concurrency_monitor 把 queue payload[cd] 直接交给 spawn-codex.sh --cd,可让 mutable task 跑在 repo-root/main worktree
-    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 DESIGN_DECISION_PATH
+    #   New principle: structural consensus: dispatch queue mutable-prefix cwd guard,无 shared workspace policy。详见 .refactor-loop/runs/phase9-issue133-r4-judge.md
     def test_dispatch_queue_workspace_guard_is_documented_and_enforced(self) -> None:
         monitor_text = (SKILL_ROOT / "scripts" / "concurrency_monitor.py").read_text(encoding="utf-8")
         reference_text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## 共识来源
- 设计 issue: #133
- Phase 9 r4: `META_JUDGE_DONE:consensus:structural`
- artifact: `.refactor-loop/runs/phase9-issue133-r4-judge.md`

## 改动
`concurrency_monitor` 消费 dispatch queue 前校验 cwd:mutable 前缀 task 的 `cd` 必须在 `$REPO_ROOT/.worktrees/` 下,否则 reject 到 `dispatch-rejected/` 并发 `DISPATCH_REJECTED` 事件,继续扫描下一条;main-readonly 前缀允许 repo-root。无新 workspace policy 抽象、无 schema 迁移。

## 验证
`python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → 363 OK

⟦AI:AUTO-LOOP⟧