### PR TITLE
feat(#169): 实现 Phase 9 共识方案

### DIFF
--- a/skills/codex-refactor-loop/prompts/_github-post-rules.md
+++ b/skills/codex-refactor-loop/prompts/_github-post-rules.md
@@ -1,5 +1,7 @@
 # GitHub post rules (shared 共享规则,各 codex prompt 引用本文件)
 
+Artifact profile: github-ai-post-body
+
 任何 codex(solver / meta-judge / fix / reviewer / clarifier / investigator / analyst 等)产出 user-facing 内容时,**自己直接调 `gh`** post 到 GitHub,不需要 controller 中转、不需要 dedicated writer-codex。
 
 ## Body 结构(强制)

--- a/skills/codex-refactor-loop/prompts/audit.md
+++ b/skills/codex-refactor-loop/prompts/audit.md
@@ -175,8 +175,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/audit.md
+++ b/skills/codex-refactor-loop/prompts/audit.md
@@ -1,5 +1,7 @@
 # 任务：审计 `$REPO_ROOT` 仓库中违反软件工程哲学的位置
 
+Artifact profile: marker-only-work-unit
+
 你是审计员，不是问题确认器。先**发现违规**再做 cluster 筛选，**两个产物分别落盘**。
 
 ## 必读

--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -95,8 +95,8 @@ ${VERIFICATION_HINTS}
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -1,5 +1,7 @@
 # 任务：实施 ${WORK_UNIT_ID}
 
+Artifact profile: marker-only-work-unit
+
 <!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 你以无人值守模式在 worktree `${WORKTREE_PATH}` 中工作，对应分支 `${BRANCH}`。

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -1,5 +1,7 @@
 # Role: Meta-judge — Phase 9 consensus arbiter
 
+Artifact profile: phase9-meta-judge
+
 You are the **4th codex** for design-issue **${ISSUE_NUMBER}** (work unit `${WORK_UNIT_ID}`, audit cluster alias `${CLUSTER_ID}`). You did NOT propose a solution. Your job: read all 3 solver outputs and decide ONE of:
 
 1. **Consensus reached** → auto-dispatch implement (3/3 same framing; this is sufficient authorization for any file or tier)

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -168,8 +168,8 @@ Refactor (iter6/issue-118):
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/meta-reflector-stalled.md
+++ b/skills/codex-refactor-loop/prompts/meta-reflector-stalled.md
@@ -1,5 +1,7 @@
 # Role: Meta-reflector - stalled route resolver
 
+Artifact profile: marker-only-work-unit
+
 You resolve a stalled Phase 8/Phase 9 route without writing code.
 
 ## Priority 0: mandatory no-framing drop

--- a/skills/codex-refactor-loop/prompts/meta-reflector-stalled.md
+++ b/skills/codex-refactor-loop/prompts/meta-reflector-stalled.md
@@ -56,6 +56,6 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## Marker contract
 
-AI 内容标识符必须保留。最终 marker 必须在末尾独立一行:
+AI content identifier must be preserved. The sentinel must be the penultimate line before the final routing marker:
 
 `⟦AI:AUTO-LOOP⟧`

--- a/skills/codex-refactor-loop/prompts/remote-ci-fix.md
+++ b/skills/codex-refactor-loop/prompts/remote-ci-fix.md
@@ -83,8 +83,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/remote-ci-fix.md
+++ b/skills/codex-refactor-loop/prompts/remote-ci-fix.md
@@ -1,5 +1,7 @@
 # 任务：修复 PR 远端 CI 失败 ${CHECK_NAME}
 
+Artifact profile: marker-only-work-unit
+
 worktree: `${WORKTREE_PATH}`，分支 `${BRANCH}` （通常是 trunk）。
 PR: `${PR_NUMBER}`，失败 check: `${CHECK_NAME}`，run url: `${RUN_URL}`。
 

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -1,5 +1,7 @@
 # Role: Fix codex — address all reject demands on PR
 
+Artifact profile: review-fix
+
 <!-- Refactor (iter3/skill-merge-policy): Old pattern: unanimous-approve merge gate + Phase 8 文案矛盾  New principle: 固定真值表 reject=0 && approve>=1 → MERGE;comment 是 advisory(#26 minimal option B 共识) -->
 
 You are the fix-codex for PR **${PR_NUMBER}** (`${PR_TITLE}`). Round **${FIX_ROUND}** of max **${MAX_FIX_ROUNDS}**.

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -142,8 +142,8 @@ Begin.
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -35,7 +35,7 @@ blocking demands come only from `reject` reviewer evidence. Comments are context
 Categorize each demand into one of:
 
 - **(A) Fixable in-scope** — concrete code change within `scope_paths` of this cluster. Apply it.
-- **(B) Fixable but scope-extend** — concrete code change outside scope_paths. Print `SCOPE_EXTEND: <file> <reason>` and apply it ONLY if rejecting this demand would block consensus AND the file is in the same logical refactor (e.g. add missing test file for the new public method).
+- **(B) Fixable but scope-extend** — concrete code change outside scope_paths. Record `scope-extend: <file> <reason>` in the fix report and apply it ONLY if rejecting this demand would block consensus AND the file is in the same logical refactor (e.g. add missing test file for the new public method).
 - **(C) False positive** — the reviewer mis-read (e.g. cited a file not in the PR, cited a deletion that never happened, demand contradicts `$PROJECT_RULES`). Do NOT apply. Record in `FIX_REPORT.md` with evidence proving it's a false positive.
 - **(D) Conflicting demands** — Architect demands X, Quality demands ¬X. Do NOT apply either side without resolution. Record both sides in `FIX_REPORT.md` and emit `FIX_BLOCKED:conflict:<short>` at the end.
 - **(E) Outside fix-codex authority** — demand requires a design decision (e.g. "delete this feature entirely" / "split this into 3 PRs" / "rename core type that other clusters depend on"). Record in `FIX_REPORT.md` and emit `FIX_BLOCKED:human-decision:<short>`.
@@ -69,7 +69,7 @@ Write `${FIX_OUTPUT_PATH}` with this structure:
 
 ## Applied
 - (A) <file:line>: <what was fixed> (addresses reviewer:<role>'s evidence #<n>)
-- (B) <file:line>: <SCOPE_EXTEND reason> ; <what was added>
+- (B) <file:line>: <scope-extend reason> ; <what was added>
 
 ## Rejected as false positive
 - <file:line cited by reviewer:<role>>: <evidence that this is wrong — e.g. "file not in PR's three-dot diff", "cited test still exists at line N", "PROJECT_RULES clause M actually requires this">
@@ -98,7 +98,6 @@ End your output with EXACTLY one of:
 <!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
-- `SCOPE_EXTEND:<file>:<reason>`
 - `FIX_DONE:${PR_NUMBER}:round-${FIX_ROUND}:applied-<N>:rejected-<M>:blocked-<K>`
 - `FIX_BLOCKED:${PR_NUMBER}:round-${FIX_ROUND}:<conflict|human-decision|build-broken|other>:<short>`
 

--- a/skills/codex-refactor-loop/prompts/reviewer-architect.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-architect.md
@@ -1,5 +1,7 @@
 # Role: Architect reviewer (CLAUDE.md compliance angle)
 
+Artifact profile: phase8-reviewer
+
 <!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 You are reviewing PR **${PR_NUMBER}** (`${PR_TITLE}`) against `${BASE_BRANCH}` from an **architecture compliance** perspective.

--- a/skills/codex-refactor-loop/prompts/reviewer-architect.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-architect.md
@@ -97,8 +97,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/reviewer-quality.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-quality.md
@@ -1,5 +1,7 @@
 # Role: Code quality reviewer (readability + simplicity angle)
 
+Artifact profile: phase8-reviewer
+
 <!--
 Refactor (iter1/issue-126):
   Old pattern: 跨平台 prompt 含 '该项目'/'该项目AI' 等硬编码 host 占位文本,违反 host-agnostic;应复用 host.env surface(GH_REPO_SLUG / MAINTAINER_WHITELIST)。

--- a/skills/codex-refactor-loop/prompts/reviewer-quality.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-quality.md
@@ -100,8 +100,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/reviewer-tests.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-tests.md
@@ -1,5 +1,7 @@
 # Role: Tests reviewer (test coverage + test quality angle)
 
+Artifact profile: phase8-reviewer
+
 <!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 You are reviewing PR **${PR_NUMBER}** (`${PR_TITLE}`) against `${BASE_BRANCH}` from a **test quality** perspective.

--- a/skills/codex-refactor-loop/prompts/reviewer-tests.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-tests.md
@@ -99,8 +99,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -1,5 +1,7 @@
 # Role: Solver — delete framing(no defer)
 
+Artifact profile: phase9-solver
+
 <!-- Refactor (iter213/cluster-213-006-delete-solver-defer-escape):
   Old pattern: delete solver forbids defer, then defines Deferrable and asks for a tracking issue creation suggestion(prompt 内部矛盾,且 gh issue create 后被禁)
   New principle: delete solver 单 terminal vocabulary:delete/collapse/abstain/escalate;无 deferred side-channel、无 issue-create 命令建议;'not now' map 到 abstain/false-positive,lifecycle 决策归 controller/maintainer。 -->

--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -141,8 +141,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -1,6 +1,6 @@
 # Role: Solver — delete framing(no defer)
 
-Artifact profile: phase9-solver
+Artifact profile: phase9-delete-solver
 
 <!-- Refactor (iter213/cluster-213-006-delete-solver-defer-escape):
   Old pattern: delete solver forbids defer, then defines Deferrable and asks for a tracking issue creation suggestion(prompt 内部矛盾,且 gh issue create 后被禁)

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -1,5 +1,7 @@
 # Role: Solver — minimal-change framing
 
+Artifact profile: phase9-solver
+
 You are **one of 3 independent design solvers** evaluating issue **${ISSUE_NUMBER}** (cluster `${CLUSTER_ID}`). You see only the issue + repo, NOT the other solvers' outputs. Reach your own conclusion.
 
 Your bias: **smallest viable change** that resolves the audit's flagged violation. You may propose a documented rule exception if the violation reduces to "rule too broad for this narrow case". You explicitly do NOT over-engineer.

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -123,8 +123,8 @@ Refactor (iter6/issue-118):
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -1,5 +1,7 @@
 # Role: Solver — structural / CLAUDE-aligned framing
 
+Artifact profile: phase9-solver
+
 You are **one of 3 independent design solvers** evaluating issue **${ISSUE_NUMBER}** (cluster `${CLUSTER_ID}`). You see only the issue + repo, NOT the other solvers' outputs.
 
 Your bias: **CLAUDE-philosophy-aligned, structurally clean**. You accept higher implementation cost (new helper types, an extra actor inbox hop, a small additional abstraction) to land a solution that an architecture reviewer cannot reject six months later. You prefer code that does not need rule exceptions, but philosophy/architecture rules are also evolvable when changing them is the clean structural solution.

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -124,8 +124,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/test-add.md
+++ b/skills/codex-refactor-loop/prompts/test-add.md
@@ -1,5 +1,7 @@
 # 任务：补测试覆盖重构引入的未覆盖代码 — ${CLUSTER_ID}
 
+Artifact profile: marker-only-work-unit
+
 <!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 worktree: `${WORKTREE_PATH}`，分支 `${BRANCH}`。

--- a/skills/codex-refactor-loop/prompts/test-add.md
+++ b/skills/codex-refactor-loop/prompts/test-add.md
@@ -102,8 +102,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/triage-external-issue.md
+++ b/skills/codex-refactor-loop/prompts/triage-external-issue.md
@@ -125,4 +125,4 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## AI 内容标识符
 
-所有 GitHub comment / artifact 必须末尾独立一行 `⟦AI:AUTO-LOOP⟧`。
+GitHub comments must end with the sentinel as the final standalone line. Marker-bearing internal artifacts must put `⟦AI:AUTO-LOOP⟧` on the penultimate line, immediately before the final routing marker.

--- a/skills/codex-refactor-loop/prompts/triage-external-issue.md
+++ b/skills/codex-refactor-loop/prompts/triage-external-issue.md
@@ -1,5 +1,7 @@
 # Triage codex — 外部 issue 评估 + 接入(or 拒绝)
 
+Artifact profile: marker-only-work-unit
+
 你是 triage codex,任务:把 maintainer 加了 `auto-loop-triage` label 的**外部 issue** 评估为:
 - **accept** — 是 concrete repository work unit suitable for consensus;reshape body 为 `manual-issue` WorkUnit-backed design issue + 切换 label 进入 Phase 9 三 solver 流程
 - **reject** — 不适合作为 consensus work unit(产品需求 / runtime bug report / 外部依赖 / duplicate / unclear / scope 过大),评论解释 + 移除 triage label

--- a/skills/codex-refactor-loop/prompts/verify.md
+++ b/skills/codex-refactor-loop/prompts/verify.md
@@ -127,8 +127,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## AI 内容标识符(强制)
 
-所有 AI 生成的对外内容(GitHub issue/PR comment、PR body、commit message、`runs/*.md` artifact、push notification)**必须末尾独立一行**加 sentinel:
+所有 AI 生成的 GitHub issue/PR comment、PR body、commit message、push notification **must end with the sentinel as the final standalone line**. Internal marker-bearing `runs/*.md` artifacts must put the sentinel on the penultimate line, immediately before the final routing marker:
 
     ⟦AI:AUTO-LOOP⟧
 
-不可修改字符 / 不放代码注释 / 不放路径分支名。无 sentinel = 产生失败,controller 拒绝 post。
+Do not modify the sentinel characters; do not place them in code comments, paths, or branch names. No sentinel = generation failure; controller rejects the artifact or post.

--- a/skills/codex-refactor-loop/prompts/verify.md
+++ b/skills/codex-refactor-loop/prompts/verify.md
@@ -1,5 +1,7 @@
 # 任务：验证 ${WORK_UNIT_ID} 的实施改动
 
+Artifact profile: marker-only-work-unit
+
 <!-- Refactor (iter3/skill-host-language-policy): Old: prompt hardcoded host-language defaults  New: 6 HOST_* variables are optional and empty by default, injected by host.env (#20 structural consensus) -->
 
 你以无人值守模式在 worktree `${WORKTREE_PATH}` 中工作。前一个 codex 已完成实施，改动在工作树未提交。

--- a/skills/codex-refactor-loop/scripts/test_marker_emission_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_emission_contract.py
@@ -108,6 +108,52 @@ PROMPT_ALLOWLISTS = {
     ),
 }
 
+KNOWN_ARTIFACT_PROFILES = {
+    "phase9-solver",
+    "phase9-meta-judge",
+    "phase8-reviewer",
+    "review-fix",
+    "marker-only-work-unit",
+    "github-ai-post-body",
+}
+
+PROMPT_ARTIFACT_PROFILES = {
+    "audit.md": "marker-only-work-unit",
+    "implement.md": "marker-only-work-unit",
+    "verify.md": "marker-only-work-unit",
+    "remote-ci-fix.md": "marker-only-work-unit",
+    "review-fix.md": "review-fix",
+    "reviewer-architect.md": "phase8-reviewer",
+    "reviewer-tests.md": "phase8-reviewer",
+    "reviewer-quality.md": "phase8-reviewer",
+    "solver-minimal.md": "phase9-solver",
+    "solver-structural.md": "phase9-solver",
+    "solver-delete.md": "phase9-solver",
+    "meta-judge.md": "phase9-meta-judge",
+    "meta-reflector-stalled.md": "marker-only-work-unit",
+    "test-add.md": "marker-only-work-unit",
+    "triage-external-issue.md": "marker-only-work-unit",
+}
+
+PROFILE_TERMINAL_MARKER_TOKENS = {
+    "marker-only-work-unit": {
+        "AUDIT_DONE",
+        "AUDIT_INCOMPLETE",
+        "SCOPE_EXTEND",
+        "IMPLEMENT_DONE",
+        "VERIFY_DONE",
+        "REMOTE_CI_FIX_DONE",
+        "META_RESOLVED",
+        "TEST_BLOCKED",
+        "TEST_ADD_DONE",
+        "TRIAGE_DECISION_DONE",
+    },
+    "review-fix": {"SCOPE_EXTEND", "FIX_DONE", "FIX_BLOCKED"},
+    "phase8-reviewer": {"REVIEW_DONE"},
+    "phase9-solver": {"SOLVER_DONE"},
+    "phase9-meta-judge": {"META_JUDGE_DONE"},
+}
+
 
 def allowlist_section(body: str) -> str:
     start = body.find(SECTION_HEADING)
@@ -122,6 +168,10 @@ def allowlist_section(body: str) -> str:
 
 def marker_token(marker: str) -> str:
     return marker.split(":", 1)[0]
+
+
+def artifact_profile_anchors(body: str) -> list[str]:
+    return re.findall(r"(?m)^Artifact profile: ([a-z0-9-]+)$", body)
 
 
 class MarkerEmissionContractTests(unittest.TestCase):
@@ -184,6 +234,33 @@ class MarkerEmissionContractTests(unittest.TestCase):
                     offenders.append(f"{path.name}: {pattern}")
 
         self.assertEqual(offenders, [])
+
+    def test_each_marker_prompt_declares_exactly_one_known_artifact_profile(self) -> None:
+        self.assertEqual(set(PROMPT_ARTIFACT_PROFILES), set(PROMPT_ALLOWLISTS))
+        for filename, expected_profile in PROMPT_ARTIFACT_PROFILES.items():
+            with self.subTest(prompt=filename):
+                body = (PROMPTS_DIR / filename).read_text(encoding="utf-8")
+                anchors = artifact_profile_anchors(body)
+
+                self.assertEqual(anchors, [expected_profile])
+                self.assertIn(expected_profile, KNOWN_ARTIFACT_PROFILES)
+
+    def test_prompt_artifact_profile_terminal_marker_policy_matches_allowlist(self) -> None:
+        for filename, allowed_markers in PROMPT_ALLOWLISTS.items():
+            with self.subTest(prompt=filename):
+                profile = PROMPT_ARTIFACT_PROFILES[filename]
+                profile_tokens = PROFILE_TERMINAL_MARKER_TOKENS[profile]
+                allowed_tokens = {marker_token(marker) for marker in allowed_markers}
+
+                self.assertLessEqual(
+                    allowed_tokens,
+                    profile_tokens,
+                    f"{filename} allowlist tokens must fit profile {profile}",
+                )
+
+    def test_github_post_rules_declares_post_body_artifact_profile(self) -> None:
+        body = (PROMPTS_DIR / "_github-post-rules.md").read_text(encoding="utf-8")
+        self.assertEqual(artifact_profile_anchors(body), ["github-ai-post-body"])
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_marker_emission_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_emission_contract.py
@@ -52,7 +52,6 @@ PROMPT_ALLOWLISTS = {
         "REMOTE_CI_FIX_DONE:${CHECK_NAME}:<status>",
     ),
     "review-fix.md": (
-        "SCOPE_EXTEND:<file>:<reason>",
         "FIX_DONE:${PR_NUMBER}:round-${FIX_ROUND}:applied-<N>:rejected-<M>:blocked-<K>",
         "FIX_BLOCKED:${PR_NUMBER}:round-${FIX_ROUND}:<conflict|human-decision|build-broken|other>:<short>",
     ),
@@ -110,6 +109,7 @@ PROMPT_ALLOWLISTS = {
 
 KNOWN_ARTIFACT_PROFILES = {
     "phase9-solver",
+    "phase9-delete-solver",
     "phase9-meta-judge",
     "phase8-reviewer",
     "review-fix",
@@ -128,7 +128,7 @@ PROMPT_ARTIFACT_PROFILES = {
     "reviewer-quality.md": "phase8-reviewer",
     "solver-minimal.md": "phase9-solver",
     "solver-structural.md": "phase9-solver",
-    "solver-delete.md": "phase9-solver",
+    "solver-delete.md": "phase9-delete-solver",
     "meta-judge.md": "phase9-meta-judge",
     "meta-reflector-stalled.md": "marker-only-work-unit",
     "test-add.md": "marker-only-work-unit",
@@ -148,9 +148,10 @@ PROFILE_TERMINAL_MARKER_TOKENS = {
         "TEST_ADD_DONE",
         "TRIAGE_DECISION_DONE",
     },
-    "review-fix": {"SCOPE_EXTEND", "FIX_DONE", "FIX_BLOCKED"},
+    "review-fix": {"FIX_DONE", "FIX_BLOCKED"},
     "phase8-reviewer": {"REVIEW_DONE"},
     "phase9-solver": {"SOLVER_DONE"},
+    "phase9-delete-solver": {"SOLVER_DONE"},
     "phase9-meta-judge": {"META_JUDGE_DONE"},
 }
 

--- a/skills/codex-refactor-loop/scripts/test_role_artifact_profiles.py
+++ b/skills/codex-refactor-loop/scripts/test_role_artifact_profiles.py
@@ -64,6 +64,23 @@ PROFILES = {
         forbidden_marker_tokens=tuple(token for token in ROLE_MARKER_TOKENS if token != "SOLVER_DONE"),
         sentinel_policy="penultimate-before-final-marker",
     ),
+    "phase9-delete-solver": ArtifactProfile(
+        required_metadata=("solver", "issue", "cluster", "verdict"),
+        required_sections=(
+            "Classification",
+            "Recommended action",
+            "Concrete plan",
+            "Reverse-evidence",
+            "Risks",
+            "Escalation triggers",
+            "Reasoning trace",
+        ),
+        final_marker_patterns=(
+            r"^SOLVER_DONE:delete:(propose|abstain|escalate|false-positive):.+$",
+        ),
+        forbidden_marker_tokens=tuple(token for token in ROLE_MARKER_TOKENS if token != "SOLVER_DONE"),
+        sentinel_policy="penultimate-before-final-marker",
+    ),
     "phase9-meta-judge": ArtifactProfile(
         required_metadata=("issue", "cluster", "convergence_round", "solver_verdicts", "decision"),
         required_sections=("Decision", "If consensus", "If converge", "If escalate", "Round audit trail"),
@@ -142,6 +159,38 @@ The profile checks remain shape-only.
 
 ⟦AI:AUTO-LOOP⟧
 SOLVER_DONE:minimal:propose:test-only profile inventory
+"""
+
+VALID_DELETE_SOLVER = """---
+solver: delete
+issue: 169
+cluster: issue-169
+verdict: propose
+---
+
+## Classification
+a
+
+## Recommended action
+Delete the dead path.
+
+## Concrete plan (if propose)
+- Files to delete: one file
+
+## Reverse-evidence (why this is safe to delete)
+- No callers.
+
+## Risks
+- Caller search could be incomplete.
+
+## Escalation triggers (if any)
+- none
+
+## Reasoning trace
+The profile matches the delete solver template.
+
+⟦AI:AUTO-LOOP⟧
+SOLVER_DONE:delete:propose:delete dead path
 """
 
 VALID_META_JUDGE = """---
@@ -297,6 +346,33 @@ def final_nonempty_line(text: str) -> str:
     return ""
 
 
+def fenced_marker_templates(section: str) -> tuple[str, ...]:
+    templates = []
+    token_pattern = "|".join(re.escape(token) for token in ROLE_MARKER_TOKENS)
+    for template in re.findall(r"`([^`\n]+)`", section):
+        if re.match(rf"^(?:{token_pattern}):", template):
+            templates.append(template)
+    return tuple(templates)
+
+
+def review_fix_terminal_marker_section(body: str) -> str:
+    match = re.search(
+        r"End your output with EXACTLY one of:\n(?P<section>.*?)\n## Marker emission allowlist",
+        body,
+        flags=re.S,
+    )
+    return match.group("section") if match else ""
+
+
+def marker_allowlist_section(body: str) -> str:
+    match = re.search(
+        r"## Marker emission allowlist\(强制\)\n(?P<section>.*?)\n## Hard rules",
+        body,
+        flags=re.S,
+    )
+    return match.group("section") if match else ""
+
+
 def validate_internal_artifact(profile_id: str, text: str) -> list[str]:
     profile = PROFILES[profile_id]
     errors: list[str] = []
@@ -362,6 +438,12 @@ class RoleArtifactProfileTests(unittest.TestCase):
 
     def test_phase9_solver_valid_fixture_passes_shape_only(self) -> None:
         self.assertEqual(validate_internal_artifact("phase9-solver", VALID_SOLVER), [])
+
+    def test_phase9_delete_solver_valid_fixture_passes_shape_only(self) -> None:
+        self.assertEqual(validate_internal_artifact("phase9-delete-solver", VALID_DELETE_SOLVER), [])
+
+    def test_phase9_solver_rejects_delete_solver_output_shape(self) -> None:
+        self.assertInvalidBecause("phase9-solver", VALID_DELETE_SOLVER, "missing sections")
 
     def test_phase9_solver_rejects_embedded_foreign_marker(self) -> None:
         artifact = VALID_SOLVER.replace(
@@ -463,6 +545,46 @@ class RoleArtifactProfileTests(unittest.TestCase):
         for section in PROFILES["review-fix"].required_sections:
             self.assertRegex(body, rf"(?m)^## {re.escape(section)}(?:\b|$)")
         self.assertNotIn("Rejected as false-positive findings", body)
+
+    def test_review_fix_terminal_marker_contract_is_single_source(self) -> None:
+        body = (PROMPTS_DIR / "review-fix.md").read_text(encoding="utf-8")
+        expected_templates = (
+            "FIX_DONE:${PR_NUMBER}:round-${FIX_ROUND}:applied-<N>:rejected-<M>:blocked-<K>",
+            "FIX_BLOCKED:${PR_NUMBER}:round-${FIX_ROUND}:<conflict|human-decision|build-broken|other>:<short>",
+        )
+
+        self.assertEqual(fenced_marker_templates(review_fix_terminal_marker_section(body)), expected_templates)
+        self.assertEqual(fenced_marker_templates(marker_allowlist_section(body)), expected_templates)
+        self.assertEqual(
+            PROFILES["review-fix"].final_marker_patterns,
+            (
+                r"^FIX_DONE:[^:]+:round-\d+:applied-\d+:rejected-\d+:blocked-\d+$",
+                r"^FIX_BLOCKED:[^:]+:round-\d+:(conflict|human-decision|build-broken|other):.+$",
+            ),
+        )
+        self.assertEqual(
+            PROFILES["review-fix"].forbidden_marker_tokens,
+            tuple(token for token in ROLE_MARKER_TOKENS if token not in {"FIX_DONE", "FIX_BLOCKED"}),
+        )
+
+    def test_phase9_solver_profiles_match_live_prompt_output_sections(self) -> None:
+        prompt_profiles = {
+            "solver-minimal.md": "phase9-solver",
+            "solver-structural.md": "phase9-solver",
+            "solver-delete.md": "phase9-delete-solver",
+        }
+        for filename, profile_id in prompt_profiles.items():
+            with self.subTest(prompt=filename):
+                body = (PROMPTS_DIR / filename).read_text(encoding="utf-8")
+
+                self.assertIn(f"Artifact profile: {profile_id}", body)
+                for section in PROFILES[profile_id].required_sections:
+                    self.assertRegex(body, rf"(?m)^## {re.escape(section)}(?:\b|$)")
+                for other_profile_id, other_profile in PROFILES.items():
+                    if not other_profile_id.startswith("phase9-") or other_profile_id == profile_id:
+                        continue
+                    for section in set(other_profile.required_sections) - set(PROFILES[profile_id].required_sections):
+                        self.assertNotRegex(body, rf"(?m)^## {re.escape(section)}(?:\b|$)")
 
     def test_marker_only_profile_does_not_invent_shared_output_sections(self) -> None:
         self.assertEqual(PROFILES["marker-only-work-unit"].required_metadata, ())

--- a/skills/codex-refactor-loop/scripts/test_role_artifact_profiles.py
+++ b/skills/codex-refactor-loop/scripts/test_role_artifact_profiles.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Behavior fixtures for role artifact shape and routing-marker safety."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__)
+SKILL_DIR = SCRIPT_PATH.parents[1]
+PROMPTS_DIR = SKILL_DIR / "prompts"
+RUNTIME_PROFILE_MODULE = SCRIPT_PATH.parent / "codex_refactor_loop" / "artifacts" / "profiles.py"
+PROSE_PROFILE_RULES = PROMPTS_DIR / "_artifact-profile-rules.md"
+SENTINEL = "⟦AI:AUTO-LOOP⟧"
+PROFILE_AUTHORITY_PATH = "skills/codex-refactor-loop/scripts/test_role_artifact_profiles.py"
+
+# This mirrors test_marker_emission_contract.py while keeping profile rules test-only.
+ROLE_MARKER_TOKENS = (
+    "AUDIT_DONE",
+    "AUDIT_INCOMPLETE",
+    "SCOPE_EXTEND",
+    "IMPLEMENT_DONE",
+    "VERIFY_DONE",
+    "REMOTE_CI_FIX_DONE",
+    "REVIEW_DONE",
+    "FIX_DONE",
+    "FIX_BLOCKED",
+    "SOLVER_DONE",
+    "META_JUDGE_DONE",
+    "META_RESOLVED",
+    "TEST_BLOCKED",
+    "TEST_ADD_DONE",
+    "TRIAGE_DECISION_DONE",
+)
+
+
+@dataclass(frozen=True)
+class ArtifactProfile:
+    required_metadata: tuple[str, ...]
+    required_sections: tuple[str, ...]
+    final_marker_patterns: tuple[str, ...]
+    forbidden_marker_tokens: tuple[str, ...]
+    sentinel_policy: str
+    requires_folded_raw_artifact: bool = False
+    requires_github_banner: bool = False
+
+
+PROFILES = {
+    "phase9-solver": ArtifactProfile(
+        required_metadata=("solver", "issue", "cluster", "verdict"),
+        required_sections=(
+            "Recommended framing",
+            "Concrete plan",
+            "Risks",
+            "Escalation triggers",
+            "Reasoning trace",
+        ),
+        final_marker_patterns=(
+            r"^SOLVER_DONE:(minimal|structural|delete):(propose|abstain|escalate|false-positive):.+$",
+        ),
+        forbidden_marker_tokens=tuple(token for token in ROLE_MARKER_TOKENS if token != "SOLVER_DONE"),
+        sentinel_policy="penultimate-before-final-marker",
+    ),
+    "phase9-meta-judge": ArtifactProfile(
+        required_metadata=("issue", "cluster", "convergence_round", "solver_verdicts", "decision"),
+        required_sections=("Decision", "If consensus", "If converge", "If escalate", "Round audit trail"),
+        final_marker_patterns=(r"^META_JUDGE_DONE:(consensus|converge|escalate):.+$",),
+        forbidden_marker_tokens=tuple(token for token in ROLE_MARKER_TOKENS if token != "META_JUDGE_DONE"),
+        sentinel_policy="penultimate-before-final-marker",
+    ),
+    "phase8-reviewer": ArtifactProfile(
+        required_metadata=("pr", "role", "verdict"),
+        required_sections=("Verdict", "Findings", "Risks", "Recommendation"),
+        final_marker_patterns=(r"^REVIEW_DONE:[^:]+:(architect|tests|quality):.+$",),
+        forbidden_marker_tokens=tuple(token for token in ROLE_MARKER_TOKENS if token != "REVIEW_DONE"),
+        sentinel_policy="penultimate-before-final-marker",
+    ),
+    "review-fix": ArtifactProfile(
+        required_metadata=("pr", "fix_round", "max_fix_rounds"),
+        required_sections=(
+            "Applied",
+            "Rejected as false positive",
+            "Blocked",
+            "Build status",
+            "Recommendation for next round",
+        ),
+        final_marker_patterns=(
+            r"^FIX_DONE:[^:]+:round-\d+:applied-\d+:rejected-\d+:blocked-\d+$",
+            r"^FIX_BLOCKED:[^:]+:round-\d+:(conflict|human-decision|build-broken|other):.+$",
+        ),
+        forbidden_marker_tokens=tuple(
+            token for token in ROLE_MARKER_TOKENS if token not in {"FIX_DONE", "FIX_BLOCKED"}
+        ),
+        sentinel_policy="penultimate-before-final-marker",
+    ),
+    "marker-only-work-unit": ArtifactProfile(
+        required_metadata=("cluster_id", "status"),
+        required_sections=("Summary", "Checks"),
+        final_marker_patterns=(
+            r"^(AUDIT_DONE|AUDIT_INCOMPLETE|SCOPE_EXTEND|IMPLEMENT_DONE|VERIFY_DONE|REMOTE_CI_FIX_DONE|"
+            r"META_RESOLVED|TEST_BLOCKED|TEST_ADD_DONE|TRIAGE_DECISION_DONE):.+$",
+        ),
+        forbidden_marker_tokens=("REVIEW_DONE", "FIX_DONE", "FIX_BLOCKED", "SOLVER_DONE", "META_JUDGE_DONE"),
+        sentinel_policy="penultimate-before-final-marker",
+    ),
+    "github-ai-post-body": ArtifactProfile(
+        required_metadata=(),
+        required_sections=("TL;DR", "详细说明"),
+        final_marker_patterns=(),
+        forbidden_marker_tokens=(),
+        sentinel_policy="final-sentinel",
+        requires_folded_raw_artifact=True,
+        requires_github_banner=True,
+    ),
+}
+
+
+VALID_SOLVER = """---
+solver: minimal
+issue: 169
+cluster: issue-169
+verdict: propose
+---
+
+## Recommended framing
+Use a test-only profile inventory.
+
+## Concrete plan
+- Add fixture tests.
+
+## Risks
+- Future runtime consumers need a separate design.
+
+## Escalation triggers (if any)
+- none
+
+## Reasoning trace
+The profile checks remain shape-only.
+
+⟦AI:AUTO-LOOP⟧
+SOLVER_DONE:minimal:propose:test-only profile inventory
+"""
+
+VALID_META_JUDGE = """---
+issue: 169
+cluster: issue-169
+convergence_round: 2
+solver_verdicts:
+  minimal: propose
+  structural: propose
+  delete: propose
+decision: consensus
+---
+
+## Decision
+Consensus reached on test-only profile fixtures.
+
+## If consensus
+- Chosen framing: test-only
+
+## If converge
+- Not applicable.
+
+## If escalate
+- Not applicable.
+
+## Round audit trail
+- solver-minimal: path
+
+⟦AI:AUTO-LOOP⟧
+META_JUDGE_DONE:consensus:test-only:all solvers aligned
+"""
+
+VALID_REVIEWER = """---
+pr: 42
+role: architect
+verdict: approve
+---
+
+## Verdict
+Approve.
+
+## Findings
+- None.
+
+## Risks
+- None.
+
+## Recommendation
+- Merge.
+
+⟦AI:AUTO-LOOP⟧
+REVIEW_DONE:42:architect:approve
+"""
+
+VALID_REVIEW_FIX = """---
+pr: 42
+fix_round: 2
+max_fix_rounds: 5
+---
+
+## Applied
+- Fixed one demand.
+
+## Rejected as false positive
+- None.
+
+## Blocked
+- None.
+
+## Build status
+- build: pass
+- tests: pass
+
+## Recommendation for next round
+- Re-review.
+
+⟦AI:AUTO-LOOP⟧
+FIX_DONE:42:round-2:applied-1:rejected-0:blocked-0
+"""
+
+VALID_MARKER_ONLY = """---
+cluster_id: issue-169
+status: ok
+---
+
+## Summary
+Implementation finished.
+
+## Checks
+- tests: pass
+
+⟦AI:AUTO-LOOP⟧
+IMPLEMENT_DONE:issue-169:ok
+"""
+
+VALID_GITHUB_POST = """## 🤖 Profile check reached consensus
+
+### TL;DR
+- 这是什么:test-only artifact profile fixture。
+- 现在到哪一步:已完成。
+- 下一步:controller 继续。
+
+---
+
+### 详细说明
+
+正文保持中文,raw artifact 折叠。
+
+---
+
+<details>
+<summary>📎 完整 codex 原始输出(存档备查)</summary>
+
+---
+solver: minimal
+---
+
+⟦AI:AUTO-LOOP⟧
+SOLVER_DONE:minimal:propose:test-only
+
+</details>
+
+⟦AI:AUTO-LOOP⟧
+"""
+
+
+def frontmatter_keys(text: str) -> set[str]:
+    lines = text.splitlines()
+    if not lines or lines[0] != "---":
+        return set()
+    keys = set()
+    for line in lines[1:]:
+        if line == "---":
+            return keys
+        if line and not line.startswith(" ") and ":" in line:
+            keys.add(line.split(":", 1)[0])
+    return keys
+
+
+def section_headings(text: str) -> set[str]:
+    return set(re.findall(r"(?m)^#{2,3} (.+)$", text))
+
+
+def missing_required_sections(text: str, required_sections: tuple[str, ...]) -> list[str]:
+    headings = section_headings(text)
+    missing = []
+    for section in required_sections:
+        if not any(heading == section or heading.startswith(f"{section} ") for heading in headings):
+            missing.append(section)
+    return missing
+
+
+def role_marker_occurrences(text: str) -> list[str]:
+    token_pattern = "|".join(re.escape(token) for token in ROLE_MARKER_TOKENS)
+    return re.findall(rf"(?<![A-Z_])(?:{token_pattern}):[^\n`]*", text)
+
+
+def final_nonempty_line(text: str) -> str:
+    for line in reversed(text.splitlines()):
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def validate_internal_artifact(profile_id: str, text: str) -> list[str]:
+    profile = PROFILES[profile_id]
+    errors: list[str] = []
+    lines = [line.rstrip() for line in text.strip().splitlines()]
+    final_line = final_nonempty_line(text)
+
+    missing_metadata = set(profile.required_metadata) - frontmatter_keys(text)
+    if missing_metadata:
+        errors.append(f"missing metadata: {sorted(missing_metadata)}")
+
+    missing_sections = missing_required_sections(text, profile.required_sections)
+    if missing_sections:
+        errors.append(f"missing sections: {missing_sections}")
+
+    markers = role_marker_occurrences(text)
+    if len(markers) != 1:
+        errors.append(f"expected exactly one routing marker, found {len(markers)}")
+
+    if not any(re.match(pattern, final_line) for pattern in profile.final_marker_patterns):
+        errors.append("final line does not match allowed marker pattern")
+
+    if len(lines) < 2 or lines[-2] != SENTINEL:
+        errors.append("sentinel must be the penultimate line before the final marker")
+    if text.count(SENTINEL) != 1:
+        errors.append("internal artifact must contain exactly one sentinel")
+
+    for token in profile.forbidden_marker_tokens:
+        if re.search(rf"(?<![A-Z_]){re.escape(token)}:", text):
+            errors.append(f"forbidden routing marker token: {token}")
+
+    return errors
+
+
+def validate_github_post_body(text: str) -> list[str]:
+    profile = PROFILES["github-ai-post-body"]
+    errors: list[str] = []
+    lines = [line.rstrip() for line in text.strip().splitlines()]
+    final_line = final_nonempty_line(text)
+
+    if profile.requires_github_banner and not lines[0].startswith("## 🤖 "):
+        errors.append("first line must start with GitHub AI banner")
+
+    missing_sections = missing_required_sections(text, profile.required_sections)
+    if missing_sections:
+        errors.append(f"missing sections: {missing_sections}")
+
+    if profile.requires_folded_raw_artifact and not re.search(r"(?ms)<details>.+</details>", text):
+        errors.append("raw artifact must be folded in details")
+
+    if final_line != SENTINEL:
+        errors.append("GitHub post body must end with final sentinel")
+
+    if any(final_line.startswith(f"{token}:") for token in ROLE_MARKER_TOKENS):
+        errors.append("GitHub post body must not end with a role-routing marker")
+
+    return errors
+
+
+class RoleArtifactProfileTests(unittest.TestCase):
+    def assertInvalidBecause(self, profile_id: str, text: str, needle: str) -> None:
+        errors = validate_internal_artifact(profile_id, text)
+        self.assertTrue(any(needle in error for error in errors), errors)
+
+    def test_phase9_solver_valid_fixture_passes_shape_only(self) -> None:
+        self.assertEqual(validate_internal_artifact("phase9-solver", VALID_SOLVER), [])
+
+    def test_phase9_solver_rejects_embedded_foreign_marker(self) -> None:
+        artifact = VALID_SOLVER.replace(
+            "The profile checks remain shape-only.",
+            "The profile checks remain shape-only.\nREVIEW_DONE:42:architect:approve",
+        )
+
+        self.assertInvalidBecause("phase9-solver", artifact, "forbidden routing marker token: REVIEW_DONE")
+
+    def test_meta_judge_missing_audit_trail_fails(self) -> None:
+        artifact = VALID_META_JUDGE.replace("\n## Round audit trail\n- solver-minimal: path\n", "\n")
+
+        self.assertInvalidBecause("phase9-meta-judge", artifact, "missing sections")
+
+    def test_reviewer_with_wrong_marker_fails(self) -> None:
+        artifact = VALID_REVIEWER.replace("REVIEW_DONE:42:architect:approve", "SOLVER_DONE:minimal:propose:no")
+
+        self.assertInvalidBecause("phase8-reviewer", artifact, "final line does not match")
+
+    def test_review_fix_marker_count_shape(self) -> None:
+        self.assertEqual(validate_internal_artifact("review-fix", VALID_REVIEW_FIX), [])
+        artifact = VALID_REVIEW_FIX.replace("applied-1:rejected-0:blocked-0", "applied-one:rejected-0:blocked-0")
+
+        self.assertInvalidBecause("review-fix", artifact, "final line does not match")
+
+    def test_marker_only_work_unit_requires_sentinel_before_final_marker(self) -> None:
+        self.assertEqual(validate_internal_artifact("marker-only-work-unit", VALID_MARKER_ONLY), [])
+        artifact = VALID_MARKER_ONLY.replace(f"\n{SENTINEL}\nIMPLEMENT_DONE", "\nIMPLEMENT_DONE")
+
+        self.assertInvalidBecause("marker-only-work-unit", artifact, "sentinel must be the penultimate")
+
+    def test_github_ai_post_body_requires_banner_details_and_final_sentinel(self) -> None:
+        self.assertEqual(validate_github_post_body(VALID_GITHUB_POST), [])
+        missing_details = re.sub(r"(?ms)\n<details>.+?</details>\n", "\nraw artifact inline\n", VALID_GITHUB_POST)
+        missing_sentinel = VALID_GITHUB_POST.replace(f"\n{SENTINEL}\n", "\n")
+
+        self.assertTrue(
+            any("raw artifact must be folded" in error for error in validate_github_post_body(missing_details))
+        )
+        self.assertTrue(
+            any("must end with final sentinel" in error for error in validate_github_post_body(missing_sentinel))
+        )
+
+    def test_profile_inventory_is_shape_safety_only(self) -> None:
+        allowed_fields = {
+            "required_metadata",
+            "required_sections",
+            "final_marker_patterns",
+            "forbidden_marker_tokens",
+            "sentinel_policy",
+            "requires_folded_raw_artifact",
+            "requires_github_banner",
+        }
+        for profile in PROFILES.values():
+            with self.subTest(profile=profile):
+                self.assertEqual(set(profile.__dataclass_fields__), allowed_fields)
+        source = SCRIPT_PATH.read_text(encoding="utf-8")
+        forbidden_terms = (
+            "plan " + "quality",
+            "reviewer " + "quality",
+            "verdict " + "correctness",
+            "prose " + "quality",
+            "good " + "plan",
+            "bad " + "plan",
+        )
+        for forbidden in forbidden_terms:
+            self.assertNotIn(forbidden, source)
+
+    def test_profile_authority_stays_in_unittest_not_runtime_or_prompt_prose(self) -> None:
+        self.assertTrue(str(SCRIPT_PATH).endswith(PROFILE_AUTHORITY_PATH))
+        self.assertFalse(RUNTIME_PROFILE_MODULE.exists(), "do not add runtime artifact profile authority")
+        self.assertFalse(PROSE_PROFILE_RULES.exists(), "do not add a second prose profile authority")
+        skill_body = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        self.assertNotIn("Artifact profile:", skill_body)
+
+    def test_github_post_rules_profile_source_regression(self) -> None:
+        body = (PROMPTS_DIR / "_github-post-rules.md").read_text(encoding="utf-8")
+        self.assertIn("Artifact profile: github-ai-post-body", body)
+        self.assertIn("## Body 结构(强制)", body)
+        self.assertIn("第一行 `## 🤖 ` 开头", body)
+        self.assertIn("raw artifact 必折叠", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_role_artifact_profiles.py
+++ b/skills/codex-refactor-loop/scripts/test_role_artifact_profiles.py
@@ -73,7 +73,7 @@ PROFILES = {
     ),
     "phase8-reviewer": ArtifactProfile(
         required_metadata=("pr", "role", "verdict"),
-        required_sections=("Verdict", "Findings", "Risks", "Recommendation"),
+        required_sections=("Verdict", "Evidence"),
         final_marker_patterns=(r"^REVIEW_DONE:[^:]+:(architect|tests|quality):.+$",),
         forbidden_marker_tokens=tuple(token for token in ROLE_MARKER_TOKENS if token != "REVIEW_DONE"),
         sentinel_policy="penultimate-before-final-marker",
@@ -97,8 +97,8 @@ PROFILES = {
         sentinel_policy="penultimate-before-final-marker",
     ),
     "marker-only-work-unit": ArtifactProfile(
-        required_metadata=("cluster_id", "status"),
-        required_sections=("Summary", "Checks"),
+        required_metadata=(),
+        required_sections=(),
         final_marker_patterns=(
             r"^(AUDIT_DONE|AUDIT_INCOMPLETE|SCOPE_EXTEND|IMPLEMENT_DONE|VERIFY_DONE|REMOTE_CI_FIX_DONE|"
             r"META_RESOLVED|TEST_BLOCKED|TEST_ADD_DONE|TRIAGE_DECISION_DONE):.+$",
@@ -183,14 +183,8 @@ verdict: approve
 ## Verdict
 Approve.
 
-## Findings
+## Evidence
 - None.
-
-## Risks
-- None.
-
-## Recommendation
-- Merge.
 
 ⟦AI:AUTO-LOOP⟧
 REVIEW_DONE:42:architect:approve
@@ -229,9 +223,6 @@ status: ok
 
 ## Summary
 Implementation finished.
-
-## Checks
-- tests: pass
 
 ⟦AI:AUTO-LOOP⟧
 IMPLEMENT_DONE:issue-169:ok
@@ -452,6 +443,43 @@ class RoleArtifactProfileTests(unittest.TestCase):
         self.assertIn("## Body 结构(强制)", body)
         self.assertIn("第一行 `## 🤖 ` 开头", body)
         self.assertIn("raw artifact 必折叠", body)
+
+    def test_phase8_reviewer_profile_matches_live_prompt_output_sections(self) -> None:
+        for filename in ("reviewer-architect.md", "reviewer-tests.md", "reviewer-quality.md"):
+            with self.subTest(prompt=filename):
+                body = (PROMPTS_DIR / filename).read_text(encoding="utf-8")
+
+                self.assertIn("Artifact profile: phase8-reviewer", body)
+                for section in PROFILES["phase8-reviewer"].required_sections:
+                    self.assertRegex(body, rf"(?m)^## {re.escape(section)}(?:\b|$)")
+                self.assertNotIn("## Findings", body)
+                self.assertNotIn("## Risks", body)
+                self.assertNotIn("## Recommendation", body)
+
+    def test_review_fix_profile_matches_live_prompt_output_sections(self) -> None:
+        body = (PROMPTS_DIR / "review-fix.md").read_text(encoding="utf-8")
+
+        self.assertIn("Artifact profile: review-fix", body)
+        for section in PROFILES["review-fix"].required_sections:
+            self.assertRegex(body, rf"(?m)^## {re.escape(section)}(?:\b|$)")
+        self.assertNotIn("Rejected as false-positive findings", body)
+
+    def test_marker_only_profile_does_not_invent_shared_output_sections(self) -> None:
+        self.assertEqual(PROFILES["marker-only-work-unit"].required_metadata, ())
+        self.assertEqual(PROFILES["marker-only-work-unit"].required_sections, ())
+
+    def test_profiled_internal_prompts_distinguish_sentinel_from_final_marker(self) -> None:
+        contradicted = []
+        for path in sorted(PROMPTS_DIR.glob("*.md")):
+            body = path.read_text(encoding="utf-8")
+            if "Artifact profile:" not in body or "Artifact profile: github-ai-post-body" in body:
+                continue
+            if "runs/*.md` artifact" in body and "必须末尾独立一行**加 sentinel" in body:
+                contradicted.append(path.name)
+            if not re.search(r"sentinel.*penultimate line.*final routing marker", body):
+                contradicted.append(f"{path.name}: missing internal sentinel policy")
+
+        self.assertEqual(contradicted, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
实现 #169 的 Phase 9 共识 concrete plan(含 behavior + source-regression test,全量套件本地绿)。Closes #169。

走 Phase 8 多 reviewer 共识 gate。注意:本批 6 个实现触及共享文件(cli.py/SKILL.md/prompts/tests),需**串行 merge**(逐个 rebase)。

⟦AI:AUTO-LOOP⟧