### PR TITLE
feat(#202): durable artifact 路径相对 $REPO_ROOT(写相对读绝对)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/context.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/context.py
@@ -7,7 +7,7 @@ import re
 import shlex
 import subprocess
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Mapping
 
 
@@ -38,7 +38,11 @@ class LoopPaths:
 
 @dataclass(frozen=True)
 class LoopContext:
-    """Resolved host repository and skill context."""
+    """Resolved host repository and skill context.
+
+    Refactor (iter202/issue-202): Old pattern: durable artifact(ledger log_path、pending-event JSON log_path、meta-judge/reflector evidence、dev-sync resolver prompt、DEV_SYNC_REQUEST marker)写入 host absolute repo/worktree/log path,违反 CLAUDE.md R24『artifact 路径相对 $REPO_ROOT,不引入具体 host 事实』。
+    New principle: 分层 durable-text-path vs execution-path:写入时所有 durable artifact/prompt/marker 只存 repo-relative POSIX text;读取或传 subprocess 时由 LoopContext.repo_root/rel_path 解析回 absolute;spawn-codex --cd/--add-dir/--prompt/--log 与 Popen argv 仍用 absolute(execution boundary 非 durable truth)。配套 behavior(写入存相对、读取解析绝对)+ source-regression(无 host absolute prefix)测试。不改 daemon lifecycle authority,不加规则例外。
+    """
 
     repo_root: Path
     skill_root: Path
@@ -94,6 +98,25 @@ class LoopContext:
         if self.gh_repo_slug:
             result["GH_REPO_SLUG"] = self.gh_repo_slug
         return result
+
+    def durable_artifact_path(self, path: Path) -> str:
+        """Return repo-relative POSIX durable text for a host artifact path."""
+        try:
+            return path.resolve().relative_to(self.repo_root.resolve()).as_posix()
+        except ValueError as exc:
+            raise LoopContextError(f"artifact path points outside REPO_ROOT: {path}") from exc
+
+    def artifact_execution_path(self, text: str) -> Path:
+        """Resolve stored repo-relative durable text back to an execution path."""
+        pure = PurePosixPath(text)
+        if not text or pure.is_absolute() or "\\" in text or ".." in pure.parts:
+            raise LoopContextError(f"artifact path must be repo-relative POSIX text: {text!r}")
+        path = (self.repo_root / Path(*pure.parts)).resolve()
+        try:
+            path.relative_to(self.repo_root.resolve())
+        except ValueError as exc:
+            raise LoopContextError(f"artifact path escapes REPO_ROOT: {text!r}") from exc
+        return path
 
 
 def _resolve_repo_root(

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -157,6 +157,8 @@ def parse_phase9_log_identity(name: str) -> Phase9LogIdentity | None:
 
 
 class Phase9Router:
+    # Refactor (iter202/issue-202): Old pattern: durable artifact(ledger log_path、pending-event JSON log_path、meta-judge/reflector evidence、dev-sync resolver prompt、DEV_SYNC_REQUEST marker)写入 host absolute repo/worktree/log path,违反 CLAUDE.md R24『artifact 路径相对 $REPO_ROOT,不引入具体 host 事实』。
+    # New principle: 分层 durable-text-path vs execution-path:写入时所有 durable artifact/prompt/marker 只存 repo-relative POSIX text;读取或传 subprocess 时由 LoopContext.repo_root/rel_path 解析回 absolute;spawn-codex --cd/--add-dir/--prompt/--log 与 Popen argv 仍用 absolute(execution boundary 非 durable truth)。配套 behavior(写入存相对、读取解析绝对)+ source-regression(无 host absolute prefix)测试。不改 daemon lifecycle authority,不加规则例外。
     def __init__(
         self,
         repo_root: Path | None = None,
@@ -334,7 +336,7 @@ class Phase9Router:
                 continue
             log_path = event.get("log_path")
             if isinstance(log_path, str):
-                seen.add(f"fallback:{log_path}")
+                seen.add(f"fallback:{self._stored_artifact_path_key(log_path)}")
             key = event.get("key")
             if isinstance(key, str) and key.startswith("phase9-triplet-evidence-invalid:"):
                 seen.add(key)
@@ -452,7 +454,7 @@ class Phase9Router:
                 continue
             if marker.marker.startswith("SOLVER_DONE:"):
                 continue
-            event_key = f"fallback:{marker.log_path}"
+            event_key = f"fallback:{self._artifact_path(marker.log_path)}"
             if event_key in self._fallback_seen:
                 continue
             self._fallback_seen.add(event_key)
@@ -557,7 +559,7 @@ class Phase9Router:
         entry = {
             "key": key,
             "marker": marker,
-            "log_path": self._artifact_path(log_path) if extra else str(log_path),
+            "log_path": self._artifact_path(log_path),
             "dispatched_at": self._now(),
         }
         if extra:
@@ -570,7 +572,7 @@ class Phase9Router:
         event = {
             "key": f"fallback:{marker.issue}-{marker.round}",
             "marker": marker.marker,
-            "log_path": str(marker.log_path),
+            "log_path": self._artifact_path(marker.log_path),
             "dispatched_at": self._now(),
         }
         with self.pending_events_path.open("a", encoding="utf-8") as pending:
@@ -626,7 +628,9 @@ class Phase9Router:
         return prompt
 
     def _meta_judge_prompt(self, issue: str, round_no: int, markers: Iterable[Marker]) -> str:
-        marker_lines = "\n".join(f"- {m.role}: {m.log_path}" for m in sorted(markers, key=lambda m: m.role or ""))
+        marker_lines = "\n".join(
+            f"- {m.role}: {self._artifact_path(m.log_path)}" for m in sorted(markers, key=lambda m: m.role or "")
+        )
         evidence_line = f"Dispatch ledger evidence: .refactor-loop/phase9-router-ledger.jsonl key={self._key(issue, round_no, 'judge')}"
         return (
             f"# {format_stage('design-consensus')} meta-judge\n\nIssue: #{issue}\nRound: {round_no}\n\n"
@@ -687,7 +691,7 @@ class Phase9Router:
             return template_path.read_text(encoding="utf-8")
         except OSError as exc:
             return (
-                f"FATAL: missing stalled reflector template: {template_path}\n"
+                f"FATAL: missing stalled reflector template: {self._skill_artifact_path(template_path)}\n"
                 f"Reason: {exc}\n"
                 "Do not infer a fallback route. Emit META_RESOLVED:escalate-human:missing-stalled-reflector-template\n"
             )
@@ -696,7 +700,7 @@ class Phase9Router:
         lines = []
         for r in range(round_no - 2, round_no + 1):
             for role in ROLES:
-                paths = " or ".join(str(path) for path in self._solver_history_log_paths(issue, r, role))
+                paths = " or ".join(self._artifact_path(path) for path in self._solver_history_log_paths(issue, r, role))
                 lines.append(f"- r{r} {role}: {paths}")
         return lines
 
@@ -777,10 +781,24 @@ class Phase9Router:
         )
 
     def _artifact_path(self, path: Path) -> str:
+        return self.ctx.durable_artifact_path(path)
+
+    def _skill_artifact_path(self, path: Path) -> str:
         try:
-            return str(path.relative_to(self.repo_root))
+            return path.resolve().relative_to(self.skill_root.resolve()).as_posix()
         except ValueError:
-            return str(path)
+            return path.name
+
+    def _stored_artifact_path_key(self, text: str) -> str:
+        if Path(text).is_absolute():
+            try:
+                return self._artifact_path(Path(text))
+            except Exception:
+                return text
+        try:
+            return self._artifact_path(self.ctx.artifact_execution_path(text))
+        except Exception:
+            return text
 
     def _key(self, issue: str, round_no: int, actor: str) -> str:
         return f"{issue}-{round_no}-{actor}"

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/sync/dev.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/sync/dev.py
@@ -179,23 +179,38 @@ def dispatch_codex_resolve(
     spawn_codex: Path,
     logger: Callable[[str], None] = log,
 ) -> None:
-    """Spawn a codex to resolve the in-progress merge conflicts in worktree."""
+    """Spawn a codex to resolve the in-progress merge conflicts in worktree.
+
+    Refactor (iter202/issue-202): Old pattern: durable artifact(ledger log_path、pending-event JSON log_path、meta-judge/reflector evidence、dev-sync resolver prompt、DEV_SYNC_REQUEST marker)写入 host absolute repo/worktree/log path,违反 CLAUDE.md R24『artifact 路径相对 $REPO_ROOT,不引入具体 host 事实』。
+    New principle: 分层 durable-text-path vs execution-path:写入时所有 durable artifact/prompt/marker 只存 repo-relative POSIX text;读取或传 subprocess 时由 LoopContext.repo_root/rel_path 解析回 absolute;spawn-codex --cd/--add-dir/--prompt/--log 与 Popen argv 仍用 absolute(execution boundary 非 durable truth)。配套 behavior(写入存相对、读取解析绝对)+ source-regression(无 host absolute prefix)测试。不改 daemon lifecycle authority,不加规则例外。
+    """
+    ctx = LoopContext.load(repo_root=main_repo)
     ts = int(time.time())
     prompt_file = main_repo / ".refactor-loop" / "prompts" / f"dev-sync-conflict-{ts}.md"
     log_file = main_repo / ".refactor-loop" / "logs" / f"dev-sync-codex-{ts}.log"
+    worktree_display = ctx.durable_artifact_path(worktree)
+    main_repo_display = "."
+    prompt_file_display = ctx.durable_artifact_path(prompt_file)
+    log_file_display = ctx.durable_artifact_path(log_file)
     prompt_file.parent.mkdir(parents=True, exist_ok=True)
     prompt_body = f"""# Task: resolve merge conflict on {integration} from origin/{review_base} sync
 
 ## Context
 
 dev_sync_daemon (Python) detected a conflict in the dedicated worktree
-`{worktree}`. Resolve conflicts and stage files in that worktree, then emit the
+`{worktree_display}`. The worker is launched with --cd already set to that
+dedicated worktree. Resolve conflicts and stage files in that worktree, then emit the
 marker. The daemon owns the later narrow #53 integration-branch apply after it
 detects a resolved merge state.
 
+Durable artifact paths in this prompt are repo-relative text:
+- main repo: `{main_repo_display}`
+- prompt artifact: `{prompt_file_display}`
+- resolver log artifact: `{log_file_display}`
+
 ## Task
 
-1. `cd {worktree}`
+1. Confirm `pwd` is the dedicated worktree.
 2. Run `git status` to find conflicted files.
 3. Read each conflicted file and understand `origin/{review_base}` changes
    versus `{integration}` changes.
@@ -216,7 +231,7 @@ detects a resolved merge state.
   resolution and build verification.
 - Proto field conflicts with the same field number and different semantics
   must emit `DEV_SYNC_BLOCKED:proto-schema-conflict`.
-- Do all work in the worktree and do not modify main repo `{main_repo}`.
+- Do all work in the worktree and do not modify main repo `{main_repo_display}`.
 
 Write the marker to stdout when done so the daemon can read it from the log:
 - Success: `DEV_SYNC_RESOLVED:<file1>,<file2>,...`
@@ -225,7 +240,7 @@ Write the marker to stdout when done so the daemon can read it from the log:
 ⟦AI:AUTO-LOOP⟧
 """
     prompt_file.write_text(prompt_body)
-    logger(f"dispatching codex: prompt={prompt_file} log={log_file}")
+    logger(f"dispatching codex: prompt={prompt_file_display} log={log_file_display}")
     subprocess.Popen(
         [
             "nohup",
@@ -288,7 +303,11 @@ class RollupDetection:
 # carry stable artifact intent; compatibility/version policy lives in
 # contracts/tests, not identifier suffixes.
 class IntegrationSyncDaemon:
-    """Narrow detector and executor for integration-branch sync transitions."""
+    """Narrow detector and executor for integration-branch sync transitions.
+
+    Refactor (iter202/issue-202): Old pattern: durable artifact(ledger log_path、pending-event JSON log_path、meta-judge/reflector evidence、dev-sync resolver prompt、DEV_SYNC_REQUEST marker)写入 host absolute repo/worktree/log path,违反 CLAUDE.md R24『artifact 路径相对 $REPO_ROOT,不引入具体 host 事实』。
+    New principle: 分层 durable-text-path vs execution-path:写入时所有 durable artifact/prompt/marker 只存 repo-relative POSIX text;读取或传 subprocess 时由 LoopContext.repo_root/rel_path 解析回 absolute;spawn-codex --cd/--add-dir/--prompt/--log 与 Popen argv 仍用 absolute(execution boundary 非 durable truth)。配套 behavior(写入存相对、读取解析绝对)+ source-regression(无 host absolute prefix)测试。不改 daemon lifecycle authority,不加规则例外。
+    """
 
     def __init__(
         self,

--- a/skills/codex-refactor-loop/scripts/test_loop_context.py
+++ b/skills/codex-refactor-loop/scripts/test_loop_context.py
@@ -85,6 +85,32 @@ class LoopContextTests(unittest.TestCase):
         with self.assertRaisesRegex(LoopContextError, "REPO_ROOT is unset"):
             LoopContext.load(env={}, cwd=self.repo)
 
+    def test_durable_artifact_path_writes_posix_repo_relative_text(self) -> None:
+        ctx = LoopContext.load(repo_root=self.repo, env={})
+        path = self.repo / ".refactor-loop" / "logs" / "x.log"
+        self.assertEqual(".refactor-loop/logs/x.log", ctx.durable_artifact_path(path))
+        self.assertNotIn(str(self.repo), ctx.durable_artifact_path(path))
+
+    def test_durable_artifact_path_rejects_repo_outside_paths(self) -> None:
+        ctx = LoopContext.load(repo_root=self.repo, env={})
+        outside = self.tmp_root / "outside.log"
+        with self.assertRaisesRegex(LoopContextError, "outside REPO_ROOT"):
+            ctx.durable_artifact_path(outside)
+
+    def test_artifact_execution_path_resolves_against_repo_root(self) -> None:
+        ctx = LoopContext.load(repo_root=self.repo, env={})
+        self.assertEqual(
+            self.repo.resolve() / ".refactor-loop" / "logs" / "x.log",
+            ctx.artifact_execution_path(".refactor-loop/logs/x.log"),
+        )
+
+    def test_artifact_execution_path_rejects_absolute_or_parent_escape(self) -> None:
+        ctx = LoopContext.load(repo_root=self.repo, env={})
+        for text in ("/tmp/x", "../x", ".refactor-loop/../outside", r".refactor-loop\\logs\\x.log", ""):
+            with self.subTest(text=text):
+                with self.assertRaisesRegex(LoopContextError, "repo-relative POSIX"):
+                    ctx.artifact_execution_path(text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_loop_context.py
+++ b/skills/codex-refactor-loop/scripts/test_loop_context.py
@@ -111,6 +111,15 @@ class LoopContextTests(unittest.TestCase):
                 with self.assertRaisesRegex(LoopContextError, "repo-relative POSIX"):
                     ctx.artifact_execution_path(text)
 
+    def test_artifact_execution_path_rejects_symlink_escape_after_resolve(self) -> None:
+        ctx = LoopContext.load(repo_root=self.repo, env={})
+        outside_dir = self.tmp_root / "outside"
+        outside_dir.mkdir()
+        (self.repo / "link").symlink_to(outside_dir, target_is_directory=True)
+
+        with self.assertRaisesRegex(LoopContextError, "escapes REPO_ROOT"):
+            ctx.artifact_execution_path("link/out.log")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -294,6 +294,42 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertNotRegex(prompt, re.compile(r"\bPhase\s+[0-9]\b"))
         self.assertNotIn("phase9-evidence", prompt)
         self.assertNotIn("Dispatch ledger:", prompt)
+        self.assertNotIn(str(self.repo), prompt)
+
+    def test_phase9_router_durable_artifacts_store_relative_paths_but_spawn_argv_absolute(self) -> None:
+        self.solver_triplet(issue=202, round_no=1)
+
+        self.router.tick()
+
+        ledger = self.ledger_entries()[0]
+        self.assertEqual(".refactor-loop/logs/phase9-issue202-r1-judge.log", ledger["log_path"])
+        self.assertNotIn(str(self.repo), json.dumps(ledger, ensure_ascii=False))
+        command = self.commands[0]
+        self.assertIn(str((self.repo / ".refactor-loop" / "prompts" / "phase9" / "phase9-issue202-r1-judge.md").resolve()), command)
+        self.assertIn(str((self.repo / ".refactor-loop" / "logs" / "phase9-issue202-r1-judge.log").resolve()), command)
+
+        self.write_log("phase9-issue202-r2-judge.log", "META_RESOLVED:re-design:scope")
+        self.router.tick()
+
+        events = self.pending_events()
+        self.assertIn('"log_path": ".refactor-loop/logs/phase9-issue202-r2-judge.log"', events)
+        self.assertNotIn(str(self.repo), events)
+
+    def test_phase9_router_fallback_restart_dedupe_reads_legacy_absolute_and_writes_relative(self) -> None:
+        legacy_log = self.repo / ".refactor-loop" / "logs" / "phase9-issue203-r1-judge.log"
+        pending = self.repo / ".refactor-loop" / ".controller-pending-events.log"
+        pending.write_text(
+            "2026-05-29T00:00:00Z phase9-router-fallback "
+            + json.dumps({"log_path": str(legacy_log), "marker": "META_RESOLVED:old"}, sort_keys=True)
+            + "\n",
+            encoding="utf-8",
+        )
+        self.write_log("phase9-issue203-r1-judge.log", "META_RESOLVED:old")
+
+        fresh_router = Phase9Router(self.repo, command_runner=self.commands.append)
+        fresh_router.tick()
+
+        self.assertEqual(self.pending_events().count("META_RESOLVED:old"), 1)
 
     def test_phase9_router_peer_solver_prompt_reference_fails_closed(self) -> None:
         self.solver_triplet(issue=170, round_no=3)
@@ -723,9 +759,10 @@ class Phase9RouterDaemonTests(unittest.TestCase):
 
         for round_no in (1, 2, 3):
             for role in ("minimal", "structural", "delete"):
-                expected = str(self.repo / ".refactor-loop" / "logs" / f"phase9-issue85-r{round_no}-{role}.log")
+                expected = f".refactor-loop/logs/phase9-issue85-r{round_no}-{role}.log"
                 with self.subTest(expected=expected):
                     self.assertIn(expected, prompt)
+        self.assertNotIn(str(self.repo), prompt)
 
         self.assertNotEqual(
             prompt.strip(),
@@ -764,11 +801,12 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             "META_RESOLVED:escalate-human:missing-stalled-reflector-template",
             "template unavailable",
             stalled_marker,
-            str(self.repo / ".refactor-loop" / "logs" / "phase9-issue86-r3-minimal.log"),
+            ".refactor-loop/logs/phase9-issue86-r3-minimal.log",
             "⟦AI:AUTO-LOOP⟧",
         ):
             with self.subTest(token=token):
                 self.assertIn(token, prompt)
+        self.assertNotIn(str(self.repo), prompt)
 
     def test_phase9_router_stalled_rejects_changed_recent_verdict_text(self) -> None:
         for round_no, verdict in ((1, "same"), (2, "changed"), (3, "same")):
@@ -880,6 +918,19 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertNotIn("class Phase9RoundProjection", src)
         self.assertNotIn("Phase9RoundProjection(", src)
         self.assertNotIn("VALID_MARKER_PAYLOAD.match(candidate)", src)
+
+    def test_phase9_router_source_regression_uses_loop_context_artifact_path_boundary(self) -> None:
+        src = PHASE9_ROUTER.read_text(encoding="utf-8")
+        self.assertIn("self.ctx.durable_artifact_path(path)", src)
+        self.assertIn("self.ctx.artifact_execution_path(text)", src)
+        for forbidden in (
+            '"log_path": self._artifact_path(log_path) if extra else str(log_path)',
+            '"log_path": str(marker.log_path)',
+            "f\"- {m.role}: {m.log_path}\"",
+            "str(path) for path in self._solver_history_log_paths",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, src)
 
     def test_main_once_dispatches_via_temp_repo_root(self) -> None:
         self.solver_triplet(issue=37, round_no=4)

--- a/skills/codex-refactor-loop/scripts/test_sync_dev.py
+++ b/skills/codex-refactor-loop/scripts/test_sync_dev.py
@@ -10,12 +10,13 @@ import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from codex_refactor_loop.sync.dev import IntegrationSyncDaemon, codex_resolve_in_flight, merge_in_progress
+from codex_refactor_loop.sync.dev import IntegrationSyncDaemon, codex_resolve_in_flight, dispatch_codex_resolve, merge_in_progress
 
 
 SYNC_DEV = SCRIPT_DIR / "codex_refactor_loop" / "sync" / "dev.py"
@@ -312,6 +313,43 @@ class SyncDevBehaviorTests(unittest.TestCase):
 
         self.assertTrue(merge_in_progress(self.worktree, command_runner))
 
+    def test_conflict_resolver_prompt_stores_relative_paths_but_spawn_argv_absolute(self) -> None:
+        worktree = self.repo / ".worktrees" / "dev-sync"
+        worktree.mkdir(parents=True)
+        popen_calls: list[list[str]] = []
+        logger_lines: list[str] = []
+
+        with mock.patch("codex_refactor_loop.sync.dev.time.time", return_value=1234), mock.patch(
+            "codex_refactor_loop.sync.dev.subprocess.Popen",
+            side_effect=lambda argv, **_kwargs: popen_calls.append(argv),
+        ):
+            dispatch_codex_resolve(
+                worktree=worktree,
+                main_repo=self.repo,
+                integration="auto-refact-dev",
+                review_base="dev",
+                spawn_codex=self.repo / "skills" / "codex-refactor-loop" / "scripts" / "consensus-rnd-cli",
+                logger=logger_lines.append,
+            )
+
+        prompt_file = self.repo / ".refactor-loop" / "prompts" / "dev-sync-conflict-1234.md"
+        log_file = self.repo / ".refactor-loop" / "logs" / "dev-sync-codex-1234.log"
+        prompt = prompt_file.read_text(encoding="utf-8")
+        self.assertIn("`.worktrees/dev-sync`", prompt)
+        self.assertIn("prompt artifact: `.refactor-loop/prompts/dev-sync-conflict-1234.md`", prompt)
+        self.assertIn("resolver log artifact: `.refactor-loop/logs/dev-sync-codex-1234.log`", prompt)
+        self.assertIn("main repo: `.`", prompt)
+        self.assertNotIn(str(self.repo), prompt)
+        self.assertEqual(["dispatching codex: prompt=.refactor-loop/prompts/dev-sync-conflict-1234.md log=.refactor-loop/logs/dev-sync-codex-1234.log"], logger_lines)
+
+        argv = popen_calls[0]
+        self.assertEqual(str(worktree), argv[argv.index("--cd") + 1])
+        self.assertEqual(str(self.repo), argv[argv.index("--add-dir") + 1])
+        self.assertEqual(str(prompt_file), argv[argv.index("--prompt") + 1])
+        self.assertEqual(str(log_file), argv[argv.index("--log") + 1])
+        self.assertTrue(Path(argv[argv.index("--cd") + 1]).is_absolute())
+        self.assertTrue(Path(argv[argv.index("--prompt") + 1]).is_absolute())
+
 
 class SyncDevSourceRegressionTests(unittest.TestCase):
     def test_module_is_import_safe_without_repo_root(self) -> None:
@@ -340,6 +378,21 @@ class SyncDevSourceRegressionTests(unittest.TestCase):
         self.assertIn('append_pending_event("missing-integration-branch", self.integration)', src)
         self.assertIn('head_name.startswith("rollup/")', src)
         self.assertNotIn("DEV_SYNC_REQUEST:", src)
+
+    def test_sync_source_regression_uses_durable_display_paths(self) -> None:
+        src = SYNC_DEV.read_text(encoding="utf-8")
+        self.assertIn("ctx.durable_artifact_path(worktree)", src)
+        self.assertIn("ctx.durable_artifact_path(prompt_file)", src)
+        self.assertIn("ctx.durable_artifact_path(log_file)", src)
+        self.assertIn("spawn-codex --cd/--add-dir/--prompt/--log", src)
+        for forbidden in (
+            "`{worktree}`. Resolve conflicts",
+            "`cd {worktree}`",
+            "main repo `{main_repo}`",
+            "prompt={prompt_file} log={log_file}",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 动机
durable artifact(ledger/pending-event/evidence/dev-sync prompt/DEV_SYNC_REQUEST marker)写入 host 绝对路径违反 CLAUDE.md R24(closes #202)。Phase 9 共识 3/3(r5,宪法 tie-break 收敛 framing=write-relative-read-absolute)。

## 改动
分层 durable-text-path vs execution-path:持久层只存 repo-relative POSIX text;读取/传 subprocess 时 LoopContext.repo_root/rel_path 解析回 absolute;spawn-codex/Popen argv 仍 absolute(execution boundary)。context.py/router.py/dev.py + 配套 behavior+source-regression 测试。

## 验证
`python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'`

⟦AI:AUTO-LOOP⟧