### PR TITLE
feat(#107): 去版本后缀 — 删 state schema_version + rename versioned identifiers

### DIFF
--- a/skills/codex-refactor-loop/prompts/audit.md
+++ b/skills/codex-refactor-loop/prompts/audit.md
@@ -140,7 +140,7 @@ human_brief:
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `AUDIT_DONE:$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md:<N>`

--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -55,7 +55,7 @@ ${SCOPE_PATHS}
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `SCOPE_EXTEND:<file>:<reason>`

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -123,7 +123,7 @@ End with EXACTLY ONE marker:
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `META_JUDGE_DONE:consensus:<framing>:<summary>`

--- a/skills/codex-refactor-loop/prompts/meta-reflector-stalled.md
+++ b/skills/codex-refactor-loop/prompts/meta-reflector-stalled.md
@@ -41,7 +41,7 @@ Valid outputs:
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `META_RESOLVED:retry-fix:<reason>`

--- a/skills/codex-refactor-loop/prompts/remote-ci-fix.md
+++ b/skills/codex-refactor-loop/prompts/remote-ci-fix.md
@@ -49,7 +49,7 @@ PR: `${PR_NUMBER}`，失败 check: `${CHECK_NAME}`，run url: `${RUN_URL}`。
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `REMOTE_CI_FIX_DONE:${CHECK_NAME}:<status>`

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -93,7 +93,7 @@ End your output with EXACTLY one of:
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `SCOPE_EXTEND:<file>:<reason>`

--- a/skills/codex-refactor-loop/prompts/reviewer-architect.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-architect.md
@@ -63,7 +63,7 @@ End with marker line: `REVIEW_DONE:${PR_NUMBER}:architect:<verdict>`
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `REVIEW_DONE:${PR_NUMBER}:architect:<verdict>`

--- a/skills/codex-refactor-loop/prompts/reviewer-quality.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-quality.md
@@ -67,7 +67,7 @@ End with marker: `REVIEW_DONE:${PR_NUMBER}:quality:<verdict>`
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `REVIEW_DONE:${PR_NUMBER}:quality:<verdict>`

--- a/skills/codex-refactor-loop/prompts/reviewer-tests.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-tests.md
@@ -66,7 +66,7 @@ End with marker: `REVIEW_DONE:${PR_NUMBER}:tests:<verdict>`
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `REVIEW_DONE:${PR_NUMBER}:tests:<verdict>`

--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -99,7 +99,7 @@ End with EXACTLY ONE marker line:
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `SOLVER_DONE:delete:propose:<summary>`

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -75,7 +75,7 @@ End with EXACTLY ONE marker line:
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `SOLVER_DONE:minimal:propose:<one-line summary>`

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -83,7 +83,7 @@ End with EXACTLY ONE marker line:
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `SOLVER_DONE:structural:propose:<summary>`

--- a/skills/codex-refactor-loop/prompts/test-add.md
+++ b/skills/codex-refactor-loop/prompts/test-add.md
@@ -66,7 +66,7 @@ ${UNCOVERED_LINES}
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `TEST_BLOCKED:<reason>`

--- a/skills/codex-refactor-loop/prompts/triage-external-issue.md
+++ b/skills/codex-refactor-loop/prompts/triage-external-issue.md
@@ -103,7 +103,7 @@
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `TRIAGE_DECISION_DONE:${ISSUE_NUMBER}:accept:.refactor-loop/runs/triage-issue-${ISSUE_NUMBER}.json`

--- a/skills/codex-refactor-loop/prompts/verify.md
+++ b/skills/codex-refactor-loop/prompts/verify.md
@@ -96,7 +96,7 @@ verified_at: <ISO8601>
 
 ## Marker emission allowlist(强制)
 
-<!-- MarkerEmissionContractV1: single-valid-invalid-role-marker-source -->
+<!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->
 
 ALLOWED markers:
 - `VERIFY_DONE:${CLUSTER_ID}:<verdict>`

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/checks/degradation.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/checks/degradation.py
@@ -47,8 +47,8 @@ FORBIDDEN_RUNTIME_FILES = (
 
 FORBIDDEN_SURFACE_PATTERNS = (
     re.compile(r"\b" + "Degradation" + r"Check\b"),
-    re.compile(r"\b" + "SkillDegradation" + r"CheckV1\b"),
-    re.compile(r"\b" + "WorkUnit" + r"V2\b"),
+    re.compile(r"\b" + "SkillDegradation" + r"Check\b"),
+    re.compile(r"\b" + "WorkUnit" + r"Replacement\b"),
     re.compile(r"\b" + "Controller" + r"Event\b"),
     re.compile(r"\b" + "Controller" + r"Command\b"),
     re.compile(r"\b" + "Controller" + r"Orchestrator\b"),

--- a/skills/codex-refactor-loop/scripts/test_check_skill_degradation.py
+++ b/skills/codex-refactor-loop/scripts/test_check_skill_degradation.py
@@ -108,6 +108,32 @@ class SkillDegradationCheckerBehaviorTests(unittest.TestCase):
 
         self.assertTrue(any(f.check == "forbidden-surface" and "DegradationCheck" in f.message for f in findings))
 
+    def test_checker_detects_skill_degradation_check_surface(self) -> None:
+        with copy_minimal_repo() as tmp:
+            repo = Path(tmp) / "repo"
+            skill = repo / "skills/codex-refactor-loop/SKILL.md"
+            skill.write_text(
+                skill.read_text(encoding="utf-8") + "\nRuntime creates SkillDegradationCheck objects.\n",
+                encoding="utf-8",
+            )
+
+            findings = self.checker_module.SkillDriftChecker(repo).run_static()
+
+        self.assertTrue(any(f.check == "forbidden-surface" and "SkillDegradation" in f.message for f in findings))
+
+    def test_checker_detects_work_unit_replacement_surface(self) -> None:
+        with copy_minimal_repo() as tmp:
+            repo = Path(tmp) / "repo"
+            skill = repo / "skills/codex-refactor-loop/SKILL.md"
+            skill.write_text(
+                skill.read_text(encoding="utf-8") + "\nRuntime creates WorkUnitReplacement objects.\n",
+                encoding="utf-8",
+            )
+
+            findings = self.checker_module.SkillDriftChecker(repo).run_static()
+
+        self.assertTrue(any(f.check == "forbidden-surface" and "WorkUnit" in f.message for f in findings))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_design_identifier_boundary.py
+++ b/skills/codex-refactor-loop/scripts/test_design_identifier_boundary.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """Source-regression guard for versioned design identifiers."""
 
+# Refactor (iter5/issue107-design-identifier-boundary):
+#   Old: design-facing names carried version-number suffixes, and root controller
+#   state exposed a schema metadata field as part of its durable shape.
+#   New: only release semver fields listed in .version-bump.json may carry
+#   version coordinates; this source-regression guard locks that boundary.
+
 from __future__ import annotations
 
 import json

--- a/skills/codex-refactor-loop/scripts/test_design_identifier_boundary.py
+++ b/skills/codex-refactor-loop/scripts/test_design_identifier_boundary.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Source-regression guard for versioned design identifiers."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[3]
+VERSION_BUMP = REPO_ROOT / ".version-bump.json"
+STATE_FILE = REPO_ROOT / ".refactor-loop" / "state.json"
+
+TEXT_SUFFIXES = {
+    ".md",
+    ".py",
+    ".sh",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".toml",
+}
+EXCLUDED_PREFIXES = (
+    ".git/",
+    ".worktrees/",
+    ".refactor-loop/runs/",
+    ".refactor-loop/prompts/",
+)
+VERSIONED_IDENTIFIER_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9_]*V[0-9]+\b")
+STATE_SCHEMA_FIELD_RE = re.compile(r"\b(?:work_unit_)?" + "schema" + r"_version\b")
+
+
+def git_tracked_paths() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return [REPO_ROOT / line for line in result.stdout.splitlines() if line]
+
+
+def repo_relative(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def version_bump_release_fields() -> set[tuple[str, str]]:
+    data = json.loads(VERSION_BUMP.read_text(encoding="utf-8"))
+    return {
+        (entry["path"], entry["field"])
+        for entry in data["files"]
+    }
+
+
+def version_bump_allowed_lines() -> set[tuple[str, int]]:
+    allowed = {(repo_relative(VERSION_BUMP), index) for index, _line in enumerate(VERSION_BUMP.read_text(encoding="utf-8").splitlines(), 1)}
+    for relative, field in version_bump_release_fields():
+        path = REPO_ROOT / relative
+        parts = field.split(".")
+        leaf = parts[-1]
+        for index, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if f'"{leaf}"' in line:
+                allowed.add((relative, index))
+    return allowed
+
+
+def is_source_path(path: Path) -> bool:
+    relative = repo_relative(path)
+    if any(relative.startswith(prefix) for prefix in EXCLUDED_PREFIXES):
+        return False
+    if path.is_symlink():
+        return False
+    return path.suffix in TEXT_SUFFIXES
+
+
+def queue_container_names() -> set[str]:
+    return {"clusters_planned", "clusters_active", "clusters_done", "clusters_failed"}
+
+
+class DesignIdentifierBoundaryTests(unittest.TestCase):
+    def test_tracked_source_has_no_versioned_design_identifiers(self) -> None:
+        allowed_lines = version_bump_allowed_lines()
+        offenders: list[str] = []
+        for path in git_tracked_paths():
+            if not is_source_path(path):
+                continue
+            relative = repo_relative(path)
+            try:
+                lines = path.read_text(encoding="utf-8").splitlines()
+            except UnicodeDecodeError:
+                continue
+            for index, line in enumerate(lines, 1):
+                if (relative, index) in allowed_lines:
+                    continue
+                matches = [
+                    *VERSIONED_IDENTIFIER_RE.findall(line),
+                    *STATE_SCHEMA_FIELD_RE.findall(line),
+                ]
+                if matches:
+                    offenders.append(f"{relative}:{index}: {', '.join(matches)}")
+
+        self.assertEqual([], offenders)
+
+    def test_release_semver_carveout_is_limited_to_version_bump_targets(self) -> None:
+        fields = version_bump_release_fields()
+        self.assertEqual(
+            {
+                ("package.json", "version"),
+                (".claude-plugin/plugin.json", "version"),
+                (".claude-plugin/marketplace.json", "plugins.0.version"),
+                (".codex-plugin/plugin.json", "version"),
+                (".cursor-plugin/plugin.json", "version"),
+                ("gemini-extension.json", "version"),
+            },
+            fields,
+        )
+
+    def test_live_state_uses_shape_not_version_field(self) -> None:
+        if not STATE_FILE.exists():
+            self.skipTest("local controller state file is absent")
+
+        data: Any = json.loads(STATE_FILE.read_text(encoding="utf-8"))
+        self.assertIsInstance(data, dict)
+        self.assertFalse(STATE_SCHEMA_FIELD_RE.search("\n".join(data.keys())))
+        self.assertLessEqual(queue_container_names(), set(data))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
+++ b/skills/codex-refactor-loop/scripts/test_dev_sync_daemon_state_machine.py
@@ -249,7 +249,7 @@ class IntegrationSyncDaemonSourceRegressionTests(unittest.TestCase):
                 SYNC_APPLY,
             )
         )
-        for forbidden in ("ControllerLifecycleIntentV1", "ControllerCommand", "ControllerOrchestrator", "generic event bus"):
+        for forbidden in ("ControllerLifecycleIntent", "ControllerCommand", "ControllerOrchestrator", "generic event bus"):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, combined)
 

