### PR TITLE
fix(#154): release gate fresh_heartbeats 读真实 heartbeat 源(解最后一个永红信号)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -910,7 +910,7 @@ Stability score is the percentage of the eight boolean signals that pass. `ready
 | `no_phase8_reject_churn` | `.refactor-loop/state/phase8-review-state.json` reports fewer than three consecutive reject rounds. |
 | `p0_alert_streak_ok` | `.refactor-loop/.concurrency-monitor-state.json` zero streak and recent P0 alert lines are both at most 3 in the last 30 minutes. |
 | `recent_pr_merges_min` | `.refactor-loop/state/recent-pr-merges.json` reports at least `RELEASE_AUTO_MIN_MERGES` commits in the last two hours(default 1). `merge_pr` produces the controller-owned projection after successful `gh pr merge`; schema fields are `count/window_hours/updated_at/merges[]`; the decider only reads this artifact. |
-| `fresh_heartbeats` | At least five entries in `.refactor-loop/state/daemon-heartbeats.json` are fresh within 90 seconds. |
+| `fresh_heartbeats` | At least five `.refactor-loop/heartbeats/*.ts` files are fresh within 90 seconds. |
 | `no_unresolved_human_escalation` | `.refactor-loop/state/meta-resolutions.json` has zero `unresolved_escalate_human` entries. |
 
 Tests or controller-side aggregators may write `.refactor-loop/state/auto-release-signals.json` with either booleans or `{ "passed": bool, ... }` objects for those same keys. When that file exists, it is the deterministic source for the eight gate signals.

--- a/skills/codex-refactor-loop/scripts/auto_release_gate.py
+++ b/skills/codex-refactor-loop/scripts/auto_release_gate.py
@@ -172,6 +172,10 @@ class AutoReleaseGate:
     def recent_merges_path(self) -> Path:
         return self.state_dir / "recent-pr-merges.json"
 
+    @property
+    def heartbeat_dir(self) -> Path:
+        return self.repo_root / ".refactor-loop" / "heartbeats"
+
     def current_version(self) -> str:
         targets = self.load_manifest_targets()
         versions = {target["version"] for target in targets}
@@ -385,15 +389,26 @@ class AutoReleaseGate:
         return signal
 
     def fresh_heartbeats(self) -> dict[str, Any]:
-        raw = load_json(self.state_dir / "daemon-heartbeats.json", {})
+        # Refactor (iter1/issue-154):
+        #   Old pattern: auto_release_gate.fresh_heartbeats 读 .refactor-loop/state/daemon-heartbeats.json,但无 producer 写该文件(daemon 健康实际在 heartbeats/*.ts 与 statusline-snapshot.json)→ 信号永红,release gate 永不 ready。
+        #   New principle: 按 .refactor-loop/runs/phase9-issue154-r1-judge.md consensus(minimal):fresh_heartbeats 改读真实 .refactor-loop/heartbeats/*.ts(保持 >=5 fresh @ HEARTBEAT_FRESH_SECONDS=90 语义),删除 phantom daemon-heartbeats.json 契约与对它的 test 引用。事实源唯一,不新增并行 telemetry,不加 lifecycle authority。
+        #   硬约束:不重建 REFERENCE.md;refactor 注释自含 Old/New。
         now = self.now()
         fresh: dict[str, bool] = {}
-        for name in DAEMON_NAMES:
-            heartbeat = parse_time(raw.get(name)) if isinstance(raw, dict) else None
-            fresh[name] = bool(heartbeat and now - heartbeat <= timedelta(seconds=HEARTBEAT_FRESH_SECONDS))
+        if self.heartbeat_dir.is_dir():
+            for heartbeat_file in sorted(self.heartbeat_dir.glob("*.ts")):
+                try:
+                    raw = heartbeat_file.read_text(encoding="utf-8").strip()
+                    heartbeat = datetime.fromtimestamp(int(raw), tz=timezone.utc)
+                except (OSError, ValueError, OverflowError):
+                    heartbeat = None
+                fresh[heartbeat_file.stem] = bool(
+                    heartbeat
+                    and timedelta(0) <= now - heartbeat <= timedelta(seconds=HEARTBEAT_FRESH_SECONDS)
+                )
         passed = sum(1 for ok in fresh.values() if ok) >= 5
         reason = None if passed else "heartbeat_stale"
-        return {"passed": passed, "reason": reason, "heartbeats": fresh, "source": "state"}
+        return {"passed": passed, "reason": reason, "heartbeats": fresh, "source": "heartbeats/*.ts"}
 
     def no_unresolved_human_escalation(self) -> dict[str, Any]:
         raw = load_json(self.state_dir / "meta-resolutions.json", {})

--- a/skills/codex-refactor-loop/scripts/test_auto_release_gate.py
+++ b/skills/codex-refactor-loop/scripts/test_auto_release_gate.py
@@ -146,20 +146,30 @@ print("[]")
 
 
 def write_live_state(repo: Path) -> None:
-    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    now = int(datetime.now(timezone.utc).timestamp())
     state = repo / ".refactor-loop/state"
-    write_json(state / "daemon-heartbeats.json", {name: now for name in (
+    heartbeat_dir = repo / ".refactor-loop/heartbeats"
+    heartbeat_dir.mkdir(parents=True, exist_ok=True)
+    for name in (
         "concurrency_monitor.py",
         "codex-progress-reporter.sh",
         "comment-monitor.sh",
         "dev_sync_daemon.py",
         "phase9_router_daemon.py",
-    )})
+    ):
+        (heartbeat_dir / f"{name}.ts").write_text(f"{now}\n", encoding="utf-8")
     write_json(state / "phase8-review-state.json", {"max_consecutive_reject_rounds": 0})
     write_json(state / "meta-resolutions.json", {"unresolved_escalate_human": []})
     write_json(state / "recent-pr-merges.json", {"count": 1})
     write_json(state / "release-commits.json", {"commits": [{"sha": "abc123", "subject": "fix: fixture", "body": ""}]})
     write_json(repo / ".refactor-loop/.concurrency-monitor-state.json", {"zero_streak": 0})
+
+
+def write_heartbeat_files(repo: Path, values: dict[str, int | str]) -> None:
+    heartbeat_dir = repo / ".refactor-loop/heartbeats"
+    heartbeat_dir.mkdir(parents=True, exist_ok=True)
+    for name, value in values.items():
+        (heartbeat_dir / f"{name}.ts").write_text(f"{value}\n", encoding="utf-8")
 
 
 def run_gate_cli(repo: Path, bin_dir: Path | None = None, *extra: str) -> subprocess.CompletedProcess[str]:
@@ -512,15 +522,15 @@ class AutoReleaseGateBehaviorTests(unittest.TestCase):
     def test_fail_closed_when_daemon_heartbeat_stale(self) -> None:
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"
-            stale = (NOW - timedelta(seconds=91)).isoformat().replace("+00:00", "Z")
-            state = repo / ".refactor-loop/state"
-            write_json(state / "daemon-heartbeats.json", {name: stale for name in (
+            stale = int((NOW - timedelta(seconds=91)).timestamp())
+            write_heartbeat_files(repo, {name: stale for name in (
                 "concurrency_monitor.py",
                 "codex-progress-reporter.sh",
                 "comment-monitor.sh",
                 "dev_sync_daemon.py",
                 "phase9_router_daemon.py",
             )})
+            state = repo / ".refactor-loop/state"
             write_json(state / "phase8-review-state.json", {"max_consecutive_reject_rounds": 0})
             write_json(state / "meta-resolutions.json", {"unresolved_escalate_human": []})
             write_json(repo / ".refactor-loop/.concurrency-monitor-state.json", {"zero_streak": 0})
@@ -529,6 +539,65 @@ class AutoReleaseGateBehaviorTests(unittest.TestCase):
 
             self.assertFalse(score.ready)
             self.assertIn("heartbeat_stale", score.signals["fresh_heartbeats"]["reason"])
+
+    def test_fresh_heartbeats_reads_real_heartbeat_files_without_legacy_state_artifact(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            fresh = int(NOW.timestamp())
+            write_heartbeat_files(repo, {name: fresh for name in (
+                "concurrency_monitor.py",
+                "codex-progress-reporter.sh",
+                "comment-monitor.sh",
+                "dev_sync_daemon.py",
+                "phase9_router_daemon.py",
+                "extra-observer",
+            )})
+            gate = AutoReleaseGate(repo, now=lambda: NOW, runner=FakeRunner())
+
+            signal = gate.fresh_heartbeats()
+
+            self.assertTrue(signal["passed"])
+            self.assertEqual(signal["source"], "heartbeats/*.ts")
+            self.assertEqual(sum(1 for value in signal["heartbeats"].values() if value), 6)
+            self.assertTrue(signal["heartbeats"]["concurrency_monitor.py"])
+
+    def test_fail_closed_when_fewer_than_five_real_heartbeats_are_fresh(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            fresh = int(NOW.timestamp())
+            stale = int((NOW - timedelta(seconds=91)).timestamp())
+            write_heartbeat_files(repo, {
+                "concurrency_monitor.py": fresh,
+                "codex-progress-reporter.sh": fresh,
+                "comment-monitor.sh": fresh,
+                "dev_sync_daemon.py": fresh,
+                "phase9_router_daemon.py": stale,
+            })
+            gate = AutoReleaseGate(repo, now=lambda: NOW, runner=FakeRunner())
+
+            signal = gate.fresh_heartbeats()
+
+            self.assertFalse(signal["passed"])
+            self.assertIn("heartbeat_stale", signal["reason"])
+            self.assertEqual(sum(1 for value in signal["heartbeats"].values() if value), 4)
+
+    def test_fail_closed_when_real_heartbeat_file_is_malformed(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            fresh = int(NOW.timestamp())
+            write_heartbeat_files(repo, {
+                "concurrency_monitor.py": fresh,
+                "codex-progress-reporter.sh": fresh,
+                "comment-monitor.sh": fresh,
+                "dev_sync_daemon.py": fresh,
+                "phase9_router_daemon.py": "not-an-epoch",
+            })
+            gate = AutoReleaseGate(repo, now=lambda: NOW, runner=FakeRunner())
+
+            signal = gate.fresh_heartbeats()
+
+            self.assertFalse(signal["passed"])
+            self.assertFalse(signal["heartbeats"]["phase9_router_daemon.py"])
 
     def test_fail_closed_when_phase8_reject_churn_reaches_limit(self) -> None:
         with copy_repo_fixture() as tmp:

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -2693,6 +2693,17 @@ class AutonomousReleaseGateContractTests(unittest.TestCase):
         assert match is not None
         return match.group(1)
 
+    def release_decision_schema_section(self) -> str:
+        text = self.read_skill()
+        match = re.search(
+            r"<a id=\"release-decision-schema\"></a>\n### Release decision schema(.*?)\n<a id=\"host-runtime-details\"></a>",
+            text,
+            flags=re.S,
+        )
+        self.assertIsNotNone(match)
+        assert match is not None
+        return match.group(1)
+
     def test_skill_documents_autonomous_release_gate_title(self) -> None:
         self.assertIn("## Named runtime exception — autonomous release gate(per #56)", self.read_skill())
 
@@ -2755,6 +2766,19 @@ class AutonomousReleaseGateContractTests(unittest.TestCase):
         for forbidden in ("git log", "git rev-list", "gh pr view", "gh api"):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, gate_source)
+
+    def test_release_schema_documents_real_heartbeat_files_not_phantom_state(self) -> None:
+        release_schema = self.release_decision_schema_section()
+        heartbeat_rows = [
+            line for line in release_schema.splitlines()
+            if "| `fresh_heartbeats` |" in line
+        ]
+
+        self.assertEqual(len(heartbeat_rows), 1)
+        heartbeat_row = heartbeat_rows[0]
+        self.assertNotIn(".refactor-loop/state/daemon-heartbeats.json", heartbeat_row)
+        self.assertIn(".refactor-loop/heartbeats/*.ts", heartbeat_row)
+        self.assertRegex(heartbeat_row, r"At least five .* fresh within 90 seconds")
 
 # Refactor (hygiene/634a608-followup): delete stranded paragraph tests matching
 # the CLAUDE.md philosophy-only rewrite; the paragraph no longer exists.

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -3228,6 +3228,12 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
             "merge_pr 成功 merge 后未写 .refactor-loop/state/recent-pr-merges.json",
             "按 .refactor-loop/runs/phase9-issue145-r5-judge.md consensus",
         )
+        issue154_self_doc_contexts = (
+            "Refactor (iter1/issue-154):",
+            "auto_release_gate.fresh_heartbeats 读 .refactor-loop/state/daemon-heartbeats.json",
+            "按 .refactor-loop/runs/phase9-issue154-r1-judge.md consensus",
+            "硬约束:不重建 REFERENCE.md;refactor 注释自含 Old/New",
+        )
         log_error_context_re = re.compile(
             r"\b(log|print|sys\.stderr\.write|raise|argparse|help=|description=|epilog=|"
             r"set_defaults|ArgumentParser|error|warning)\b",
@@ -3262,7 +3268,7 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
                         continue
                     if path.name == "test_ensure_project_rules_fixed_points.py" and any(needle in context for needle in issue126_self_doc_contexts):
                         continue
-                    if any(needle in context for needle in issue145_self_doc_contexts):
+                    if any(needle in context for needle in issue145_self_doc_contexts + issue154_self_doc_contexts):
                         continue
                     offenders.append(f"{rel}:{token.start[0]}: {context.strip()}")
 
@@ -3276,7 +3282,7 @@ class SkillContractSourceRegressionTests(unittest.TestCase):
                     continue
                 if any(needle in line for needle in allowed_shell_contexts):
                     continue
-                if any(needle in line for needle in issue145_self_doc_contexts):
+                if any(needle in line for needle in issue145_self_doc_contexts + issue154_self_doc_contexts):
                     continue
                 offenders.append(f"{rel}:{line_no}: {stripped}")
 


### PR DESCRIPTION
Phase 9 r1 consensus(minimal)。fresh_heartbeats 改读 .refactor-loop/heartbeats/*.ts(>=5 fresh @90s 语义不变),删除无 producer 的 phantom daemon-heartbeats.json 契约。**解除 release gate 最后一个代码阻塞**。Closes #154

⟦AI:AUTO-LOOP⟧