### PR TITLE
feat(#190): 未push产出检测 — wakeup-plan read-only helper

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -292,9 +292,10 @@ Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event
 `consensus-rnd-cli wakeup-plan` named read-only surface:
 
 - **Allowed**: read `.refactor-loop` files, scan `.refactor-loop/heartbeats/*.ts`, read clean-exit log tails, run read-only GitHub list/check/view commands, and print JSON recommendations.
-- **Forbidden / no lifecycle authority**: no restart, no spawn, no git, no commit, no push, no merge, no label mutation, no issue/PR create-close-edit, no tag/release, and no GitHub lifecycle mutation.
+- **Allowed git topology observation(issue #190 only)**: `git fetch origin --quiet`, `git -C <repo-root> worktree list --porcelain`, `git -C <worktree> rev-parse --verify HEAD`, `git -C <worktree> rev-parse --verify refs/remotes/origin/<head>`, and `git -C <worktree> rev-list --count refs/remotes/origin/<head>..HEAD`, solely for committed-but-unpushed worker output detection on open auto-loop PR heads. Committed `FIX_DONE` / `IMPLEMENT_DONE` output is not reviewer/CI visible until `origin/<head>` contains it; ahead local output emits actionable `UNPUSHED_WORKER_OUTPUT:<pr>:<n>`.
+- **Forbidden / no lifecycle authority**: no restart, no spawn, no git lifecycle or mutation commands, no checkout/switch, no branch create/delete/update, no worktree add/remove/prune, no commit, no push, no reset, no rebase, no merge, no label mutation, no issue/PR create-close-edit, no tag/release, and no GitHub lifecycle mutation.
 - **Hard-gate**: computes canonical `actual`, `target=max(CODEX_FLOOR, expected_from_active_tasks)`, `deficit=max(0,target-actual)`, and when `deficit>0` emits `HARD_GATE:dispatch_required=N` plus structured `hard_gate`; this is not advisory and requires dispatching enough ordered actionable tasks or audit fallback before ending the wakeup. There is no `AUDIT_DONE:none:0` exemption.
-- Output priority order mirrors the controller checklist: bootstrap or missing wake source, maintainer comment, completed `EXIT=0` marker, CI red, no-gap violation, `🎯 milestone` open issue/PR, ordinary open existing issue/PR, then producer or audit fixed-point recommendation.
+- Output priority order mirrors the controller checklist: bootstrap or missing wake source, maintainer comment, unpushed worker output, completed `EXIT=0` marker, CI red, no-gap violation, `🎯 milestone` open issue/PR, ordinary open existing issue/PR, then producer or audit fixed-point recommendation.
 - If no actionable open work exists, it emits `RECOMMEND:audit`; audit is always available as the floor fallback.
 
 ## Phase Index

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/peek.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/peek.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
 from .context import LoopContext, LoopContextError
+from .wakeup_plan import load_github_items, unpushed_worker_output_actions
 
 
 REVIEW_MARKER_TAIL_LINES = 30
@@ -43,6 +44,8 @@ class PeekStatusLens:
         lines.extend(self._milestone_items())
         lines.extend(["", "▍Open auto-loop PRs:"])
         lines.extend(self._open_prs())
+        lines.extend(["", "▍Unpushed worker output:"])
+        lines.extend(self._unpushed_worker_output())
         lines.extend(["", "▍Monitor zero_streak (last 10 ticks):"])
         lines.extend(self._zero_streak())
         lines.extend(["", "▍Mergeable PRs (controller should merge immediately):"])
@@ -143,6 +146,16 @@ class PeekStatusLens:
             state = self.gh_text(["pr", "view", num, "--json", "mergeStateStatus", "--jq", ".mergeStateStatus"]).strip()
             lines.append(f"  • PR #{num} [{state}] CI: fail={fail} pending={pending} pass={passed} — {str(item.get('title') or '')[:60]}")
         return lines
+
+    def _unpushed_worker_output(self) -> list[str]:
+        out = []
+        for action in unpushed_worker_output_actions(self.ctx.repo_root, load_github_items(self.ctx.repo_root)):
+            out.append(
+                "  ⚠️ "
+                f"{action['line']} head={action['head_ref']} ahead={action['ahead_count']} "
+                f"worktree={action['worktree']} — {action['suggested_command']}"
+            )
+        return out
 
     def _zero_streak(self) -> list[str]:
         lines = _tail(self.ctx.paths.logs / "concurrency-monitor.log", 10)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -10,11 +10,18 @@ Refactor (iter1/wakeup-plan-script):
   action to the controller.
 
 Allowed: read `.refactor-loop` files, read daemon heartbeats, run read-only
-GitHub list/check/view commands, and print JSON recommendations.
-Forbidden: no restart/spawn, no git, no GitHub lifecycle mutation, no commit,
-push, merge, label, issue/PR create/close/edit, tag, release, or worker
-dispatch. Authorization source:
+GitHub list/check/view commands, observe git topology with the issue-190
+allowlist (`git fetch origin --quiet`, `git worktree list --porcelain`,
+`git rev-parse --verify HEAD`, `git rev-parse --verify refs/remotes/origin/<head>`,
+and `git rev-list --count refs/remotes/origin/<head>..HEAD`), and print JSON
+recommendations. Forbidden: no restart/spawn, no git lifecycle or mutation
+commands, no GitHub lifecycle mutation, no commit, push, checkout/switch,
+branch create/delete/update, worktree add/remove/prune, reset, rebase, merge,
+label, issue/PR create/close/edit, tag, release, or worker dispatch.
+Authorization source:
 `.refactor-loop/runs/maintainer-directives/2026-05-29-wakeup-plan-script.md`.
+Issue-190 consensus source:
+`.refactor-loop/runs/phase9-issue190-r3-judge.md`.
 """
 
 from __future__ import annotations
@@ -82,6 +89,7 @@ class GhItem:
     number: int
     title: str
     labels: tuple[str, ...]
+    head_ref: str | None = None
 
     @property
     def item(self) -> str:
@@ -520,7 +528,7 @@ def load_github_items(repo_root: Path) -> list[GhItem]:
     items: list[GhItem] = []
     for kind, command in (
         ("issue", ["gh", "issue", "list", *gh_args(slug), "--label", "auto-loop", "--state", "open", "--json", "number,title,labels"]),
-        ("PR", ["gh", "pr", "list", *gh_args(slug), "--label", "auto-loop", "--state", "open", "--json", "number,title,labels"]),
+        ("PR", ["gh", "pr", "list", *gh_args(slug), "--label", "auto-loop", "--state", "open", "--json", "number,title,labels,headRefName"]),
     ):
         data = run_json(command, cwd=repo_root)
         if not isinstance(data, list):
@@ -537,8 +545,99 @@ def load_github_items(repo_root: Path) -> list[GhItem]:
                 for label in raw.get("labels", [])
                 if isinstance(label, dict) and label.get("name")
             )
-            items.append(GhItem(kind=kind, number=number, title=str(raw.get("title") or ""), labels=labels))
+            items.append(
+                GhItem(
+                    kind=kind,
+                    number=number,
+                    title=str(raw.get("title") or ""),
+                    labels=labels,
+                    head_ref=(str(raw.get("headRefName") or "") or None) if kind == "PR" else None,
+                )
+            )
     return items
+
+
+def git_text(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
+
+
+def parse_worktree_branches(porcelain: str) -> dict[str, Path]:
+    worktrees: dict[str, Path] = {}
+    current: Path | None = None
+    for line in porcelain.splitlines():
+        if line.startswith("worktree "):
+            current = Path(line.removeprefix("worktree "))
+            continue
+        if not line.startswith("branch ") or current is None:
+            continue
+        branch = line.removeprefix("branch refs/heads/")
+        if branch and not branch.startswith("refs/"):
+            worktrees[branch] = current
+    return worktrees
+
+
+def safe_head_ref(value: str | None) -> str | None:
+    if not value or value.startswith("-"):
+        return None
+    if any(ch.isspace() or ord(ch) < 32 for ch in value):
+        return None
+    return value
+
+
+def unpushed_worker_output_actions(repo_root: Path, gh_items: list[GhItem]) -> list[dict[str, Any]]:
+    # Refactor (issue-190/unpushed-worker-output):
+    #   Old pattern: FIX_DONE/IMPLEMENT_DONE could leave committed worker output
+    #   only in a local worktree branch, so reviewers and CI read stale origin.
+    #   New principle: wakeup-plan owns a local read-only topology check; peek
+    #   may reuse this helper as status, but controller push remains external.
+    prs = [item for item in gh_items if item.kind == "PR" and safe_head_ref(item.head_ref)]
+    if not prs:
+        return []
+    fetch = git_text(["git", "-C", str(repo_root), "fetch", "origin", "--quiet"], cwd=repo_root)
+    if fetch.returncode != 0:
+        return []
+    listed = git_text(["git", "-C", str(repo_root), "worktree", "list", "--porcelain"], cwd=repo_root)
+    if listed.returncode != 0:
+        return []
+    worktrees = parse_worktree_branches(listed.stdout)
+    actions: list[dict[str, Any]] = []
+    for item in prs:
+        head_ref = safe_head_ref(item.head_ref)
+        if not head_ref:
+            continue
+        worktree = worktrees.get(head_ref)
+        if worktree is None:
+            continue
+        local = git_text(["git", "-C", str(worktree), "rev-parse", "--verify", "HEAD"], cwd=repo_root)
+        remote_ref = f"refs/remotes/origin/{head_ref}"
+        remote = git_text(["git", "-C", str(worktree), "rev-parse", "--verify", remote_ref], cwd=repo_root)
+        count = git_text(["git", "-C", str(worktree), "rev-list", "--count", f"{remote_ref}..HEAD"], cwd=repo_root)
+        if local.returncode != 0 or remote.returncode != 0 or count.returncode != 0:
+            continue
+        try:
+            ahead_count = int(count.stdout.strip())
+        except ValueError:
+            continue
+        if ahead_count <= 0:
+            continue
+        actions.append(
+            {
+                "priority": 3,
+                "kind": "unpushed-worker-output",
+                "item": item.item,
+                "phase": "controller-push-required",
+                "actor": "controller",
+                "head_ref": head_ref,
+                "worktree": str(worktree),
+                "ahead_count": ahead_count,
+                "local_head": local.stdout.strip(),
+                "remote_head": remote.stdout.strip(),
+                "line": f"UNPUSHED_WORKER_OUTPUT:{item.number}:{ahead_count}",
+                "suggested_command": f"python3 <skill-root>/scripts/consensus-rnd-cli safe-push origin {head_ref}",
+                "no_lifecycle_authority": True,
+            }
+        )
+    return actions
 
 
 def ci_red_actions(repo_root: Path, items: list[GhItem]) -> list[dict[str, Any]]:
@@ -641,6 +740,7 @@ def build_plan(repo_root: Path) -> dict[str, Any]:
     actions: list[dict[str, Any]] = []
     actions.extend(pending_bootstrap_actions(repo_root, health))
     actions.extend(maintainer_comment_actions(repo_root, gh_items))
+    actions.extend(unpushed_worker_output_actions(repo_root, gh_items))
     actions.extend(completed_marker_actions(repo_root))
     actions.extend(ci_red_actions(repo_root, gh_items))
     actions.extend(no_gap_actions(repo_root))

--- a/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
+++ b/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
@@ -42,12 +42,19 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
             textwrap.dedent(
                 """\
                 #!/usr/bin/env bash
-                case "$1" in
-                  fetch) exit 0 ;;
-                  worktree) exit 0 ;;
-                  rev-parse) printf '%s\\n' "$REPO_ROOT"; exit 0 ;;
-                  *) exit 0 ;;
-                esac
+                args="$*"
+                if [[ "$args" == *"fetch origin --quiet"* ]]; then exit 0; fi
+                if [[ "$args" == *"worktree list --porcelain"* ]]; then
+                  if [[ "${PEEK_TEST_UNPUSHED:-}" == "1" ]]; then
+                    printf 'worktree %s/.worktrees/pr%s\nbranch refs/heads/refactor/iter%s-worker\n\n' "$REPO_ROOT" "$PEEK_TEST_PR" "$PEEK_TEST_PR"
+                  fi
+                  exit 0
+                fi
+                if [[ "$args" == *"rev-parse --verify HEAD"* ]]; then printf 'local-sha\n'; exit 0; fi
+                if [[ "$args" == *"rev-parse --verify refs/remotes/origin/refactor/iter"* ]]; then printf 'remote-sha\n'; exit 0; fi
+                if [[ "$args" == *"rev-list --count refs/remotes/origin/refactor/iter"* ]]; then printf '3\n'; exit 0; fi
+                if [[ "$1" == "rev-parse" ]]; then printf '%s\\n' "$REPO_ROOT"; exit 0; fi
+                exit 0
                 """
             ).lstrip(),
             encoding="utf-8",
@@ -121,6 +128,10 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
                     printf '{"number":%s,"title":"stub PR"}\\n' "$pr"
                     exit 0
                   fi
+                  if [[ "${PEEK_TEST_UNPUSHED:-}" == "1" ]]; then
+                    printf '[{"number":%s,"title":"stub PR","headRefName":"refactor/iter%s-worker","labels":[{"name":"auto-loop"},{"name":"👀 phase:reviewing"}]}]\\n' "$pr" "$pr"
+                    exit 0
+                  fi
                   printf '[{"number":%s,"title":"stub PR","labels":[]}]\\n' "$pr"
                   exit 0
                 fi
@@ -147,7 +158,14 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
         )
         gh.chmod(0o755)
 
-    def run_peek(self, args: list[str] | None = None, *, pr: int | None = None, milestone_fixtures: bool = False) -> subprocess.CompletedProcess[str]:
+    def run_peek(
+        self,
+        args: list[str] | None = None,
+        *,
+        pr: int | None = None,
+        milestone_fixtures: bool = False,
+        unpushed: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
             {
@@ -160,6 +178,8 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
             env["PEEK_TEST_PR"] = str(pr)
         if milestone_fixtures:
             env["PEEK_TEST_MILESTONE_FIXTURES"] = "1"
+        if unpushed:
+            env["PEEK_TEST_UNPUSHED"] = "1"
         return subprocess.run(
             [sys.executable, str(PEEK), "peek", *(args or [])],
             cwd=self.root,
@@ -255,6 +275,17 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("MERGE_READY approve=2 comment=1 reject=0", result.stdout)
         self.assertNotIn("MERGE_READY approve=3 comment=0 reject=0", result.stdout)
+
+    def test_peek_displays_unpushed_worker_output_as_status_only(self) -> None:
+        result = self.run_peek(pr=77, unpushed=True)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("▍Unpushed worker output:", result.stdout)
+        self.assertIn("UNPUSHED_WORKER_OUTPUT:77:3", result.stdout)
+        self.assertIn("head=refactor/iter77-worker", result.stdout)
+        self.assertIn("safe-push origin refactor/iter77-worker", result.stdout)
+        self.assertNotIn('"actions"', result.stdout)
+        self.assertNotIn('"schema": "wakeup-plan"', result.stdout)
 
     def test_peek_counts_codex_via_canonical_monitor_cli(self) -> None:
         text = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "peek.py").read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -205,10 +205,18 @@ class SkillEntrypointContractTests(unittest.TestCase):
             "Mechanically call `python3 <skill-root>/scripts/consensus-rnd-cli wakeup-plan --repo-root \"$REPO_ROOT\"`",
             ".refactor-loop/runs/maintainer-directives/2026-05-29-wakeup-plan-script.md",
             "**Allowed**",
+            "**Allowed git topology observation(issue #190 only)**",
             "**Forbidden / no lifecycle authority**",
             "no restart",
             "no spawn",
-            "no git",
+            "git fetch origin --quiet",
+            "worktree list --porcelain",
+            "rev-list --count refs/remotes/origin/<head>..HEAD",
+            "UNPUSHED_WORKER_OUTPUT:<pr>:<n>",
+            "no git lifecycle or mutation commands",
+            "no checkout/switch",
+            "no branch create/delete/update",
+            "no worktree add/remove/prune",
             "no GitHub lifecycle mutation",
             "`RECOMMEND:audit`",
             "`AUDIT_DONE:none:0` no longer exempts",
@@ -226,8 +234,16 @@ class SkillEntrypointContractTests(unittest.TestCase):
         script = read(PACKAGE_WAKEUP_PLAN)
         for needle in (
             "Allowed: read `.refactor-loop` files",
-            "Forbidden: no restart/spawn, no git",
+            "issue-190",
+            "git fetch origin --quiet",
+            "git worktree list --porcelain",
+            "git rev-parse --verify HEAD",
+            "git rev-parse --verify refs/remotes/origin/<head>",
+            "git rev-list --count refs/remotes/origin/<head>..HEAD",
+            "Forbidden: no restart/spawn, no git lifecycle or mutation",
+            "no commit, push, checkout/switch",
             "no GitHub lifecycle mutation",
+            ".refactor-loop/runs/phase9-issue190-r3-judge.md",
             "no_lifecycle_authority",
             "count_in_flight_codex",
             "HARD_GATE:dispatch_required",
@@ -236,6 +252,8 @@ class SkillEntrypointContractTests(unittest.TestCase):
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, script)
+        self.assertNotIn("WorkerOutputProjection", script)
+        self.assertNotIn("codex_refactor_loop.projections", script)
 
     def test_phase0_bootstrap_uses_session_monitor_not_first_wakeup_substitute(self) -> None:
         phase0 = section_between(

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -33,6 +33,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         (self.repo / ".refactor-loop" / ".controller-pending-events.log").write_text("", encoding="utf-8")
         self.write_fresh_heartbeats()
         self.write_fake_gh()
+        self.write_fake_git()
         self.write_fake_ps()
 
     def tearDown(self) -> None:
@@ -70,6 +71,9 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                 fi
                 if [[ "$1 $2" == "pr list" ]]; then
                   case "$fixture" in
+                    unpushed|unpushed_fetch_fail|unpushed_no_ahead|unpushed_no_remote|unpushed_no_worktree)
+                      printf '[{"number":77,"title":"worker output PR","headRefName":"refactor/iter77-worker","labels":[{"name":"auto-loop"},{"name":"👀 phase:reviewing"}]}]\n'
+                      ;;
                     ci_red)
                       printf '[{"number":31,"title":"red PR","labels":[{"name":"auto-loop"},{"name":"⚙️ phase:ci-running"}]}]\n'
                       ;;
@@ -101,6 +105,49 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             encoding="utf-8",
         )
         gh.chmod(0o755)
+
+    def write_fake_git(self) -> None:
+        git = self.fakebin / "git"
+        git.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                fixture="${WAKEUP_PLAN_GH_FIXTURE:-empty}"
+                if [[ -n "${WAKEUP_PLAN_GIT_LOG:-}" ]]; then
+                  printf '%s\n' "$*" >> "$WAKEUP_PLAN_GIT_LOG"
+                fi
+                if [[ "$*" == *"fetch origin --quiet"* ]]; then
+                  [[ "$fixture" == "unpushed_fetch_fail" ]] && exit 42
+                  exit 0
+                fi
+                if [[ "$*" == *"worktree list --porcelain"* ]]; then
+                  [[ "$fixture" == "unpushed_no_worktree" ]] && exit 0
+                  printf 'worktree %s/.worktrees/pr77\nbranch refs/heads/refactor/iter77-worker\n\n' "$WAKEUP_PLAN_REPO_ROOT"
+                  exit 0
+                fi
+                if [[ "$*" == *"rev-parse --verify HEAD"* ]]; then
+                  printf 'local-sha\n'
+                  exit 0
+                fi
+                if [[ "$*" == *"rev-parse --verify refs/remotes/origin/refactor/iter77-worker"* ]]; then
+                  [[ "$fixture" == "unpushed_no_remote" ]] && exit 1
+                  printf 'remote-sha\n'
+                  exit 0
+                fi
+                if [[ "$*" == *"rev-list --count refs/remotes/origin/refactor/iter77-worker..HEAD"* ]]; then
+                  if [[ "$fixture" == "unpushed_no_ahead" ]]; then
+                    printf '0\n'
+                  else
+                    printf '2\n'
+                  fi
+                  exit 0
+                fi
+                exit 0
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
+        git.chmod(0o755)
 
     def write_fake_ps(self) -> None:
         ps = self.fakebin / "ps"
@@ -148,6 +195,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                 "WAKEUP_PLAN_GH_FIXTURE": fixture,
                 "WAKEUP_PLAN_PS_COUNT": str(ps_count),
                 "WAKEUP_PLAN_REPO_ROOT": str(self.repo.resolve()),
+                "WAKEUP_PLAN_GIT_LOG": str(self.repo / "git-commands.log"),
             }
         )
         result = subprocess.run(
@@ -181,6 +229,52 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(plan["actions"][0]["kind"], "completed-marker")
         self.assertEqual(plan["actions"][0]["actor"], "controller")
         self.assertIn("IMPLEMENT_DONE:real", plan["actions"][0]["marker"])
+
+    def test_unpushed_worker_output_routes_before_completed_marker_ci_and_existing_issue(self) -> None:
+        self.write_completed_log("fix-pr77-r3.log", "FIX_DONE")
+
+        plan = self.run_plan(fixture="unpushed")
+
+        self.assertEqual(plan["actions"][0]["kind"], "unpushed-worker-output")
+        self.assertEqual(plan["actions"][0]["item"], "PR #77")
+        self.assertEqual(plan["actions"][0]["line"], "UNPUSHED_WORKER_OUTPUT:77:2")
+        self.assertEqual(plan["actions"][0]["head_ref"], "refactor/iter77-worker")
+        self.assertIn("safe-push origin refactor/iter77-worker", plan["actions"][0]["suggested_command"])
+        kinds = [action["kind"] for action in plan["actions"]]
+        self.assertLess(kinds.index("unpushed-worker-output"), kinds.index("completed-marker"))
+        self.assertLess(kinds.index("unpushed-worker-output"), kinds.index("existing-issue"))
+
+    def test_unpushed_worker_output_fetch_failure_fails_closed(self) -> None:
+        plan = self.run_plan(fixture="unpushed_fetch_fail")
+
+        self.assertNotIn("unpushed-worker-output", [action["kind"] for action in plan["actions"]])
+
+    def test_unpushed_worker_output_requires_open_auto_loop_pr_local_worktree_remote_ref_and_ahead(self) -> None:
+        for fixture in ("empty", "unpushed_no_worktree", "unpushed_no_remote", "unpushed_no_ahead"):
+            with self.subTest(fixture=fixture):
+                plan = self.run_plan(fixture=fixture)
+                self.assertNotIn("unpushed-worker-output", [action["kind"] for action in plan["actions"]])
+
+    def test_unpushed_worker_output_uses_only_allowlisted_git_topology_probes(self) -> None:
+        self.run_plan(fixture="unpushed")
+
+        commands = (self.repo / "git-commands.log").read_text(encoding="utf-8").splitlines()
+        allowed_fragments = (
+            "-C",
+            "fetch origin --quiet",
+            "worktree list --porcelain",
+            "rev-parse --verify HEAD",
+            "rev-parse --verify refs/remotes/origin/refactor/iter77-worker",
+            "rev-list --count refs/remotes/origin/refactor/iter77-worker..HEAD",
+        )
+        self.assertTrue(any("fetch origin --quiet" in command for command in commands))
+        self.assertTrue(any("worktree list --porcelain" in command for command in commands))
+        self.assertTrue(any("rev-list --count refs/remotes/origin/refactor/iter77-worker..HEAD" in command for command in commands))
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertTrue(any(fragment in command for fragment in allowed_fragments))
+                self.assertNotRegex(command, r"\b(push|commit|checkout|switch|reset|rebase|merge|tag)\b")
+                self.assertNotRegex(command, r"\b(add|remove|prune)\b")
 
     def test_ci_red_routes_before_no_gap(self) -> None:
         (self.repo / ".refactor-loop" / ".concurrency-alert.log").write_text(

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -74,6 +74,15 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                     unpushed|unpushed_fetch_fail|unpushed_no_ahead|unpushed_no_remote|unpushed_no_worktree)
                       printf '[{"number":77,"title":"worker output PR","headRefName":"refactor/iter77-worker","labels":[{"name":"auto-loop"},{"name":"👀 phase:reviewing"}]}]\n'
                       ;;
+                    unpushed_head_dash)
+                      printf '[{"number":78,"title":"unsafe dash head","headRefName":"-bad","labels":[{"name":"auto-loop"},{"name":"👀 phase:reviewing"}]}]\n'
+                      ;;
+                    unpushed_head_space)
+                      printf '[{"number":79,"title":"unsafe space head","headRefName":"bad ref","labels":[{"name":"auto-loop"},{"name":"👀 phase:reviewing"}]}]\n'
+                      ;;
+                    unpushed_head_control)
+                      printf '[{"number":80,"title":"unsafe control head","headRefName":"bad\\u0001ref","labels":[{"name":"auto-loop"},{"name":"👀 phase:reviewing"}]}]\n'
+                      ;;
                     ci_red)
                       printf '[{"number":31,"title":"red PR","labels":[{"name":"auto-loop"},{"name":"⚙️ phase:ci-running"}]}]\n'
                       ;;
@@ -255,24 +264,33 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                 plan = self.run_plan(fixture=fixture)
                 self.assertNotIn("unpushed-worker-output", [action["kind"] for action in plan["actions"]])
 
+    def test_unpushed_worker_output_ignores_unsafe_head_ref_before_worktree_git_probes(self) -> None:
+        for fixture in ("unpushed_head_dash", "unpushed_head_space", "unpushed_head_control"):
+            with self.subTest(fixture=fixture):
+                plan = self.run_plan(fixture=fixture)
+                command_log = self.repo / "git-commands.log"
+                commands = command_log.read_text(encoding="utf-8").splitlines() if command_log.exists() else []
+
+                self.assertNotIn("unpushed-worker-output", [action["kind"] for action in plan["actions"]])
+                self.assertFalse(any("rev-parse --verify HEAD" in command for command in commands))
+                self.assertFalse(any("rev-list --count" in command for command in commands))
+
     def test_unpushed_worker_output_uses_only_allowlisted_git_topology_probes(self) -> None:
         self.run_plan(fixture="unpushed")
 
         commands = (self.repo / "git-commands.log").read_text(encoding="utf-8").splitlines()
-        allowed_fragments = (
-            "-C",
-            "fetch origin --quiet",
-            "worktree list --porcelain",
-            "rev-parse --verify HEAD",
-            "rev-parse --verify refs/remotes/origin/refactor/iter77-worker",
-            "rev-list --count refs/remotes/origin/refactor/iter77-worker..HEAD",
+        repo_root = str(self.repo.resolve())
+        worktree = f"{repo_root}/.worktrees/pr77"
+        allowed_commands = (
+            f"-C {repo_root} fetch origin --quiet",
+            f"-C {repo_root} worktree list --porcelain",
+            f"-C {worktree} rev-parse --verify HEAD",
+            f"-C {worktree} rev-parse --verify refs/remotes/origin/refactor/iter77-worker",
+            f"-C {worktree} rev-list --count refs/remotes/origin/refactor/iter77-worker..HEAD",
         )
-        self.assertTrue(any("fetch origin --quiet" in command for command in commands))
-        self.assertTrue(any("worktree list --porcelain" in command for command in commands))
-        self.assertTrue(any("rev-list --count refs/remotes/origin/refactor/iter77-worker..HEAD" in command for command in commands))
+        self.assertEqual(commands, list(allowed_commands))
         for command in commands:
             with self.subTest(command=command):
-                self.assertTrue(any(fragment in command for fragment in allowed_fragments))
                 self.assertNotRegex(command, r"\b(push|commit|checkout|switch|reset|rebase|merge|tag)\b")
                 self.assertNotRegex(command, r"\b(add|remove|prune)\b")
 


### PR DESCRIPTION
## 摘要

实现 #190 未 push 产出检测(Phase 9 r3 structural consensus)。

- **New**:wakeup-plan 本地只读 helper(被 peek 复用),检测 open auto-loop PR 关联 worktree branch ahead-of-`origin/<head>`(未push worker 产出),输出 `UNPUSHED_WORKER_OUTPUT:<pr>:<n>`;纯检测 read-only,不自动 push(push 仍 controller-owned)。不建独立 projection 模块。

属 goal #191。Closes #190。本地套件 OK。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