--- a/skills/codex-refactor-loop/scripts/test_marker_emission_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_emission_contract.py
@@ -11,7 +11,7 @@ from pathlib import Path
 SCRIPT_PATH = Path(__file__)
 PROMPTS_DIR = SCRIPT_PATH.parents[1] / "prompts"
 
-CONTRACT_MARKER = "MarkerEmissionContractV1: single-valid-invalid-role-marker-source"
+CONTRACT_MARKER = "MarkerEmissionContract: single-valid-invalid-role-marker-source"
 SECTION_HEADING = "## Marker emission allowlist(强制)"
 REQUIRED_PROHIBITION = (
     "Only the markers listed above are valid role-routing markers for this prompt. "

--- a/skills/codex-refactor-loop/scripts/test_no_new_prose_detection.py
+++ b/skills/codex-refactor-loop/scripts/test_no_new_prose_detection.py
@@ -14,7 +14,7 @@ BASE_REF = "origin/auto-refact-dev"
 
 # Refactor (iter326/issue-106):
 #   Old pattern: source-regression tests literally matched Chinese/English prose, so switching languages broke them wholesale
-#   New principle: no DetectionInvariantV1; use stable protocol tokens (markers/labels/anchors/sentinels/script names),
+#   New principle: no detection-invariant schema suffix; use stable protocol tokens (markers/labels/anchors/sentinels/script names),
 #   explicit anchors, source-regression guard against future localized prose detectors (Phase 9 r1 consensus:structural)
 FORBIDDEN_NEW_TEST_TOKENS = (
     "事实源唯一",

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -819,7 +819,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         """#37 consensus exception allows only private ledger plus fallback event."""
         src = PHASE9_ROUTER.read_text(encoding="utf-8")
         for forbidden in (
-            "WorkUnitV2",
+            "WorkUnitReplacement",
             "ControllerOrchestrator",
             "ControllerEvent",
             "ControllerCommand",

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
@@ -184,7 +184,7 @@ class Phase9RouterPackageTests(unittest.TestCase):
                 self.assertIn(required, src)
 
         for forbidden in (
-            "WorkUnitV2",
+            "WorkUnitReplacement",
             "phase9-evidence",
             "Phase9RoundEvidence",
             "evidence.py",

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -265,8 +265,10 @@ class SkillEntrypointContractTests(unittest.TestCase):
             with self.subTest(anchor=anchor):
                 self.assertIn(f"(#{anchor})", self.skill)
                 self.assertIn(anchor, self.skill)
-        self.assertNotIn('"schema_version": 1', self.skill)
-        self.assertNotIn('"work_unit_schema_version": 1', self.skill)
+        schema_field = "schema" + "_version"
+        work_unit_schema_field = "work_unit_" + schema_field
+        self.assertNotIn(f'"{schema_field}": 1', self.skill)
+        self.assertNotIn(f'"{work_unit_schema_field}": 1', self.skill)
         for emoji_heading in ("📊", "🆘"):
             with self.subTest(emoji_heading=emoji_heading):
                 self.assertRegex(self.skill, rf"(?m)^## {emoji_heading} ")
@@ -278,12 +280,14 @@ class SkillEntrypointContractTests(unittest.TestCase):
             "prompts/verify.md": read(SKILL_ROOT / "prompts" / "verify.md"),
             "prompts/meta-judge.md": read(SKILL_ROOT / "prompts" / "meta-judge.md"),
         }
+        schema_field = "schema" + "_version"
+        work_unit_schema_field = "work_unit_" + schema_field
         forbidden_fragments = (
             "state-v2",
             "v1 audit-backed work unit",
             "v1 audit cluster alias",
-            '"schema_version": 1',
-            '"work_unit_schema_version": 1',
+            f'"{schema_field}": 1',
+            f'"{work_unit_schema_field}": 1',
         )
         for path, text in docs.items():
             with self.subTest(path=path):

--- a/skills/codex-refactor-loop/scripts/test_sync_requests_apply.py
+++ b/skills/codex-refactor-loop/scripts/test_sync_requests_apply.py
@@ -368,7 +368,7 @@ class PackagedIntegrationSyncSourceRegressionTests(unittest.TestCase):
                 self.assertIn(required, combined)
 
         for forbidden in (
-            "ControllerLifecycleIntentV1",
+            "ControllerLifecycleIntent",
             "ControllerCommand",
             "ControllerOrchestrator",
             "generic event bus",


### PR DESCRIPTION
## 摘要

实现 #107(Phase 9 r1 共识)。rename versioned identifiers,删 state `schema_version`,加 source-regression guard(release-semver-only carveout)。

## 范围

24 files (+166/-27)。新增 `test_design_identifier_boundary.py`;本地全量 **420 OK(skip 1)**。Closes #107。授权:`.refactor-loop/runs/phase9-issue107-r1-judge.md`。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
