### PR TITLE
feat(#140): host.env.example 补全(v1.0 泛化 A)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -33,8 +33,13 @@ Use intra-file anchors when a phase needs the detailed body, such as [host runti
 
 ## Host 配置(通用化注入点)
 <!-- Refactor (iter1/issue-140):
-  Old pattern: 见 issue #140 与 design decision
-  New principle: 严格按 .refactor-loop/runs/phase9-issue140-r4-judge.md 的 consensus Implement plan 逐条落地;不超范围;改 SKILL.md 只动相关段(单文件)。
+  Old pattern: host.env.example documented only a subset of host
+  variables, so exported keys could drift from the SKILL.md Host config
+  and Host language policy tables.
+  New principle: keep host.env.example exports equal to the SKILL.md host
+  configuration table key set with source-regression coverage, while
+  reusing the existing host.env/SKILL.md surfaces instead of adding a new
+  schema or runtime contract.
 -->
 These variables are injected by the host project. The skill must not hardcode project facts.
 | Variable | Meaning | Default / example |

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -32,20 +32,33 @@ Use intra-file anchors when a phase needs the detailed body, such as [host runti
 | Language | Source files are English-only; external user-facing artifacts are 中文 by default. No mandatory parallel English section. | Enforce on prompts, GitHub posts, commits, docs, source comments/logs. | [language policy details](#language-policy-details), [historical bilingual notes](#historical-bilingual-notes) | prompts, docs, commit text |
 
 ## Host 配置(通用化注入点)
+<!-- Refactor (iter1/issue-140):
+  Old pattern: 见 issue #140 与 design decision
+  New principle: 严格按 .refactor-loop/runs/phase9-issue140-r4-judge.md 的 consensus Implement plan 逐条落地;不超范围;改 SKILL.md 只动相关段(单文件)。
+-->
 These variables are injected by the host project. The skill must not hardcode project facts.
 | Variable | Meaning | Default / example |
 |---|---|---|
 | `$REPO_ROOT` | host repository root | required in `host.env` |
+| `$GH_REPO_SLUG` | GitHub `OWNER/REPO` slug | required for `gh --repo` |
+| `$GH_OWNER` / `$GH_REPO_NAME` | compatibility fields for slug construction | optional compatibility exports |
+| `$BUILD_CMD` | build command | host-specific |
+| `$TEST_CMD` | test command | host-specific |
 | `$INTEGRATION_BRANCH` | integration branch | `auto-refact-dev` |
 | `$REVIEW_BASE_BRANCH` | review base branch | `dev` |
 | `$PROJECT_RULES` | project rules file and Phase 0 fixed-point target | `CLAUDE.md` |
-| `$BUILD_CMD` | build command | host-specific |
-| `$TEST_CMD` | test command | host-specific |
+| `$RELEASE_AUTO_ENABLE` | host opt-in for autonomous release decision artifacts | `false`; noop unless `true` |
+| `$RELEASE_AUTO_MIN_MERGES` | minimum recent merges for the release gate stability signal | `1` |
+| `$RELEASE_AUTO_MIN_INTERVAL_HOURS` | minimum hours since the last release decision | `2` |
+| `$RELEASE_ROLLUP_MIN_COMMITS` | minimum integration-ahead commits before release-rollup pending event | `1` |
+| `$RELEASE_ROLLUP_COOLDOWN_SECONDS` | duplicate pending-event cooldown for the same integration SHA | `21600` |
 | `$CI_GUARDS` | optional CI guard script | host-specific; guard only when non-empty |
+| `$CODEX_FLOOR` | host-scoped codex concurrency floor | default `5`; hard lower bound `2` |
+| `$DEGRADATION_WATCH_INTERVAL_SECONDS` | optional skill degradation runtime hook interval | `1800`; `0` disables runtime hook |
+| `$DEGRADATION_WATCH_TIMEOUT_SECONDS` | skill degradation checker timeout | `30` |
+| `$DEGRADATION_ALERT_TAIL_LINES` | alert tail lines included for degradation failures | `10` |
 | `$SOURCE_GLOBS` | source globs for review diffs | host-specific |
-| `$MAINTAINER_WHITELIST` | handles allowed for explicit maintainer decisions | host-specific |
-| `$GH_REPO_SLUG` | GitHub `OWNER/REPO` slug | required for `gh --repo` |
-| `$GH_OWNER` / `$GH_REPO_NAME` | compatibility fields for slug construction | optional |
+| `$MAINTAINER_WHITELIST` | handles allowed for comment-monitor/direct-mention maintainer decisions | optional for hosts without that surface; fail-closed requirement when comment-monitor/direct-mention is enabled |
 
 ### Host language policy
 These optional fields carry host language, test-layout, comment, schema, and architecture-review policy into prompt text. Their default is empty. Empty means the prompt must infer from existing repository evidence plus `$PROJECT_RULES`, `$SOURCE_GLOBS`, `$TEST_CMD`, `$BUILD_CMD`, and the actual diff; it must not invent C#, .NET, protobuf, or any other host-specific default.
@@ -114,7 +127,7 @@ The r7 judge artifact `.refactor-loop/runs/phase9-issue65-r7-judge.md` authorize
 **Producer**:`concurrency_monitor.py` 每 tick 末尾原子写 `.refactor-loop/state/statusline-snapshot.json`(reuse 现有 daemon,**无新 daemon**)。Snapshot 包含 `daemons` map(扫 `.refactor-loop/heartbeats/*.ts` 动态发现,每条记 `age_seconds` + `stale`,stale 阈值 90s)+ 汇总 `daemons_healthy` / `daemons_total`。
 **Consumer**:`statusline.sh` 读 snapshot,bash + jq < 200ms。任一 daemon stale → ⚠ 红色。显示形如 `⚙ 5/10 PR:1 issue:9 d:5/5`。
 
-**Install**(host project,**手动一行,无 installer script**):
+**Install one-liner**(host project,**手动一行,无 installer script**):
 
 ```json
 // ~/.claude/settings.json
@@ -122,7 +135,7 @@ The r7 judge artifact `.refactor-loop/runs/phase9-issue65-r7-judge.md` authorize
 ```
 (host 用安装后的 `<skill-root>/scripts/statusline.sh` 或拷过去的对应路径。)
 
-**Uninstall**:删 `statusLine` 字段即可。
+**Uninstall one-liner**:删 `statusLine` 字段即可。
 
 **Named runtime exception(per #51 consensus)**:
 - **Narrow allowlist**:concurrency_monitor 写 snapshot + 顺手 stat `heartbeats/*.ts` 汇总 daemon 健康;不引入新 daemon、不持 lifecycle authority、不读 prompt body。
@@ -140,7 +153,7 @@ New principle: singleton wrapper + actor-owned heartbeat lease; stale means acto
 Same heartbeat path/epoch/90s consumers; no new daemon, lifecycle authority, CLAUDE.md, or Tier change. -->
 `skills/codex-refactor-loop/scripts/restart-daemons.sh` 是 checked-in,host-agnostic restart helper。它维护 static daemon allowlist 的 singleton wrapper + actor-owned heartbeat lease(`concurrency_monitor`, `comment-monitor`, `codex-progress-reporter`, `dev_sync_daemon`, `phase9_router_daemon`),若 wrapper alive 且 actor-loop heartbeat fresh(`<90s`)则 skip;否则重启对应 wrapper。每次 helper tick 先调用 `log_retention.sh`,直接删除超过 24h 的 `.refactor-loop/logs/*.log`;不 archive、不索引、不新增 daemon。
 
-Host project cron install one-liner(每 5 min):
+Host project cron install one-liner(每 5 min, cron/launchd-only):
 
 ```bash
 */5 * * * * cd $REPO_ROOT && bash skills/codex-refactor-loop/scripts/restart-daemons.sh >> .refactor-loop/logs/restart-cron.log 2>&1
@@ -157,6 +170,8 @@ launchd host template:
 </array>
 <key>StartInterval</key><integer>300</integer>
 ```
+
+Uninstall note: remove the cron line or unload/delete the launchd plist; do not replace it with a new watchdog daemon, installer script, or lifecycle actor.
 
 ## Named runtime exception — anti-stop restart helper(per #49)
 

--- a/skills/codex-refactor-loop/host.env.example
+++ b/skills/codex-refactor-loop/host.env.example
@@ -12,8 +12,13 @@
 #    BUILD_CMD="cargo build --workspace")会被 env 当成 "build" 是命令而崩。
 #
 # Refactor (iter1/issue-140):
-#   Old pattern: 见 issue #140 与 design decision
-#   New principle: 严格按 .refactor-loop/runs/phase9-issue140-r4-judge.md 的 consensus Implement plan 逐条落地;不超范围;改 SKILL.md 只动相关段(单文件)。
+#   Old pattern: host.env.example documented only a subset of host
+#   variables, so exported keys could drift from the SKILL.md Host config
+#   and Host language policy tables.
+#   New principle: keep host.env.example exports equal to the SKILL.md host
+#   configuration table key set with source-regression coverage, while
+#   reusing the existing host.env/SKILL.md surfaces instead of adding a new
+#   schema or runtime contract.
 
 # ─── required ─────────────────────────────────────────────────────
 

--- a/skills/codex-refactor-loop/host.env.example
+++ b/skills/codex-refactor-loop/host.env.example
@@ -10,81 +10,97 @@
 # ⚠️ daemon / codex 启动必须用 `bash -c 'source host.env && exec ...'` 注入(见 SKILL.md
 #    「Daemon 启动」节),不能用 `env $(grep ... host.env)` —— 含空格的值(如
 #    BUILD_CMD="cargo build --workspace")会被 env 当成 "build" 是命令而崩。
+#
+# Refactor (iter1/issue-140):
+#   Old pattern: 见 issue #140 与 design decision
+#   New principle: 严格按 .refactor-loop/runs/phase9-issue140-r4-judge.md 的 consensus Implement plan 逐条落地;不超范围;改 SKILL.md 只动相关段(单文件)。
 
-# ─── 必填 ─────────────────────────────────────────────────────────
+# ─── required ─────────────────────────────────────────────────────
 
-# host 仓库根(绝对路径)
+# Requirement: host 仓库根(绝对路径); missing means bootstrap fails closed.
 export REPO_ROOT="/abs/path/to/your/repo"
 
-# GitHub 完整 slug,OWNER/REPO 格式。
-# ⚠️ 不要导出裸 GH_REPO=<repo-name>:gh CLI 把 GH_REPO 当 --repo 默认值且要求
-#    OWNER/REPO 格式,裸 repo 名会让所有 gh issue/pr/api 命令报错。统一用 GH_REPO_SLUG。
+# Requirement: GitHub 完整 slug,OWNER/REPO 格式; required by gh --repo.
+# Do not export bare GH_REPO=<repo-name>; gh requires OWNER/REPO.
 export GH_REPO_SLUG="your-org/your-repo"
-# 可选:脚本在 GH_REPO_SLUG 缺失时用这两个拼 slug(兼容旧 host)
-export GH_OWNER="your-org"
-export GH_REPO_NAME="your-repo"
 
-# 构建命令。值含空格时本文件能正确保留(source 注入,非 env)。
+# Requirement: 构建命令; values with spaces are preserved by source injection.
 export BUILD_CMD="cargo build --workspace"        # 例:dotnet build / npm run build
 
-# 测试命令(host 专属)。本 skill 仓库 dogfood 有多个 test_*.py 时必须用 discovery
-# 覆盖全部契约/回归测试:
-#   export TEST_CMD="python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'"
-# Rust host 提示:permit 池 / cwd 等共享 fs 状态并行会 race 出假失败,带 --test-threads=1。
+# Requirement: 测试命令(host 专属); dogfood must use unittest discovery.
+# Rust host 提示:shared fs 状态并行会 race 出假失败,带 --test-threads=1。
 export TEST_CMD="cargo test --workspace -- --test-threads=1"
 
-# ─── 有默认值,可覆盖 ────────────────────────────────────────────
+# ─── defaulted ────────────────────────────────────────────────────
 
-# 集成分支:所有 cluster PR 先 land 这里,再开一个 rollup PR 到 review base。
+# Default: 集成分支; cluster PRs land here before rollup to review base.
 export INTEGRATION_BRANCH="auto-refact-dev"
 
-# review 基线分支(rollup PR 的目标;日常人审从这里看)。
+# Default: review 基线分支(rollup PR 的目标;日常人审从这里看)。
 export REVIEW_BASE_BRANCH="dev"
 
-# release rollup pending-event detector: minimum integration-ahead commits before
-# dev_sync_daemon writes DEV_SYNC_PENDING:release-rollup-needed. Cooldown only
-# suppresses duplicate pending events for the same integration SHA; controller
-# still owns PR create/label/review/merge lifecycle.
-export RELEASE_ROLLUP_MIN_COMMITS="1"
-export RELEASE_ROLLUP_COOLDOWN_SECONDS="21600"
-
-# audit / review codex 读的规则文档(违反它的地方就是工作单元的种子)。
-# Phase 0 会在此文件中维护 consensus-rnd foundational invariant managed block;无 opt-out。
+# Default: audit/review codex 读的规则文档; Phase 0 maintains fixed points.
 export PROJECT_RULES="CLAUDE.md"
 
-# ─── 可选 ─────────────────────────────────────────────────────────
+# Default: release auto gate opt-in; false/empty exits 0 with noop reason.
+export RELEASE_AUTO_ENABLE="false"
 
-# CI 守卫脚本(本地跑的架构守卫;留空表示无)。
-export CI_GUARDS=""                               # 例:scripts/ci-guards.sh
+# Default: minimum recent merges required by auto_release_gate stability.
+export RELEASE_AUTO_MIN_MERGES="1"
 
-# Host language policy(可选,空默认):prompt 文本注入;为空时从现有仓库证据 +
-# PROJECT_RULES/SOURCE_GLOBS/TEST_CMD/BUILD_CMD/实际 diff 推断,不得臆造语言默认。
-export HOST_TEST_FILE_GLOBS=""
-export HOST_TEST_NAMING_RULE=""
-export HOST_COMMENT_RULE=""
-export HOST_CODE_FENCE_LANG=""
-export HOST_PROTO_POLICY=""
-export HOST_ARCHITECTURE_GREP_CHECKS=""
+# Default: minimum hours since last release before auto release decision.
+export RELEASE_AUTO_MIN_INTERVAL_HOURS="2"
 
-# 并发 floor:controller 确保始终有 ≥ 此数个**本仓库** codex 并行(防单线程死等)。
-# 未设默认 5;**硬下限 2**(设 <2 一律按 2)。小型仓(文档/skills,可派独立工作少)设 2;
-# 大型代码仓可设 5+。计数按 $REPO_ROOT 绝对路径 scope,只算本仓库 codex。
+# Default: minimum integration-ahead commits before release-rollup pending event.
+export RELEASE_ROLLUP_MIN_COMMITS="1"
+
+# Default: suppress duplicate release-rollup events for same integration SHA.
+export RELEASE_ROLLUP_COOLDOWN_SECONDS="21600"
+
+# Default: concurrency floor; unset means 5 and values below 2 are clamped to 2.
 export CODEX_FLOOR="5"
 
-# SkillDegradationWatch(per #66): existing concurrency_monitor.py may run the
-# single read-only checker on this interval and alert locally on failures only.
-# Paths remain $REPO_ROOT relative: .refactor-loop/.degradation-alert.log and
-# .refactor-loop/.controller-pending-events.log. Set interval to 0 to disable
-# the runtime hook; CI still runs skill-degradation.
+# Default: degradation watch interval; 0 disables runtime hook, CI still checks.
 export DEGRADATION_WATCH_INTERVAL_SECONDS="1800"
+
+# Default: degradation checker timeout in seconds.
 export DEGRADATION_WATCH_TIMEOUT_SECONDS="30"
+
+# Default: degradation alert tail lines to include from .refactor-loop/.degradation-alert.log.
 export DEGRADATION_ALERT_TAIL_LINES="10"
 
-# review diff 关注的源文件 glob(空格分隔)。
+# ─── optional-empty-or-noop ───────────────────────────────────────
+
+# Empty/noop: compatibility owner used only when GH_REPO_SLUG is absent.
+export GH_OWNER="your-org"
+
+# Empty/noop: compatibility repo name used only when GH_REPO_SLUG is absent.
+export GH_REPO_NAME="your-repo"
+
+# Empty/noop: CI 守卫脚本; leave empty to skip with reported noop reason.
+export CI_GUARDS=""                               # 例:scripts/ci-guards.sh
+
+# Empty/noop: test file glob hints; infer from existing tests when empty.
+export HOST_TEST_FILE_GLOBS=""
+
+# Empty/noop: test naming rule; mirror existing tests when empty.
+export HOST_TEST_NAMING_RULE=""
+
+# Empty/noop: comment syntax/applicability; match surrounding style when empty.
+export HOST_COMMENT_RULE=""
+
+# Empty/noop: illustrative code fence language; omit language tag when empty.
+export HOST_CODE_FENCE_LANG=""
+
+# Empty/noop: schema/protocol policy; use diff/project rules only when empty.
+export HOST_PROTO_POLICY=""
+
+# Empty/noop: reviewer grep hints; use rules/globs/guards/diff only when empty.
+export HOST_ARCHITECTURE_GREP_CHECKS=""
+
+# Empty/noop: review diff source globs; host should fill for useful reviews.
 export SOURCE_GLOBS="*.rs"                        # 例:*.cs *.proto / *.ts
 
-# 维护者 GitHub handle 白名单(空格或逗号分隔)。
-# ⚠️ comment-monitor.sh **fails-closed**:此项为空会让该 daemon 立即 FATAL 退出。
-#    5 个 daemon 必须全起,所以这是**事实上的必填项**,不是可选。
-# ⚠️ 必须经 git blame / host 配置验证;严禁写未确认的人名(防误 @-ping)。
+# Fail-closed surface: required only for comment-monitor/direct-mention intake.
+# Empty makes that surface stop instead of trusting unknown maintainers.
 export MAINTAINER_WHITELIST="your-gh-handle"      # 例:alice bob

--- a/skills/codex-refactor-loop/scripts/test_anti_stop_restart_helper_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_anti_stop_restart_helper_contract.py
@@ -18,6 +18,11 @@ def read(path: Path) -> str:
 
 
 class AntiStopRestartHelperContractTests(unittest.TestCase):
+    # Refactor (iter1/issue-140):
+    #   Old pattern: restart-helper install wording was not pinned to the
+    #   local cron/launchd-only surface.
+    #   New principle: keep cron, launchd, uninstall, and no-lifecycle wording
+    #   in the anti-stop section without creating a new installer or daemon.
     def setUp(self) -> None:
         self.skill = read(SKILL_MD)
         self.helper = read(RESTART_HELPER)
@@ -50,6 +55,33 @@ class AntiStopRestartHelperContractTests(unittest.TestCase):
         for needle in required:
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.skill)
+
+    def test_restart_helper_install_uninstall_anchor_is_local_cron_launchd_only(self) -> None:
+        section = self.skill.split(
+            "## Anti-stop restart helper cron/launchd install(per #49)",
+            1,
+        )[1].split("## Wakeup Skeleton", 1)[0]
+        required = (
+            "cron install one-liner",
+            "launchd host template",
+            "Uninstall note",
+            "cron/launchd-only",
+            "No lifecycle authority",
+            "不新增 watchdog daemon",
+        )
+        for needle in required:
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
+        forbidden = (
+            "installer.sh",
+            "install-restart",
+            "gh pr create",
+            "gh issue create",
+            "git push",
+        )
+        for token in forbidden:
+            with self.subTest(token=token):
+                self.assertNotIn(token, section)
 
     def test_skill_references_issue49_r3_judge_artifact(self) -> None:
         self.assertIn(

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -2754,6 +2754,18 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
     def read_rel(self, rel: str) -> str:
         return (REPO_ROOT / rel).read_text(encoding="utf-8")
 
+    # Refactor (iter1/issue-140):
+    #   Old pattern: host env variables drifted between the SKILL.md tables and
+    #   host.env.example without a source-regression equality check.
+    #   New principle: keep the existing host config and language-policy tables
+    #   as the only host-facing variable list, mechanically matched to exports.
+    def skill_host_config_section(self) -> str:
+        return self.read_rel("skills/codex-refactor-loop/SKILL.md").split("## Host 配置(通用化注入点)", 1)[1].split("## Skill Root Contract", 1)[0]
+
+    def host_env_export_keys(self) -> set[str]:
+        host_env = self.read_rel("skills/codex-refactor-loop/host.env.example")
+        return set(re.findall(r"^export ([A-Z0-9_]+)=", host_env, re.MULTILINE))
+
     def rel_paths(self, *patterns: str) -> list[Path]:
         return [path for pattern in patterns for path in sorted(REPO_ROOT.glob(pattern))]
 
@@ -3225,6 +3237,52 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
                 offenders.append(f"{rel}:{line_no}: {stripped}")
 
         self.assertEqual(offenders, [])
+
+    def test_host_env_example_exports_match_skill_host_tables(self) -> None:
+        section = self.skill_host_config_section()
+        table_vars = set(re.findall(r"`\$([A-Z0-9_]+)`", section))
+        exports = self.host_env_export_keys()
+
+        self.assertEqual(exports, table_vars)
+        self.assertIn("GH_OWNER", exports)
+        self.assertIn("GH_REPO_NAME", exports)
+        compatibility_exports = {"GH_OWNER", "GH_REPO_NAME"}
+        compatibility_lines = [
+            line for line in section.splitlines() if "compatibility" in line and ("GH_OWNER" in line or "GH_REPO_NAME" in line)
+        ]
+        self.assertEqual(compatibility_exports, {name for line in compatibility_lines for name in compatibility_exports if name in line})
+
+    def test_host_env_example_exports_have_requirement_behavior_comments(self) -> None:
+        host_env = self.read_rel("skills/codex-refactor-loop/host.env.example")
+        lines = host_env.splitlines()
+        export_lines = [(idx, line) for idx, line in enumerate(lines) if line.startswith("export ")]
+        self.assertGreaterEqual(len(export_lines), 20)
+
+        behavior_re = re.compile(r"Requirement:|Default:|Empty/noop:|Fail-closed surface:")
+        for idx, line in export_lines:
+            with self.subTest(export=line):
+                preceding = "\n".join(lines[max(0, idx - 3) : idx])
+                self.assertRegex(preceding, behavior_re)
+
+    def test_host_env_contract_stays_on_existing_surfaces(self) -> None:
+        skill = self.read_rel("skills/codex-refactor-loop/SKILL.md")
+        host_env = self.read_rel("skills/codex-refactor-loop/host.env.example")
+        combined = "\n".join([skill, host_env])
+
+        self.assertIn("## Host 配置(通用化注入点)", skill)
+        self.assertIn("### Host language policy", skill)
+        for heading in ("# ─── required", "# ─── defaulted", "# ─── optional-empty-or-noop"):
+            with self.subTest(heading=heading):
+                self.assertIn(heading, host_env)
+        self.assertNotIn("HostRuntimeContract", combined)
+        self.assertNotIn("HOST_RUNTIME_CONTRACT", combined)
+        self.assertNotIn("host env schema", combined.lower())
+        self.assertNotIn("Host env schema", combined)
+        self.assertNotIn("export GH_REPO=", host_env)
+        self.assertNotIn("CODEX_REFACTOR_LOOP_SKILL_ROOT", host_env)
+        self.assertFalse((SKILL_ROOT / "scripts" / "host_runtime_contract.py").exists())
+        self.assertFalse((SKILL_ROOT / "scripts" / "host_env_schema.py").exists())
+        self.assertFalse((SKILL_ROOT / "INSTALL.md").exists())
 
     # Refactor (iter3/skill-host-language-policy): Old: hard-coded
     # C#/.NET/proto defaults. New: 6 optional HOST_* values default empty and

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -163,6 +163,11 @@ class SkillReferenceAnchorTests(unittest.TestCase):
 
 
 class AutoLoopStatuslineContractTests(unittest.TestCase):
+    # Refactor (iter1/issue-140):
+    #   Old pattern: statusline install wording was not pinned to the local
+    #   manual one-liner surface.
+    #   New principle: keep install/uninstall anchors local to the statusline
+    #   section and reject installer-script drift.
     def setUp(self) -> None:
         self.skill = read(SKILL_MD)
 
@@ -175,7 +180,8 @@ class AutoLoopStatuslineContractTests(unittest.TestCase):
         required = (
             "**Producer**",
             "**Consumer**",
-            "**Install**",
+            "**Install one-liner**",
+            "**Uninstall one-liner**",
             "**无新 daemon**",
             "**手动一行,无 installer script**",
             "Named runtime exception",
@@ -199,6 +205,24 @@ class AutoLoopStatuslineContractTests(unittest.TestCase):
         for token in forbidden:
             with self.subTest(token=token):
                 self.assertNotIn(token, combined)
+
+    def test_statusline_install_uninstall_anchor_is_local_and_manual(self) -> None:
+        section = self.skill.split("## Claude Code statusline(per #51 consensus)", 1)[1].split(
+            "## Anti-stop restart helper cron/launchd install(per #49)",
+            1,
+        )[0]
+        required = (
+            "Install one-liner",
+            "Uninstall one-liner",
+            "statusLine",
+            "手动一行,无 installer script",
+        )
+        for needle in required:
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
+        scripts_dir = SKILL_ROOT / "scripts"
+        self.assertFalse((scripts_dir / "installer.sh").exists())
+        self.assertFalse((scripts_dir / "install-statusline.sh").exists())
 
     def test_skill_documents_statusline_snapshot_schema(self) -> None:
         self.assertIn("### Statusline snapshot schema", self.skill)


### PR DESCRIPTION
Phase 9 r4 consensus(minimal 3/3)。复用现有 Host 配置表 + statusline/restart 锚点补全 host.env.example,key-set 相等 + source-regression 守卫。全量 396 tests 绿。Closes #140

⟦AI:AUTO-LOOP⟧