### PR TITLE
feat(#201): 删除 public lifecycle CLI surface,迁回 controller-internal

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -15,7 +15,7 @@ Use intra-file anchors when a phase needs the detailed body, such as [host runti
 ## Controller Contract Index
 | Contract | Keep-local invariant | Controller action | Reference anchor | Prompt/script surface |
 |---|---|---|---|---|
-| Host config | Host facts come only from `host.env`; skill text remains host-agnostic. | `source .refactor-loop/host.env` before running actors; fail closed if required vars are absent. | [host runtime details](#host-runtime-details) | `host.env.example`, `consensus-rnd-cli controller actions` |
+| Host config | Host facts come only from `host.env`; skill text remains host-agnostic. | `source .refactor-loop/host.env` before running actors; fail closed if required vars are absent. | [host runtime details](#host-runtime-details) | `host.env.example`, controller-internal `ControllerActions` |
 | GitHub state | GitHub 是系统状态唯一显示面. Maintainer must see current state without local logs. | Post status banners and labels in the same turn as every spawn, completion, consensus, merge, block, or escalation. | [status and escalation templates](#status-and-escalation-templates) | `consensus-rnd-cli post-banner`, GitHub labels |
 | Pure orchestration | Controller = pure orchestration. It routes, posts, labels, spawns, commits, pushes, merges; codex workers change code. Narrow Consensus-rnd Phase design-consensus allowlist dispatch is the named daemon exception. | Never implement product/refactor code in the controller conversation. Dispatch a codex for implementation, verification, fixing, review, and design solving; let `consensus-rnd-cli phase9-router` handle only its allowlisted deterministic routes. | [controller contract details](#controller-contract-details) | `consensus-rnd-cli spawn-codex`, prompt files |
 | Sentinel | Every AI-authored GitHub body ends with a final independent `⟦AI:AUTO-LOOP⟧` line. | Filter AI comments by sentinel and AI banner prefixes; never react to own comments as maintainer input. | [sentinel and comment filters](#sentinel-and-comment-filters) | prompts, `consensus-rnd-cli comment-monitor` |
@@ -28,7 +28,7 @@ Use intra-file anchors when a phase needs the detailed body, such as [host runti
 | Phase routing | Markers route immediately to the next actor in the same wakeup. | Sweep `EXIT=0` logs, parse verdict markers only after clean exit, then spawn next work if actionable. | [phase routing details](#phase-routing-details) | logs, prompts |
 | 3/3 consensus | Concrete plans require Consensus-rnd Phase design-consensus multi-solver consensus and meta-judge consensus. | Dispatch minimal, structural, delete solvers; meta-judge may return only consensus, converge, or stalled-style escalation path. | [design-consensus details](#design-consensus-details) | `solver-*.md`, `meta-judge.md` |
 | Floor | Keep `$CODEX_FLOOR` host-scoped codexes, default 5, hard lower bound 2. | Count only this loop's `consensus-rnd-cli spawn-codex` processes containing absolute `$REPO_ROOT`; top up before ScheduleWakeup. | [concurrency floor details](#concurrency-floor-details) | `consensus-rnd-cli concurrency`, `consensus-rnd-cli peek` |
-| Labels | Every issue/PR has exactly one phase label and one human label. | Sync labels and banner together; `👤 human:需-maintainer-决策` only after allowed meta-layer routes. | [label bootstrap loops](#label-bootstrap-loops) | `consensus-rnd-cli controller actions`, GitHub labels |
+| Labels | Every issue/PR has exactly one phase label and one human label. | Sync labels and banner together; `👤 human:需-maintainer-决策` only after allowed meta-layer routes. | [label bootstrap loops](#label-bootstrap-loops) | controller-internal `ControllerActions`, GitHub labels |
 | Spawn | Mainline codex spawn uses harness background tasks, not detached nohup. | Use one background task per codex; if detached already happened, preserve work and rely on log sweep plus wake source. | [codex invocation details](#codex-invocation-details) | `consensus-rnd-cli spawn-codex` |
 | Hard rules | All worker prompts inherit controller-level hard rules. | Include scope, git, test, language, and no-scope-creep constraints in every spawned prompt. | [hard rules details](#hard-rules-details) | prompt templates |
 | Language | Source files are English-only; external user-facing artifacts are 中文 by default. No mandatory parallel English section. | Enforce on prompts, GitHub posts, commits, docs, source comments/logs. | [language policy details](#language-policy-details), [historical bilingual notes](#historical-bilingual-notes) | prompts, docs, commit text |
@@ -200,8 +200,9 @@ Stability requires all signals green and fail-closed handling on missing or red 
 The release lifecycle surface consumes decision-artifact-only output: a scheduled/on-demand controller may read `.refactor-loop/state/release-candidate.json`, re-check `$RELEASE_AUTO_ENABLE=true`, call the existing version bump command, commit/push mapped manifests, and let `release.yml` publish; or `release.yml` may read `.refactor-loop/state/release-decision.json` directly, re-check the same opt-in, bump/publish through guarded jobs, and record the result. `consensus-rnd-cli release-gate` remains decider only; controller/workflow owns lifecycle operations and must re-validate host opt-in. Forbidden: per-release maintainer emoji ratification, approval-ticket gating, or release-candidate JSON authorization.
 
 <!-- Refactor (iter1/issue-166): Old pattern: CLI command authority was represented by coarse read_only metadata and prose-only runtime exception text, so the matrix could under-report command surfaces. New principle: `cli.py::COMMANDS[*].authority` is the inline closed-token mechanical fact source, including named narrow carveouts such as dev-sync's integration-worktree git surface, and SKILL prose cannot grant missing runtime authority. -->
+<!-- Refactor (iter201/issue-201): Old pattern: public consensus-rnd-cli exposed merge-pr/open-pr/safe-push/apply-sync/apply-triage lifecycle commands and wakeup_plan/peek rendered copyable suggested_command, forming generic lifecycle authority. New principle: delete public lifecycle CLI surface; COMMANDS covers public non-lifecycle commands only, controller lifecycle primitives stay internal, wakeup-plan emits fixed controller_action facts with no_lifecycle_authority:true, and dev-sync keeps only the #53 carveout. -->
 ## CLI runtime authority fact source(per #166)
-`skills/codex-refactor-loop/scripts/codex_refactor_loop/cli.py::COMMANDS[*].authority` is the unique mechanical fact source for CLI runtime command authority. Each `CommandSpec.authority` is an inline closed-token tuple that states the command's maximum git/gh/spawn/write-artifact/label/merge capability. SKILL prose explains the human contract, narrow allowlist, durable authorization source, and no lifecycle authority by default; it must not grant a CLI capability missing from `CommandSpec.authority`. Worker prompt authority remains in prompt contracts and prompt tests, not as pseudo-commands in `COMMANDS`. New or expanded CLI runtime authority requires matching behavior test and source-regression anchor coverage.
+`skills/codex-refactor-loop/scripts/codex_refactor_loop/cli.py::COMMANDS[*].authority` is the unique mechanical fact source for CLI runtime command authority for worker-visible, non-lifecycle public commands. Each `CommandSpec.authority` is an inline closed-token tuple that states a public command's maximum git/gh/spawn/write-artifact/label/merge capability. Controller lifecycle primitives such as `merge_pr`, `open_pr_with_label`, `open_release_rollup_pr_from_pending_event`, `apply_human_label_or_skip`, `safe_push`, `safe_sync_main`, and triage apply stay outside `COMMANDS`; their authorization comes from controller-owned decisions/action facts and direct internal call boundaries. `wakeup-plan` may emit only fixed facts such as `controller_action: "safe_push"` with `no_lifecycle_authority: true`; `peek` may display those facts but must not render executable lifecycle commands. SKILL prose explains the human contract, narrow allowlist, durable authorization source, and no lifecycle authority by default; it must not grant a CLI capability missing from `CommandSpec.authority`. Worker prompt authority remains in prompt contracts and prompt tests, not as pseudo-commands in `COMMANDS`. New or expanded public CLI runtime authority requires matching behavior test and source-regression anchor coverage.
 
 ## Named runtime exception — autonomous-release-gate lifecycle boundary(per #56)
 Host-agnostic, no lifecycle authority: only read repo/GitHub evidence and write durable decision/candidate artifacts; do not run `git`, bump mapped manifests, commit, push, tag, publish, open, close, label, approve, merge, or otherwise lifecycle-manage issues or PRs.
@@ -653,7 +654,7 @@ Operational details live in [language policy details](#language-policy-details);
 - [prompts/meta-judge.md](prompts/meta-judge.md) — Consensus-rnd Phase design-consensus meta-judge.
 - [scripts/consensus-rnd-cli spawn-codex](scripts/consensus-rnd-cli spawn-codex) — codex supervisor.
 - [scripts/consensus-rnd-cli peek](scripts/consensus-rnd-cli peek) — controller wakeup summary.
-- [scripts/consensus-rnd-cli controller actions](scripts/consensus-rnd-cli controller actions) — shared controller helpers.
+- `scripts/codex_refactor_loop/controller_actions.py` — controller-internal lifecycle primitives; not a public CLI command surface.
 - [scripts/consensus-rnd-cli post-banner](scripts/consensus-rnd-cli post-banner) — GitHub banner posting helper.
 - [scripts/consensus-rnd-cli ensure-project-rules](scripts/consensus-rnd-cli ensure-project-rules) — Consensus-rnd Phase bootstrap fixed-point helper.
 - [scripts/consensus-rnd-cli concurrency](scripts/consensus-rnd-cli concurrency) — no-gap sentinel daemon.
@@ -1271,26 +1272,30 @@ disown
 - ❌ 看到 concurrency-alert.log 有 entry 但 controller 不读
 - ❌ active issue 0 codex 跑 >= 1 wakeup 周期(说明 controller 漏派)
 
-### Controller helper 库:`<skill-root>/scripts/consensus-rnd-cli controller actions`(强制)
+### Controller-internal lifecycle primitives(强制)
 
-7 个曾发生的 bug 都来自 controller boilerplate 重复 + bash 变量传值 bug。统一抽 helper:
+<!-- Refactor (iter201/issue-201): Old pattern: lifecycle helpers were
+documented as public consensus-rnd-cli/controller-actions shell commands.
+New principle: lifecycle operations are controller-internal ControllerActions
+methods/direct package calls, never worker-visible public CLI verbs. -->
 
-```bash
-source <skill-root>/scripts/consensus-rnd-cli controller actions
+7 个曾发生的 bug 都来自 controller boilerplate 重复 + shell 变量传值 bug。统一用 controller-internal `ControllerActions` primitives, not public CLI commands:
 
-safe_worktree iterN cluster-026 origin/auto-refact-dev   # → exports WT_PATH + BRANCH
-open_pr_with_label "iterN cluster-XXX: title" body.md    # → exports PR_NUM(原地传值,无 grep subshell bug)
-merge_pr <pr>                                             # auto-close linked issue + cleanup labels
-render_template implement.md out.md                       # 处理 {{var}} 和 $VAR 两种语法
-sweep_stale_labels                                        # 清 closed but 仍挂 in-flight label
-validate_prompt out.md                                    # check 0 unresolved {{var}}
+```python
+actions = ControllerActions(LoopContext.load(cwd=os.getcwd()))
+actions.safe_worktree(iteration, cluster, base)
+actions.open_pr_with_label(title, body_file, base=base, head=head)
+actions.merge_pr(pr)
+actions.render_template(input_path, output_path)
+actions.apply_human_label_or_skip(pr_number, source_marker, reason)
 ```
 
 **强制**:
-- 派 codex 前必须 `validate_prompt` — 防 codex blocked on unresolved placeholder
-- merge PR 必须用 `merge_pr <pr>` — auto-close + label cleanup,不留尾巴。`merge_pr` is a post-decision lifecycle primitive: call it only after the controller has already decided `MERGE` or `MERGE_WITH_COMMENTS`; it never computes Consensus-rnd Phase review-gate reviewer policy.
-- worktree 创建必须用 `safe_worktree` — 处理 "already exists" race
-- PR 号捕获必须用 `open_pr_with_label`(直接 export PR_NUM)— **禁止** `pr_num=$(...grep -oE...)` 这种 subshell 变量传值模式
+- 派 codex 前必须 validate rendered prompt output — 防 codex blocked on unresolved placeholder
+- merge PR 必须用 internal `merge_pr(pr)` — auto-close + label cleanup,不留尾巴。`merge_pr` is a post-decision lifecycle primitive: call it only after the controller has already decided `MERGE` or `MERGE_WITH_COMMENTS`; it never computes Consensus-rnd Phase review-gate reviewer policy.
+- worktree 创建必须用 internal `safe_worktree(iteration, cluster, base)` — 处理 "already exists" race
+- PR 号捕获必须用 internal `open_pr_with_label(...)` returned tuple — **禁止** shell `pr_num=$(...grep -oE...)` 这种 subshell 变量传值模式
+- `safe_push`, `safe_sync_main`, triage apply, and human-label apply are internal primitives/direct package calls only; `consensus-rnd-cli merge-pr/open-pr/open-release-rollup-pr/apply-human-label/safe-push/safe-sync-main/apply-sync/apply-triage` must fail closed as unknown public commands.
 
 **Label 生命周期(强制状态机)**:
 <!--
@@ -2211,7 +2216,7 @@ When reviewer evidence conflicts with maintainer prior session directive, encode
 
 If architect or quality rejects because the PR "needs Consensus-rnd Phase design-consensus artifact", do not apply `👤 human:需-maintainer-决策`. Open a real Consensus-rnd Phase design-consensus path. If maintainer already authorized that topic in-session, encode or reuse the maintainer-directive artifact and reframe Consensus-rnd Phase design-consensus with that directive as evidence. This is the Consensus-rnd Phase design-consensus-artifact replacement path; the label is not an interchange format for architect/quality reject.
 
-Controller label application must use `apply_human_label_or_skip <pr-number> <source-marker> <reason-or-topic>` from `consensus-rnd-cli controller actions`, with the full `META_RESOLVED:escalate-human:<reason>` marker as `<source-marker>`. `META_JUDGE_DONE:*` and `FIX_BLOCKED:*` must route through reflector/meta-layer and must not call the helper. If the helper finds a matching `.refactor-loop/runs/maintainer-directives/<date>-<topic>.md`, it prints `skip-label: maintainer-directive 已覆盖,见 .refactor-loop/runs/maintainer-directives/` and leaves the item automatic.
+Controller label application must use internal `ControllerActions.apply_human_label_or_skip(pr_number, source_marker, reason)` with the full `META_RESOLVED:escalate-human:<reason>` marker as `source_marker`. `META_JUDGE_DONE:*` and `FIX_BLOCKED:*` must route through reflector/meta-layer and must not call the primitive. If it finds a matching `.refactor-loop/runs/maintainer-directives/<date>-<topic>.md`, it prints `skip-label: maintainer-directive 已覆盖,见 .refactor-loop/runs/maintainer-directives/` and leaves the item automatic.
 
 ### Historical anti-pattern:`👤 human:需-maintainer-决策` 误用 (2026-05-26)
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/cli.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/cli.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Callable, Sequence
 
 from . import banners, github_body, project_rules, spawn, statusline
-from .controller_actions import main as controller_actions_main
 from .checks.degradation import main as degradation_main
 from .checks.manifest import main as manifest_main
 from .monitors.comment import main as comment_monitor_main
@@ -22,7 +21,6 @@ from .restart import main as restart_main
 from .retention import main as retention_main
 from .sync.dev import main as dev_sync_main
 from .phase9.router import main as phase9_router_main
-from .triage import main as triage_main
 from .wakeup_plan import main as wakeup_plan_main
 
 
@@ -36,12 +34,11 @@ class CommandSpec:
     authority: tuple[str, ...]
 
 
-# Refactor (iter1/issue-166): Old pattern: CommandSpec exposed a coarse
-# read_only boolean, so daemon/controller git, GitHub, spawn, and artifact
-# surfaces were inferred from prose and could drift from runtime. New principle:
-# COMMANDS keeps one inline closed-token authority tuple per command as the
-# mechanical CLI authority fact source; named runtime exceptions, such as
-# dev-sync's integration-worktree carveout, must be explicit here and in tests.
+# Refactor (iter201/issue-201): Old pattern: public consensus-rnd-cli exposed
+# lifecycle commands and wakeup_plan/peek rendered copyable suggested_command,
+# forming a generic lifecycle authority surface. New principle: COMMANDS keeps
+# only public non-lifecycle CLI primitives; controller lifecycle actions stay
+# controller-internal, with dev-sync's narrow integration-worktree carveout.
 COMMANDS: dict[str, CommandSpec] = {
     "spawn-codex": CommandSpec(spawn.main, "run the Python codex spawn supervisor", ("spawn", "write-log")),
     "peek": CommandSpec(peek_main, "run the Python read-only state sweep", ("read-state", "read-gh")),
@@ -104,36 +101,6 @@ COMMANDS: dict[str, CommandSpec] = {
         "render a self-contained GitHub body from local artifacts",
         ("read-artifact",),
     ),
-    "merge-pr": CommandSpec(
-        controller_actions_main,
-        "invoke Python controller action merge_pr",
-        ("read-gh", "gh-merge", "gh-label", "gh-close", "git-worktree", "write-state"),
-    ),
-    "open-pr": CommandSpec(
-        controller_actions_main,
-        "invoke Python controller action open_pr_with_label",
-        ("gh-open", "gh-label"),
-    ),
-    "open-release-rollup-pr": CommandSpec(
-        controller_actions_main,
-        "open release rollup PR from throwaway head branch",
-        ("read-git", "git-push", "gh-open", "gh-label"),
-    ),
-    "apply-human-label": CommandSpec(
-        controller_actions_main,
-        "apply maintainer-decision label after guard checks",
-        ("read-state", "gh-label"),
-    ),
-    "safe-push": CommandSpec(
-        controller_actions_main,
-        "push after bounded fetch/rebase catch-up",
-        ("git-fetch", "git-rebase", "git-push"),
-    ),
-    "safe-sync-main": CommandSpec(
-        controller_actions_main,
-        "catch current branch up to the remote tip",
-        ("git-fetch", "git-rebase"),
-    ),
     "post-banner": CommandSpec(banners.main, "post a controller status banner", ("gh-comment",)),
     "check-degradation": CommandSpec(
         degradation_main,
@@ -141,11 +108,6 @@ COMMANDS: dict[str, CommandSpec] = {
         ("read-source", "read-state"),
     ),
     "check-manifest": CommandSpec(manifest_main, "run manifest version sync check", ("read-source",)),
-    "apply-triage": CommandSpec(
-        triage_main,
-        "apply a ManualIssueTriageDecision artifact",
-        ("read-artifact", "write-artifact", "read-gh", "gh-comment", "gh-label", "gh-edit"),
-    ),
     "log-retention": CommandSpec(retention_main, "run daemonless log retention", ("delete-log",)),
     "ensure-project-rules": CommandSpec(project_rules.main, "ensure host project rules fixed points", ("write-source",)),
 }
@@ -175,8 +137,6 @@ class RuntimeCommandRouter:
         if spec is None:
             sys.stderr.write(f"unknown command: {command}\n")
             return 2
-        if command in {"merge-pr", "open-pr", "open-release-rollup-pr", "apply-human-label", "safe-push", "safe-sync-main"}:
-            return spec.handler([command, *args])
         return spec.handler(args)
 
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -400,4 +400,3 @@ def _parse_time(value: object) -> datetime | None:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
-

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import argparse
 import json
 import os
 import re
@@ -14,8 +13,9 @@ from pathlib import Path
 from string import Template
 from typing import Mapping, Sequence
 
-from .context import LoopContext, LoopContextError
+from .context import LoopContext
 from .github_body import GitHubBodyError, validate_self_contained_github_body
+from .triage import apply_decision, load_triage_apply_config
 
 
 PR_LABELS_REMOVE = (
@@ -41,6 +41,10 @@ ISSUE_LABELS_REMOVE = (
 
 
 class ControllerActions:
+    # Refactor (iter201/issue-201): Old pattern: public consensus-rnd-cli exposed
+    # merge/open/safe-push/apply lifecycle commands as generic callable verbs.
+    # New principle: keep these as controller-internal primitives only; callers
+    # construct ControllerActions directly and public CLI routing cannot reach them.
     def __init__(self, ctx: LoopContext) -> None:
         self.ctx = ctx
         self.integration_branch = os.environ.get("INTEGRATION_BRANCH") or os.environ.get("INTEGRATION") or "auto-refact-dev"
@@ -342,13 +346,17 @@ class ControllerActions:
         Path(tmp).replace(path)
 
     def apply_triage_decision_marker(self, marker: str) -> int:
+        # Refactor (iter201/issue-201): Old pattern: controller marker handling
+        # subprocessed consensus-rnd-cli apply-triage, preserving public lifecycle
+        # reachability. New principle: direct internal call keeps validation and
+        # applied/rejected artifacts without exposing a public lifecycle command.
         match = re.fullmatch(r"TRIAGE_DECISION_DONE:([0-9]+):(accept|reject):(\.refactor-loop/runs/.*\.json)", marker)
         if not match:
             sys.stderr.write("apply_triage_decision_marker: invalid marker\n")
             return 2
-        cli = self.ctx.skill_root / "scripts" / "consensus-rnd-cli"
         issue, verdict, rel_path = match.groups()
-        return subprocess.call([sys.executable, str(cli), "apply-triage", issue, verdict, str(self.ctx.repo_root / rel_path)], env=self.ctx.env_for_subprocess())
+        config = load_triage_apply_config(repo_root=self.ctx.repo_root, env=self.ctx.env_for_subprocess(), cwd=self.ctx.repo_root)
+        return apply_decision(config, self.ctx.repo_root / rel_path, issue_number=int(issue), verdict=verdict)
 
     def render_template(self, input_path: str, output_path: str, env: Mapping[str, str] | None = None) -> None:
         values = dict(os.environ)
@@ -393,58 +401,3 @@ def _parse_time(value: object) -> datetime | None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
 
-
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Run controller-owned action helpers")
-    sub = parser.add_subparsers(dest="command", required=True)
-    merge = sub.add_parser("merge-pr")
-    merge.add_argument("pr")
-    merge.add_argument("issue", nargs="?")
-    open_pr = sub.add_parser("open-pr")
-    open_pr.add_argument("title")
-    open_pr.add_argument("body_file")
-    open_pr.add_argument("base", nargs="?")
-    open_pr.add_argument("head", nargs="?")
-    rollup_pr = sub.add_parser("open-release-rollup-pr")
-    rollup_pr.add_argument("event_json")
-    rollup_pr.add_argument("body_file")
-    rollup_pr.add_argument("title", nargs="?", default="Release rollup")
-    human = sub.add_parser("apply-human-label")
-    human.add_argument("pr_number")
-    human.add_argument("source_marker", nargs="?")
-    human.add_argument("reason", nargs="?")
-    safe_push = sub.add_parser("safe-push")
-    safe_push.add_argument("remote", nargs="?", default="origin")
-    safe_push.add_argument("branch", nargs="?")
-    safe_sync = sub.add_parser("safe-sync-main")
-    safe_sync.add_argument("remote", nargs="?", default="origin")
-    safe_sync.add_argument("branch", nargs="?")
-    args = parser.parse_args(argv)
-    try:
-        actions = ControllerActions(LoopContext.load(cwd=os.getcwd()))
-        if args.command == "merge-pr":
-            return actions.merge_pr(args.pr, args.issue or "")
-        if args.command == "open-pr":
-            pr_num, url = actions.open_pr_with_label(args.title, args.body_file, args.base, args.head or "")
-            os.environ["PR_NUM"] = str(pr_num)
-            print(url)
-            return 0
-        if args.command == "open-release-rollup-pr":
-            pr_num, url = actions.open_release_rollup_pr_from_pending_event(args.event_json, args.body_file, args.title)
-            os.environ["PR_NUM"] = str(pr_num)
-            print(url)
-            return 0
-        if args.command == "apply-human-label":
-            return actions.apply_human_label_or_skip(args.pr_number, args.source_marker or "", args.reason or "")
-        if args.command == "safe-push":
-            return actions.safe_push(args.remote, args.branch or "")
-        if args.command == "safe-sync-main":
-            return actions.safe_sync_main(args.remote, args.branch or "")
-    except (LoopContextError, RuntimeError) as exc:
-        sys.stderr.write(f"{exc}\n")
-        return 2
-    return 2
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/peek.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/peek.py
@@ -149,12 +149,17 @@ class PeekStatusLens:
         return lines
 
     def _unpushed_worker_output(self) -> list[str]:
+        # Refactor (iter201/issue-201): Old pattern: peek displayed a copyable
+        # consensus-rnd-cli safe-push command, making a status lens look like a
+        # lifecycle dispatcher. New principle: show fixed facts only; controller
+        # lifecycle execution remains internal and non-public.
         out = []
         for action in unpushed_worker_output_actions(self.ctx.repo_root, load_github_items(self.ctx.repo_root)):
             out.append(
                 "  ⚠️ "
                 f"{action['line']} head={action['head_ref']} ahead={action['ahead_count']} "
-                f"worktree={action['worktree']} — {action['suggested_command']}"
+                f"worktree={action['worktree']} controller_action={action['controller_action']} "
+                f"no_lifecycle_authority={str(action['no_lifecycle_authority']).lower()}"
             )
         return out
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -616,11 +616,10 @@ def safe_head_ref(value: str | None) -> str | None:
 
 
 def unpushed_worker_output_actions(repo_root: Path, gh_items: list[GhItem]) -> list[dict[str, Any]]:
-    # Refactor (issue-190/unpushed-worker-output):
-    #   Old pattern: FIX_DONE/IMPLEMENT_DONE could leave committed worker output
-    #   only in a local worktree branch, so reviewers and CI read stale origin.
-    #   New principle: wakeup-plan owns a local read-only topology check; peek
-    #   may reuse this helper as status, but controller push remains external.
+    # Refactor (iter201/issue-201): Old pattern: wakeup_plan rendered a copyable
+    # consensus-rnd-cli safe-push suggested_command, exposing public lifecycle
+    # reachability. New principle: emit only a fixed controller_action fact with
+    # no_lifecycle_authority; controller maps it to an internal primitive.
     prs = [item for item in gh_items if item.kind == "PR" and safe_head_ref(item.head_ref)]
     if not prs:
         return []
@@ -665,7 +664,7 @@ def unpushed_worker_output_actions(repo_root: Path, gh_items: list[GhItem]) -> l
                 "local_head": local.stdout.strip(),
                 "remote_head": remote.stdout.strip(),
                 "line": f"UNPUSHED_WORKER_OUTPUT:{item.number}:{ahead_count}",
-                "suggested_command": f"python3 <skill-root>/scripts/consensus-rnd-cli safe-push origin {head_ref}",
+                "controller_action": "safe_push",
                 "no_lifecycle_authority": True,
             }
         )

--- a/skills/codex-refactor-loop/scripts/test_cli_command_router.py
+++ b/skills/codex-refactor-loop/scripts/test_cli_command_router.py
@@ -83,17 +83,6 @@ DAEMON_LIFECYCLE_CARVEOUTS = {
     "dev-sync": {"git-fetch", "git-worktree", "git-merge", "git-push", "git-rebase", "git-reset"},
 }
 
-CONTROLLER_LIFECYCLE_COMMANDS = {
-    "apply-human-label",
-    "apply-triage",
-    "merge-pr",
-    "open-pr",
-    "open-release-rollup-pr",
-    "post-banner",
-    "safe-push",
-    "safe-sync-main",
-}
-
 LIFECYCLE_TOKENS = {
     "gh-close",
     "gh-edit",
@@ -112,7 +101,6 @@ class RuntimeCommandRouterTests(unittest.TestCase):
     def test_each_public_operation_is_registered(self) -> None:
         self.assertEqual(
             {
-                "apply-triage",
                 "check-degradation",
                 "check-manifest",
                 "concurrency",
@@ -131,12 +119,6 @@ class RuntimeCommandRouterTests(unittest.TestCase):
                 "release-gate",
                 "release-required-checks",
                 "render-github-body",
-                "merge-pr",
-                "open-pr",
-                "open-release-rollup-pr",
-                "apply-human-label",
-                "safe-push",
-                "safe-sync-main",
             },
             set(COMMANDS),
         )
@@ -206,48 +188,38 @@ class RuntimeCommandRouterTests(unittest.TestCase):
             & {"git-fetch", "git-worktree", "git-merge", "git-push", "git-rebase", "git-reset"},
         )
 
-    def test_legacy_sync_request_cli_commands_are_removed(self) -> None:
-        self.assertNotIn("apply-sync", COMMANDS)
-        self.assertNotIn("sync-request", COMMANDS)
-
-    def test_handler_live_surfaces_are_declared_in_command_authority(self) -> None:
-        handler_surface_requirements = {
-            "merge-pr": {
-                "source": SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py",
-                "needles": ("record_recent_pr_merge", "recent-pr-merges.json"),
-                "authority": {"write-state"},
-            },
-            "apply-triage": {
-                "source": SCRIPT_DIR / "codex_refactor_loop" / "triage.py",
-                "needles": ('["issue", "view", str(issue_number), "--json", "labels"]',),
-                "authority": {"read-gh"},
-            },
-        }
-        for command, requirement in handler_surface_requirements.items():
+    def test_public_lifecycle_cli_commands_are_removed(self) -> None:
+        for command in {
+            "apply-human-label",
+            "apply-sync",
+            "apply-triage",
+            "merge-pr",
+            "open-pr",
+            "open-release-rollup-pr",
+            "safe-push",
+            "safe-sync-main",
+            "sync-request",
+        }:
             with self.subTest(command=command):
-                source = requirement["source"].read_text(encoding="utf-8")
-                for needle in requirement["needles"]:
-                    self.assertIn(needle, source)
-                self.assertTrue(requirement["authority"].issubset(COMMANDS[command].authority))
+                self.assertNotIn(command, COMMANDS)
 
-    def test_lifecycle_tokens_stay_on_controller_apply_surfaces(self) -> None:
+    def test_public_commands_expose_no_generic_lifecycle_authority_tokens(self) -> None:
         for name, spec in COMMANDS.items():
             with self.subTest(command=name):
                 lifecycle_tokens = set(spec.authority) & LIFECYCLE_TOKENS
                 allowed = DAEMON_LIFECYCLE_CARVEOUTS.get(name, set())
-                if lifecycle_tokens - allowed:
-                    self.assertIn(name, CONTROLLER_LIFECYCLE_COMMANDS)
+                self.assertFalse(lifecycle_tokens - allowed)
 
     def test_authority_refactor_self_doc_source_regression(self) -> None:
         cli = (SCRIPT_DIR / "codex_refactor_loop" / "cli.py").read_text(encoding="utf-8")
         for token in (
-            "Refactor (iter1/issue-166)",
-            "Old pattern: CommandSpec exposed a coarse",
-            "read_only boolean",
-            "New principle:",
-            "inline closed-token authority tuple",
-            "mechanical CLI authority fact source",
-            "dev-sync's integration-worktree carveout",
+            "Refactor (iter201/issue-201)",
+            "public consensus-rnd-cli exposed",
+            "lifecycle commands",
+            "generic lifecycle authority surface",
+            "only public non-lifecycle CLI primitives",
+            "controller lifecycle actions stay",
+            "dev-sync's narrow integration-worktree carveout",
         ):
             with self.subTest(token=token):
                 self.assertIn(token, cli)
@@ -270,12 +242,14 @@ class RuntimeCommandRouterTests(unittest.TestCase):
             self.assertEqual(0, router.run("wakeup-plan", ["--repo-root", "/tmp/repo"]))
         handler.assert_called_once_with(["--repo-root", "/tmp/repo"])
 
-    def test_controller_actions_dispatch_to_python_action_handler(self) -> None:
+    def test_removed_lifecycle_commands_fail_closed_without_handler_dispatch(self) -> None:
         router = RuntimeCommandRouter(script_dir=SCRIPT_DIR)
         handler = mock.Mock(return_value=0)
-        with mock.patch.dict("codex_refactor_loop.cli.COMMANDS", {"merge-pr": COMMANDS["merge-pr"].__class__(handler, "merge", ("gh-merge",))}):
-            self.assertEqual(0, router.run("merge-pr", ["123", "45"]))
-        handler.assert_called_once_with(["merge-pr", "123", "45"])
+        with mock.patch.dict("codex_refactor_loop.cli.COMMANDS", dict(COMMANDS), clear=True):
+            for command in ("merge-pr", "apply-sync", "apply-triage", "safe-push"):
+                with self.subTest(command=command):
+                    self.assertEqual(2, router.run(command, ["123"]))
+        handler.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -50,6 +51,60 @@ class ControllerActionsTests(unittest.TestCase):
 
     def test_triage_apply_marker_rejects_unbounded_paths(self) -> None:
         self.assertEqual(2, self.actions.apply_triage_decision_marker("TRIAGE_DECISION_DONE:x:accept:/tmp/out.json"))
+
+    def test_triage_apply_marker_accepts_valid_marker_through_internal_apply_path(self) -> None:
+        runs = self.tmp / ".refactor-loop" / "runs"
+        runs.mkdir(parents=True, exist_ok=True)
+        comment = runs / "triage-comment.md"
+        comment.write_text("comment\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
+        decision = runs / "triage-issue-53.json"
+        decision.write_text(
+            json.dumps(
+                {
+                    "schema": "ManualIssueTriageDecision",
+                    "issue_number": 53,
+                    "verdict": "reject",
+                    "body_artifact_path": "",
+                    "comment_artifact_path": ".refactor-loop/runs/triage-comment.md",
+                    "add_labels": [],
+                    "remove_labels": ["auto-loop-triage"],
+                    "sentinel_present": True,
+                    "lifecycle_owner": "controller",
+                    "lifecycle_authority": False,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], *, repo: Path, repo_slug: str | None = None) -> subprocess.CompletedProcess[str]:
+            self.assertEqual(self.tmp.resolve(), repo)
+            self.assertEqual("owner/repo", repo_slug)
+            calls.append(args)
+            return subprocess.CompletedProcess(["gh", *args], 0, "", "")
+
+        marker = "TRIAGE_DECISION_DONE:53:reject:.refactor-loop/runs/triage-issue-53.json"
+        with mock.patch("codex_refactor_loop.triage.current_labels", lambda _config, _issue: ["auto-loop-triage"]):
+            with mock.patch("codex_refactor_loop.triage.run_gh", fake_gh):
+                with mock.patch(
+                    "codex_refactor_loop.controller_actions.subprocess.run",
+                    side_effect=AssertionError("controller marker path must not shell through apply-triage"),
+                ):
+                    self.assertEqual(0, self.actions.apply_triage_decision_marker(marker))
+
+        self.assertEqual(
+            calls,
+            [
+                ["issue", "comment", "53", "--body-file", str(comment.resolve())],
+                ["issue", "edit", "53", "--remove-label", "auto-loop-triage"],
+            ],
+        )
+        applied = json.loads(
+            (runs / "triage-decisions-applied" / "triage-issue-53.applied.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual("applied", applied["status"])
+        self.assertEqual("reject", applied["reason"])
 
     def test_open_release_rollup_pr_uses_throwaway_head_and_preserves_integration_ref(self) -> None:
         event = {

--- a/skills/codex-refactor-loop/scripts/test_controller_lib_label_helper.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_lib_label_helper.py
@@ -9,13 +9,19 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime, timedelta, timezone
+from io import StringIO
 from pathlib import Path
 
 
 SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[3]
-CLI = REPO_ROOT / "skills" / "codex-refactor-loop" / "scripts" / "consensus-rnd-cli"
+sys.path.insert(0, str(REPO_ROOT / "skills" / "codex-refactor-loop" / "scripts"))
+
+from codex_refactor_loop.context import LoopContext
+from codex_refactor_loop.controller_actions import ControllerActions
+
 HUMAN_LABEL = "👤 human:需-maintainer-决策"
 VALID_MARKER = "META_RESOLVED:escalate-human:human-label-semantics-guard"
 
@@ -53,12 +59,26 @@ class ControllerLibHumanLabelPrHelperTests(unittest.TestCase):
                 "HUMAN_LABEL_SOURCE_MARKER": marker_env,
             }
         )
-        return subprocess.run(
-            [sys.executable, str(CLI), "apply-human-label", *args],
-            env=env,
-            text=True,
-            capture_output=True,
-            check=False,
+        stdout = StringIO()
+        stderr = StringIO()
+        old_env = os.environ.copy()
+        try:
+            os.environ.clear()
+            os.environ.update(env)
+            actions = ControllerActions(LoopContext.load(env=env, cwd=self.root))
+            pr_number = args[0] if len(args) > 0 else ""
+            source_marker = args[1] if len(args) > 1 else ""
+            reason = args[2] if len(args) > 2 else ""
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                returncode = actions.apply_human_label_or_skip(pr_number, source_marker, reason)
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
+        return subprocess.CompletedProcess(
+            ["controller-internal", "apply_human_label_or_skip", *args],
+            returncode,
+            stdout.getvalue(),
+            stderr.getvalue(),
         )
 
     def write_directive(self, name: str, body: str) -> None:
@@ -253,12 +273,29 @@ exit 0
                 "RECENT_PR_MERGE_RETRY_SLEEP_SECONDS": "0",
             }
         )
-        return subprocess.run(
-            [sys.executable, str(CLI), "merge-pr", *args],
-            env=env,
-            text=True,
-            capture_output=True,
-            check=False,
+        stdout = StringIO()
+        stderr = StringIO()
+        old_env = os.environ.copy()
+        try:
+            os.environ.clear()
+            os.environ.update(env)
+            actions = ControllerActions(LoopContext.load(env=env, cwd=self.root))
+            pr = args[0] if len(args) > 0 else ""
+            issue = args[1] if len(args) > 1 else ""
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                try:
+                    returncode = actions.merge_pr(pr, issue)
+                except RuntimeError as exc:
+                    print(str(exc), file=sys.stderr)
+                    returncode = 2
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
+        return subprocess.CompletedProcess(
+            ["controller-internal", "merge_pr", *args],
+            returncode,
+            stdout.getvalue(),
+            stderr.getvalue(),
         )
 
     def gh_calls(self) -> list[str]:

--- a/skills/codex-refactor-loop/scripts/test_controller_lib_safe_push.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_lib_safe_push.py
@@ -14,12 +14,17 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
 
 
 SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[3]
-CLI = REPO_ROOT / "skills" / "codex-refactor-loop" / "scripts" / "consensus-rnd-cli"
+sys.path.insert(0, str(REPO_ROOT / "skills" / "codex-refactor-loop" / "scripts"))
+
+from codex_refactor_loop.context import LoopContext
+from codex_refactor_loop.controller_actions import ControllerActions
 
 
 def git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -67,8 +72,29 @@ class SafePushHelperTests(unittest.TestCase):
         env = os.environ.copy()
         env.update({"REPO_ROOT": str(self.local)})
         parts = fn_call.split()
-        command = {"safe_push": "safe-push", "safe_sync_main": "safe-sync-main"}[parts[0]]
-        return subprocess.run([sys.executable, str(CLI), command, *parts[1:]], env=env, text=True, capture_output=True)
+        stdout = StringIO()
+        stderr = StringIO()
+        old_env = os.environ.copy()
+        try:
+            os.environ.clear()
+            os.environ.update(env)
+            actions = ControllerActions(LoopContext.load(env=env, cwd=self.local))
+            remote = parts[1] if len(parts) > 1 else "origin"
+            branch = parts[2] if len(parts) > 2 else ""
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                if parts[0] == "safe_push":
+                    returncode = actions.safe_push(remote, branch)
+                else:
+                    returncode = actions.safe_sync_main(remote, branch)
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
+        return subprocess.CompletedProcess(
+            ["controller-internal", *parts],
+            returncode,
+            stdout.getvalue(),
+            stderr.getvalue(),
+        )
 
     def test_safe_push_succeeds_when_remote_up_to_date(self) -> None:
         (self.local / "a.txt").write_text("a", encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
+++ b/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
@@ -283,7 +283,10 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
         self.assertIn("▍Unpushed worker output:", result.stdout)
         self.assertIn("UNPUSHED_WORKER_OUTPUT:77:3", result.stdout)
         self.assertIn("head=refactor/iter77-worker", result.stdout)
-        self.assertIn("safe-push origin refactor/iter77-worker", result.stdout)
+        self.assertIn("controller_action=safe_push", result.stdout)
+        self.assertIn("no_lifecycle_authority=true", result.stdout)
+        self.assertNotIn("consensus-rnd-cli safe-push", result.stdout)
+        self.assertNotIn("safe-push origin refactor/iter77-worker", result.stdout)
         self.assertNotIn('"actions"', result.stdout)
         self.assertNotIn('"schema": "wakeup-plan"', result.stdout)
 

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -258,7 +258,9 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(plan["actions"][0]["item"], "PR #77")
         self.assertEqual(plan["actions"][0]["line"], "UNPUSHED_WORKER_OUTPUT:77:2")
         self.assertEqual(plan["actions"][0]["head_ref"], "refactor/iter77-worker")
-        self.assertIn("safe-push origin refactor/iter77-worker", plan["actions"][0]["suggested_command"])
+        self.assertEqual(plan["actions"][0]["controller_action"], "safe_push")
+        self.assertTrue(plan["actions"][0]["no_lifecycle_authority"])
+        self.assertNotIn("suggested_command", plan["actions"][0])
         kinds = [action["kind"] for action in plan["actions"]]
         self.assertLess(kinds.index("unpushed-worker-output"), kinds.index("completed-marker"))
         self.assertLess(kinds.index("unpushed-worker-output"), kinds.index("existing-issue"))


### PR DESCRIPTION
## 动机
移除 `consensus-rnd-cli` 的 public lifecycle 命令面(generic lifecycle authority surface),迁回 controller-internal,守 CLAUDE.md「窄扩展点 / controller 纯编排」(closes #201)。Phase 9 共识 3/3(framing=delete,r4)。

## 改动
- **cli.py**:COMMANDS 删 `merge-pr`/`open-pr`/`open-release-rollup-pr`/`apply-human-label`/`safe-push`/`safe-sync-main`/`apply-sync`/`apply-triage` 8 个 + public-router imports + special-case。
- **controller_actions/sync/triage**:controller 直接构造 class 调用,不经 public CLI。
- **wakeup_plan.py**:输出 fixed `controller_action` fact(`no_lifecycle_authority:true`),不再渲染可复制 `suggested_command`。
- **peek.py**:只展示 facts,不渲染可执行命令。
- **SKILL.md**:文案改 controller-internal primitive。
- 净 -203/+167(删除为主)。保留 read/check/daemon/render/sync-request 与 #53 dev-sync carveout。

## 影响范围
controller 编排面收窄;daemon/worker lifecycle authority 不变。daemonization 北极星砖。

## 验证
`python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` —— implement worker EXIT=0。

⟦AI:AUTO-LOOP⟧