### PR TITLE
feat(#218): project-rules 改 read-only check-project-rules probe + patch artifact

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -7,6 +7,8 @@ description: Use when the user wants an unattended Consensus R&D work-unit loop 
 > Maintainer directive merges the former REFERENCE.md back into this single SKILL.md; use intra-file anchor links.
 > Refactor (iter1/issue-141): Old pattern: 下游没有 installer 时,装机步骤散落在 README、SKILL statusline 段和 restart helper 段,缺乏从安装 skill 到配置 host.env、调度守护进程、接入 statusLine 的单步 walkthrough。
 > New principle: Downstream install walkthrough 是唯一装机主段;README 链到 SKILL 锚点,SKILL 内部段落互链;source-regression 锁住单文件链接与必备 surface,bounded scheduler behavior test 锁住 consensus-rnd-cli restart-daemons 不无限阻塞。
+> Refactor (iter218/issue-218): Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+> New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
 # Codex Refactor Loop — Controller Contract
 This SKILL.md is the single controller contract and detailed reference. It must be enough to run the loop safely on first load while keeping heavy schemas, full templates, command bodies, and recovery runbooks reachable by intra-file anchors.
 
@@ -68,7 +70,7 @@ This matrix is the only manually maintained host.env contract. `host.env.example
 | `$TEST_CMD` | required | LoopContext | host shell command string | fail closed for test-required work; callers must execute with `bash -lc "$TEST_CMD"` after sourcing host.env | prompt templates | `test_skill_entrypoint_contract.py` |
 | `$INTEGRATION_BRANCH` | defaulted | sync helpers | `auto-refact-dev` | default to `auto-refact-dev`; release checks fail closed when branch evidence is empty | sync helpers, release-gate | `test_sync_dev.py`, `test_auto_release_gate.py` |
 | `$REVIEW_BASE_BRANCH` | defaulted | sync helpers | `dev` | default to `dev`; release checks fail closed when branch evidence is empty | sync helpers, release-gate | `test_sync_dev.py`, `test_auto_release_gate.py` |
-| `$PROJECT_RULES` | defaulted | LoopContext | `CLAUDE.md` | default to `CLAUDE.md` for Consensus-rnd Phase bootstrap fixed-point and prompt evidence | LoopContext, prompt templates | `test_ensure_project_rules_fixed_points.py` |
+| `$PROJECT_RULES` | defaulted | LoopContext | `CLAUDE.md` | default to `CLAUDE.md` as host-owned read-only prompt/bootstrap evidence; non-current fixed points produce a patch artifact and fail closed | LoopContext, prompt templates | `test_ensure_project_rules_fixed_points.py` |
 | `$RELEASE_AUTO_ENABLE` | defaulted | release-gate | `false` | false or empty exits 0 with noop reason and writes no release decision artifact | release-gate | `test_auto_release_gate.py`, `test_release_gate_module.py` |
 | `$RELEASE_AUTO_MIN_MERGES` | defaulted | release-gate | `1` | default to `1` recent merge for stability scoring | release-gate | `test_auto_release_gate.py` |
 | `$RELEASE_AUTO_MIN_INTERVAL_HOURS` | defaulted | release-gate | `2` | default to `2` hours since last release decision | release-gate | `test_auto_release_gate.py` |
@@ -97,7 +99,7 @@ Host config rules:
 4. Source `$REPO_ROOT/.refactor-loop/host.env` before daemon or codex supervision commands.
 5. `$BUILD_CMD` and `$TEST_CMD` are shell command strings. They may contain `cd`, `&&`, pipes, and host script invocations; callers must run `bash -lc "$BUILD_CMD"` / `bash -lc "$TEST_CMD"` or an equivalent sourced shell invocation, never split them into argv.
 6. Detailed daemon start examples live in [daemon command bodies](#daemon-command-bodies), including the `bash -c 'source .refactor-loop/host.env && exec` pattern and why `env $(grep ...)` is unsafe.
-7. The ProjectRules fixed-point target is `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}`.
+7. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` is host-owned read-only evidence. `consensus-rnd-cli check-project-rules` may inspect the sentinel block and write `.refactor-loop/runs/project-rules-fixed-point.patch`; it must never apply host policy edits.
 
 ## Skill Root Contract
 `<skill-root>` means the installed `skills/codex-refactor-loop` directory containing this `SKILL.md`, `scripts/consensus-rnd-cli spawn-codex`, and `prompts/`. Runtime scripts self-locate from their own file path; `CODEX_REFACTOR_LOOP_SKILL_ROOT` is optional and only for wrappers or nonstandard packaging. If that override is set but invalid, scripts fail closed instead of falling back to `.claude/skills`.
@@ -337,8 +339,8 @@ Consensus-rnd Phase bootstrap is mandatory and ordered for each controller sessi
 
 1. `source .refactor-loop/host.env` from `$REPO_ROOT`; if it is absent, unreadable, or lacks required values, fail closed.
 2. Validate `REPO_ROOT`, `GH_REPO_SLUG`, `INTEGRATION_BRANCH`, `REVIEW_BASE_BRANCH`, `BUILD_CMD`, `TEST_CMD`, and `SOURCE_GLOBS` according to host policy.
-3. Run `ProjectRulesFixedPointEnsurer(强制,先于任何 actor 派发)` against `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}`.
-4. If the helper exits non-zero, helper 退出非 0 → bootstrap fail closed; post the failure and stop before actors.
+3. Run `ProjectRulesFixedPointProbe(强制,先于任何 actor 派发)` through `consensus-rnd-cli check-project-rules` against `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}`.
+4. If the probe exits non-zero, including `patch-required` with `.refactor-loop/runs/project-rules-fixed-point.patch`, bootstrap fail closed; post the failure and stop before actors, 不得派 audit / solver / reviewer / implement actor.
 5. Create `.refactor-loop/{logs,runs,clusters,prompts,worktrees,state}` if missing; do not create or maintain root `.refactor-loop/state.json`.
 6. Ensure the integration branch exists locally and remotely; create it from `$REVIEW_BASE_BRANCH` only when missing.
 7. ensure labels for the exact phase/human taxonomy; bootstrap command loops live in [label bootstrap loops](#label-bootstrap-loops).
@@ -351,7 +353,7 @@ Consensus-rnd Phase bootstrap is mandatory and ordered for each controller sessi
 Consensus-rnd Phase bootstrap anti-patterns stay local because they are safety gates:
 
 - Do not continue with missing `host.env` under guessed defaults.
-- Do not skip `ProjectRulesFixedPointEnsurer` because `$PROJECT_RULES` already exists.
+- Do not skip `ProjectRulesFixedPointProbe` because `$PROJECT_RULES` already exists.
 - Do not start fewer than the five required restart-helper-managed daemons.
 - Do not initialize an alternate state model, alternate queue, wrapper envelope, root state file, or renamed work-unit schema.
 - Do not post local-only bootstrap status; GitHub must show the state.
@@ -663,7 +665,7 @@ Operational details live in [language policy details](#language-policy-details);
 - [scripts/consensus-rnd-cli peek](scripts/consensus-rnd-cli peek) — controller wakeup summary.
 - `scripts/codex_refactor_loop/controller_actions.py` — controller-internal lifecycle primitives; not a public CLI command surface.
 - [scripts/consensus-rnd-cli post-banner](scripts/consensus-rnd-cli post-banner) — GitHub banner posting helper.
-- [scripts/consensus-rnd-cli ensure-project-rules](scripts/consensus-rnd-cli ensure-project-rules) — Consensus-rnd Phase bootstrap fixed-point helper.
+- [scripts/consensus-rnd-cli check-project-rules](scripts/consensus-rnd-cli check-project-rules) — read-only Consensus-rnd Phase bootstrap fixed-point probe; writes patch artifact only.
 - [scripts/consensus-rnd-cli concurrency](scripts/consensus-rnd-cli concurrency) — no-gap sentinel daemon.
 - [scripts/consensus-rnd-cli restart-daemons](scripts/consensus-rnd-cli restart-daemons) — cron/launchd anti-stop helper for existing daemon wrappers.
 - [scripts/consensus-rnd-cli log-retention](scripts/consensus-rnd-cli log-retention) — daemonless 24h direct-rm helper for `.refactor-loop/logs/*.log`.
@@ -931,7 +933,7 @@ Worker-owned operations:
 
 Maintainer-owned operations:
 
-1. Change the host policy or project rules outside the managed fixed-point block.
+1. Change the host policy or project rules, including applying any fixed-point patch artifact.
 2. Approve a real human-needed decision after `META_RESOLVED:escalate-human`.
 3. Stop the loop.
 4. Expand scope beyond the current work unit or repo.
@@ -1383,15 +1385,16 @@ You are the **Controller**. You never edit production code yourself. You orchest
 0. **host.env 自检(缺失即停,绝不臆造)**:`source .refactor-loop/host.env` 取 `$REPO_ROOT/$GH_REPO_SLUG/$BUILD_CMD/$TEST_CMD/...`。
    - 不存在 → 从 `skills/codex-refactor-loop/host.env.example` 复制到 `.refactor-loop/host.env` 并填必填项;无法确定必填值(REPO_ROOT/GH_REPO_SLUG/BUILD_CMD/TEST_CMD)→ **PushNotification 请 maintainer 填,end turn,不 spawn 任何东西**。
    - ❌ 严禁用 `git rev-parse` / `gh repo view` 猜值后带空 BUILD_CMD/TEST_CMD 硬跑。
-0b. **ProjectRulesFixedPointEnsurer(强制,先于任何 actor 派发)**:在 `host.env` 注入后立即运行:
+0b. **ProjectRulesFixedPointProbe(强制,先于任何 actor 派发)**:在 `host.env` 注入后立即运行:
    ```bash
-   python3 skills/codex-refactor-loop/scripts/consensus-rnd-cli ensure-project-rules
+   python3 skills/codex-refactor-loop/scripts/consensus-rnd-cli check-project-rules
    ```
-   - 该 helper 只维护解析后的 `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 内一个 `consensus-rnd:foundational-invariants` sentinel managed 区块;区块外 host 内容保持不变。
-   - helper 退出非 0 → bootstrap fail closed:不得初始化 state、不得建 labels、不得起 daemon、不得派 audit / solver / reviewer / implement actor。
-   - # Refactor (iter1/host-claude-md-fixed-points):
-     #   Old pattern: host 的 PROJECT_RULES/CLAUDE.md 不保证基础不动点(泛化理论)在场,跑 loop 时基础理论未被可靠加载
-     #   New principle: Consensus-rnd Phase bootstrap ProjectRulesFixedPointEnsurer 幂等向 $PROJECT_RULES 写入带 sentinel 的 managed 不动点区块(consensus:minimal,不覆盖 host 已有内容)
+   - 该 probe 只读解析后的 `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 内 `consensus-rnd:foundational-invariants` sentinel block;`$PROJECT_RULES` 是 host-owned read-only evidence,不是 skill 可写 surface。
+   - 非 current 时只写 `.refactor-loop/runs/project-rules-fixed-point.patch`,并以非 0 退出;controller 把该 patch artifact 交给 maintainer / host policy 流程处理。
+   - probe 退出非 0 → bootstrap fail closed:不得初始化 state、不得建 labels、不得起 daemon、不得派 audit / solver / reviewer / implement actor。
+   - # Refactor (iter218/issue-218):
+     #   Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+     #   New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
 1. **runtime dirs + integration 分支**:`mkdir -p .refactor-loop/{logs,runs,clusters,prompts,worktrees,state}` + idempotent 建/推 `$INTEGRATION_BRANCH`(下方细节)。Do not create or maintain root `.refactor-loop/state.json`.
 2. **建全套 labels**:跑「Label 系统」节的 catalog validation / GitHub drift plan, then controller-owned apply if authorized. **漏建 = 后续 phase transition 无 canonical label 可挂、comment-monitor 查 catalog-managed items 漏掉 PR**。
 3. **起并挂载全部 5 个 daemon**:按「Host 运行编排 → Daemon 启动」节的 `bash -c 'source host.env && exec'` pattern 起齐 `consensus-rnd-cli concurrency` / `consensus-rnd-cli progress-reporter` / `consensus-rnd-cli comment-monitor` / `consensus-rnd-cli dev-sync` / `consensus-rnd-cli phase9-router`。随后运行 `python3 <skill-root>/scripts/consensus-rnd-cli restart-daemons` 规范化 heartbeat-managed daemon,再读 `.refactor-loop/heartbeats/*.ts` / `.refactor-loop/state/statusline-snapshot.json` / `python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80` 确认健康面可见;Consensus-rnd Phase design-consensus router 读其 lock/ledger/log/fallback event surface。**首轮就必须把 5 个全起起来——它不是「以后某次 wakeup 才做的 liveness 检查」**。

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/cli.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/cli.py
@@ -40,6 +40,8 @@ class CommandSpec:
 # forming a generic lifecycle authority surface. New principle: COMMANDS keeps
 # only public non-lifecycle CLI primitives; controller lifecycle actions stay
 # controller-internal, with dev-sync's narrow integration-worktree carveout.
+# Refactor (iter218/issue-218): Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+# New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
 COMMANDS: dict[str, CommandSpec] = {
     "spawn-codex": CommandSpec(spawn.main, "run the Python codex spawn supervisor", ("spawn", "write-log")),
     "peek": CommandSpec(peek_main, "run the Python read-only state sweep", ("read-state", "read-gh")),
@@ -115,7 +117,11 @@ COMMANDS: dict[str, CommandSpec] = {
     ),
     "check-manifest": CommandSpec(manifest_main, "run manifest version sync check", ("read-source",)),
     "log-retention": CommandSpec(retention_main, "run daemonless log retention", ("delete-log",)),
-    "ensure-project-rules": CommandSpec(project_rules.main, "ensure host project rules fixed points", ("write-source",)),
+    "check-project-rules": CommandSpec(
+        project_rules.main,
+        "check host project rules fixed points and write patch artifact when needed",
+        ("read-source", "write-artifact"),
+    ),
 }
 
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/project_rules.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/project_rules.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-"""Ensure the host project rules file carries consensus-rnd fixed points."""
+"""Read-only probe for consensus-rnd fixed points in host project rules."""
 
 from __future__ import annotations
 
+import difflib
 import hashlib
 import os
 import re
 import sys
-import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -45,39 +46,76 @@ KNOWN_CANONICAL_HASHES = frozenset({sha256_text(OLD_CANONICAL_BODY)})
 
 
 class FixedPointError(Exception):
-    """Raised when the managed block cannot be safely ensured."""
+    """Raised when the managed block cannot be safely inspected."""
 
 
-class ProjectRulesFixedPointEnsurer:
-    # Refactor (iter1/host-claude-md-fixed-points):
-    #   Old pattern: host PROJECT_RULES/CLAUDE.md did not guarantee that
-    #   foundational fixed points were present, so the loop did not reliably
-    #   load the base theory.
-    #   New principle: bootstrap ProjectRulesFixedPointEnsurer idempotently writes
-    #   a sentinel-wrapped managed fixed-point block to $PROJECT_RULES
-    #   (consensus:minimal), without overwriting host-owned content.
+@dataclass(frozen=True)
+class ProjectRulesFixedPointReport:
+    """refactor helper, no behavior change: immutable probe result payload."""
+
+    status: str
+    reason: str
+    target: Path
+    target_relative: Path
+    original_text: str
+    proposed_text: str | None = None
+    detail: str = ""
+    artifact: Path | None = None
+
+    @property
+    def is_current(self) -> bool:
+        return self.status == "current"
+
+    @property
+    def needs_patch(self) -> bool:
+        return self.status == "patch-required" and self.proposed_text is not None
+
+
+class ProjectRulesPatchArtifact:
+    # Refactor (iter218/issue-218):
+    #   Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+    #   New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
+    def __init__(self, repo_root: Path, filename: str = "project-rules-fixed-point.patch") -> None:
+        self.repo_root = repo_root
+        self.path = repo_root / ".refactor-loop" / "runs" / filename
+
+    def write(self, report: ProjectRulesFixedPointReport) -> Path:
+        if report.proposed_text is None:
+            raise FixedPointError("patch artifact requires proposed project rules text")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        original_name = str(report.target_relative)
+        updated_name = str(report.target_relative)
+        patch = "".join(
+            difflib.unified_diff(
+                report.original_text.splitlines(keepends=True),
+                report.proposed_text.splitlines(keepends=True),
+                fromfile=f"a/{original_name}",
+                tofile=f"b/{updated_name}",
+            )
+        )
+        self.path.write_text(patch, encoding="utf-8")
+        return self.path
+
+
+class ProjectRulesFixedPointProbe:
+    # Refactor (iter218/issue-218):
+    #   Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+    #   New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
     def __init__(self, repo_root: str, project_rules: str | None = None) -> None:
         self.repo_root = self._resolve_repo_root(repo_root)
         self.target = self._resolve_target(project_rules if project_rules else "CLAUDE.md")
+        self.target_relative = self.target.relative_to(self.repo_root)
 
     @classmethod
-    def from_env(cls) -> "ProjectRulesFixedPointEnsurer":
+    def from_env(cls) -> "ProjectRulesFixedPointProbe":
         return cls(os.environ.get("REPO_ROOT", ""), os.environ.get("PROJECT_RULES"))
 
-    def ensure(self) -> str:
-        # Refactor (iter1/host-claude-md-fixed-points):
-        #   Old pattern: host PROJECT_RULES/CLAUDE.md did not guarantee that
-        #   foundational fixed points were present, so the loop did not
-        #   reliably load the base theory.
-        #   New principle: bootstrap ProjectRulesFixedPointEnsurer idempotently
-        #   writes a sentinel-wrapped managed fixed-point block to $PROJECT_RULES
-        #   (consensus:minimal), without overwriting host-owned content.
+    def inspect(self) -> ProjectRulesFixedPointReport:
+        # Refactor (iter218/issue-218):
+        #   Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+        #   New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
         original = self._read_target()
-        updated = self._updated_text(original)
-        if updated == original:
-            return "already-current"
-        self._atomic_write(updated)
-        return "updated"
+        return self._inspect_text(original)
 
     def _resolve_repo_root(self, repo_root: str) -> Path:
         if not repo_root:
@@ -107,39 +145,62 @@ class ProjectRulesFixedPointEnsurer:
             raise FixedPointError(f"PROJECT_RULES file is empty: {self.target}")
         return text
 
-    def _updated_text(self, text: str) -> str:
-        # Refactor (iter1/host-claude-md-fixed-points):
-        #   Old pattern: host PROJECT_RULES/CLAUDE.md did not guarantee that
-        #   foundational fixed points were present, so the loop did not
-        #   reliably load the base theory.
-        #   New principle: bootstrap ProjectRulesFixedPointEnsurer idempotently
-        #   writes a sentinel-wrapped managed fixed-point block to $PROJECT_RULES
-        #   (consensus:minimal), without overwriting host-owned content.
+    def _inspect_text(self, text: str) -> ProjectRulesFixedPointReport:
+        # Refactor (iter218/issue-218):
+        #   Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+        #   New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
         starts = list(START_RE.finditer(text))
         end_count = text.count(END_MARKER)
         if len(starts) != end_count:
-            raise FixedPointError("managed marker pair is missing or unbalanced")
+            return self._blocked_report(text, "invalid-marker", "managed marker pair is missing or unbalanced")
         if len(starts) > 1:
-            raise FixedPointError("duplicate managed marker blocks are not allowed")
+            return self._blocked_report(text, "invalid-marker", "duplicate managed marker blocks are not allowed")
         if not starts:
-            return text + "\n\n" + self._managed_block()
+            return self._patch_report(text, text + "\n\n" + self._managed_block(), "missing")
 
         start = starts[0]
         end_index = text.find(END_MARKER, start.end())
         if end_index < 0:
-            raise FixedPointError("managed end marker is missing")
+            return self._blocked_report(text, "invalid-marker", "managed end marker is missing")
 
         enclosed = text[start.end() + 1:end_index]
         enclosed_hash = sha256_text(enclosed)
         marker_hash = start.group(1)
         if marker_hash != enclosed_hash:
-            raise FixedPointError("managed block hash mismatch; refusing to overwrite manual edits")
+            return self._blocked_report(text, "tampered", "managed block hash mismatch; refusing to apply repair")
         if enclosed_hash == CANONICAL_HASH:
-            return text
+            return ProjectRulesFixedPointReport(
+                status="current",
+                reason="current",
+                target=self.target,
+                target_relative=self.target_relative,
+                original_text=text,
+            )
         if enclosed_hash not in KNOWN_CANONICAL_HASHES:
-            raise FixedPointError("unknown managed block version; refusing to overwrite")
+            return self._blocked_report(text, "unknown-old", "unknown managed block version; refusing to apply repair")
 
-        return text[: start.start()] + self._managed_block() + text[end_index + len(END_MARKER):]
+        proposed = text[: start.start()] + self._managed_block() + text[end_index + len(END_MARKER):]
+        return self._patch_report(text, proposed, "known-old")
+
+    def _patch_report(self, original: str, proposed: str, reason: str) -> ProjectRulesFixedPointReport:
+        return ProjectRulesFixedPointReport(
+            status="patch-required",
+            reason=reason,
+            target=self.target,
+            target_relative=self.target_relative,
+            original_text=original,
+            proposed_text=proposed,
+        )
+
+    def _blocked_report(self, original: str, reason: str, detail: str) -> ProjectRulesFixedPointReport:
+        return ProjectRulesFixedPointReport(
+            status="blocked",
+            reason=reason,
+            target=self.target,
+            target_relative=self.target_relative,
+            original_text=original,
+            detail=detail,
+        )
 
     def _managed_block(self) -> str:
         return (
@@ -148,28 +209,27 @@ class ProjectRulesFixedPointEnsurer:
             f"{END_MARKER}"
         )
 
-    def _atomic_write(self, text: str) -> None:
-        self.target.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_name = tempfile.mkstemp(prefix=f".{self.target.name}.", dir=self.target.parent)
-        tmp_path = Path(tmp_name)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(text)
-            os.replace(tmp_path, self.target)
-        finally:
-            if tmp_path.exists():
-                tmp_path.unlink()
-
 
 def main(argv: list[str] | None = None) -> int:
     del argv
     try:
-        status = ProjectRulesFixedPointEnsurer.from_env().ensure()
+        probe = ProjectRulesFixedPointProbe.from_env()
+        report = probe.inspect()
     except FixedPointError as exc:
         sys.stderr.write(f"PROJECT_RULES_FIXED_POINT_ERROR: {exc}\n")
         return 1
-    sys.stdout.write(f"PROJECT_RULES_FIXED_POINT:{status}\n")
-    return 0
+    if report.is_current:
+        sys.stdout.write("PROJECT_RULES_FIXED_POINT:current\n")
+        return 0
+    if report.needs_patch:
+        artifact = ProjectRulesPatchArtifact(probe.repo_root).write(report)
+        relative_artifact = artifact.relative_to(probe.repo_root)
+        sys.stdout.write(
+            f"PROJECT_RULES_FIXED_POINT:patch-required artifact={relative_artifact} reason={report.reason}\n"
+        )
+        return 1
+    sys.stderr.write(f"PROJECT_RULES_FIXED_POINT_ERROR: reason={report.reason} {report.detail}\n")
+    return 1
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_cli_command_router.py
+++ b/skills/codex-refactor-loop/scripts/test_cli_command_router.py
@@ -98,15 +98,18 @@ LIFECYCLE_TOKENS = {
 
 
 class RuntimeCommandRouterTests(unittest.TestCase):
+    # Refactor (iter218/issue-218):
+    #   Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+    #   New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
     def test_each_public_operation_is_registered(self) -> None:
         self.assertEqual(
             {
                 "check-degradation",
                 "check-manifest",
+                "check-project-rules",
                 "labels",
                 "concurrency",
                 "dev-sync",
-                "ensure-project-rules",
                 "log-retention",
                 "spawn-codex",
                 "peek",
@@ -194,6 +197,7 @@ class RuntimeCommandRouterTests(unittest.TestCase):
             "apply-human-label",
             "apply-sync",
             "apply-triage",
+            "ensure-project-rules",
             "merge-pr",
             "open-pr",
             "open-release-rollup-pr",
@@ -210,6 +214,15 @@ class RuntimeCommandRouterTests(unittest.TestCase):
                 lifecycle_tokens = set(spec.authority) & LIFECYCLE_TOKENS
                 allowed = DAEMON_LIFECYCLE_CARVEOUTS.get(name, set())
                 self.assertFalse(lifecycle_tokens - allowed)
+
+    def test_check_project_rules_cli_declares_read_source_write_artifact_only(self) -> None:
+        self.assertIn("check-project-rules", COMMANDS)
+        self.assertNotIn("ensure-project-rules", COMMANDS)
+        self.assertEqual(("read-source", "write-artifact"), COMMANDS["check-project-rules"].authority)
+        for name, spec in COMMANDS.items():
+            if "project-rules" in name:
+                with self.subTest(command=name):
+                    self.assertNotIn("write-source", spec.authority)
 
     def test_authority_refactor_self_doc_source_regression(self) -> None:
         cli = (SCRIPT_DIR / "codex_refactor_loop" / "cli.py").read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -25,54 +25,129 @@ from codex_refactor_loop.project_rules import (
     CANONICAL_HASH,
     END_MARKER,
     OLD_CANONICAL_BODY,
-    ProjectRulesFixedPointEnsurer,
+    ProjectRulesFixedPointProbe,
+    ProjectRulesPatchArtifact,
     START_RE,
     sha256_text,
 )
 
 
 class ProjectRulesFixedPointTests(unittest.TestCase):
+    # Refactor (iter218/issue-218):
+    #   Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+    #   New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
     def setUp(self) -> None:
         self.tmp = Path(tempfile.mkdtemp(prefix="project-rules-test-"))
         self.rules = self.tmp / "CLAUDE.md"
         self.rules.write_text("# Host rules\n", encoding="utf-8")
+        self.artifact = self.tmp / ".refactor-loop" / "runs" / "project-rules-fixed-point.patch"
 
     def tearDown(self) -> None:
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def test_ensure_appends_managed_block_and_is_idempotent(self) -> None:
-        ensurer = ProjectRulesFixedPointEnsurer(str(self.tmp))
-        self.assertEqual("updated", ensurer.ensure())
-        text = self.rules.read_text(encoding="utf-8")
-        self.assertIn(CANONICAL_BODY, text)
-        self.assertIn(CANONICAL_HASH, text)
-        self.assertEqual("already-current", ensurer.ensure())
+    def test_probe_current_exits_zero_without_modifying_project_rules(self) -> None:
+        block = self._managed_block(CANONICAL_BODY)
+        self.rules.write_text(f"# Host rules\n\n{block}", encoding="utf-8")
+        before = self.rules.read_bytes()
+        before_mtime = self.rules.stat().st_mtime_ns
 
-    def test_refuses_manual_edit_inside_managed_block(self) -> None:
-        ensurer = ProjectRulesFixedPointEnsurer(str(self.tmp))
-        ensurer.ensure()
-        self.rules.write_text(self.rules.read_text(encoding="utf-8").replace("FI-007 删除优先", "FI-007 edited"), encoding="utf-8")
-        with self.assertRaisesRegex(Exception, "hash mismatch"):
-            ensurer.ensure()
+        report = ProjectRulesFixedPointProbe(str(self.tmp)).inspect()
+
+        self.assertTrue(report.is_current)
+        self.assertEqual("current", report.reason)
+        self.assertEqual(before, self.rules.read_bytes())
+        self.assertEqual(before_mtime, self.rules.stat().st_mtime_ns)
+        self.assertFalse(self.artifact.exists())
+
+    def test_probe_missing_block_writes_patch_artifact_and_leaves_target_unchanged(self) -> None:
+        before = self.rules.read_bytes()
+        report = ProjectRulesFixedPointProbe(str(self.tmp)).inspect()
+
+        self.assertTrue(report.needs_patch)
+        self.assertEqual("missing", report.reason)
+        artifact = ProjectRulesPatchArtifact(self.tmp).write(report)
+        self.assertEqual(self.artifact, artifact)
+        patch = artifact.read_text(encoding="utf-8")
+        self.assertIn("--- a/CLAUDE.md", patch)
+        self.assertIn("+++ b/CLAUDE.md", patch)
+        self.assertIn("+## 共识研发不动点（由 consensus-rnd 管理）", patch)
+        self.assertIn("+- FI-007 删除优先；废弃路径直接移除，除非 host 规则明确要求迁移期兼容。", patch)
+        self.assertEqual(before, self.rules.read_bytes())
+
+    def test_probe_known_old_block_writes_replacement_patch_without_overwrite(self) -> None:
+        old_text = f"# Host rules\n\n{self._managed_block(OLD_CANONICAL_BODY)}"
+        self.rules.write_text(old_text, encoding="utf-8")
+        report = ProjectRulesFixedPointProbe(str(self.tmp)).inspect()
+
+        self.assertTrue(report.needs_patch)
+        self.assertEqual("known-old", report.reason)
+        artifact = ProjectRulesPatchArtifact(self.tmp).write(report)
+        patch = artifact.read_text(encoding="utf-8")
+        self.assertIn("- FI-001 AI 产物默认不可信；进入主线前必须经过独立检查。", patch)
+        self.assertIn("+- FI-007 删除优先；废弃路径直接移除，除非 host 规则明确要求迁移期兼容。", patch)
+        self.assertEqual(old_text, self.rules.read_text(encoding="utf-8"))
+
+    def test_probe_tampered_block_fails_closed_without_apply(self) -> None:
+        self.rules.write_text(f"# Host rules\n\n{self._managed_block(CANONICAL_BODY)}", encoding="utf-8")
+        tampered = self.rules.read_text(encoding="utf-8").replace("FI-007 删除优先", "FI-007 edited")
+        self.rules.write_text(tampered, encoding="utf-8")
+
+        report = ProjectRulesFixedPointProbe(str(self.tmp)).inspect()
+
+        self.assertEqual("blocked", report.status)
+        self.assertEqual("tampered", report.reason)
+        self.assertIn("hash mismatch", report.detail)
+        self.assertIsNone(report.proposed_text)
+        self.assertEqual(tampered, self.rules.read_text(encoding="utf-8"))
+        self.assertFalse(self.artifact.exists())
 
     def test_cli_operation_runs_from_single_entrypoint(self) -> None:
         env = os.environ.copy()
         env["REPO_ROOT"] = str(self.tmp)
         result = subprocess.run(
-            [sys.executable, str(CLI), "ensure-project-rules"],
+            [sys.executable, str(CLI), "check-project-rules"],
             env=env,
             capture_output=True,
             text=True,
             check=False,
         )
-        self.assertEqual(0, result.returncode, result.stderr)
-        self.assertIn("PROJECT_RULES_FIXED_POINT:updated", result.stdout)
+        self.assertEqual(1, result.returncode, result.stderr)
+        self.assertIn("PROJECT_RULES_FIXED_POINT:patch-required", result.stdout)
+        self.assertIn("artifact=.refactor-loop/runs/project-rules-fixed-point.patch", result.stdout)
+        self.assertIn("reason=missing", result.stdout)
+        self.assertEqual("# Host rules\n", self.rules.read_text(encoding="utf-8"))
+        self.assertTrue(self.artifact.is_file())
+
+    def test_ensure_project_rules_command_is_removed_and_no_writer_remains(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(CLI), "ensure-project-rules"],
+            env={**os.environ.copy(), "REPO_ROOT": str(self.tmp)},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(2, result.returncode)
+        self.assertIn("unknown command: ensure-project-rules", result.stderr)
+        source = (SCRIPT_DIR / "codex_refactor_loop" / "project_rules.py").read_text(encoding="utf-8")
+        runtime_source = "\n".join(line for line in source.splitlines() if "Refactor (iter218/issue-218)" not in line and "Old pattern:" not in line and "New principle:" not in line)
+        self.assertNotIn("_atomic_write", runtime_source)
+        self.assertNotIn("tempfile", source)
+        self.assertNotIn("os.replace", source)
+        self.assertNotIn("PROJECT_RULES_WRITE_ENABLE", runtime_source)
+        self.assertNotIn("ProjectRulesFixedPointEnsurer", runtime_source)
 
     def test_hash_helpers_are_stable(self) -> None:
         self.assertEqual(CANONICAL_HASH, sha256_text(CANONICAL_BODY))
         self.assertNotEqual(CANONICAL_HASH, sha256_text(OLD_CANONICAL_BODY))
         self.assertRegex(START_RE.pattern, "sha256")
         self.assertIn("consensus-rnd:foundational-invariants:end", END_MARKER)
+
+    def _managed_block(self, body: str) -> str:
+        return (
+            f"<!-- consensus-rnd:foundational-invariants:start version=1 sha256={sha256_text(body)} -->\n"
+            f"{body}"
+            f"{END_MARKER}"
+        )
 
 
 class RuntimeShellRemovalSourceTests(unittest.TestCase):

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -115,7 +115,8 @@ class SkillEntrypointContractTests(unittest.TestCase):
         obligations = (
             "source .refactor-loop/host.env",
             "fail closed",
-            "ProjectRulesFixedPointEnsurer",
+            "ProjectRulesFixedPointProbe",
+            "consensus-rnd-cli check-project-rules",
             "Create `.refactor-loop/{logs,runs,clusters,prompts,worktrees,state}`",
             "integration branch",
             "ensure labels",
@@ -140,6 +141,30 @@ class SkillEntrypointContractTests(unittest.TestCase):
         ):
             with self.subTest(daemon=daemon):
                 self.assertIn(daemon, phase0)
+
+    def test_skill_bootstrap_requires_probe_before_actor_dispatch(self) -> None:
+        # Refactor (iter218/issue-218):
+        #   Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+        #   New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
+        phase0 = section_between(
+            self.skill,
+            r"^## Consensus-rnd Phase bootstrap .+Bootstrap .+$",
+            r"^## Phase Routing$",
+        )
+        required_order = (
+            "ProjectRulesFixedPointProbe",
+            "consensus-rnd-cli check-project-rules",
+            ".refactor-loop/runs/project-rules-fixed-point.patch",
+            "不得派 audit / solver / reviewer / implement actor",
+            "Create `.refactor-loop/{logs,runs,clusters,prompts,worktrees,state}`",
+        )
+        cursor = -1
+        for token in required_order:
+            index = phase0.find(token)
+            with self.subTest(token=token):
+                self.assertNotEqual(index, -1)
+                self.assertGreater(index, cursor)
+            cursor = index
 
     def test_wake_source_contract_requires_session_monitor_with_fallback_only(self) -> None:
         wake_row = next(line for line in self.skill.splitlines() if line.startswith("| Wake source |"))

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -331,6 +331,36 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.skill)
 
+    def test_skill_project_rules_surface_has_no_apply_opt_in(self) -> None:
+        # Refactor (iter218/issue-218):
+        #   Old pattern: ensure-project-rules 是 public CLI 默认写 host policy 文件($PROJECT_RULES),违反 skill 无 host 改动权边界
+        #   New principle: 改为 read-only check-project-rules probe + patch artifact:probe 只读判 sentinel block,非 current 写 .refactor-loop/runs/ patch 并 fail-closed 不派 actor;删 ensure-project-rules/_atomic_write,不引入 PROJECT_RULES_WRITE_ENABLE。严格按 plan 逐条改。
+        for needle in (
+            "host-owned read-only prompt/bootstrap evidence",
+            "patch artifact",
+            "fail closed",
+            "不得派 audit / solver / reviewer / implement actor",
+            ".refactor-loop/runs/project-rules-fixed-point.patch",
+            "consensus-rnd-cli check-project-rules",
+            "must never apply host policy edits",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.skill)
+        contract_text = "\n".join(
+            line
+            for line in self.skill.splitlines()
+            if "Refactor (iter218/issue-218)" not in line and "Old pattern:" not in line and "New principle:" not in line
+        )
+        for forbidden in (
+            "幂等向 $PROJECT_RULES 写入",
+            "ensure-project-rules",
+            "PROJECT_RULES_WRITE_ENABLE",
+            "--apply",
+            "ProjectRulesFixedPointEnsurer",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, contract_text)
+
     def test_phase9_router_filename_identity_source_regression(self) -> None:
         router = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "phase9" / "router.py").read_text(encoding="utf-8")
         helper = router + "\n" + (SKILL_ROOT / "scripts" / "consensus-rnd-cli").read_text(encoding="utf-8")


### PR DESCRIPTION
## 摘要

按 #218 Consensus-rnd Phase design-consensus r2 structural 共识(3/3 unanimous)落地。

- **Old**:`ensure-project-rules` 是 public worker-visible CLI,默认通过 `_atomic_write()` 改 host 的 `$PROJECT_RULES`(CLAUDE.md),违反「skill 无 host 改动权」边界。
- **New**:改为只读 `check-project-rules` probe —— 只读判 `consensus-rnd:foundational-invariants` sentinel block 是否 current;非 current 时只向 `.refactor-loop/runs/` 写 unified-diff patch artifact 并 bootstrap fail-closed(不派 actor),绝不写 host 文件。删除 `ensure-project-rules` 与 `_atomic_write`,不引入 `PROJECT_RULES_WRITE_ENABLE`。

违反条款:CLAUDE.md「host 项目 … skill 无 host 项目改动权:不修改 host 的 .git 配置 / CI 配置 / policy 文档」+「最小权限动作」。

## 范围

7 files changed。`project_rules.py`(ensure→probe/inspect/render_patch,删 _atomic_write)、`cli.py`(ensure-project-rules→check-project-rules,authority=read-source+write-artifact)、`SKILL.md`(bootstrap 段 + $PROJECT_RULES 改 read-only evidence)、4 个 test 文件(behavior + source-regression)。

本地 314 tests OK(`python3 -m unittest discover -s skills/codex-refactor-loop/scripts`)。

Closes #218

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
