### PR TITLE
#231: notify-only update-check + VERSION.json + shared semver

### DIFF
--- a/.version-bump.json
+++ b/.version-bump.json
@@ -5,7 +5,8 @@
     { "path": ".claude-plugin/marketplace.json", "field": "plugins.0.version" },
     { "path": ".codex-plugin/plugin.json", "field": "version" },
     { "path": ".cursor-plugin/plugin.json", "field": "version" },
-    { "path": "gemini-extension.json", "field": "version" }
+    { "path": "gemini-extension.json", "field": "version" },
+    { "path": "skills/codex-refactor-loop/VERSION.json", "field": "version" }
   ],
   "audit": {
     "exclude": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@
 
 ## 版本同步(强制)
 
-改版本号时,`.version-bump.json` 列出的所有文件必须同步为同一版本:`package.json`、`.claude-plugin/plugin.json`、`.claude-plugin/marketplace.json`、`.codex-plugin/plugin.json`、`.cursor-plugin/plugin.json`、`gemini-extension.json`。漏改任一份会让某个平台装到旧版。
+改版本号时,`.version-bump.json` 列出的所有文件必须同步为同一版本:`package.json`、`.claude-plugin/plugin.json`、`.claude-plugin/marketplace.json`、`.codex-plugin/plugin.json`、`.cursor-plugin/plugin.json`、`gemini-extension.json`、`skills/codex-refactor-loop/VERSION.json`。漏改任一份会让某个平台装到旧版。
 
 ## 版本迭代(规范)
 

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -75,6 +75,9 @@ This matrix is the only manually maintained host.env contract. `host.env.example
 | `$REVIEW_BASE_BRANCH` | defaulted | sync helpers | `dev` | default to `dev`; release checks fail closed when branch evidence is empty | sync helpers, release-gate | `test_sync_dev.py`, `test_auto_release_gate.py` |
 | `$PROJECT_RULES` | defaulted | LoopContext | `CLAUDE.md` | default to `CLAUDE.md` as host-owned read-only prompt/bootstrap evidence; non-current fixed points produce a patch artifact and fail closed | LoopContext, prompt templates | `test_ensure_project_rules_fixed_points.py` |
 | `$RELEASE_AUTO_ENABLE` | defaulted | release-gate | `false` | false or empty exits 0 with noop reason and writes no release decision artifact | release-gate | `test_auto_release_gate.py`, `test_release_gate_module.py` |
+| `$UPDATE_CHECK_ENABLE` | optional-noop | update-check probe | `false` | false or empty exits 0 with noop reason and writes disabled update-check state | update-check, restart-daemons | `test_update_check.py`, `test_restart_daemons.py` |
+| `$UPDATE_CHECK_INTERVAL_SECONDS` | defaulted | update-check probe | `21600` | default to `21600` seconds; fresh local update-check state is reused for manual probes | update-check, concurrency snapshot projection | `test_update_check.py`, `test_concurrency_monitor_snapshot.py` |
+| `$UPDATE_CHECK_TIMEOUT_SECONDS` | defaulted | update-check probe | `5` | default to `5` seconds for GitHub release/tag reads; failures write unknown state and never block restart | update-check | `test_update_check.py` |
 | `$RELEASE_AUTO_MIN_MERGES` | defaulted | release-gate | `1` | default to `1` recent merge for stability scoring | release-gate | `test_auto_release_gate.py` |
 | `$RELEASE_AUTO_MIN_INTERVAL_HOURS` | defaulted | release-gate | `2` | default to `2` hours since last release decision | release-gate | `test_auto_release_gate.py` |
 | `$RELEASE_ROLLUP_MIN_COMMITS` | defaulted | sync helpers | `1` | default to `1` integration-ahead commit before release-rollup pending event | sync helpers | `test_sync_dev.py` |
@@ -211,6 +214,15 @@ Stability requires all signals green and fail-closed handling on missing or red 
 <!-- Refactor (iter217/issue-217): Old pattern: release.yml 保留 tag/release mutation,无法可靠读本地 runtime fact,绕过 release-gate decider-only 边界. New principle: controller-only publication via ReleasePublishPreflight+ReleasePublisher; release.yml is read-only preview(contents:read) and forbidden to create tags/releases. -->
 The release lifecycle surface consumes decision-artifact-only output through the controller only: a scheduled/on-demand controller may read `.refactor-loop/state/release-candidate.json`, re-check `$RELEASE_AUTO_ENABLE=true`, target ref, candidate expiry, decision digest, mapped manifest version, and required signals through `ReleasePublishPreflight`, then `ReleasePublisher` may run the existing version bump command, commit/push mapped manifests, create `v<to_version>` at the candidate target ref, and write `.refactor-loop/state/release-publish-result.json`. `consensus-rnd-cli release-gate` remains decider only; `release.yml` is read-only manual preview/verification with `contents: read` and no tag or GitHub Release authority. Forbidden: per-release maintainer emoji ratification, approval-ticket gating, release-candidate JSON authorization, workflow tag/release creation, or public `consensus-rnd-cli` release-publish commands.
 
+## Notify-only update check(per #231)
+Authorization source: `skills/codex-refactor-loop/authorizations/runtime-exceptions.md#update-check-231`. `skills/codex-refactor-loop/VERSION.json` is the checked-in `VersionSourceManifest`: data-only fields are `schema`, `version`, `repository`, `release_source`, and `install_hint`; only `version` is listed in `.version-bump.json`.
+
+`consensus-rnd-cli update-check` is notify-only. It reads local `VERSION.json`, reads the GitHub latest release and then tags for `ChronoAIProject/consensus-rnd`, and atomically writes `.refactor-loop/state/update-check.json`. `$UPDATE_CHECK_ENABLE` missing, empty, or not true exits 0 and writes disabled state with a reason. GitHub/network/manifest errors write unknown state and do not block `restart-daemons`.
+
+Downstream apply remains host-owned: the probe must not copy, overwrite, reinstall, edit host config, run installers, mutate `.git`, commit, push, tag, release, open/close/edit issues or PRs, mutate labels, or create a daemon. `restart-daemons` may call `maybe_run_update_check(startup=True)` only after the fixed five daemon start/skip pass, and failures are warnings. `concurrency` may project fresh, positive update state into `statusline-snapshot.json`; `statusline` remains snapshot-only and never reads `update-check.json` directly or touches the network. When `update_available=true`, statusline displays `up:v<latest>`.
+
+Verification is locked by `test_update_check.py`, `test_cli_command_router.py`, `test_restart_daemons.py`, `test_concurrency_monitor_snapshot.py`, `test_statusline.py`, `test_runtime_exception_authorization_sources.py`, and `test_skill_reference_anchors.py`.
+
 <!-- Refactor (iter1/issue-166): Old pattern: CLI command authority was represented by coarse read_only metadata and prose-only runtime exception text, so the matrix could under-report command surfaces. New principle: `cli.py::COMMANDS[*].authority` is the inline closed-token mechanical fact source, including named narrow carveouts such as dev-sync's integration-worktree git surface, and SKILL prose cannot grant missing runtime authority. -->
 <!-- Refactor (iter201/issue-201): Old pattern: public consensus-rnd-cli exposed merge-pr/open-pr/safe-push/apply-sync/apply-triage lifecycle commands and wakeup_plan/peek rendered copyable suggested_command, forming generic lifecycle authority. New principle: delete public lifecycle CLI surface; COMMANDS covers public non-lifecycle commands only, controller lifecycle primitives stay internal, wakeup-plan emits fixed controller_action facts with no_lifecycle_authority:true, and dev-sync keeps only the #53 carveout. -->
 ## CLI runtime authority fact source(per #166)
@@ -218,6 +230,9 @@ The release lifecycle surface consumes decision-artifact-only output through the
 
 ## Named runtime exception — autonomous-release-gate lifecycle boundary(per #56)
 Host-agnostic, no lifecycle authority: only read repo/GitHub evidence and write durable decision/candidate artifacts; do not run `git`, bump mapped manifests, commit, push, tag, publish, open, close, label, approve, merge, or otherwise lifecycle-manage issues or PRs.
+
+## Named runtime exception - update-check(per #231)
+Authorization source: `skills/codex-refactor-loop/authorizations/runtime-exceptions.md#update-check-231`. Narrow allowlist: read checked-in `skills/codex-refactor-loop/VERSION.json`, read GitHub release/tag metadata, write `.refactor-loop/state/update-check.json`, and let `concurrency` project fresh positive update fields into `statusline-snapshot.json`. Forbidden: no copy/overwrite/reinstall, host config edit, git or GitHub lifecycle mutation, installer, new daemon, commit, push, merge, tag, release, issue/PR lifecycle, label lifecycle, or apply/update command surface.
 
 <a id="named-runtime-exception--active-controller-leaseper-191"></a>
 ## Named runtime exception - active controller lease(per #191)
@@ -241,10 +256,10 @@ Authorization mirror: `skills/codex-refactor-loop/authorizations/runtime-excepti
 `skill-degradation` is source-repo CI/release validation, not downstream host runtime authority. Source validation runs through `consensus-rnd-cli check-degradation --static`; CI required `skill-degradation` runs `<skill-root>/scripts/consensus-rnd-cli check-degradation --static`; `consensus-rnd-cli release-gate` requires it beside `contract-tests` and `manifest-version-sync`. A downstream host has no runtime watch, no alert log, no pending event, no peek lens, and no host.env knobs for skill-degradation. **Forbidden actions**: no source mutation; no git reset/rebase/merge/push; no GitHub issue/PR/body/label lifecycle mutation; no codex dispatch; no standalone daemon creation; no WorkUnit/schema/envelope changes; no protocol/plugin registry; no auto-clean root garbage; no auto-fix API. Details: [skill degradation source-repo validation details](#skill-degradation-source-repo-validation-details).
 
 ## Claude Code statusline(per #51 consensus)
-`skills/codex-refactor-loop/scripts/consensus-rnd-cli statusline` 是 fast (<200ms) read-only Claude Code statusline reader,显示本仓库 loop 实时状态(codex 计数、PR/issue 数、daemon 健康、P0 streak、freeze 指示)。
+`skills/codex-refactor-loop/scripts/consensus-rnd-cli statusline` 是 fast (<200ms) read-only Claude Code statusline reader,显示本仓库 loop 实时状态(codex 计数、PR/issue 数、daemon 健康、P0 streak、freeze 指示、optional update notice)。
 
 **Producer**:`consensus-rnd-cli concurrency` 每 tick 末尾原子写 `.refactor-loop/state/statusline-snapshot.json`(reuse 现有 daemon,**无新 daemon**)。Snapshot 包含 `daemons` map(扫 `.refactor-loop/heartbeats/*.ts` 动态发现,每条记 `age_seconds` + `stale`,stale 阈值 90s)+ 汇总 `daemons_healthy` / `daemons_total`。
-**Consumer**:`consensus-rnd-cli statusline` 读 snapshot,bash + jq < 200ms。任一 daemon stale → ⚠ 红色。显示形如 `⚙ 5/10 PR:1 issue:9 d:5/5`。
+**Consumer**:`consensus-rnd-cli statusline` 读 snapshot,bash + jq < 200ms。任一 daemon stale → ⚠ 红色。显示形如 `⚙ 5/10 PR:1 issue:9 d:5/5`;当 snapshot 中 `update_available=true` 时追加 `up:v<latest>`。Statusline 不直读 `update-check.json`,不触网。
 
 **Install one-liner**(host project,**手动一行,无 installer script**):
 

--- a/skills/codex-refactor-loop/VERSION.json
+++ b/skills/codex-refactor-loop/VERSION.json
@@ -1,0 +1,7 @@
+{
+  "schema": "codex-refactor-loop-version",
+  "version": "1.0.0-beta.3",
+  "repository": "ChronoAIProject/consensus-rnd",
+  "release_source": "github-release-then-tag",
+  "install_hint": "host-owned"
+}

--- a/skills/codex-refactor-loop/authorizations/runtime-exceptions.md
+++ b/skills/codex-refactor-loop/authorizations/runtime-exceptions.md
@@ -47,6 +47,19 @@ schema, or source of new authority. The executable contract remains in
 - verification: `test_release_commits.py`, `test_cli_command_router.py`, `test_release_gate_module.py`
 - no_new_runtime_authority: This mirror documents only the independent narrow producer; it does not widen `release-gate`, which remains no-git decision-artifact-only.
 
+<a id="update-check-231"></a>
+## update-check-231
+
+- surface: `consensus-rnd-cli update-check`
+- source_issue: `#231`
+- source_round: `r4 structural`
+- source_marker: `META_JUDGE_DONE:consensus:B-structural-profile:notify-only-update-check-with-version-manifest-snapshot-projection-shared-semver`
+- skill_anchor: `#notify-only-update-checkper-231`
+- allowed: read checked-in `skills/codex-refactor-loop/VERSION.json`; read GitHub latest release and tags for the repository named in that manifest; atomically write `.refactor-loop/state/update-check.json`; let `restart-daemons` call the probe after the fixed five-daemon start/skip pass; let `concurrency` project fresh positive update fields into `statusline-snapshot.json`.
+- forbidden: no copy/overwrite/reinstall, host config edit, git lifecycle, GitHub lifecycle, installer, new daemon, commit, push, merge, rebase, reset, tag, release, issue lifecycle, PR lifecycle, label lifecycle, or apply/update command surface.
+- verification: `test_update_check.py`, `test_cli_command_router.py`, `test_restart_daemons.py`, `test_concurrency_monitor_snapshot.py`, `test_statusline.py`, `test_runtime_exception_authorization_sources.py`, `test_skill_reference_anchors.py`
+- no_new_runtime_authority: This is notify-only state projection; downstream installation or update application is host-owned and outside the skill runtime.
+
 <a id="integration-sync-daemon-53"></a>
 ## integration-sync-daemon-53
 

--- a/skills/codex-refactor-loop/host.env.example
+++ b/skills/codex-refactor-loop/host.env.example
@@ -54,6 +54,15 @@ export PROJECT_RULES="CLAUDE.md"
 # Default: release auto gate opt-in; false/empty exits 0 with noop reason.
 export RELEASE_AUTO_ENABLE="false"
 
+# Default/noop: notify-only skill update check; false/empty exits 0 with noop reason.
+export UPDATE_CHECK_ENABLE="false"
+
+# Default: minimum seconds between manual update-check probes.
+export UPDATE_CHECK_INTERVAL_SECONDS="21600"
+
+# Default: GitHub release/tag read timeout seconds.
+export UPDATE_CHECK_TIMEOUT_SECONDS="5"
+
 # Default: minimum recent merges required by auto_release_gate stability.
 export RELEASE_AUTO_MIN_MERGES="1"
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/cli.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/cli.py
@@ -22,6 +22,7 @@ from .restart import main as restart_main
 from .retention import main as retention_main
 from .sync.dev import main as dev_sync_main
 from .phase9.router import main as phase9_router_main
+from .update_check import main as update_check_main
 from .wakeup_plan import main as wakeup_plan_main
 
 
@@ -111,6 +112,11 @@ COMMANDS: dict[str, CommandSpec] = {
         release_required_checks_main,
         "check exact release required check-runs",
         ("read-gh",),
+    ),
+    "update-check": CommandSpec(
+        update_check_main,
+        "run the notify-only version update check probe",
+        ("read-source", "read-gh", "write-state"),
     ),
     "render-github-body": CommandSpec(
         github_body.main,

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -9,7 +9,7 @@ import re
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Sequence
 
@@ -18,6 +18,7 @@ from ..context import LoopContext, LoopContextError
 from ..heartbeat import DaemonHeartbeatLease
 from .. import labels as label_catalog
 from ..state import read_json, write_json
+from ..update_check import parse_time
 
 
 PROGRESS_MARKER_RE = re.compile(r"\b(PHASE|REVIEW|FIX|META)[A-Z_]*:")
@@ -154,10 +155,44 @@ class ConcurrencyMonitor:
             "daemons_healthy": healthy,
             "daemons_total": len(daemons),
         }
+        update_projection = self.read_update_projection(now=now)
+        if update_projection:
+            payload.update(update_projection)
         self.statusline_snapshot.parent.mkdir(parents=True, exist_ok=True)
         tmp = self.statusline_snapshot.with_name(f".{self.statusline_snapshot.name}.tmp.{os.getpid()}")
         tmp.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
         os.replace(tmp, self.statusline_snapshot)
+
+    def read_update_projection(self, *, now: datetime) -> dict[str, object]:
+        raw = read_json(self.ctx.paths.state / "update-check.json", {})
+        if not isinstance(raw, dict):
+            return {}
+        if raw.get("status") in {"disabled", "unknown"}:
+            return {}
+        checked_at = parse_time(raw.get("checked_at"))
+        if checked_at is None:
+            return {}
+        interval = raw.get("interval_seconds")
+        ttl = int(interval) if isinstance(interval, int) and interval > 0 else 21600
+        if now - checked_at > timedelta(seconds=ttl * 2):
+            return {}
+        if raw.get("update_available") is not True:
+            return {}
+        latest = raw.get("latest_version")
+        source = raw.get("update_source")
+        release_url = raw.get("release_url")
+        if not isinstance(latest, str) or not latest:
+            return {}
+        projection: dict[str, object] = {
+            "update_available": True,
+            "update_latest_version": latest,
+            "update_checked_at": raw["checked_at"],
+        }
+        if isinstance(source, str) and source:
+            projection["update_source"] = source
+        if isinstance(release_url, str) and release_url:
+            projection["update_release_url"] = release_url
+        return projection
 
     def list_in_flight_codex_lines(self) -> list[str]:
         lines: list[str] = []

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/gate.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/gate.py
@@ -6,7 +6,6 @@ import argparse
 import hashlib
 import json
 import os
-import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -17,6 +16,7 @@ from typing import Any, Callable, Sequence
 from .. import labels as label_catalog
 from ..state import read_json, write_json
 from .required_checks import REQUIRED_RELEASE_CHECKS, ReleaseRequiredChecksProjection
+from .versions import SEMVER_RE, bump_semver, compare_semver, parse_semver
 
 
 # Refactor (issue160-p3-auto-release-gate):
@@ -33,12 +33,6 @@ from .required_checks import REQUIRED_RELEASE_CHECKS, ReleaseRequiredChecksProje
 #   Old pattern: release.yml 保留 tag/release mutation,无法可靠读本地 runtime fact,绕过 release-gate decider-only 边界
 #   New principle: controller-only publication:新增 ReleasePublishPreflight+ReleasePublisher 替代 workflow 发布权;release.yml 降为 read-only preview(contents:read,禁 gh release create)。严格按 plan 'Concrete plan' 逐条改。
 
-SEMVER_RE = re.compile(
-    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
-    r"(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
-    r"(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?"
-    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
-)
 SIGNAL_NAMES = (
     "required_checks_recent_green",
     "no_open_blocked_pr",
@@ -539,27 +533,6 @@ def resolve_field(data: Any, field: str) -> Any:
             raise KeyError(f"cannot resolve {part!r} in {field}")
         current = current[part]
     return current
-
-
-def parse_semver(version: Any) -> tuple[int, int, int]:
-    if not isinstance(version, str):
-        raise ValueError(f"invalid semver: {version}")
-    match = SEMVER_RE.match(version)
-    if not match:
-        raise ValueError(f"invalid semver: {version}")
-    return tuple(int(part) for part in match.group(1, 2, 3))
-
-
-def bump_semver(version: str, bump_type: str) -> str:
-    # Bumps apply to the core version and intentionally drop pre-release/build metadata.
-    major, minor, patch = parse_semver(version)
-    if bump_type == "major":
-        return f"{major + 1}.0.0"
-    if bump_type == "minor":
-        return f"{major}.{minor + 1}.0"
-    if bump_type == "patch":
-        return f"{major}.{minor}.{patch + 1}"
-    raise ValueError(f"invalid bump type: {bump_type}")
 
 
 def classify_bump(commits: list[CommitInfo]) -> str:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publish_preflight.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publish_preflight.py
@@ -12,6 +12,7 @@ from typing import Any, Callable
 from ..state import read_json
 from .gate import isoformat, load_host_env, parse_time, resolve_field
 from .required_checks import REQUIRED_RELEASE_CHECKS
+from .versions import compare_semver
 
 
 REQUIRED_CANDIDATE_SCHEMA = "decision-artifact-only/v2"
@@ -199,7 +200,11 @@ class ReleasePublishPreflight:
         if not isinstance(to_version, str) or not to_version:
             reasons.append("candidate_version_missing")
             return
-        if version != to_version:
+        try:
+            versions_match = compare_semver(version, to_version) == 0
+        except ValueError:
+            versions_match = False
+        if not versions_match:
             reasons.append("manifest_version_mismatch")
         if decision and decision.get("to_version") != to_version:
             reasons.append("decision_version_mismatch")

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/versions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/versions.py
@@ -1,0 +1,119 @@
+"""Shared semver helpers for release and update-check surfaces."""
+
+from __future__ import annotations
+
+import re
+from functools import cmp_to_key
+from typing import Any
+
+
+# Refactor (issue231-update-check):
+#   Old pattern: release semver parsing lived inside release-gate and callers
+#   compared versions as exact strings.
+#   New principle: keep parse/bump compatibility while sharing SemVer ordering
+#   for release preflight and notify-only update checks.
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?"
+    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+
+class SemVer(tuple):
+    """Comparable semver value; tuple shape preserves lightweight callers."""
+
+    __slots__ = ()
+
+    def __new__(
+        cls,
+        major: int,
+        minor: int,
+        patch: int,
+        prerelease: tuple[str, ...] = (),
+        build: str | None = None,
+    ) -> "SemVer":
+        return tuple.__new__(cls, (major, minor, patch, prerelease, build))
+
+    @property
+    def major(self) -> int:
+        return self[0]
+
+    @property
+    def minor(self) -> int:
+        return self[1]
+
+    @property
+    def patch(self) -> int:
+        return self[2]
+
+    @property
+    def prerelease(self) -> tuple[str, ...]:
+        return self[3]
+
+    @property
+    def build(self) -> str | None:
+        return self[4]
+
+
+def parse_semver(version: Any) -> tuple[int, int, int]:
+    return parse_semver_full(version)[:3]
+
+
+def parse_semver_full(version: Any) -> SemVer:
+    if not isinstance(version, str):
+        raise ValueError(f"invalid semver: {version}")
+    match = SEMVER_RE.match(version)
+    if not match:
+        raise ValueError(f"invalid semver: {version}")
+    major, minor, patch = (int(part) for part in match.group(1, 2, 3))
+    prerelease = tuple((match.group(4) or "").split(".")) if match.group(4) else ()
+    return SemVer(major, minor, patch, prerelease, match.group(5))
+
+
+def bump_semver(version: str, bump_type: str) -> str:
+    # Bumps apply to the core version and intentionally drop pre-release/build metadata.
+    major, minor, patch = parse_semver(version)
+    if bump_type == "major":
+        return f"{major + 1}.0.0"
+    if bump_type == "minor":
+        return f"{major}.{minor + 1}.0"
+    if bump_type == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    raise ValueError(f"invalid bump type: {bump_type}")
+
+
+def compare_semver(left: str, right: str) -> int:
+    left_value = parse_semver_full(left)
+    right_value = parse_semver_full(right)
+    core_left = left_value[:3]
+    core_right = right_value[:3]
+    if core_left != core_right:
+        return (core_left > core_right) - (core_left < core_right)
+    return _compare_prerelease(left_value.prerelease, right_value.prerelease)
+
+
+def sort_semver(versions: list[str]) -> list[str]:
+    return sorted(versions, key=cmp_to_key(compare_semver))
+
+
+def _compare_prerelease(left: tuple[str, ...], right: tuple[str, ...]) -> int:
+    if not left and not right:
+        return 0
+    if not left:
+        return 1
+    if not right:
+        return -1
+    for left_part, right_part in zip(left, right):
+        if left_part == right_part:
+            continue
+        left_numeric = left_part.isdigit()
+        right_numeric = right_part.isdigit()
+        if left_numeric and right_numeric:
+            left_int = int(left_part)
+            right_int = int(right_part)
+            return (left_int > right_int) - (left_int < right_int)
+        if left_numeric != right_numeric:
+            return -1 if left_numeric else 1
+        return (left_part > right_part) - (left_part < right_part)
+    return (len(left) > len(right)) - (len(left) < len(right))

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/restart.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/restart.py
@@ -18,6 +18,7 @@ from typing import Any, Sequence
 from .active_controller import require_active_controller, write_active_controller_status
 from .context import LoopContext, LoopContextError
 from .retention import retain_logs
+from .update_check import maybe_run_update_check
 
 
 # Refactor (issue-160/phase2-shell-runtime): Old: restart-daemons.sh owned the
@@ -160,6 +161,7 @@ class RestartDaemons:
                 self.start_daemon(name, command)
         finally:
             self._release_restart_lock()
+        self._run_update_check()
         return 0
 
     def start_daemon(self, name: str, command_template: Sequence[str]) -> None:
@@ -227,6 +229,22 @@ class RestartDaemons:
             return
         suffix = " missing=true" if missing else ""
         self._log(f"log_retention: ttl_hours=24 deleted={deleted} kept={kept} target={target}{suffix}")
+
+    def _run_update_check(self) -> None:
+        # Refactor (issue231-update-check):
+        #   Old pattern: restart-daemons maintained only daemon wrappers and had
+        #   no startup projection for installed skill version drift.
+        #   New principle: after the fixed five-daemon pass, run the opt-in
+        #   notify-only probe and log warnings without blocking daemon restart.
+        try:
+            result = maybe_run_update_check(self.ctx, startup=True)
+        except Exception as exc:
+            self._log(f"update_check warning: {exc!r}")
+            return
+        status = result.get("status") if isinstance(result, dict) else "unknown"
+        reason = result.get("reason") if isinstance(result, dict) else None
+        suffix = f" reason={reason}" if reason else ""
+        self._log(f"update_check: status={status}{suffix}")
 
     def _acquire_restart_lock(self) -> None:
         attempts = 0

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/statusline.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/statusline.py
@@ -52,7 +52,10 @@ def render_snapshot(data: Mapping[str, Any]) -> str:
     freeze_seg = f" [STUCK {freeze}m]" if freeze > 5 else ""
     p0_seg = f" P0×{p0}" if p0 > 2 else ""
     d_seg = f" d:{d_healthy}/{d_total}" if d_total > 0 else ""
-    return f"{color}{icon} {actual}/{floor} PR:{prs} issue:{issues}{d_seg}{p0_seg}{freeze_seg}\033[0m"
+    update_seg = ""
+    if data.get("update_available") is True and data.get("update_latest_version"):
+        update_seg = f" up:v{data['update_latest_version']}"
+    return f"{color}{icon} {actual}/{floor} PR:{prs} issue:{issues}{d_seg}{update_seg}{p0_seg}{freeze_seg}\033[0m"
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/update_check.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/update_check.py
@@ -1,0 +1,262 @@
+"""Notify-only codex-refactor-loop update check probe."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from .context import LoopContext, LoopContextError
+from .release.versions import compare_semver
+from .state import read_json, write_json
+
+
+MANIFEST_RELATIVE = "skills/codex-refactor-loop/VERSION.json"
+STATE_RELATIVE = ".refactor-loop/state/update-check.json"
+DEFAULT_INTERVAL_SECONDS = 21600
+DEFAULT_TIMEOUT_SECONDS = 5
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_time(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def env_bool(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def env_int(value: str | None, default: int) -> int:
+    try:
+        parsed = int(value or "")
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+@dataclass(frozen=True)
+class GitHubReleaseVersion:
+    version: str
+    source: str
+    release_url: str | None = None
+
+
+class UpdateCheckProbe:
+    """Read local version and GitHub release/tag state, then write local notice state.
+
+    Refactor (issue231-update-check):
+      Old pattern: downstream installs had no checked-in version snapshot or
+      notify-only update surface.
+      New principle: opt-in probe only reads VERSION.json and GitHub release/tag
+      metadata, writes local state, and never applies, installs, or mutates hosts.
+    """
+
+    def __init__(
+        self,
+        ctx: LoopContext,
+        *,
+        now: Callable[[], datetime] = utc_now,
+        runner: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] | None = None,
+    ) -> None:
+        self.ctx = ctx
+        self.now = now
+        self.runner = runner or self._run
+
+    @property
+    def state_path(self) -> Path:
+        return self.ctx.paths.state / "update-check.json"
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.ctx.skill_root / "VERSION.json"
+
+    def maybe_run(self, *, startup: bool = False) -> dict[str, Any]:
+        env = self.ctx.host_env
+        now = self.now()
+        interval = env_int(env.get("UPDATE_CHECK_INTERVAL_SECONDS"), DEFAULT_INTERVAL_SECONDS)
+        if not env_bool(env.get("UPDATE_CHECK_ENABLE")):
+            return self._write_state(
+                status="disabled",
+                checked_at=now,
+                reason="UPDATE_CHECK_ENABLE is not true in host.env",
+                startup=startup,
+                interval_seconds=interval,
+            )
+        previous = read_json(self.state_path, {})
+        if not startup and isinstance(previous, dict):
+            checked_at = parse_time(previous.get("checked_at"))
+            if checked_at is not None and now - checked_at < timedelta(seconds=interval):
+                return previous
+        try:
+            manifest = self._load_manifest()
+            latest = self._latest_release_version(
+                manifest["repository"],
+                timeout=env_int(env.get("UPDATE_CHECK_TIMEOUT_SECONDS"), DEFAULT_TIMEOUT_SECONDS),
+            )
+            comparison = compare_semver(latest.version, manifest["version"])
+            return self._write_state(
+                status="ok",
+                checked_at=now,
+                local_version=manifest["version"],
+                latest_version=latest.version,
+                update_available=comparison > 0,
+                update_source=latest.source,
+                release_url=latest.release_url,
+                startup=startup,
+                interval_seconds=interval,
+            )
+        except Exception as exc:
+            return self._write_state(
+                status="unknown",
+                checked_at=now,
+                reason=f"{type(exc).__name__}: {exc}",
+                startup=startup,
+                interval_seconds=interval,
+            )
+
+    def _load_manifest(self) -> dict[str, str]:
+        raw = read_json(self.manifest_path, None)
+        if not isinstance(raw, dict):
+            raise RuntimeError("VERSION.json is missing or invalid")
+        expected = {
+            "schema": "codex-refactor-loop-version",
+            "release_source": "github-release-then-tag",
+            "install_hint": "host-owned",
+        }
+        for key, value in expected.items():
+            if raw.get(key) != value:
+                raise RuntimeError(f"VERSION.json {key} mismatch")
+        version = raw.get("version")
+        repository = raw.get("repository")
+        if not isinstance(version, str) or not version:
+            raise RuntimeError("VERSION.json version missing")
+        if not isinstance(repository, str) or "/" not in repository:
+            raise RuntimeError("VERSION.json repository missing")
+        return {"version": version, "repository": repository}
+
+    def _latest_release_version(self, repository: str, *, timeout: int) -> GitHubReleaseVersion:
+        try:
+            release = self._gh_api(["repos", repository, "releases", "latest"], timeout=timeout)
+            tag_name = release.get("tag_name") if isinstance(release, dict) else None
+            html_url = release.get("html_url") if isinstance(release, dict) else None
+            version = normalize_tag_version(tag_name)
+            if version:
+                return GitHubReleaseVersion(version=version, source="github-release", release_url=html_url if isinstance(html_url, str) else None)
+        except RuntimeError:
+            pass
+        tags = self._gh_api(["repos", repository, "tags"], timeout=timeout)
+        first_tag = tags[0] if isinstance(tags, list) and tags else None
+        tag_name = first_tag.get("name") if isinstance(first_tag, dict) else None
+        version = normalize_tag_version(tag_name)
+        if version:
+            return GitHubReleaseVersion(version=version, source="github-tag", release_url=f"https://github.com/{repository}/releases/tag/v{version}")
+        raise RuntimeError("no release or tag version found")
+
+    def _gh_api(self, args: Sequence[str], *, timeout: int) -> Any:
+        result = self.runner(["gh", "api", *args])
+        if result.returncode != 0:
+            raise RuntimeError((result.stderr or result.stdout or "gh api failed").strip())
+        try:
+            return json.loads(result.stdout or "null")
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("invalid gh api JSON") from exc
+
+    def _run(self, cmd: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        timeout = env_int(self.ctx.host_env.get("UPDATE_CHECK_TIMEOUT_SECONDS"), DEFAULT_TIMEOUT_SECONDS)
+        return subprocess.run(list(cmd), cwd=self.ctx.repo_root, capture_output=True, text=True, check=False, timeout=timeout)
+
+    def _write_state(
+        self,
+        *,
+        status: str,
+        checked_at: datetime,
+        reason: str | None = None,
+        local_version: str | None = None,
+        latest_version: str | None = None,
+        update_available: bool | None = None,
+        update_source: str | None = None,
+        release_url: str | None = None,
+        startup: bool = False,
+        interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "status": status,
+            "checked_at": isoformat(checked_at),
+            "startup": startup,
+            "interval_seconds": interval_seconds,
+            "manifest": MANIFEST_RELATIVE,
+            "authority": ["read-source", "read-gh", "write-state"],
+            "apply": "host-owned",
+        }
+        if reason:
+            payload["reason"] = reason
+        if local_version:
+            payload["local_version"] = local_version
+        if latest_version:
+            payload["latest_version"] = latest_version
+        if update_available is not None:
+            payload["update_available"] = update_available
+        if update_source:
+            payload["update_source"] = update_source
+        if release_url:
+            payload["release_url"] = release_url
+        write_json(self.state_path, payload)
+        return payload
+
+
+def normalize_tag_version(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if candidate.startswith("v"):
+        candidate = candidate[1:]
+    try:
+        compare_semver(candidate, candidate)
+    except ValueError:
+        return None
+    return candidate
+
+
+def maybe_run_update_check(ctx: LoopContext | None = None, *, startup: bool = False) -> dict[str, Any]:
+    if ctx is None:
+        ctx = LoopContext.load(cwd=os.getcwd())
+    return UpdateCheckProbe(ctx).maybe_run(startup=startup)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--startup", action="store_true", help="record this as a startup probe")
+    args = parser.parse_args(argv)
+    try:
+        result = maybe_run_update_check(startup=args.startup)
+    except LoopContextError as exc:
+        sys.stderr.write(f"FATAL: {exc}\n")
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex-refactor-loop/scripts/test_auto_release_gate.py
+++ b/skills/codex-refactor-loop/scripts/test_auto_release_gate.py
@@ -51,6 +51,7 @@ def copy_repo_fixture() -> tempfile.TemporaryDirectory[str]:
         ".codex-plugin/plugin.json",
         ".cursor-plugin/plugin.json",
         "gemini-extension.json",
+        "skills/codex-refactor-loop/VERSION.json",
     ]
     for relative in paths:
         source = REPO_ROOT / relative

--- a/skills/codex-refactor-loop/scripts/test_cli_command_router.py
+++ b/skills/codex-refactor-loop/scripts/test_cli_command_router.py
@@ -124,6 +124,7 @@ class RuntimeCommandRouterTests(unittest.TestCase):
                 "release-gate",
                 "release-required-checks",
                 "render-github-body",
+                "update-check",
             },
             set(COMMANDS),
         )
@@ -215,9 +216,17 @@ class RuntimeCommandRouterTests(unittest.TestCase):
             "sync-request",
             "release-publish",
             "publish-release",
+            "apply-update",
+            "check-update",
+            "install-update",
+            "update-apply",
         }:
             with self.subTest(command=command):
                 self.assertNotIn(command, COMMANDS)
+
+    def test_update_check_declares_exact_notify_only_authority(self) -> None:
+        self.assertEqual(("read-source", "read-gh", "write-state"), COMMANDS["update-check"].authority)
+        self.assertFalse(set(COMMANDS["update-check"].authority) & LIFECYCLE_TOKENS)
 
     def test_public_commands_expose_no_generic_lifecycle_authority_tokens(self) -> None:
         for name, spec in COMMANDS.items():

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor_snapshot.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor_snapshot.py
@@ -61,6 +61,11 @@ class ConcurrencyMonitorSnapshotTests(unittest.TestCase):
         )
         return json.loads(self.snapshot_path().read_text(encoding="utf-8"))
 
+    def write_update_state(self, payload: dict[str, object]) -> None:
+        path = self.repo / ".refactor-loop" / "state" / "update-check.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
     def fake_gh(self, cmd: list[str]) -> SimpleNamespace:
         if cmd[:3] == ["gh", "issue", "list"]:
             return SimpleNamespace(
@@ -229,6 +234,42 @@ class ConcurrencyMonitorSnapshotTests(unittest.TestCase):
         data = json.loads(self.snapshot_path().read_text(encoding="utf-8"))
         self.assertIn("last_p0_at", data)
         self.assertRegex(data["last_p0_at"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+    def test_snapshot_projects_only_fresh_positive_update_state(self) -> None:
+        now = datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+        self.write_update_state(
+            {
+                "status": "ok",
+                "checked_at": "2026-05-31T11:00:00Z",
+                "interval_seconds": 21600,
+                "update_available": True,
+                "latest_version": "1.0.0-rc.1",
+                "update_source": "github-release",
+                "release_url": "https://example/release",
+            }
+        )
+
+        data = self.write_snapshot(now=now)
+
+        self.assertTrue(data["update_available"])
+        self.assertEqual("1.0.0-rc.1", data["update_latest_version"])
+        self.assertEqual("2026-05-31T11:00:00Z", data["update_checked_at"])
+        self.assertEqual("github-release", data["update_source"])
+        self.assertEqual("https://example/release", data["update_release_url"])
+
+    def test_snapshot_omits_disabled_unknown_and_stale_update_state(self) -> None:
+        now = datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+        cases = (
+            {"status": "disabled", "checked_at": "2026-05-31T11:00:00Z", "update_available": True, "latest_version": "1.0.0"},
+            {"status": "unknown", "checked_at": "2026-05-31T11:00:00Z", "update_available": True, "latest_version": "1.0.0"},
+            {"status": "ok", "checked_at": "2026-05-30T00:00:00Z", "interval_seconds": 10, "update_available": True, "latest_version": "1.0.0"},
+            {"status": "ok", "checked_at": "2026-05-31T11:00:00Z", "interval_seconds": 21600, "update_available": False, "latest_version": "1.0.0"},
+        )
+        for payload in cases:
+            with self.subTest(payload=payload):
+                self.write_update_state(payload)
+                data = self.write_snapshot(now=now)
+                self.assertNotIn("update_available", data)
 
     def test_non_p0_tick_snapshot_path(self) -> None:
         state_path = self.repo / ".refactor-loop" / ".concurrency-monitor-state.json"

--- a/skills/codex-refactor-loop/scripts/test_design_identifier_boundary.py
+++ b/skills/codex-refactor-loop/scripts/test_design_identifier_boundary.py
@@ -123,6 +123,7 @@ class DesignIdentifierBoundaryTests(unittest.TestCase):
                 (".codex-plugin/plugin.json", "version"),
                 (".cursor-plugin/plugin.json", "version"),
                 ("gemini-extension.json", "version"),
+                ("skills/codex-refactor-loop/VERSION.json", "version"),
             },
             fields,
         )

--- a/skills/codex-refactor-loop/scripts/test_host_env_surface_matrix.py
+++ b/skills/codex-refactor-loop/scripts/test_host_env_surface_matrix.py
@@ -148,6 +148,9 @@ class HostEnvSurfaceMatrixTests(unittest.TestCase):
     def test_defaults_and_missing_behaviors_match(self) -> None:
         cases = {
             "RELEASE_AUTO_ENABLE": ("false", "false or empty exits 0 with noop reason"),
+            "UPDATE_CHECK_ENABLE": ("false", "disabled update-check state"),
+            "UPDATE_CHECK_INTERVAL_SECONDS": ("21600", "fresh local update-check state"),
+            "UPDATE_CHECK_TIMEOUT_SECONDS": ("5", "failures write unknown state"),
             "CODEX_FLOOR": ("5", "hard min `2`"),
             "ACTIVE_CONTROLLER_DEVICE_ID": ("", "single-device local-owner noop"),
             "ACTIVE_CONTROLLER_TTL_SECONDS": ("1800", "expired lease may be acquired by another device"),
@@ -163,6 +166,9 @@ class HostEnvSurfaceMatrixTests(unittest.TestCase):
                 self.assertIn(behavior, self.rows[key]["Missing/empty behavior"])
 
         self.assertEqual("optional-noop", self.rows["ACTIVE_CONTROLLER_DEVICE_ID"]["Category"])
+        self.assertEqual("optional-noop", self.rows["UPDATE_CHECK_ENABLE"]["Category"])
+        self.assertEqual("defaulted", self.rows["UPDATE_CHECK_INTERVAL_SECONDS"]["Category"])
+        self.assertEqual("defaulted", self.rows["UPDATE_CHECK_TIMEOUT_SECONDS"]["Category"])
         self.assertEqual("defaulted", self.rows["ACTIVE_CONTROLLER_TTL_SECONDS"]["Category"])
         self.assertEqual("defaulted", self.rows["ACTIVE_CONTROLLER_REF"]["Category"])
         self.assertIn("all devices upgraded", read(HOST_ENV_EXAMPLE))
@@ -244,6 +250,7 @@ class HostEnvSurfaceMatrixTests(unittest.TestCase):
         self.assertIn("MAINTAINER_WHITELIST is unset; comment-monitor fails closed", comment_monitor)
         self.assertIn('os.environ.get("CODEX_FLOOR", "5")', concurrency_monitor)
         self.assertIn("return max(2, floor)", concurrency_monitor)
+        self.assertIn('env.get("UPDATE_CHECK_ENABLE")', read(SCRIPTS_DIR / "codex_refactor_loop" / "update_check.py"))
         self.assertNotIn("DEGRADATION_WATCH_INTERVAL_SECONDS", concurrency_monitor)
         self.assertNotIn("DEGRADATION_WATCH_TIMEOUT_SECONDS", concurrency_monitor)
         self.assertIn("DEFAULT_RELEASE_ROLLUP_COOLDOWN_SECONDS = 21600", sync_dev)

--- a/skills/codex-refactor-loop/scripts/test_manifest_version_sync.py
+++ b/skills/codex-refactor-loop/scripts/test_manifest_version_sync.py
@@ -28,6 +28,7 @@ EXPECTED_VERSION_RECORDS = {
     (".codex-plugin/plugin.json", "version"),
     (".cursor-plugin/plugin.json", "version"),
     ("gemini-extension.json", "version"),
+    ("skills/codex-refactor-loop/VERSION.json", "version"),
 }
 
 
@@ -45,6 +46,7 @@ class ManifestVersionSyncTests(unittest.TestCase):
             {"path": ".codex-plugin/plugin.json", "field": "version"},
             {"path": ".cursor-plugin/plugin.json", "field": "version"},
             {"path": "gemini-extension.json", "field": "version"},
+            {"path": "skills/codex-refactor-loop/VERSION.json", "field": "version"},
         ]
         self.write_json(root, ".version-bump.json", {"files": files})
         self.write_json(root, "package.json", {"version": "1.2.3"})
@@ -54,6 +56,17 @@ class ManifestVersionSyncTests(unittest.TestCase):
         self.write_json(root, ".cursor-plugin/plugin.json", {"version": "1.2.3"})
         gemini_manifest = {"version": gemini_version} if include_gemini_field else {"name": "consensus-rnd"}
         self.write_json(root, "gemini-extension.json", gemini_manifest)
+        self.write_json(
+            root,
+            "skills/codex-refactor-loop/VERSION.json",
+            {
+                "schema": "codex-refactor-loop-version",
+                "version": "1.2.3",
+                "repository": "ChronoAIProject/consensus-rnd",
+                "release_source": "github-release-then-tag",
+                "install_hint": "host-owned",
+            },
+        )
 
     def write_single_record_fixture(
         self,

--- a/skills/codex-refactor-loop/scripts/test_package_checks.py
+++ b/skills/codex-refactor-loop/scripts/test_package_checks.py
@@ -27,6 +27,7 @@ EXPECTED_VERSION_RECORDS = {
     (".codex-plugin/plugin.json", "version"),
     (".cursor-plugin/plugin.json", "version"),
     ("gemini-extension.json", "version"),
+    ("skills/codex-refactor-loop/VERSION.json", "version"),
 }
 
 

--- a/skills/codex-refactor-loop/scripts/test_release_gate_module.py
+++ b/skills/codex-refactor-loop/scripts/test_release_gate_module.py
@@ -43,6 +43,7 @@ def copy_repo_fixture() -> tempfile.TemporaryDirectory[str]:
         ".codex-plugin/plugin.json",
         ".cursor-plugin/plugin.json",
         "gemini-extension.json",
+        "skills/codex-refactor-loop/VERSION.json",
     ]
     for relative in paths:
         source = REPO_ROOT / relative

--- a/skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py
@@ -119,6 +119,7 @@ class ReleasePipelineContractTests(unittest.TestCase):
             ".codex-plugin/plugin.json",
             ".cursor-plugin/plugin.json",
             "gemini-extension.json",
+            "skills/codex-refactor-loop/VERSION.json",
             ".github/scripts/bump_version.py",
         ]
         with tempfile.TemporaryDirectory() as tmp:

--- a/skills/codex-refactor-loop/scripts/test_release_publish_preflight.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publish_preflight.py
@@ -40,6 +40,7 @@ def copy_repo_fixture() -> tempfile.TemporaryDirectory[str]:
         ".codex-plugin/plugin.json",
         ".cursor-plugin/plugin.json",
         "gemini-extension.json",
+        "skills/codex-refactor-loop/VERSION.json",
     ):
         source = REPO_ROOT / relative
         target = repo / relative
@@ -336,6 +337,17 @@ class ReleasePublishPreflightTests(unittest.TestCase):
 
             self.assertFalse(result.allowed)
             self.assertIn("manifest_version_mismatch", result.reasons)
+
+    def test_manifest_version_compare_ignores_build_metadata(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            write_host_opt_in(repo)
+            write_ready_artifacts(repo, version="2.0.0+candidate")
+            set_mapped_version(repo, "2.0.0+manifest")
+
+            result = ReleasePublishPreflight(repo, now=lambda: NOW).validate(target_ref="abc123")
+
+            self.assertTrue(result.allowed, result.reasons)
 
     def test_unsynchronized_mapped_manifests_fail_closed(self) -> None:
         with copy_repo_fixture() as tmp:

--- a/skills/codex-refactor-loop/scripts/test_release_publisher.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publisher.py
@@ -42,6 +42,7 @@ def copy_repo_fixture() -> tempfile.TemporaryDirectory[str]:
         ".codex-plugin/plugin.json",
         ".cursor-plugin/plugin.json",
         "gemini-extension.json",
+        "skills/codex-refactor-loop/VERSION.json",
     ):
         source = REPO_ROOT / relative
         target = repo / relative
@@ -111,6 +112,7 @@ def expected_success_commands() -> list[list[str]]:
             ".codex-plugin/plugin.json",
             ".cursor-plugin/plugin.json",
             "gemini-extension.json",
+            "skills/codex-refactor-loop/VERSION.json",
         ],
         ["git", "commit", "-m", "Release v2.0.0"],
         ["git", "rev-parse", "HEAD"],
@@ -225,6 +227,7 @@ class ReleasePublisherTests(unittest.TestCase):
                 ".codex-plugin/plugin.json",
                 ".cursor-plugin/plugin.json",
                 "gemini-extension.json",
+                "skills/codex-refactor-loop/VERSION.json",
             ]
             runner.failures[tuple(failed_add)] = subprocess.CompletedProcess(failed_add, 1, stdout="", stderr="add failed")
             publisher = ReleasePublisher(repo, preflight=FakePreflight(allowed_result(repo)), runner=runner, now=lambda: NOW)

--- a/skills/codex-refactor-loop/scripts/test_release_versions.py
+++ b/skills/codex-refactor-loop/scripts/test_release_versions.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Behavior tests for shared semver helpers."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.release.versions import bump_semver, compare_semver, parse_semver
+
+
+class ReleaseVersionsTests(unittest.TestCase):
+    def test_parse_and_bump_compatibility(self) -> None:
+        self.assertEqual((1, 2, 3), parse_semver("1.2.3-beta.4+build.5"))
+        self.assertEqual("1.3.0", bump_semver("1.2.3-rc.1", "minor"))
+
+    def test_compare_prerelease_ordering(self) -> None:
+        self.assertGreater(compare_semver("1.0.0-beta.5", "1.0.0-beta.4"), 0)
+        self.assertGreater(compare_semver("1.0.0-rc.1", "1.0.0-beta.99"), 0)
+        self.assertGreater(compare_semver("1.0.0", "1.0.0-rc.1"), 0)
+        self.assertLess(compare_semver("1.0.0-alpha.1", "1.0.0-alpha.beta"), 0)
+
+    def test_build_metadata_does_not_affect_precedence(self) -> None:
+        self.assertEqual(0, compare_semver("1.0.0+abc", "1.0.0+def"))
+
+    def test_invalid_semver_fails_closed(self) -> None:
+        with self.assertRaises(ValueError):
+            compare_semver("v1.0", "1.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_restart_daemons.py
+++ b/skills/codex-refactor-loop/scripts/test_restart_daemons.py
@@ -89,6 +89,14 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         path = self.repo / ".refactor-loop" / "logs" / f"{name}.starts"
         return len(path.read_text(encoding="utf-8").splitlines()) if path.exists() else 0
 
+    def assert_start_count(self, name: str, expected: int) -> None:
+        deadline = time.time() + 2
+        while time.time() < deadline:
+            if self.start_count(name) == expected:
+                return
+            time.sleep(0.02)
+        self.assertEqual(expected, self.start_count(name))
+
     def read_pid(self, name: str) -> int:
         return int((self.repo / ".refactor-loop" / "locks" / f"{name}.pid").read_text(encoding="utf-8").strip())
 
@@ -136,6 +144,7 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
             self.assertIn("consensus-rnd-cli", joined)
             self.assertIn("--daemon", command)
         self.assertEqual({name for name, _command in DAEMON_COMMANDS}, set(DAEMON_NAMES))
+        self.assertEqual(5, len(DAEMON_COMMANDS))
 
     def test_help_exits_without_starting_daemons(self) -> None:
         with mock.patch.object(restart.RestartDaemons, "run") as run:
@@ -152,13 +161,14 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
 
     def test_restarts_dead_wrapper_pid_even_with_fresh_heartbeat(self) -> None:
         self.run_helper()
+        self.assert_start_count("concurrency_monitor", 1)
         old_pid = self.read_pid("concurrency_monitor")
         (self.repo / ".refactor-loop" / "heartbeats" / "concurrency_monitor.ts").write_text(f"{int(time.time())}\n", encoding="utf-8")
         self.terminate(old_pid)
         self.run_helper()
         new_pid = self.read_pid("concurrency_monitor")
         self.assertNotEqual(old_pid, new_pid)
-        self.assertEqual(2, self.start_count("concurrency_monitor"))
+        self.assert_start_count("concurrency_monitor", 2)
 
     def test_restarts_when_launch_fingerprint_changes(self) -> None:
         self.run_helper()
@@ -267,6 +277,30 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
 
         for name in DAEMON_NAMES:
             self.assertEqual(1, self.start_count(name))
+
+    def test_update_check_runs_after_static_daemon_pass_and_is_nonblocking(self) -> None:
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="restart-daemons", lease_id="lease", expires_at="")
+        calls: list[str] = []
+
+        def fake_start(helper: RestartDaemons, name: str, command: tuple[str, ...]) -> None:
+            calls.append(name)
+
+        with mock.patch("codex_refactor_loop.restart.require_active_controller", return_value=decision):
+            with mock.patch("codex_refactor_loop.restart.retain_logs", return_value=(0, 0, self.repo / ".refactor-loop" / "logs", False)):
+                with mock.patch.object(RestartDaemons, "start_daemon", fake_start):
+                    with mock.patch("codex_refactor_loop.restart.maybe_run_update_check", return_value={"status": "disabled", "reason": "noop"}) as update:
+                        helper = RestartDaemons(self.ctx, self.config)
+                        self.assertEqual(0, helper.run())
+
+        self.assertEqual(list(DAEMON_NAMES), calls)
+        update.assert_called_once_with(self.ctx, startup=True)
+
+        with mock.patch("codex_refactor_loop.restart.require_active_controller", return_value=decision):
+            with mock.patch("codex_refactor_loop.restart.retain_logs", return_value=(0, 0, self.repo / ".refactor-loop" / "logs", False)):
+                with mock.patch.object(RestartDaemons, "start_daemon", fake_start):
+                    with mock.patch("codex_refactor_loop.restart.maybe_run_update_check", side_effect=RuntimeError("network")):
+                        helper = RestartDaemons(self.ctx, self.config)
+                        self.assertEqual(0, helper.run())
 
     def test_restart_helper_source_mentions_launch_fingerprint_contract(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "restart.py").read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_runtime_exception_authorization_sources.py
+++ b/skills/codex-refactor-loop/scripts/test_runtime_exception_authorization_sources.py
@@ -24,6 +24,7 @@ TARGET_ANCHORS = {
     # Refactor (fix/pr236-mirror-source-regression): Old pattern: a new runtime mirror entry could be added without joining the targeted source-regression set. New principle: every named runtime exception mirror added for controller authority must be linked from SKILL.md and locked by focused source tests.
     "active-controller-lease-191": "## Named runtime exception - active controller lease(per #191)",
     "release-commits-producer-232": "release-commits` is the independent narrow producer",
+    "update-check-231": "## Notify-only update check(per #231)",
     "integration-sync-daemon-53": "## Named runtime exception — integration sync daemon(per #53)",
     "observability-comment-writers-53": "## Named runtime exception — observability-comment-writers(per #53)",
     "integration-sync-release-rollup-65": "## Named runtime exception — integration sync daemon(per #65)",
@@ -163,6 +164,32 @@ class RuntimeExceptionAuthorizationSourceTests(unittest.TestCase):
             "label lifecycle",
             "generic lifecycle authority",
             "inline execution from `release-gate`",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertIn(forbidden, entry)
+
+    def test_update_check_mirror_preserves_notify_only_boundary(self) -> None:
+        entry = mirror_entry(self.mirror, "update-check-231")
+
+        for token in (
+            "notify-only",
+            "VERSION.json",
+            ".refactor-loop/state/update-check.json",
+            "restart-daemons",
+            "statusline-snapshot.json",
+            "test_update_check.py",
+            "test_statusline.py",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, entry)
+                self.assertIn(token, self.skill)
+        for forbidden in (
+            "copy/overwrite/reinstall",
+            "host config edit",
+            "GitHub lifecycle",
+            "installer",
+            "new daemon",
+            "apply/update command surface",
         ):
             with self.subTest(forbidden=forbidden):
                 self.assertIn(forbidden, entry)

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -214,6 +214,33 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             walkthrough,
         )
 
+    def test_skill_documents_update_check_notify_only_contract(self) -> None:
+        section = section_after_heading(self.skill, "Notify-only update check(per #231)")
+        for needle in (
+            "VERSION.json",
+            "VersionSourceManifest",
+            ".version-bump.json",
+            "consensus-rnd-cli update-check",
+            "notify-only",
+            "$UPDATE_CHECK_ENABLE",
+            ".refactor-loop/state/update-check.json",
+            "host-owned",
+            "create a daemon",
+            "statusline-snapshot.json",
+            "test_statusline.py",
+            "skills/codex-refactor-loop/authorizations/runtime-exceptions.md#update-check-231",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
+        for forbidden in (
+            "copy, overwrite, reinstall",
+            "run installers",
+            "mutate `.git`",
+            "touches the network",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertIn(forbidden, section)
+
     def test_skill_documents_daemon_event_monitor_command(self) -> None:
         self.assertIn(
             "tail -n 0 -F .refactor-loop/.controller-pending-events.log .refactor-loop/.concurrency-alert.log 2>/dev/null \\",

--- a/skills/codex-refactor-loop/scripts/test_statusline.py
+++ b/skills/codex-refactor-loop/scripts/test_statusline.py
@@ -81,6 +81,10 @@ class StatuslineCliTests(unittest.TestCase):
         self.write_snapshot({"actual": 7, "expected": 5, "floor": 4, "p0_streak": 0, "open_pr_count": 5, "open_issue_count": 4, "freeze_minutes": 0})
         self.assertNotIn(" d:", self.run_statusline())
 
+    def test_update_available_renders_latest_version_from_snapshot(self) -> None:
+        self.write_snapshot({"actual": 7, "expected": 5, "floor": 4, "p0_streak": 0, "open_pr_count": 5, "open_issue_count": 4, "freeze_minutes": 0, "update_available": True, "update_latest_version": "1.0.0-rc.1"})
+        self.assertIn("up:v1.0.0-rc.1", self.run_statusline())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_update_check.py
+++ b/skills/codex-refactor-loop/scripts/test_update_check.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Behavior tests for notify-only update-check probe."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.context import LoopContext
+from codex_refactor_loop.update_check import UpdateCheckProbe
+
+
+NOW = datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+
+
+class UpdateCheckTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="update-check-test-"))
+        self.repo = self.tmp / "repo"
+        self.skill = self.tmp / "skill"
+        (self.repo / ".refactor-loop").mkdir(parents=True)
+        (self.skill).mkdir(parents=True)
+        shutil.copy2(REPO_ROOT / "skills/codex-refactor-loop/VERSION.json", self.skill / "VERSION.json")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def write_host_env(self, body: str) -> None:
+        (self.repo / ".refactor-loop/host.env").write_text(
+            f'export REPO_ROOT="{self.repo}"\n' + body,
+            encoding="utf-8",
+        )
+
+    def ctx(self) -> LoopContext:
+        return LoopContext.load(repo_root=self.repo, skill_root=self.skill)
+
+    def read_state(self) -> dict[str, object]:
+        return json.loads((self.repo / ".refactor-loop/state/update-check.json").read_text(encoding="utf-8"))
+
+    def test_disabled_writes_noop_state_and_does_not_call_github(self) -> None:
+        self.write_host_env('export UPDATE_CHECK_ENABLE="false"\n')
+        calls: list[list[str]] = []
+
+        probe = UpdateCheckProbe(self.ctx(), now=lambda: NOW, runner=lambda cmd: calls.append(list(cmd)) or SimpleNamespace(returncode=1, stdout="", stderr="called"))
+        result = probe.maybe_run(startup=True)
+
+        self.assertEqual("disabled", result["status"])
+        self.assertIn("UPDATE_CHECK_ENABLE", result["reason"])
+        self.assertEqual([], calls)
+        self.assertEqual("disabled", self.read_state()["status"])
+
+    def test_release_newer_than_local_sets_update_available(self) -> None:
+        self.write_host_env('export UPDATE_CHECK_ENABLE="true"\nexport UPDATE_CHECK_INTERVAL_SECONDS="21600"\n')
+
+        def runner(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+            self.assertEqual(["gh", "api", "repos", "ChronoAIProject/consensus-rnd", "releases", "latest"], cmd)
+            return subprocess.CompletedProcess(cmd, 0, json.dumps({"tag_name": "v1.0.0-rc.1", "html_url": "https://example/release"}), "")
+
+        result = UpdateCheckProbe(self.ctx(), now=lambda: NOW, runner=runner).maybe_run(startup=True)
+
+        self.assertEqual("ok", result["status"])
+        self.assertTrue(result["update_available"])
+        self.assertEqual("1.0.0-rc.1", result["latest_version"])
+        self.assertEqual("github-release", result["update_source"])
+        self.assertEqual("https://example/release", result["release_url"])
+
+    def test_release_failure_falls_back_to_tags(self) -> None:
+        self.write_host_env('export UPDATE_CHECK_ENABLE="true"\n')
+        calls: list[list[str]] = []
+
+        def runner(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+            calls.append(list(cmd))
+            if cmd[-1] == "latest":
+                return subprocess.CompletedProcess(cmd, 1, "", "not found")
+            return subprocess.CompletedProcess(cmd, 0, json.dumps([{"name": "v1.0.0-beta.4"}]), "")
+
+        result = UpdateCheckProbe(self.ctx(), now=lambda: NOW, runner=runner).maybe_run(startup=True)
+
+        self.assertEqual("ok", result["status"])
+        self.assertEqual("github-tag", result["update_source"])
+        self.assertEqual("1.0.0-beta.4", result["latest_version"])
+        self.assertEqual(2, len(calls))
+
+    def test_github_error_writes_unknown_and_does_not_raise(self) -> None:
+        self.write_host_env('export UPDATE_CHECK_ENABLE="true"\n')
+
+        result = UpdateCheckProbe(
+            self.ctx(),
+            now=lambda: NOW,
+            runner=lambda cmd: subprocess.CompletedProcess(cmd, 1, "", "network down"),
+        ).maybe_run(startup=True)
+
+        self.assertEqual("unknown", result["status"])
+        self.assertIn("network down", result["reason"])
+        self.assertEqual("unknown", self.read_state()["status"])
+
+    def test_manual_probe_reuses_fresh_state_before_interval(self) -> None:
+        self.write_host_env('export UPDATE_CHECK_ENABLE="true"\nexport UPDATE_CHECK_INTERVAL_SECONDS="21600"\n')
+        state_path = self.repo / ".refactor-loop/state/update-check.json"
+        state_path.parent.mkdir(parents=True)
+        state_path.write_text(
+            json.dumps({"status": "ok", "checked_at": "2026-05-31T11:00:00Z", "latest_version": "1.0.0"}) + "\n",
+            encoding="utf-8",
+        )
+        calls: list[list[str]] = []
+
+        result = UpdateCheckProbe(
+            self.ctx(),
+            now=lambda: NOW,
+            runner=lambda cmd: calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 1, "", "called"),
+        ).maybe_run(startup=False)
+
+        self.assertEqual("ok", result["status"])
+        self.assertEqual([], calls)
+
+    def test_version_manifest_is_data_only(self) -> None:
+        manifest = json.loads((REPO_ROOT / "skills/codex-refactor-loop/VERSION.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            {
+                "schema",
+                "version",
+                "repository",
+                "release_source",
+                "install_hint",
+            },
+            set(manifest),
+        )
+        serialized = json.dumps(manifest, sort_keys=True)
+        for forbidden in ("/Users/", "curl ", "bash ", "install.sh", "https://"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

issue #231 design-consensus r4 consensus(**B structural**):notify-only 更新检测 + version manifest + shared semver。

- **新增** checked-in `VERSION.json`(data-only install manifest:schema/version/repository/release_source/install_hint;仅 version 进 version-bump map)。
- **新增** `update_check.py` notify-only probe(`UPDATE_CHECK_ENABLE` opt-in,读 GitHub release/tag,写 `.refactor-loop/state/update-check.json`;缺失/false noop;错误写 unknown/disabled 不阻断 restart)。
- **新增** `release/versions.py` shared semver(`compare_semver`/prerelease 排序),release gate / publish preflight / update-check 共用。
- `concurrency` 每 tick 投影 update 字段到 `statusline-snapshot.json`;`statusline` 只读 snapshot 显示 `up:v<latest>`,不触网。
- `CLAUDE.md`/`AGENTS.md` 版本同步 6→7 targets(加 VERSION.json);`update-check-231` authorization mirror。

**边界**:notify-only,apply 由 host 自理,无 host mutation,无新 daemon,无 lifecycle authority。

## 范围

31 files changed (+2107/-56)。定向 test 全绿:test_update_check / test_manifest_version_sync / test_release_versions / test_cli_command_router / test_restart_daemons。

Closes #231

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
