### PR TITLE
feat(#192): GitHub 自包含 render-github-body/validator

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1697,7 +1697,8 @@ For each `pass` cluster, serially:
 
     <N files changed (+X/-Y). Targeted test pass counts. Architecture guards green.>
 
-    See [implement summary](./.refactor-loop/runs/implement-<cluster-id>.md) and [audit](./.refactor-loop/runs/audit-iter-<N>.md#<cluster-anchor>).
+    Inline the implement summary and audit excerpt with `consensus-rnd-cli render-github-body`.
+    Local `.refactor-loop/runs/*.md` paths may appear only under `<details><summary>本机调试线索</summary>` and never as the authority source.
 
     ## Stacked-PR
 
@@ -2015,7 +2016,7 @@ Escalation action:
 
 ### GitHub traceability (mandatory — every Phase 8 action posts to the PR)
 
-All review/fix/consensus/escalation behavior MUST be observable on GitHub so the whole loop is traceable without reading local `.refactor-loop/` artifacts. Natural-language GitHub posts follow the skill language rule.
+All review/fix/consensus/escalation behavior MUST be observable on GitHub so the whole loop is traceable without reading local `.refactor-loop/` artifacts. Authority-bearing GitHub bodies(PR description, design issue body, consensus/authorization comment, escalation comment, triage body-comment) must inline the cited artifact text; local `.refactor-loop/runs/*.md` paths are allowed only under `<details><summary>本机调试线索</summary>` and never as the only source. Natural-language GitHub posts follow the skill language rule.
 
 **Hard rule**: all natural-language GitHub posts go through the codex role that produced the artifact, NOT directly composed by controller.
 

--- a/skills/codex-refactor-loop/prompts/_github-post-rules.md
+++ b/skills/codex-refactor-loop/prompts/_github-post-rules.md
@@ -39,6 +39,7 @@ escalation / consensus pick **必须**给清晰"方案 1/2/3"表格,cell 一行�
 - **中文 only**:per [SKILL.md 工作语言规则],不要平行 EN section。Code identifier / file path / schema field names 保留原英文。CLAUDE/AGENTS 条款引用 verbatim 不翻译。
 - **TL;DR ≤ 6 行**(3 bullet + 可选 cc 行)。
 - **raw artifact 必折叠**:不要让 TL;DR 之后立刻出现 raw YAML / verbatim spec dump。先用人话讲,raw 都进 `<details>`。
+- **GitHub body 必须自包含**:凡 GitHub-facing body 引用授权、共识、solver/judge 结论、escalation 或 design/triage 判断,必须内联完整 raw artifact；本地 `.refactor-loop/runs/*.md` 路径只能出现在 `<details><summary>本机调试线索</summary>` 中,且永远不是唯一授权来源。
 - **No jargon dumps**:每个技术词(如 `IActorDispatchPort`)首次出现要一句话解释("actor 之间发命令的标准通道")。
 - **Numbers > adjectives**:"delete -180 LOC" 优于 "substantial cleanup"。
 - **No filler**:"我们会分析…"、"various improvements"、"comprehensive review" 禁用。
@@ -91,6 +92,7 @@ handle map 来自 host 配置的 `$MAINTAINER_WHITELIST`；未在 whitelist 中�
 - ❌ 第一行不是 `## 🤖`(monitor false-positive react)
 - ❌ TL;DR > 6 行
 - ❌ raw YAML / verbatim spec 在 TL;DR 之后(没折叠)
+- ❌ 用 `授权:.refactor-loop/runs/phase9-issueN-rM-judge.md` 这类本地路径当唯一来源
 - ❌ 写"将彻底改造"/"comprehensive review" 等空话
 - ❌ Code identifier 直接出现没解释一句
 - ❌ TL;DR 没说"下一步 / 需要 maintainer 做什么"

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/cli.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/cli.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Sequence
 
-from . import banners, project_rules, spawn, statusline
+from . import banners, github_body, project_rules, spawn, statusline
 from .controller_actions import main as controller_actions_main
 from .checks.degradation import main as degradation_main
 from .checks.manifest import main as manifest_main
@@ -88,6 +88,11 @@ COMMANDS: dict[str, CommandSpec] = {
         release_required_checks_main,
         "check exact release required check-runs",
         ("read-gh",),
+    ),
+    "render-github-body": CommandSpec(
+        github_body.main,
+        "render a self-contained GitHub body from local artifacts",
+        ("read-artifact",),
     ),
     "merge-pr": CommandSpec(
         controller_actions_main,

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -15,6 +15,7 @@ from string import Template
 from typing import Mapping, Sequence
 
 from .context import LoopContext, LoopContextError
+from .github_body import GitHubBodyError, validate_self_contained_github_body
 
 
 PR_LABELS_REMOVE = (
@@ -213,6 +214,13 @@ class ControllerActions:
         base = base or self.integration_branch
         if not head:
             raise RuntimeError("open_pr_with_label: head branch required (avoid gh fallback to current branch = base)")
+        body_path = Path(body_file)
+        if not body_path.is_absolute():
+            body_path = self.ctx.repo_root / body_path
+        try:
+            validate_self_contained_github_body(body_path.read_text(encoding="utf-8"), authority_required=False)
+        except GitHubBodyError as exc:
+            raise RuntimeError(str(exc)) from exc
         created = self.gh(["pr", "create", "--base", base, "--head", head, "--title", title, "--body-file", body_file], check=False)
         output = created.stdout + created.stderr
         match = re.search(r"https://github\.com/[^/]+/[^/]+/pull/([0-9]+)", output)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -214,13 +214,7 @@ class ControllerActions:
         base = base or self.integration_branch
         if not head:
             raise RuntimeError("open_pr_with_label: head branch required (avoid gh fallback to current branch = base)")
-        body_path = Path(body_file)
-        if not body_path.is_absolute():
-            body_path = self.ctx.repo_root / body_path
-        try:
-            validate_self_contained_github_body(body_path.read_text(encoding="utf-8"), authority_required=False)
-        except GitHubBodyError as exc:
-            raise RuntimeError(str(exc)) from exc
+        self._validate_pr_body_file(body_file)
         created = self.gh(["pr", "create", "--base", base, "--head", head, "--title", title, "--body-file", body_file], check=False)
         output = created.stdout + created.stderr
         match = re.search(r"https://github\.com/[^/]+/[^/]+/pull/([0-9]+)", output)
@@ -229,6 +223,15 @@ class ControllerActions:
         pr_num = int(match.group(1))
         self.gh(["pr", "edit", str(pr_num), "--add-label", "auto-loop,🚀 phase:pr-open,👀 phase:reviewing,🤖 human:auto-推进"], check=False)
         return pr_num, match.group(0)
+
+    def _validate_pr_body_file(self, body_file: str) -> None:
+        body_path = Path(body_file)
+        if not body_path.is_absolute():
+            body_path = self.ctx.repo_root / body_path
+        try:
+            validate_self_contained_github_body(body_path.read_text(encoding="utf-8"), authority_required=False)
+        except GitHubBodyError as exc:
+            raise RuntimeError(str(exc)) from exc
 
     def open_release_rollup_pr_from_pending_event(
         self,
@@ -256,6 +259,7 @@ class ControllerActions:
             raise RuntimeError("open_release_rollup_pr_from_pending_event: missing integration branch, review base, or integration sha")
         if not re.fullmatch(r"[0-9A-Za-z._-]+", integration_sha):
             raise RuntimeError("open_release_rollup_pr_from_pending_event: unsafe integration sha for rollup branch")
+        self._validate_pr_body_file(body_file)
 
         remote = self.git(["ls-remote", "--exit-code", "--heads", "origin", integration_branch], check=False)
         if remote.returncode != 0 or not remote.stdout.strip():

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/github_body.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/github_body.py
@@ -1,4 +1,10 @@
-"""Read-only GitHub body renderer and self-contained authority validator."""
+"""Read-only GitHub body renderer and self-contained authority validator.
+
+Runtime boundary: this module may read local artifact files and print rendered
+Markdown to stdout. It must not write files, call Git/GitHub, spawn background processes, or
+change controller state; behavior and source-regression tests verify that
+boundary.
+"""
 
 from __future__ import annotations
 
@@ -129,7 +135,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--title", required=True)
     parser.add_argument("--artifact", action="append", required=True, default=[])
     parser.add_argument("--debug-path", action="append", default=[])
-    parser.add_argument("--output", default="-")
     args = parser.parse_args(argv)
     try:
         body = render_github_body(
@@ -138,10 +143,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             artifact_paths=args.artifact,
             debug_paths=args.debug_path,
         )
-        if args.output == "-":
-            sys.stdout.write(body)
-        else:
-            Path(args.output).write_text(body, encoding="utf-8")
+        sys.stdout.write(body)
         return 0
     except (OSError, GitHubBodyError) as exc:
         sys.stderr.write(f"{exc}\n")

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/github_body.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/github_body.py
@@ -1,0 +1,187 @@
+"""Read-only GitHub body renderer and self-contained authority validator."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import re
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+FINAL_SENTINEL = "⟦AI:AUTO-LOOP⟧"
+MAX_BODY_BYTES = 60000
+LOCAL_RUN_ARTIFACT_RE = re.compile(r"\.refactor-loop/runs/[^\s)>\]`'\"]+\.md")
+AUTHORITY_PATH_RE = re.compile(
+    r"(授权|共识|consensus|authorization|judge|solver|artifact|decision|依据|来源)\s*[:：]?\s*`?"
+    r"\.refactor-loop/runs/[^\s)>\]`'\"]+\.md",
+    re.I,
+)
+DEBUG_SUMMARY = "<summary>本机调试线索</summary>"
+ALLOWED_KINDS = {"pr", "design-issue", "consensus", "authorization", "escalation", "triage"}
+
+
+class GitHubBodyError(ValueError):
+    """Raised when a GitHub-facing body is not self-contained."""
+
+
+def render_github_body(
+    *,
+    kind: str,
+    title: str,
+    artifact_paths: Sequence[str | Path],
+    debug_paths: Sequence[str | Path] = (),
+    max_bytes: int = MAX_BODY_BYTES,
+) -> str:
+    """Render a self-contained Chinese GitHub body from local artifacts.
+
+    Refactor (issue192/self-contained-github-body):
+    Old pattern: GitHub bodies could cite `.refactor-loop/runs/*.md` as the
+    sole authorization source, leaving reviewers with machine-local dead links.
+    New principle: this read-only helper inlines the complete artifact text and
+    demotes local paths to optional debug hints under a collapsed section.
+    """
+
+    _validate_kind(kind)
+    if not title.strip():
+        raise GitHubBodyError("title required")
+    artifacts = [(Path(path), _read_artifact(Path(path))) for path in artifact_paths]
+    if not artifacts:
+        raise GitHubBodyError("at least one artifact required")
+
+    lines = [
+        f"## 🤖 {title.strip()}",
+        "",
+        "### TL;DR",
+        f"- 这是什么:{_kind_label(kind)} GitHub body。",
+        "- 结论:授权/共识 artifact 全文已内联,GitHub 正文本身可审计。",
+        "- 下一步:按正文中的自包含信息继续处理。",
+        "",
+        "---",
+        "",
+        "### 详细说明",
+        "",
+        "以下内容由只读 `render-github-body` 从本地 artifact 渲染;授权/共识正文已完整内联,本地路径不作为唯一来源。",
+        "",
+    ]
+    for index, (path, text) in enumerate(artifacts, start=1):
+        lines.extend(
+            [
+                "<details>",
+                f"<summary>内联 artifact {index}: {html.escape(path.name)}</summary>",
+                "",
+                "```markdown",
+                text.rstrip(),
+                "```",
+                "",
+                "</details>",
+                "",
+            ]
+        )
+
+    if debug_paths:
+        lines.extend(
+            [
+                "<details>",
+                DEBUG_SUMMARY,
+                "",
+                "这些路径仅供本机调试,不是授权/共识来源:",
+                "",
+            ]
+        )
+        for path in debug_paths:
+            lines.append(f"- `{Path(path).as_posix()}`")
+        lines.extend(["", "</details>", ""])
+
+    lines.append(FINAL_SENTINEL)
+    body = "\n".join(lines) + "\n"
+    validate_self_contained_github_body(body, authority_required=True, max_bytes=max_bytes)
+    return body
+
+
+def validate_self_contained_github_body(
+    text: str,
+    *,
+    authority_required: bool = False,
+    max_bytes: int = MAX_BODY_BYTES,
+) -> None:
+    """Fail closed when a GitHub body uses local run paths as sole authority."""
+
+    if not isinstance(text, str) or not text.strip():
+        raise GitHubBodyError("empty GitHub body")
+    if len(text.encode("utf-8")) > max_bytes:
+        raise GitHubBodyError("BODY_TOO_LARGE")
+    if not text.splitlines()[-1:] == [FINAL_SENTINEL]:
+        raise GitHubBodyError("missing final sentinel")
+    public_text = _mask_allowed_run_path_sections(text)
+    if AUTHORITY_PATH_RE.search(public_text):
+        raise GitHubBodyError("local .refactor-loop artifact path cannot be the only authority source")
+    if LOCAL_RUN_ARTIFACT_RE.search(public_text) is not None:
+        raise GitHubBodyError("local .refactor-loop artifact path is only allowed under 本机调试线索 details")
+    if authority_required and not _has_inline_artifact_details(text):
+        raise GitHubBodyError("authority body must inline artifact text in details")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Render a self-contained GitHub body from local artifacts")
+    parser.add_argument("--kind", required=True, choices=sorted(ALLOWED_KINDS))
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--artifact", action="append", required=True, default=[])
+    parser.add_argument("--debug-path", action="append", default=[])
+    parser.add_argument("--output", default="-")
+    args = parser.parse_args(argv)
+    try:
+        body = render_github_body(
+            kind=args.kind,
+            title=args.title,
+            artifact_paths=args.artifact,
+            debug_paths=args.debug_path,
+        )
+        if args.output == "-":
+            sys.stdout.write(body)
+        else:
+            Path(args.output).write_text(body, encoding="utf-8")
+        return 0
+    except (OSError, GitHubBodyError) as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+
+
+def _read_artifact(path: Path) -> str:
+    if not path.is_file():
+        raise GitHubBodyError(f"artifact not found: {path}")
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        raise GitHubBodyError(f"artifact empty: {path}")
+    return text
+
+
+def _validate_kind(kind: str) -> None:
+    if kind not in ALLOWED_KINDS:
+        raise GitHubBodyError(f"invalid GitHub body kind: {kind}")
+
+
+def _kind_label(kind: str) -> str:
+    return {
+        "pr": "PR 描述",
+        "design-issue": "design issue",
+        "consensus": "共识",
+        "authorization": "授权",
+        "escalation": "升级",
+        "triage": "triage",
+    }[kind]
+
+
+def _has_inline_artifact_details(text: str) -> bool:
+    return "<details>" in text and "```markdown" in text and "</details>" in text
+
+
+def _mask_allowed_run_path_sections(text: str) -> str:
+    masked = re.sub(r"<details>\s*" + re.escape(DEBUG_SUMMARY) + r".*?</details>", "", text, flags=re.S)
+    masked = re.sub(r"<details>.*?```markdown.*?</details>", "", masked, flags=re.S)
+    return masked
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/triage.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/triage.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from .context import LoopContext
+from .github_body import validate_self_contained_github_body
 
 
 ACCEPT_LABELS = [
@@ -222,6 +223,10 @@ def _artifact_has_final_sentinel(path: Path) -> bool:
     return path.exists() and path.read_text(encoding="utf-8").splitlines()[-1:] == [FINAL_SENTINEL]
 
 
+def _validate_github_body_artifact(path: Path, *, authority_required: bool) -> None:
+    validate_self_contained_github_body(path.read_text(encoding="utf-8"), authority_required=authority_required)
+
+
 def apply_decision(config: TriageApplyConfig, decision_path: Path, *, issue_number: int, verdict: str) -> int:
     try:
         if applied_marker(config, decision_path).exists():
@@ -236,6 +241,7 @@ def apply_decision(config: TriageApplyConfig, decision_path: Path, *, issue_numb
         comment_file = path_under_repo(config.repo, decision.comment_artifact_path)
         if not _artifact_has_final_sentinel(comment_file):
             raise ManualIssueTriageDecisionError("comment artifact missing final sentinel")
+        _validate_github_body_artifact(comment_file, authority_required=(decision.verdict == "accept"))
         comment = run_gh(
             ["issue", "comment", str(issue_number), "--body-file", str(comment_file)],
             repo=config.repo,
@@ -248,6 +254,7 @@ def apply_decision(config: TriageApplyConfig, decision_path: Path, *, issue_numb
             body_file = path_under_repo(config.repo, decision.body_artifact_path)
             if not _artifact_has_final_sentinel(body_file):
                 raise ManualIssueTriageDecisionError("body artifact missing final sentinel")
+            _validate_github_body_artifact(body_file, authority_required=True)
             args = ["issue", "edit", str(issue_number), "--body-file", str(body_file)]
             args += ["--remove-label", "auto-loop-triage"]
             for label in ACCEPT_LABELS:

--- a/skills/codex-refactor-loop/scripts/test_apply_artifact_helpers.py
+++ b/skills/codex-refactor-loop/scripts/test_apply_artifact_helpers.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.sync import apply as apply_integration_sync_request
 from codex_refactor_loop import triage as apply_triage_decision
+from codex_refactor_loop.github_body import render_github_body
 from codex_refactor_loop.triage import ACCEPT_LABELS
 
 
@@ -245,6 +246,13 @@ class TriageDecisionApplyHelperTests(unittest.TestCase):
         runs.mkdir(parents=True)
         (runs / "comment.md").write_text("comment\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
         (runs / "body.md").write_text("body\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
+        (runs / "authority.md").write_text("完整 triage 授权内容\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
+        self.self_contained_triage_body = render_github_body(
+            kind="triage",
+            title="triage accepted",
+            artifact_paths=[runs / "authority.md"],
+            debug_paths=[".refactor-loop/runs/authority.md"],
+        )
         self.decision_path = runs / "triage-issue-53.json"
         self.write_decision()
 
@@ -295,6 +303,8 @@ class TriageDecisionApplyHelperTests(unittest.TestCase):
 
     def test_accept_happy_path_comments_edits_body_adds_fixed_labels_and_records_applied(self) -> None:
         self.write_decision(verdict="accept", body_artifact_path=".refactor-loop/runs/body.md", add_labels=ACCEPT_LABELS)
+        (self.repo / ".refactor-loop" / "runs" / "comment.md").write_text(self.self_contained_triage_body, encoding="utf-8")
+        (self.repo / ".refactor-loop" / "runs" / "body.md").write_text(self.self_contained_triage_body, encoding="utf-8")
         calls: list[list[str]] = []
 
         def fake_gh(args: list[str], *, repo: Path, repo_slug=None) -> subprocess.CompletedProcess[str]:

--- a/skills/codex-refactor-loop/scripts/test_cli_command_router.py
+++ b/skills/codex-refactor-loop/scripts/test_cli_command_router.py
@@ -132,6 +132,7 @@ class RuntimeCommandRouterTests(unittest.TestCase):
                 "post-banner",
                 "release-gate",
                 "release-required-checks",
+                "render-github-body",
                 "merge-pr",
                 "open-pr",
                 "open-release-rollup-pr",
@@ -185,7 +186,7 @@ class RuntimeCommandRouterTests(unittest.TestCase):
                 self.assertFalse(hasattr(spec, "read_only"))
 
     def test_read_only_commands_have_only_read_authority(self) -> None:
-        for name in {"check-degradation", "check-manifest", "peek", "release-required-checks", "statusline", "sync-request", "wakeup-plan"}:
+        for name in {"check-degradation", "check-manifest", "peek", "release-required-checks", "render-github-body", "statusline", "sync-request", "wakeup-plan"}:
             with self.subTest(command=name):
                 self.assertFalse(set(COMMANDS[name].authority) & MUTATION_TOKENS)
 

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -28,6 +28,8 @@ class ControllerActionsTests(unittest.TestCase):
             encoding="utf-8",
         )
         self.actions = ControllerActions(LoopContext.load(repo_root=self.tmp))
+        self.pr_body = self.tmp / "pr-body.md"
+        self.pr_body.write_text("## 🤖 PR ready\n\n自包含正文。\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
 
     def tearDown(self) -> None:
         shutil.rmtree(self.tmp, ignore_errors=True)
@@ -74,7 +76,7 @@ class ControllerActionsTests(unittest.TestCase):
             return mock.Mock(returncode=0, stdout="", stderr="")
 
         with mock.patch.object(self.actions, "git", side_effect=fake_git), mock.patch.object(self.actions, "gh", side_effect=fake_gh):
-            pr_num, _url = self.actions.open_release_rollup_pr_from_pending_event(json.dumps(event), "body.md")
+            pr_num, _url = self.actions.open_release_rollup_pr_from_pending_event(json.dumps(event), str(self.pr_body))
 
         self.assertEqual(77, pr_num)
         self.assertIn(["push", "origin", "abc123:refs/heads/rollup/abc123"], git_calls)
@@ -154,6 +156,36 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertIn(["push", "origin", "abc123:refs/heads/rollup/abc123"], git_calls)
         self.assertFalse(any(call[:2] == ["pr", "create"] for call in gh_calls), gh_calls)
 
+    def test_open_pr_with_label_fails_closed_before_create_for_path_only_authority(self) -> None:
+        bad_body = self.tmp / "bad-pr-body.md"
+        bad_body.write_text("## 🤖 PR ready\n\n授权:.refactor-loop/runs/phase9-issue192-r1-judge.md\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
+        gh_calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            gh_calls.append(args)
+            return mock.Mock(returncode=0, stdout="https://github.com/owner/repo/pull/77\n", stderr="")
+
+        with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+            with self.assertRaisesRegex(RuntimeError, "local .refactor-loop artifact path"):
+                self.actions.open_pr_with_label("title", str(bad_body), head="refactor/branch")
+
+        self.assertFalse(any(call[:2] == ["pr", "create"] for call in gh_calls), gh_calls)
+
+    def test_open_pr_with_label_accepts_self_contained_body(self) -> None:
+        gh_calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            gh_calls.append(args)
+            if args[:2] == ["pr", "create"]:
+                return mock.Mock(returncode=0, stdout="https://github.com/owner/repo/pull/77\n", stderr="")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+            pr_num, _url = self.actions.open_pr_with_label("title", str(self.pr_body), head="refactor/branch")
+
+        self.assertEqual(77, pr_num)
+        self.assertTrue(any(call[:2] == ["pr", "create"] for call in gh_calls), gh_calls)
+
 
 class ControllerActionsSourceRegressionTests(unittest.TestCase):
     def test_required_lifecycle_helpers_exist(self) -> None:
@@ -161,6 +193,7 @@ class ControllerActionsSourceRegressionTests(unittest.TestCase):
         for needle in ("merge_pr", "open_pr_with_label", "open_release_rollup_pr_from_pending_event", "safe_worktree", "record_recent_pr_merge", "apply_dev_sync_request_marker", "apply_triage_decision_marker", "render_template"):
             with self.subTest(needle=needle):
                 self.assertIn(needle, text)
+        self.assertIn("validate_self_contained_github_body", text)
 
     def test_rollup_helper_uses_throwaway_head_ref(self) -> None:
         text = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -123,10 +123,36 @@ class ControllerActionsTests(unittest.TestCase):
 
                 with mock.patch.object(self.actions, "git", side_effect=fake_git), mock.patch.object(self.actions, "gh", side_effect=fake_gh):
                     with self.assertRaises(RuntimeError):
-                        self.actions.open_release_rollup_pr_from_pending_event(event_json, "body.md")
+                        self.actions.open_release_rollup_pr_from_pending_event(event_json, str(self.pr_body))
 
                 self.assertFalse(any(call[:1] == ["push"] for call in git_calls), git_calls)
                 self.assertFalse(any(call[:2] == ["pr", "create"] for call in gh_calls), gh_calls)
+
+    def test_open_release_rollup_pr_rejects_bad_body_before_git_push_or_pr_create(self) -> None:
+        event = {
+            "integration_branch": "auto-refact-dev",
+            "review_base_branch": "dev",
+            "integration_sha": "abc123",
+        }
+        bad_body = self.tmp / "bad-rollup-body.md"
+        bad_body.write_text("## 🤖 rollup\n\n授权:.refactor-loop/runs/phase9-issue192-r1-judge.md\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
+        git_calls: list[list[str]] = []
+        gh_calls: list[list[str]] = []
+
+        def fake_git(args: list[str], *, check: bool = True) -> mock.Mock:
+            git_calls.append(args)
+            return mock.Mock(returncode=1, stdout="", stderr="unexpected git call")
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            gh_calls.append(args)
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(self.actions, "git", side_effect=fake_git), mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+            with self.assertRaisesRegex(RuntimeError, "local .refactor-loop artifact path"):
+                self.actions.open_release_rollup_pr_from_pending_event(json.dumps(event), str(bad_body))
+
+        self.assertFalse(any(call[:1] == ["push"] for call in git_calls), git_calls)
+        self.assertFalse(any(call[:2] == ["pr", "create"] for call in gh_calls), gh_calls)
 
     def test_open_release_rollup_pr_failed_push_does_not_create_pr(self) -> None:
         event = {
@@ -151,7 +177,7 @@ class ControllerActionsTests(unittest.TestCase):
 
         with mock.patch.object(self.actions, "git", side_effect=fake_git), mock.patch.object(self.actions, "gh", side_effect=fake_gh):
             with self.assertRaisesRegex(RuntimeError, "push failed"):
-                self.actions.open_release_rollup_pr_from_pending_event(json.dumps(event), "body.md")
+                self.actions.open_release_rollup_pr_from_pending_event(json.dumps(event), str(self.pr_body))
 
         self.assertIn(["push", "origin", "abc123:refs/heads/rollup/abc123"], git_calls)
         self.assertFalse(any(call[:2] == ["pr", "create"] for call in gh_calls), gh_calls)

--- a/skills/codex-refactor-loop/scripts/test_github_body_renderer.py
+++ b/skills/codex-refactor-loop/scripts/test_github_body_renderer.py
@@ -83,6 +83,30 @@ class GitHubBodyRendererTests(unittest.TestCase):
         self.assertIn("完整共识正文", result.stdout)
         self.assertTrue(result.stdout.splitlines()[-1] == "⟦AI:AUTO-LOOP⟧")
 
+    def test_cli_rejects_output_path_to_remain_read_only(self) -> None:
+        output = self.tmp / "body.md"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(CLI),
+                "render-github-body",
+                "--kind",
+                "authorization",
+                "--title",
+                "授权卡片",
+                "--artifact",
+                str(self.artifact),
+                "--output",
+                str(output),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertFalse(output.exists())
+
 
 class GitHubBodySourceRegressionTests(unittest.TestCase):
     def test_cli_registers_renderer_as_read_artifact_only(self) -> None:
@@ -93,10 +117,11 @@ class GitHubBodySourceRegressionTests(unittest.TestCase):
 
     def test_no_new_daemon_or_lifecycle_authority_for_renderer(self) -> None:
         src = (SCRIPT_DIR / "codex_refactor_loop" / "github_body.py").read_text(encoding="utf-8")
-        for forbidden in ("subprocess", "run_gh", "gh ", "git ", "daemon", "write-state", "gh-open", "gh-label"):
+        for forbidden in ("subprocess", "run_gh", "Path(args.output).write_text", "add_argument(\"--output\"", "gh ", "git ", "daemon", "write-state", "gh-open", "gh-label"):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, src)
         self.assertIn("read-only helper", src)
+        self.assertIn("must not write files", src)
 
     def test_controller_and_triage_call_same_validator(self) -> None:
         controller = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_github_body_renderer.py
+++ b/skills/codex-refactor-loop/scripts/test_github_body_renderer.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Behavior and source-regression tests for self-contained GitHub bodies."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from codex_refactor_loop.github_body import GitHubBodyError, render_github_body, validate_self_contained_github_body
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_DIR = SCRIPT_DIR.parent
+CLI = SCRIPT_DIR / "consensus-rnd-cli"
+
+
+class GitHubBodyRendererTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="github-body-test-"))
+        self.artifact = self.tmp / "phase9-issue192-r2-judge.md"
+        self.artifact.write_text(
+            "---\nissue: 192\n---\n\n## Decision\n完整共识正文\n\n⟦AI:AUTO-LOOP⟧\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_renderer_embeds_full_artifact_and_debug_path_only_under_details(self) -> None:
+        body = render_github_body(
+            kind="consensus",
+            title="issue #192 共识",
+            artifact_paths=[self.artifact],
+            debug_paths=[".refactor-loop/runs/phase9-issue192-r2-judge.md"],
+        )
+
+        self.assertTrue(body.startswith("## 🤖 issue #192 共识\n"))
+        self.assertIn("完整共识正文", body)
+        self.assertIn("<summary>内联 artifact 1: phase9-issue192-r2-judge.md</summary>", body)
+        self.assertIn("<summary>本机调试线索</summary>", body)
+        self.assertIn("`.refactor-loop/runs/phase9-issue192-r2-judge.md`", body)
+        self.assertTrue(body.splitlines()[-1] == "⟦AI:AUTO-LOOP⟧")
+        validate_self_contained_github_body(body, authority_required=True)
+
+    def test_validator_rejects_path_only_authority(self) -> None:
+        body = "## 🤖 bad body\n\n授权:.refactor-loop/runs/phase9-issue192-r1-judge.md\n\n⟦AI:AUTO-LOOP⟧\n"
+        with self.assertRaisesRegex(GitHubBodyError, "local .refactor-loop artifact path"):
+            validate_self_contained_github_body(body)
+
+    def test_validator_allows_plain_body_without_authority_requirement(self) -> None:
+        validate_self_contained_github_body("## 🤖 status\n\n普通评论。\n\n⟦AI:AUTO-LOOP⟧\n")
+
+    def test_validator_requires_inline_details_for_authority_required_body(self) -> None:
+        with self.assertRaisesRegex(GitHubBodyError, "must inline artifact text"):
+            validate_self_contained_github_body("## 🤖 accepted\n\n结论已接受。\n\n⟦AI:AUTO-LOOP⟧\n", authority_required=True)
+
+    def test_cli_renders_to_stdout_without_mutation_authority(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(CLI),
+                "render-github-body",
+                "--kind",
+                "authorization",
+                "--title",
+                "授权卡片",
+                "--artifact",
+                str(self.artifact),
+                "--debug-path",
+                ".refactor-loop/runs/phase9-issue192-r2-judge.md",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("完整共识正文", result.stdout)
+        self.assertTrue(result.stdout.splitlines()[-1] == "⟦AI:AUTO-LOOP⟧")
+
+
+class GitHubBodySourceRegressionTests(unittest.TestCase):
+    def test_cli_registers_renderer_as_read_artifact_only(self) -> None:
+        cli = (SCRIPT_DIR / "codex_refactor_loop" / "cli.py").read_text(encoding="utf-8")
+        self.assertIn('"render-github-body": CommandSpec(', cli)
+        self.assertIn("github_body.main", cli)
+        self.assertIn('("read-artifact",)', cli)
+
+    def test_no_new_daemon_or_lifecycle_authority_for_renderer(self) -> None:
+        src = (SCRIPT_DIR / "codex_refactor_loop" / "github_body.py").read_text(encoding="utf-8")
+        for forbidden in ("subprocess", "run_gh", "gh ", "git ", "daemon", "write-state", "gh-open", "gh-label"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, src)
+        self.assertIn("read-only helper", src)
+
+    def test_controller_and_triage_call_same_validator(self) -> None:
+        controller = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")
+        triage = (SCRIPT_DIR / "codex_refactor_loop" / "triage.py").read_text(encoding="utf-8")
+        self.assertIn("from .github_body import", controller)
+        self.assertIn("validate_self_contained_github_body", controller)
+        self.assertIn("from .github_body import validate_self_contained_github_body", triage)
+        self.assertIn("validate_self_contained_github_body", triage)
+
+    def test_prompt_and_skill_document_self_contained_contract(self) -> None:
+        rules = (SKILL_DIR / "prompts" / "_github-post-rules.md").read_text(encoding="utf-8")
+        skill = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        for text in (rules, skill):
+            with self.subTest(source=text[:20]):
+                self.assertIn("GitHub body 必须自包含", text) if text is rules else self.assertIn("must inline the cited artifact text", text)
+                self.assertIn("<details><summary>本机调试线索</summary>", text)
+                self.assertTrue("永远不是唯一授权来源" in text or "never as the only source" in text)
+        self.assertNotIn("See [implement summary](./.refactor-loop/runs/implement-<cluster-id>.md)", skill)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_package_triage.py
+++ b/skills/codex-refactor-loop/scripts/test_package_triage.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from codex_refactor_loop.context import LoopContext
+from codex_refactor_loop.github_body import render_github_body
 from codex_refactor_loop.triage import ACCEPT_LABELS, TriageApplyConfig, apply_decision
 
 
@@ -33,6 +34,13 @@ class PackageTriageDecisionTests(unittest.TestCase):
         )
         (runs / "comment.md").write_text("comment\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
         (runs / "body.md").write_text("body\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
+        (runs / "authority.md").write_text("完整授权内容\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
+        self.self_contained_triage_body = render_github_body(
+            kind="triage",
+            title="triage accepted",
+            artifact_paths=[runs / "authority.md"],
+            debug_paths=[".refactor-loop/runs/authority.md"],
+        )
         self.decision_path = runs / "triage-issue-53.json"
         self.config = TriageApplyConfig(LoopContext.load(repo_root=self.repo))
         self.write_decision()
@@ -89,6 +97,8 @@ class PackageTriageDecisionTests(unittest.TestCase):
 
     def test_accept_happy_path_comments_edits_body_adds_fixed_labels_and_records_applied(self) -> None:
         self.write_decision(verdict="accept", body_artifact_path=".refactor-loop/runs/body.md", add_labels=ACCEPT_LABELS)
+        (self.repo / ".refactor-loop" / "runs" / "comment.md").write_text(self.self_contained_triage_body, encoding="utf-8")
+        (self.repo / ".refactor-loop" / "runs" / "body.md").write_text(self.self_contained_triage_body, encoding="utf-8")
         calls: list[list[str]] = []
 
         def fake_gh(args: list[str], *, repo: Path, repo_slug: str | None = None) -> subprocess.CompletedProcess[str]:
@@ -161,6 +171,20 @@ class PackageTriageDecisionTests(unittest.TestCase):
         self.assertIn("comment artifact missing final sentinel", self.rejected_record().read_text(encoding="utf-8"))
         self.assertEqual(mock_gh.call_count, 0)
 
+    def test_accept_rejects_path_only_authority_before_github_mutation(self) -> None:
+        self.write_decision(verdict="accept", body_artifact_path=".refactor-loop/runs/body.md", add_labels=ACCEPT_LABELS)
+        path_only = "## 🤖 triage\n\n授权:.refactor-loop/runs/phase9-issue192-r1-judge.md\n\n⟦AI:AUTO-LOOP⟧\n"
+        (self.repo / ".refactor-loop" / "runs" / "comment.md").write_text(path_only, encoding="utf-8")
+        (self.repo / ".refactor-loop" / "runs" / "body.md").write_text(path_only, encoding="utf-8")
+        mock_gh = Mock(return_value=subprocess.CompletedProcess(["gh"], 0, "", ""))
+
+        with patch("codex_refactor_loop.triage.current_labels", lambda _config, _issue: ["auto-loop-triage"]):
+            with patch("codex_refactor_loop.triage.run_gh", mock_gh):
+                self.assertEqual(apply_decision(self.config, self.decision_path, issue_number=53, verdict="accept"), 2)
+
+        self.assertIn("local .refactor-loop artifact path", self.rejected_record().read_text(encoding="utf-8"))
+        self.assertEqual(mock_gh.call_count, 0)
+
     def test_schema_rejects_command_like_lifecycle_fields(self) -> None:
         self.write_decision(close=True)
         with patch("codex_refactor_loop.triage.current_labels", lambda _config, _issue: ["auto-loop-triage"]):
@@ -188,6 +212,7 @@ class PackageTriageSourceRegressionTests(unittest.TestCase):
             "controller",
             "host.env",
             "⟦AI:AUTO-LOOP⟧",
+            "validate_self_contained_github_body",
             "--body-file",
             "--remove-label",
             "--add-label",


### PR DESCRIPTION
## 摘要

实现 #192 GitHub artifact 自包含(Phase 9 r2 consensus)。read-only `render-github-body`/validator:从本地 artifact 渲染**自包含**中文 body(全文内联授权/共识,不留本地路径作唯一来源);controller PR 与 triage 出口 fail-closed。不新增 daemon/owner/历史迁移/CLAUDE/Tier。属 goal #191 多设备并发(GitHub 唯一协调面前提)。Closes #192。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
