### PR TITLE
feat(#205): dogfood 运维经验写回 skill 局部合同

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -267,6 +267,21 @@ Uninstall note: remove the cron line or unload/delete the launchd plist; do not 
 
 授权来源:`skills/codex-refactor-loop/authorizations/runtime-exceptions.md#anti-stop-restart-helper-49`(Consensus-rnd Phase design-consensus r3 `META_JUDGE_DONE:consensus:A-cron-only-with-pending-event-alert`)。
 
+## Dogfood anti-rules(per #205)
+
+<!-- Refactor (iter205/issue-205):
+  Old pattern: dogfood 实测的运维经验(audit 并行撞 iteration 号、新 role prompt 漏注册 marker contract、review verdict grep log tail 误判、daemon 恢复手 kill)只靠 agent 记忆,没落进 skill 合同与机械验证。
+  New principle: 把四条经验写回局部合同:SKILL.md 增 #205 反面规则段(audit 同一时刻单 active iteration、新 role prompt 必同步 marker inventory、review verdict 权威源优先 review artifact frontmatter、daemon 恢复只走 restart-daemons);audit.md 渲染后 ITERATION 空则 fail-closed;peek.py 局部优先读 review artifact frontmatter verdict;配套 source-regression + behavior test。不新增跨模块抽象层。
+-->
+
+These are local controller contract rules learned from dogfood incidents:
+
+1. Audit fallback may have only one active `audit-iter-N` for the same `N` at a time; never start parallel audit runs that reuse `audit-iter-N.md`, `audit-iter-N-candidates.ndjson`, or `audit-iter-N.log`.
+2. Audit prompt rendering fails closed when `ITERATION` is empty; do not write `audit-iter-.md`, `audit-iter--candidates.ndjson`, or similarly empty-identity artifacts.
+3. Any new role prompt under `skills/codex-refactor-loop/prompts/*.md` must be registered in `test_marker_emission_contract.py` prompt inventory, including both `PROMPT_ALLOWLISTS` and `PROMPT_ARTIFACT_PROFILES`.
+4. Review verdict authority for merge-readiness starts from `.refactor-loop/runs/review-pr<N>-<role>-r<R>.md` frontmatter `verdict: approve|comment|reject`; only missing or invalid review artifacts fall back to clean log-tail `REVIEW_DONE` markers.
+5. Daemon recovery goes through `python3 <skill-root>/scripts/consensus-rnd-cli restart-daemons`; controller must not hand-kill daemon processes, probe process lists as liveness authority, or bypass the restart helper.
+
 ## Wakeup Skeleton
 
 Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event wakeup follows this skeleton. Each controller session must arm or confirm the mounted persistent Monitor bridge before pending-event sweep, marker parsing, concurrency-floor handling, or dispatch/spawn. Daemon pending-event wakeups are valid only through that Monitor or equivalent harness bridge; daemon alone is not a wake source. The Consensus-rnd Phase design-consensus router daemon may replace controller dispatch for SOLVER_DONE triplets, converge, and valid stalled continuation; controller fallback sweep remains authoritative for every other marker.
@@ -764,7 +779,7 @@ Producer rules:
 Consensus-rnd Phase work-intake guardrails:
 
 1. Run the producer with host-injected `$SOURCE_GLOBS`.
-2. Write audit output to `.refactor-loop/runs/audit-iter-N.md`.
+2. Write audit output to `.refactor-loop/runs/audit-iter-N.md`; `N` must be nonempty and unique among currently active audit fallback runs.
 3. Convert accepted units into work-unit items before dispatch.
 4. Clean stale worktrees before audit pollution can affect decisions.
 5. For `requires_design`, open or update GitHub design issues and label them `🔍 phase:design-solving` plus `🤖 human:auto-推进`.

--- a/skills/codex-refactor-loop/prompts/audit.md
+++ b/skills/codex-refactor-loop/prompts/audit.md
@@ -12,6 +12,15 @@ Artifact profile: marker-only-work-unit
 4. `docs/audit-scorecard/` 历史审计仅作起点参考，**不**作为唯一线索源。
 5. 当前 git 分支：`git branch --show-current`。
 
+<!-- Refactor (iter205/issue-205):
+  Old pattern: dogfood 实测的运维经验(audit 并行撞 iteration 号、新 role prompt 漏注册 marker contract、review verdict grep log tail 误判、daemon 恢复手 kill)只靠 agent 记忆,没落进 skill 合同与机械验证。
+  New principle: 把四条经验写回局部合同:SKILL.md 增 #205 反面规则段(audit 同一时刻单 active iteration、新 role prompt 必同步 marker inventory、review verdict 权威源优先 review artifact frontmatter、daemon 恢复只走 restart-daemons);audit.md 渲染后 ITERATION 空则 fail-closed;peek.py 局部优先读 review artifact frontmatter verdict;配套 source-regression + behavior test。不新增跨模块抽象层。
+-->
+
+## 渲染身份 fail-closed(强制)
+
+模板渲染后若 `ITERATION` 为空、只含空白、或仍是未替换占位符,立即输出 `AUDIT_INCOMPLETE:missing-iteration` 并停止。禁止写入 `$REPO_ROOT/.refactor-loop/runs/audit-iter-.md`、`$REPO_ROOT/.refactor-loop/runs/audit-iter--candidates.ndjson`、空 iteration log,或任何复用空 identity 的 artifact。audit fallback 同一时刻只能有一个 active `audit-iter-${ITERATION}`;不要并行复用同一 iteration 输出名。
+
 ## 强制流程（违反任一项 → 输出 `AUDIT_INCOMPLETE`，禁止 `AUDIT_DONE`）
 
 ### Step 1 — Coverage manifest（必出）

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/peek.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/peek.py
@@ -172,6 +172,9 @@ class PeekStatusLens:
         return out
 
     def _mergeable_prs(self) -> list[str]:
+        # Refactor (iter205/issue-205):
+        #   Old pattern: dogfood 实测的运维经验(audit 并行撞 iteration 号、新 role prompt 漏注册 marker contract、review verdict grep log tail 误判、daemon 恢复手 kill)只靠 agent 记忆,没落进 skill 合同与机械验证。
+        #   New principle: 把四条经验写回局部合同:SKILL.md 增 #205 反面规则段(audit 同一时刻单 active iteration、新 role prompt 必同步 marker inventory、review verdict 权威源优先 review artifact frontmatter、daemon 恢复只走 restart-daemons);audit.md 渲染后 ITERATION 空则 fail-closed;peek.py 局部优先读 review artifact frontmatter verdict;配套 source-regression + behavior test。不新增跨模块抽象层。
         out = []
         for num in self.gh_json(["pr", "list", "--label", "auto-loop", "--state", "open", "--json", "number"], []):
             pr_num = str(num.get("number")) if isinstance(num, dict) else ""
@@ -185,7 +188,12 @@ class PeekStatusLens:
                 continue
             approve = comment = reject = 0
             for role in ("architect", "tests", "quality"):
-                verdict = extract_review_verdict_tail(self.ctx.paths.logs / f"review-pr{pr_num}-{role}-r{max_round}.log", pr_num, role)
+                verdict = extract_review_verdict(
+                    self.ctx.paths.runs / f"review-pr{pr_num}-{role}-r{max_round}.md",
+                    self.ctx.paths.logs / f"review-pr{pr_num}-{role}-r{max_round}.log",
+                    pr_num,
+                    role,
+                )
                 if verdict == "approve":
                     approve += 1
                 elif verdict == "comment":
@@ -354,6 +362,33 @@ def extract_review_verdict_tail(log_path: Path, pr_num: str, role: str) -> str:
         if match:
             verdict = match.group(1)
     return verdict
+
+
+def extract_review_verdict(artifact_path: Path, log_path: Path, pr_num: str, role: str) -> str:
+    # Refactor (iter205/issue-205):
+    #   Old pattern: dogfood 实测的运维经验(audit 并行撞 iteration 号、新 role prompt 漏注册 marker contract、review verdict grep log tail 误判、daemon 恢复手 kill)只靠 agent 记忆,没落进 skill 合同与机械验证。
+    #   New principle: 把四条经验写回局部合同:SKILL.md 增 #205 反面规则段(audit 同一时刻单 active iteration、新 role prompt 必同步 marker inventory、review verdict 权威源优先 review artifact frontmatter、daemon 恢复只走 restart-daemons);audit.md 渲染后 ITERATION 空则 fail-closed;peek.py 局部优先读 review artifact frontmatter verdict;配套 source-regression + behavior test。不新增跨模块抽象层。
+    verdict = _review_artifact_frontmatter_verdict(artifact_path)
+    if verdict:
+        return verdict
+    return extract_review_verdict_tail(log_path, pr_num, role)
+
+
+def _review_artifact_frontmatter_verdict(path: Path) -> str:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    if not text.startswith("---\n"):
+        return ""
+    end = text.find("\n---", 4)
+    if end == -1:
+        return ""
+    for line in text[4:end].splitlines():
+        match = re.match(r"\s*verdict\s*:\s*(approve|comment|reject)\s*$", line)
+        if match:
+            return match.group(1)
+    return ""
 
 
 def _tail(path: Path, count: int) -> list[str]:

--- a/skills/codex-refactor-loop/scripts/test_anti_stop_restart_helper_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_anti_stop_restart_helper_contract.py
@@ -14,6 +14,9 @@ RESTART_MODULE = SKILL_ROOT / "scripts" / "codex_refactor_loop" / "restart.py"
 
 
 class AntiStopRestartHelperContractTests(unittest.TestCase):
+    # Refactor (iter205/issue-205):
+    #   Old pattern: dogfood 实测的运维经验(audit 并行撞 iteration 号、新 role prompt 漏注册 marker contract、review verdict grep log tail 误判、daemon 恢复手 kill)只靠 agent 记忆,没落进 skill 合同与机械验证。
+    #   New principle: 把四条经验写回局部合同:SKILL.md 增 #205 反面规则段(audit 同一时刻单 active iteration、新 role prompt 必同步 marker inventory、review verdict 权威源优先 review artifact frontmatter、daemon 恢复只走 restart-daemons);audit.md 渲染后 ITERATION 空则 fail-closed;peek.py 局部优先读 review artifact frontmatter verdict;配套 source-regression + behavior test。不新增跨模块抽象层。
     def setUp(self) -> None:
         self.skill = SKILL_MD.read_text(encoding="utf-8")
         self.restart = RESTART_MODULE.read_text(encoding="utf-8")
@@ -66,6 +69,20 @@ class AntiStopRestartHelperContractTests(unittest.TestCase):
         for token in ("gh ", "git ", "pr merge", "issue close", "git tag", "gh release"):
             with self.subTest(token=token):
                 self.assertNotIn(token, self.restart)
+
+    def test_issue205_daemon_recovery_uses_restart_helper_only(self) -> None:
+        section_start = self.skill.find("## Dogfood anti-rules(per #205)")
+        section_end = self.skill.find("## Wakeup Skeleton", section_start)
+        section = self.skill[section_start:section_end]
+
+        for needle in (
+            "consensus-rnd-cli restart-daemons",
+            "must not hand-kill daemon processes",
+            "probe process lists as liveness authority",
+            "bypass the restart helper",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_marker_emission_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_emission_contract.py
@@ -176,6 +176,9 @@ def artifact_profile_anchors(body: str) -> list[str]:
 
 
 class MarkerEmissionContractTests(unittest.TestCase):
+    # Refactor (iter205/issue-205):
+    #   Old pattern: dogfood 实测的运维经验(audit 并行撞 iteration 号、新 role prompt 漏注册 marker contract、review verdict grep log tail 误判、daemon 恢复手 kill)只靠 agent 记忆,没落进 skill 合同与机械验证。
+    #   New principle: 把四条经验写回局部合同:SKILL.md 增 #205 反面规则段(audit 同一时刻单 active iteration、新 role prompt 必同步 marker inventory、review verdict 权威源优先 review artifact frontmatter、daemon 恢复只走 restart-daemons);audit.md 渲染后 ITERATION 空则 fail-closed;peek.py 局部优先读 review artifact frontmatter verdict;配套 source-regression + behavior test。不新增跨模块抽象层。
     def test_each_prompt_declares_exact_allowlist_section(self) -> None:
         for filename, allowed_markers in PROMPT_ALLOWLISTS.items():
             with self.subTest(prompt=filename):
@@ -216,6 +219,7 @@ class MarkerEmissionContractTests(unittest.TestCase):
         }
 
         self.assertEqual(role_prompt_files, set(PROMPT_ALLOWLISTS))
+        self.assertEqual(role_prompt_files, set(PROMPT_ARTIFACT_PROFILES))
 
     def test_active_prompts_do_not_require_parallel_language_sections(self) -> None:
         forbidden_patterns = (
@@ -262,6 +266,17 @@ class MarkerEmissionContractTests(unittest.TestCase):
     def test_github_post_rules_declares_post_body_artifact_profile(self) -> None:
         body = (PROMPTS_DIR / "_github-post-rules.md").read_text(encoding="utf-8")
         self.assertEqual(artifact_profile_anchors(body), ["github-ai-post-body"])
+
+    def test_skill_documents_prompt_inventory_sync_for_new_role_prompts(self) -> None:
+        skill = (PROMPTS_DIR.parents[0] / "SKILL.md").read_text(encoding="utf-8")
+        section_start = skill.find("## Dogfood anti-rules(per #205)")
+        section_end = skill.find("## Wakeup Skeleton", section_start)
+        section = skill[section_start:section_end]
+
+        self.assertIn("Any new role prompt", section)
+        self.assertIn("test_marker_emission_contract.py", section)
+        self.assertIn("PROMPT_ALLOWLISTS", section)
+        self.assertIn("PROMPT_ARTIFACT_PROFILES", section)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
+++ b/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
@@ -24,8 +24,10 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
         self.root = Path(self.tmp.name)
         self.fakebin = self.root / "fakebin"
         self.logs = self.root / ".refactor-loop" / "logs"
+        self.runs = self.root / ".refactor-loop" / "runs"
         self.fakebin.mkdir(parents=True)
         self.logs.mkdir(parents=True)
+        self.runs.mkdir(parents=True)
         self.write_fake_git()
         self.write_fake_gh()
 
@@ -252,6 +254,9 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
         self.assertEqual(alert.read_text(encoding="utf-8"), "[2026-05-27T00:00:00Z] skill-degradation-alert returncode=1\n")
 
     def test_peek_review_merge_readiness_uses_tail_only_review_done(self) -> None:
+        # Refactor (iter205/issue-205):
+        #   Old pattern: dogfood 实测的运维经验(audit 并行撞 iteration 号、新 role prompt 漏注册 marker contract、review verdict grep log tail 误判、daemon 恢复手 kill)只靠 agent 记忆,没落进 skill 合同与机械验证。
+        #   New principle: 把四条经验写回局部合同:SKILL.md 增 #205 反面规则段(audit 同一时刻单 active iteration、新 role prompt 必同步 marker inventory、review verdict 权威源优先 review artifact frontmatter、daemon 恢复只走 restart-daemons);audit.md 渲染后 ITERATION 空则 fail-closed;peek.py 局部优先读 review artifact frontmatter verdict;配套 source-regression + behavior test。不新增跨模块抽象层。
         pr = 123
         (self.logs / f"review-pr{pr}-architect-r1.log").write_text(
             f"REVIEW_DONE:{pr}:architect:approve\nEXIT=0\n",
@@ -275,6 +280,35 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("MERGE_READY approve=2 comment=1 reject=0", result.stdout)
         self.assertNotIn("MERGE_READY approve=3 comment=0 reject=0", result.stdout)
+
+    def test_peek_review_merge_readiness_prefers_artifact_frontmatter_verdict(self) -> None:
+        # Refactor (iter205/issue-205):
+        #   Old pattern: dogfood 实测的运维经验(audit 并行撞 iteration 号、新 role prompt 漏注册 marker contract、review verdict grep log tail 误判、daemon 恢复手 kill)只靠 agent 记忆,没落进 skill 合同与机械验证。
+        #   New principle: 把四条经验写回局部合同:SKILL.md 增 #205 反面规则段(audit 同一时刻单 active iteration、新 role prompt 必同步 marker inventory、review verdict 权威源优先 review artifact frontmatter、daemon 恢复只走 restart-daemons);audit.md 渲染后 ITERATION 空则 fail-closed;peek.py 局部优先读 review artifact frontmatter verdict;配套 source-regression + behavior test。不新增跨模块抽象层。
+        pr = 124
+        for role in ("architect", "tests", "quality"):
+            (self.logs / f"review-pr{pr}-{role}-r1.log").write_text(
+                f"quoted prompt REVIEW_DONE:{pr}:{role}:approve\n"
+                f"REVIEW_DONE:{pr}:{role}:reject\n"
+                "EXIT=0\n",
+                encoding="utf-8",
+            )
+            (self.runs / f"review-pr{pr}-{role}-r1.md").write_text(
+                "---\n"
+                f"pr: {pr}\n"
+                f"role: {role}\n"
+                "verdict: approve\n"
+                "---\n"
+                "\n"
+                f"Body may quote REVIEW_DONE:{pr}:{role}:reject without authority.\n",
+                encoding="utf-8",
+            )
+
+        result = self.run_peek(pr=pr)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("MERGE_READY approve=3 comment=0 reject=0", result.stdout)
+        self.assertNotIn("reject=3", result.stdout)
 
     def test_peek_displays_unpushed_worker_output_as_status_only(self) -> None:
         result = self.run_peek(pr=77, unpushed=True)

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -420,6 +420,36 @@ class SkillEntrypointContractTests(unittest.TestCase):
         self.assertNotIn("| Variable | Meaning | Default / example |", host_config)
         self.assertNotIn("| Variable | Prompt meaning | Empty behavior |", host_config)
 
+    def test_issue205_dogfood_anti_rules_are_local_contract(self) -> None:
+        # Refactor (iter205/issue-205):
+        #   Old pattern: dogfood 实测的运维经验(audit 并行撞 iteration 号、新 role prompt 漏注册 marker contract、review verdict grep log tail 误判、daemon 恢复手 kill)只靠 agent 记忆,没落进 skill 合同与机械验证。
+        #   New principle: 把四条经验写回局部合同:SKILL.md 增 #205 反面规则段(audit 同一时刻单 active iteration、新 role prompt 必同步 marker inventory、review verdict 权威源优先 review artifact frontmatter、daemon 恢复只走 restart-daemons);audit.md 渲染后 ITERATION 空则 fail-closed;peek.py 局部优先读 review artifact frontmatter verdict;配套 source-regression + behavior test。不新增跨模块抽象层。
+        section = section_between(
+            self.skill,
+            r"^## Dogfood anti-rules\(per #205\)$",
+            r"^## Wakeup Skeleton$",
+        )
+        self.assertTrue(section)
+        for needle in (
+            "only one active `audit-iter-N`",
+            "fails closed when `ITERATION` is empty",
+            "do not write `audit-iter-.md`",
+            "must be registered in `test_marker_emission_contract.py` prompt inventory",
+            "PROMPT_ALLOWLISTS",
+            "PROMPT_ARTIFACT_PROFILES",
+            "review-pr<N>-<role>-r<R>.md` frontmatter `verdict: approve|comment|reject`",
+            "fall back to clean log-tail `REVIEW_DONE` markers",
+            "consensus-rnd-cli restart-daemons",
+            "must not hand-kill daemon processes",
+            "probe process lists as liveness authority",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
+        forbidden = ("WorkerCompletionEvidence", "AuditRunLease", "restart-daemons --force")
+        for token in forbidden:
+            with self.subTest(token=token):
+                self.assertNotIn(token, self.skill)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -450,6 +450,27 @@ class SkillEntrypointContractTests(unittest.TestCase):
             with self.subTest(token=token):
                 self.assertNotIn(token, self.skill)
 
+    def test_issue205_audit_prompt_fails_closed_on_empty_iteration(self) -> None:
+        # Refactor (iter205/issue-205):
+        #   Old pattern: dogfood 实测的运维经验(audit 并行撞 iteration 号、新 role prompt 漏注册 marker contract、review verdict grep log tail 误判、daemon 恢复手 kill)只靠 agent 记忆,没落进 skill 合同与机械验证。
+        #   New principle: 把四条经验写回局部合同:SKILL.md 增 #205 反面规则段(audit 同一时刻单 active iteration、新 role prompt 必同步 marker inventory、review verdict 权威源优先 review artifact frontmatter、daemon 恢复只走 restart-daemons);audit.md 渲染后 ITERATION 空则 fail-closed;peek.py 局部优先读 review artifact frontmatter verdict;配套 source-regression + behavior test。不新增跨模块抽象层。
+        audit_prompt = read(SKILL_ROOT / "prompts" / "audit.md")
+        section = section_between(
+            audit_prompt,
+            r"^## 渲染身份 fail-closed\(强制\)$",
+            r"^## 强制流程",
+        )
+        self.assertTrue(section)
+        for needle in (
+            "`ITERATION` 为空",
+            "立即输出 `AUDIT_INCOMPLETE:missing-iteration`",
+            "禁止写入 `$REPO_ROOT/.refactor-loop/runs/audit-iter-.md`",
+            "`$REPO_ROOT/.refactor-loop/runs/audit-iter--candidates.ndjson`",
+            "audit fallback 同一时刻只能有一个 active `audit-iter-${ITERATION}`",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 动机
把 2026-05-29 dogfood 实测的 4 条运维经验写回 `codex-refactor-loop` 局部合同(closes #205),经 Phase 9 共识(3/3,framing=minimal)。

## 改动
- **SKILL.md**:增 #205 反面规则段——audit 同一时刻单 active iteration;新 role prompt 必同步 marker inventory;review verdict 权威源优先 review artifact frontmatter;daemon 恢复只走 `restart-daemons`。
- **prompts/audit.md**:渲染后 ITERATION 空则 fail-closed,禁写 `audit-iter-.md`。
- **peek.py**:局部优先读 review artifact frontmatter `verdict:`,缺 artifact 才回退 tail marker。
- **测试**:source-regression(entrypoint/marker contract/anti-stop)+ behavior test(peek frontmatter 优先于 log body 引用的 reject)。

## 影响范围
仅 skill 局部合同 + 测试,不新增跨模块抽象层。

## 验证
`python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` —— implement worker 报 EXIT=0。

⟦AI:AUTO-LOOP⟧