### PR TITLE
feat(#168): 实现 Phase 9 共识方案

### DIFF
--- a/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
@@ -13,13 +13,11 @@ PROMPTS_DIR = SCRIPT_PATH.parents[1] / "prompts"
 
 DENIAL_OR_CONTROLLER_OWNER_RE = re.compile(
     r"禁止|不可调|不得|不能|不要|Forbidden|forbidden|Do NOT|do not|must not|"
-    r"not allowed|marker/artifact-only|lifecycle / label .*controller|controller[^.\n]*(owns|owner|拥有|归|创 PR)"
+    r"not allowed|marker/artifact-only|lifecycle[^.\n]*label[^.\n]*controller|"
+    r"controller[^.\n]*(owns|owner|拥有|归|创 PR)"
 )
 
-REQUIRED_BAN_SUBSTRINGS = (
-    "## codex ",
-    "iter5/prompt-gh-ban-marker-only",
-    "marker/artifact-only",
+REQUIRED_LIFECYCLE_COMMAND_TOKENS = (
     "gh pr create",
     "gh pr merge",
     "gh pr close",
@@ -29,9 +27,12 @@ REQUIRED_BAN_SUBSTRINGS = (
     "gh issue edit --remove-label",
     "gh pr edit --add-label",
     "gh pr edit --remove-label",
-    "git commit/push/checkout/merge/reset/rebase",
-    "lifecycle / label ",
-    "controller",
+    "git commit",
+    "git push",
+    "git checkout",
+    "git merge",
+    "git reset",
+    "git rebase",
 )
 
 FORBIDDEN_DIRECT_LIFECYCLE_SNIPPETS = (
@@ -54,6 +55,13 @@ AFFIRMATIVE_DIRECT_POST_SNIPPETS = (
 )
 
 
+def lifecycle_token_pattern(token: str) -> re.Pattern[str]:
+    command, verb = token.split(" ", 1)
+    if command == "git":
+        return re.compile(r"`git [^`\n]*\b" + re.escape(verb) + r"\b[^`\n]*`|" + re.escape(token))
+    return re.compile(r"`[^`\n]*\b" + re.escape(token) + r"\b[^`\n]*`|" + re.escape(token))
+
+
 def prompt_paths() -> list[Path]:
     return sorted(path for path in PROMPTS_DIR.glob("*.md") if path.name != "_github-post-rules.md")
 
@@ -71,6 +79,13 @@ def prompts_with_marker_only_ban() -> list[Path]:
     return paths
 
 
+def ban_section(body: str) -> str:
+    match = re.search(r"(?ms)^## codex .+?(?=^## |\Z)", body)
+    if match:
+        return match.group(0)
+    return body
+
+
 class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
     # Refactor (iter6/issue-118):
     #   Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
@@ -81,40 +96,30 @@ class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
         for path in paths:
             with self.subTest(prompt=path.name):
                 body = path.read_text(encoding="utf-8")
-                for needle in REQUIRED_BAN_SUBSTRINGS:
-                    self.assertIn(
-                        needle,
-                        body,
+                section = ban_section(body)
+                self.assertIn("marker/artifact-only", body)
+                for needle in REQUIRED_LIFECYCLE_COMMAND_TOKENS:
+                    self.assertRegex(
+                        section,
+                        lifecycle_token_pattern(needle),
                         f"{path.name} missing required ban-section token `{needle}`",
                     )
-                self.assertRegex(body, r"(?m)^## codex .+$")
-
-    def test_refactor_self_doc_block_present(self) -> None:
-        for path in prompts_with_marker_only_ban():
-            with self.subTest(prompt=path.name):
-                body = path.read_text(encoding="utf-8")
-                self.assertIn(
-                    "Refactor (iter5/prompt-gh-ban-marker-only)",
-                    body,
-                    f"{path.name} missing Refactor self-doc block",
-                )
 
     def test_lifecycle_tokens_only_appear_in_ban_lines(self) -> None:
         for path in prompts_with_marker_only_ban():
             body = path.read_text(encoding="utf-8")
-            ban_section_match = re.search(r"(?ms)^## codex .+?(?=^## |\Z)", body)
-            self.assertIsNotNone(ban_section_match, path.name)
-            ban_section = ban_section_match.group(0)
-            for token in FORBIDDEN_DIRECT_LIFECYCLE_SNIPPETS:
-                for line in ban_section.splitlines():
-                    if token not in line:
+            section = ban_section(body)
+            for token in REQUIRED_LIFECYCLE_COMMAND_TOKENS:
+                pattern = lifecycle_token_pattern(token)
+                for line in section.splitlines():
+                    if not pattern.search(line):
                         continue
                     with self.subTest(prompt=path.name, token=token, line=line):
                         self.assertRegex(line, DENIAL_OR_CONTROLLER_OWNER_RE)
                 affirmative_lines = [
                     line
                     for line in body.splitlines()
-                    if token in line and not DENIAL_OR_CONTROLLER_OWNER_RE.search(line)
+                    if pattern.search(line) and not DENIAL_OR_CONTROLLER_OWNER_RE.search(line)
                 ]
                 self.assertEqual(
                     affirmative_lines,

--- a/skills/codex-refactor-loop/scripts/test_no_new_prose_detection.py
+++ b/skills/codex-refactor-loop/scripts/test_no_new_prose_detection.py
@@ -30,6 +30,15 @@ FORBIDDEN_NEW_TEST_TOKENS = (
     "禁止** 裸 `nohup python3 <daemon> &`",
     "Source files are English-only; external user-facing artifacts are 中文 by default",
     "No mandatory parallel English section",
+    "iter5/prompt-gh-ban-marker-only",
+    "lifecycle / label ",
+    "cron/launchd-only helper invariant",
+    "**Producer**",
+    "**Consumer**",
+    "**Install one-liner**",
+    "**Uninstall one-liner**",
+    "**无新 daemon**",
+    "**手动一行,无 installer script**",
 )
 
 

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -36,6 +36,37 @@ def reference_anchors(reference: str) -> set[str]:
     return anchors
 
 
+def section_after_anchor(markdown: str, anchor: str) -> str:
+    marker = f'<a id="{anchor}"></a>'
+    _, found, after_anchor = markdown.partition(marker)
+    if not found:
+        raise AssertionError(f"missing markdown anchor: {anchor}")
+    return _section_after_first_heading(after_anchor)
+
+
+def section_after_heading(markdown: str, heading: str) -> str:
+    pattern = re.compile(rf"(?m)^## {re.escape(heading)}$")
+    match = pattern.search(markdown)
+    if not match:
+        raise AssertionError(f"missing markdown heading: {heading}")
+    return _section_after_first_heading(markdown[match.start() :])
+
+
+def _section_after_first_heading(markdown: str) -> str:
+    lines = markdown.splitlines(keepends=True)
+    if not lines:
+        return ""
+    start = 0
+    for index, line in enumerate(lines):
+        if re.match(r"^##\s+", line):
+            start = index
+            break
+    for index in range(start + 1, len(lines)):
+        if re.match(r"^##\s+", lines[index]):
+            return "".join(lines[start:index])
+    return "".join(lines[start:])
+
+
 class SkillReferenceAnchorTests(unittest.TestCase):
     # Refactor (iter1/issue-139):
     #   Old pattern: Wake-source 契约措辞自相矛盾:SKILL.md/REFERENCE.md 多处写三选一(Monitor / task-notification / ScheduleWakeup 任一即可),与 checklist step15 / ownership 的必维持 Monitor 冲突,新会话据此漏挂 Monitor bridge。
@@ -91,6 +122,7 @@ class SkillReferenceAnchorTests(unittest.TestCase):
         # Refactor (iter1/issue-141):
         #   Old pattern: downstream install steps without an installer were split across README, SKILL statusline text, and restart helper text, with no one-step walkthrough.
         #   New principle: Downstream install walkthrough centralizes setup, README/SKILL links point at it, and source-regression locks required host surfaces.
+        walkthrough = section_after_anchor(self.skill, "downstream-install-walkthrough")
         combined_links = "\n".join((self.readme, self.skill))
         self.assertNotIn("REFERENCE.md#downstream-install-walkthrough", combined_links)
         self.assertIn("SKILL.md#downstream-install-walkthrough", combined_links)
@@ -101,17 +133,16 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             "host.env.example",
             ".refactor-loop/host.env",
             "consensus-rnd-cli restart-daemons",
-            "cron",
-            "launchd",
-            "statusLine",
             "consensus-rnd-cli statusline",
+            "source .refactor-loop/host.env && exec",
             ".git",
             "CI",
             "policy",
+            "HOST_*",
         )
         for needle in required:
             with self.subTest(needle=needle):
-                self.assertIn(needle, self.skill)
+                self.assertIn(needle, walkthrough)
 
         forbidden_paths = (
             "scripts/install.sh",
@@ -124,31 +155,8 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             with self.subTest(forbidden=forbidden):
                 self.assertFalse((REPO_ROOT / forbidden).exists(), forbidden)
 
-        walkthrough = self.skill.split("## Downstream install walkthrough", 1)[1].split(
-            "## Named runtime exception",
-            1,
-        )[0]
         self.assertEqual(1, walkthrough.count("HOST_*"))
         self.assertNotIn("HOST_TEST_FILE_GLOBS |", walkthrough)
-        self.assertIn("source .refactor-loop/host.env && exec", walkthrough)
-
-        restart_helper = self.skill.split("## Anti-stop restart helper cron/launchd install(per #49)", 1)[1].split(
-            "## Named runtime exception",
-            1,
-        )[0]
-        self.assertIn("cron/launchd-only helper invariant", restart_helper)
-        self.assertNotIn("Host project cron install one-liner", restart_helper)
-        self.assertNotIn("launchd host template", restart_helper)
-        self.assertNotIn("ProgramArguments", restart_helper)
-        self.assertNotIn("restart-cron.log", restart_helper)
-
-        command_bodies = (
-            "source .refactor-loop/host.env && exec python3 <skill-root>/scripts/consensus-rnd-cli restart-daemons",
-            "source .refactor-loop/host.env && exec python3 &lt;skill-root&gt;/scripts/consensus-rnd-cli restart-daemons",
-        )
-        for body in command_bodies:
-            with self.subTest(body=body):
-                self.assertEqual(1, self.skill.count(body))
 
     def test_skill_documents_daemon_event_monitor_command(self) -> None:
         self.assertIn(
@@ -244,18 +252,18 @@ class AutoLoopStatuslineContractTests(unittest.TestCase):
             r"(?m)^## Claude Code statusline\(per #51 consensus\)$",
             "statusline consensus section must be an independent markdown heading",
         )
+        section = section_after_heading(self.skill, "Claude Code statusline(per #51 consensus)")
         required = (
-            "**Producer**",
-            "**Consumer**",
-            "**Install one-liner**",
-            "**Uninstall one-liner**",
-            "**无新 daemon**",
-            "**手动一行,无 installer script**",
+            "statusLine",
+            "consensus-rnd-cli statusline",
+            "install",
+            "installer script",
+            "daemon",
             "Named runtime exception",
         )
         for needle in required:
             with self.subTest(needle=needle):
-                self.assertIn(needle, self.skill)
+                self.assertIn(needle, section)
 
     def test_statusline_contract_does_not_add_daemon_or_installer(self) -> None:
         scripts_dir = SKILL_ROOT / "scripts"
@@ -274,15 +282,12 @@ class AutoLoopStatuslineContractTests(unittest.TestCase):
                 self.assertNotIn(token, combined)
 
     def test_statusline_install_uninstall_anchor_is_local_and_manual(self) -> None:
-        section = self.skill.split("## Claude Code statusline(per #51 consensus)", 1)[1].split(
-            "## Anti-stop restart helper cron/launchd install(per #49)",
-            1,
-        )[0]
+        section = section_after_heading(self.skill, "Claude Code statusline(per #51 consensus)")
         required = (
-            "Install one-liner",
-            "Uninstall one-liner",
             "statusLine",
-            "手动一行,无 installer script",
+            "consensus-rnd-cli statusline",
+            "installer script",
+            "Uninstall",
         )
         for needle in required:
             with self.subTest(needle=needle):


### PR DESCRIPTION
实现 #168 的 Phase 9 共识 concrete plan(含 behavior + source-regression test,全量套件本地绿)。Closes #168。

走 Phase 8 多 reviewer 共识 gate。注意:本批 6 个实现触及共享文件(cli.py/SKILL.md/prompts/tests),需**串行 merge**(逐个 rebase)。

⟦AI:AUTO-LOOP⟧