### PR TITLE
fix(#272): release-gate 遵循预发布阶梯(beta.3→beta.4 而非 1.0.1)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1023,7 +1023,7 @@ Stability score is the percentage of the eight boolean signals that pass. `ready
 
 Tests or controller-side aggregators may write `.refactor-loop/state/auto-release-signals.json` with either booleans or `{ "passed": bool, ... }` objects for those same keys. When that file exists, it is the deterministic source for the eight gate signals.
 
-Semver bump is computed from `.refactor-loop/state/release-commits.json` entries since the latest release: `feat!:` or `BREAKING CHANGE:` yields `major`; otherwise any `feat:` yields `minor`; otherwise `fix:`, `perf:`, `refactor:`, or any other commit yields `patch`. If stability is not ready, no commits exist, or the minimum release interval has not elapsed, `bump_type` is null and `to_version == from_version`.
+Semver bump is computed from `.refactor-loop/state/release-commits.json` entries since the latest release: `feat!:` or `BREAKING CHANGE:` yields `major`; otherwise any `feat:` yields `minor`; otherwise `fix:`, `perf:`, `refactor:`, or any other commit yields `patch`. `next_release_version()` computes `to_version` from that `bump_type`; on a prerelease base such as `X.Y.Z-beta.N` or `X.Y.Z-rc.N`, the default target is same-stage `N+1`. `bump_type` is commit-impact metadata, not promotion authority: it does not authorize beta-to-rc, beta-to-GA, rc-to-GA, or core promotion while on the prerelease ladder. If stability is not ready, no commits exist, or the minimum release interval has not elapsed, `bump_type` is null and `to_version == from_version`.
 
 `.refactor-loop/state/release-decision.json` fields:
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/gate.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/gate.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Sequence
 from .. import labels as label_catalog
 from ..state import read_json, write_json
 from .required_checks import REQUIRED_RELEASE_CHECKS, ReleaseRequiredChecksProjection
-from .versions import SEMVER_RE, bump_semver, compare_semver, parse_semver
+from .versions import SEMVER_RE, bump_semver, compare_semver, next_release_version, parse_semver
 
 
 # Refactor (issue160-p3-auto-release-gate):
@@ -444,6 +444,9 @@ class AutoReleaseGate:
         return commits
 
     def decide_release(self, stability: StabilityResult, min_interval_hours: int) -> dict[str, Any]:
+        # Refactor (iter272/issue-272):
+        #   Old pattern: release-gate semver 不遵循预发布阶梯:beta.3+patch commits → 误算 1.0.1(GA,三重越阶)
+        #   New principle: 结构化修复:新增 versions.next_release_version helper 按预发布阶梯递推(beta.N→beta.N+1,绝不自动升阶/off-ladder),preflight 增 off-ladder validation 拒绝越阶 target;不引入 schema v3 / ReleaseCoordinatePolicy
         now = self.now()
         from_version = self.current_version()
         interval = self.release_interval_status(now, min_interval_hours)
@@ -451,7 +454,7 @@ class AutoReleaseGate:
         candidate_bump = classify_bump(commits) if commits else None
         release_ready = stability.ready and interval["passed"] and bool(commits)
         bump_type = candidate_bump if release_ready else None
-        to_version = bump_semver(from_version, bump_type) if bump_type else from_version
+        to_version = next_release_version(from_version, bump_type) if bump_type else from_version
         return {
             "from_version": from_version,
             "to_version": to_version,

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publish_preflight.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publish_preflight.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 from ..state import read_json
 from .gate import isoformat, load_host_env, parse_time, resolve_field
 from .required_checks import REQUIRED_RELEASE_CHECKS
-from .versions import compare_semver
+from .versions import compare_semver, validate_release_version_coordinate
 
 
 REQUIRED_CANDIDATE_SCHEMA = "decision-artifact-only/v2"
@@ -196,6 +196,9 @@ class ReleasePublishPreflight:
         return next(iter(versions))
 
     def _validate_version(self, candidate: dict[str, Any], decision: dict[str, Any], version: str, reasons: list[str]) -> None:
+        # Refactor (iter272/issue-272):
+        #   Old pattern: release-gate semver 不遵循预发布阶梯:beta.3+patch commits → 误算 1.0.1(GA,三重越阶)
+        #   New principle: 结构化修复:新增 versions.next_release_version helper 按预发布阶梯递推(beta.N→beta.N+1,绝不自动升阶/off-ladder),preflight 增 off-ladder validation 拒绝越阶 target;不引入 schema v3 / ReleaseCoordinatePolicy
         to_version = candidate.get("to_version")
         if not isinstance(to_version, str) or not to_version:
             reasons.append("candidate_version_missing")
@@ -208,6 +211,13 @@ class ReleasePublishPreflight:
             reasons.append("manifest_version_mismatch")
         if decision and decision.get("to_version") != to_version:
             reasons.append("decision_version_mismatch")
+        from_version = candidate.get("from_version")
+        if not isinstance(from_version, str) or not from_version:
+            reasons.append("candidate_from_version_missing")
+            return
+        coordinate_reason = validate_release_version_coordinate(from_version, to_version, candidate.get("bump_type"))
+        if coordinate_reason is not None:
+            reasons.append(coordinate_reason)
 
     def _validate_required_signals(self, candidate: dict[str, Any], decision: dict[str, Any], reasons: list[str]) -> None:
         signals = candidate.get("required_signals")

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/versions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/versions.py
@@ -83,6 +83,44 @@ def bump_semver(version: str, bump_type: str) -> str:
     raise ValueError(f"invalid bump type: {bump_type}")
 
 
+def next_release_version(version: str, bump_type: str) -> str:
+    """Compute the next release coordinate.
+
+    bump_type records commit impact; for beta.N / rc.N it never authorizes
+    stage/core promotion.
+    """
+    # Refactor (iter272/issue-272):
+    #   Old pattern: release-gate semver 不遵循预发布阶梯:beta.3+patch commits → 误算 1.0.1(GA,三重越阶)
+    #   New principle: 结构化修复:新增 versions.next_release_version helper 按预发布阶梯递推(beta.N→beta.N+1,绝不自动升阶/off-ladder),preflight 增 off-ladder validation 拒绝越阶 target;不引入 schema v3 / ReleaseCoordinatePolicy
+    current = parse_semver_full(version)
+    if not current.prerelease:
+        return bump_semver(version, bump_type)
+    _validate_bump_type(bump_type)
+    if (
+        len(current.prerelease) != 2
+        or current.prerelease[0] not in {"beta", "rc"}
+        or not current.prerelease[1].isdigit()
+    ):
+        raise ValueError(f"unsupported prerelease ladder: {version}")
+    stage, index = current.prerelease
+    return f"{current.major}.{current.minor}.{current.patch}-{stage}.{int(index) + 1}"
+
+
+def validate_release_version_coordinate(from_version: str, to_version: str, bump_type: str | None) -> str | None:
+    # Refactor (iter272/issue-272):
+    #   Old pattern: release-gate semver 不遵循预发布阶梯:beta.3+patch commits → 误算 1.0.1(GA,三重越阶)
+    #   New principle: 结构化修复:新增 versions.next_release_version helper 按预发布阶梯递推(beta.N→beta.N+1,绝不自动升阶/off-ladder),preflight 增 off-ladder validation 拒绝越阶 target;不引入 schema v3 / ReleaseCoordinatePolicy
+    if not isinstance(bump_type, str) or not bump_type:
+        return "release_coordinate_off_ladder"
+    try:
+        expected = next_release_version(from_version, bump_type)
+        if compare_semver(expected, to_version) == 0:
+            return None
+    except ValueError:
+        pass
+    return "release_coordinate_off_ladder"
+
+
 def compare_semver(left: str, right: str) -> int:
     left_value = parse_semver_full(left)
     right_value = parse_semver_full(right)
@@ -95,6 +133,11 @@ def compare_semver(left: str, right: str) -> int:
 
 def sort_semver(versions: list[str]) -> list[str]:
     return sorted(versions, key=cmp_to_key(compare_semver))
+
+
+def _validate_bump_type(bump_type: str) -> None:
+    if bump_type not in {"major", "minor", "patch"}:
+        raise ValueError(f"invalid bump type: {bump_type}")
 
 
 def _compare_prerelease(left: tuple[str, ...], right: tuple[str, ...]) -> int:

--- a/skills/codex-refactor-loop/scripts/test_auto_release_gate.py
+++ b/skills/codex-refactor-loop/scripts/test_auto_release_gate.py
@@ -19,7 +19,8 @@ NOW = datetime(2026, 5, 26, 12, 0, tzinfo=timezone.utc)
 sys.path.insert(0, str(SCRIPT_PATH.parent))
 
 from codex_refactor_loop import labels as label_catalog
-from codex_refactor_loop.release.gate import AutoReleaseGate, CommitInfo, bump_semver, classify_bump
+from codex_refactor_loop.release.gate import AutoReleaseGate, CommitInfo, classify_bump
+from codex_refactor_loop.release.versions import next_release_version
 
 
 def write_json(path: Path, data: object) -> None:
@@ -259,7 +260,26 @@ def write_green_signals(repo: Path) -> None:
 
 
 def classify_expected_patch(version: str) -> str:
-    return bump_semver(version, "patch")
+    return next_release_version(version, "patch")
+
+
+def set_mapped_version(repo: Path, version: str) -> None:
+    # refactor helper, no behavior change
+    mapping = read_json(repo / ".version-bump.json")
+    assert isinstance(mapping, dict)
+    for item in mapping["files"]:
+        path = repo / item["path"]
+        data = read_json(path)
+        current = data
+        parts = item["field"].split(".")
+        for part in parts[:-1]:
+            current = current[int(part)] if isinstance(current, list) else current[part]
+        last = parts[-1]
+        if isinstance(current, list):
+            current[int(last)] = version
+        else:
+            current[last] = version
+        write_json(path, data)
 
 
 class AutoReleaseGateBehaviorTests(unittest.TestCase):
@@ -892,6 +912,46 @@ class AutoReleaseGateBehaviorTests(unittest.TestCase):
             self.assertEqual(candidate["from_version"], decision["from_version"])
             self.assertEqual(candidate["to_version"], decision["to_version"])
             self.assertEqual((repo / "package.json").read_text(encoding="utf-8"), before)
+
+    def test_dispatch_from_beta_base_writes_beta_next_candidate(self) -> None:
+        cases = (
+            ("fix: fixture", "", "patch"),
+            ("feat: fixture", "", "minor"),
+            ("feat!: fixture", "", "major"),
+        )
+        for subject, body, expected_bump in cases:
+            with self.subTest(expected_bump=expected_bump), copy_repo_fixture() as tmp:
+                repo = Path(tmp) / "repo"
+                write_opt_in(repo)
+                write_green_signals(repo)
+                set_mapped_version(repo, "1.0.0-beta.3")
+                write_json(
+                    repo / ".refactor-loop/state/release-commits.json",
+                    {"commits": [{"sha": "abc123", "subject": subject, "body": body}]},
+                )
+                env = {**os.environ, "REPO_ROOT": str(repo)}
+
+                result = subprocess.run(
+                    [sys.executable, str(SCRIPT_PATH.with_name("consensus-rnd-cli")), "release-gate", "--dispatch", "--min-recent-merges", "0"],
+                    cwd=repo,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                decision = read_json(repo / ".refactor-loop/state/release-decision.json")
+                candidate = read_json(repo / ".refactor-loop/state/release-candidate.json")
+                self.assertIsInstance(decision, dict)
+                self.assertIsInstance(candidate, dict)
+                assert isinstance(decision, dict)
+                assert isinstance(candidate, dict)
+                self.assertEqual(decision["from_version"], "1.0.0-beta.3")
+                self.assertEqual(decision["to_version"], "1.0.0-beta.4")
+                self.assertEqual(decision["bump_type"], expected_bump)
+                self.assertEqual(candidate["to_version"], "1.0.0-beta.4")
+                self.assertNotIn(decision["to_version"], {"1.0.1", "1.0.0"})
 
     def test_score_only_cli_prints_stability_no_decision_write(self) -> None:
         """--score-only path prints stability summary, does not write decision.json or bump."""

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -287,5 +287,18 @@ class MetadataOnlyIssue193SourceTests(unittest.TestCase):
                 self.assertNotIn(forbidden, combined)
 
 
+class ReleaseSemverLadderSourceTests(unittest.TestCase):
+    def test_release_gate_uses_next_release_version_not_raw_core_bump(self) -> None:
+        gate_source = (SCRIPT_DIR / "codex_refactor_loop" / "release" / "gate.py").read_text(encoding="utf-8")
+        preflight_source = (SCRIPT_DIR / "codex_refactor_loop" / "release" / "publish_preflight.py").read_text(encoding="utf-8")
+        skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+
+        self.assertIn("next_release_version", gate_source)
+        self.assertIn("validate_release_version_coordinate", preflight_source)
+        self.assertNotIn("bump_semver(from_version, bump_type)", gate_source)
+        self.assertIn("same-stage `N+1`", skill)
+        self.assertIn("`bump_type` is commit-impact metadata, not promotion authority", skill)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_release_gate_module.py
+++ b/skills/codex-refactor-loop/scripts/test_release_gate_module.py
@@ -128,7 +128,7 @@ class ReleaseGateModuleTests(unittest.TestCase):
             # (dispatch is artifact-only, no bump), surviving every release.
             current_version = read_json(repo / "package.json")["version"]
             self.assertEqual(decision["from_version"], current_version)
-            self.assertEqual(decision["to_version"], gate.bump_semver(current_version, "patch"))
+            self.assertEqual(decision["to_version"], gate.next_release_version(current_version, "patch"))
             self.assertEqual(decision["bump_type"], "patch")
             self.assertEqual(list(decision["signals"].keys()), list(gate.SIGNAL_NAMES))
             candidate = read_json(repo / ".refactor-loop/state/release-candidate.json")

--- a/skills/codex-refactor-loop/scripts/test_release_publish_preflight.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publish_preflight.py
@@ -271,6 +271,8 @@ class ReleasePublishPreflightTests(unittest.TestCase):
             ("candidate_not_ready", lambda candidate: candidate.__setitem__("ready", False)),
             ("target_ref_missing", lambda candidate: candidate.pop("target_ref")),
             ("candidate_version_missing", lambda candidate: candidate.pop("to_version")),
+            ("candidate_from_version_missing", lambda candidate: candidate.pop("from_version")),
+            ("release_coordinate_off_ladder", lambda candidate: candidate.pop("bump_type")),
             ("decision_digest_missing", lambda candidate: candidate.pop("decision_digest")),
         )
         for expected_reason, mutate_candidate in cases:

--- a/skills/codex-refactor-loop/scripts/test_release_publish_preflight.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publish_preflight.py
@@ -105,7 +105,9 @@ def green_required_signals() -> dict[str, object]:
 def write_ready_artifacts(
     repo: Path,
     *,
+    from_version: str = "1.9.9",
     version: str = "2.0.0",
+    bump_type: str = "patch",
     target_ref: str = "abc123",
     generated_at: datetime = NOW,
     expires_at: datetime | None = None,
@@ -113,9 +115,9 @@ def write_ready_artifacts(
 ) -> None:
     set_mapped_version(repo, version)
     decision = {
-        "from_version": "1.9.9",
+        "from_version": from_version,
         "to_version": version,
-        "bump_type": "patch",
+        "bump_type": bump_type,
         "commits": [{"sha": "abc", "subject": "fix: release"}],
         "decided_at": isoformat(generated_at),
         "stability_score": 100,
@@ -131,7 +133,7 @@ def write_ready_artifacts(
         "decision_artifact": ".refactor-loop/state/release-decision.json",
         "from_version": decision["from_version"],
         "to_version": version,
-        "bump_type": "patch",
+        "bump_type": bump_type,
         "ready": True,
         "target_ref": target_ref,
         "required_signals": decision["signals"],
@@ -189,13 +191,35 @@ class ReleasePublishPreflightTests(unittest.TestCase):
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"
             write_host_opt_in(repo)
-            write_ready_artifacts(repo, version="2.0.0", target_ref="abc123")
+            write_ready_artifacts(repo, from_version="1.9.9", version="1.9.10", target_ref="abc123")
 
             result = ReleasePublishPreflight(repo, now=lambda: NOW).validate(target_ref="abc123")
 
             self.assertTrue(result.allowed, result.reasons)
-            self.assertEqual(result.version, "2.0.0")
+            self.assertEqual(result.version, "1.9.10")
             self.assertEqual(result.target_ref, "abc123")
+
+    def test_publish_preflight_allows_same_stage_prerelease_candidate(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            write_host_opt_in(repo)
+            write_ready_artifacts(repo, from_version="1.0.0-beta.3", version="1.0.0-beta.4")
+
+            result = ReleasePublishPreflight(repo, now=lambda: NOW).validate(target_ref="abc123")
+
+            self.assertTrue(result.allowed, result.reasons)
+            self.assertEqual(result.version, "1.0.0-beta.4")
+
+    def test_publish_preflight_rejects_off_ladder_prerelease_candidate(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            write_host_opt_in(repo)
+            write_ready_artifacts(repo, from_version="1.0.0-beta.3", version="1.0.1")
+
+            result = ReleasePublishPreflight(repo, now=lambda: NOW).validate(target_ref="abc123")
+
+            self.assertFalse(result.allowed)
+            self.assertIn("release_coordinate_off_ladder", result.reasons)
 
     def test_candidate_path_must_be_repo_relative_artifact(self) -> None:
         with copy_repo_fixture() as tmp:
@@ -342,8 +366,8 @@ class ReleasePublishPreflightTests(unittest.TestCase):
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"
             write_host_opt_in(repo)
-            write_ready_artifacts(repo, version="2.0.0+candidate")
-            set_mapped_version(repo, "2.0.0+manifest")
+            write_ready_artifacts(repo, from_version="1.9.9", version="1.9.10+candidate")
+            set_mapped_version(repo, "1.9.10+manifest")
 
             result = ReleasePublishPreflight(repo, now=lambda: NOW).validate(target_ref="abc123")
 

--- a/skills/codex-refactor-loop/scripts/test_release_versions.py
+++ b/skills/codex-refactor-loop/scripts/test_release_versions.py
@@ -11,7 +11,13 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from codex_refactor_loop.release.versions import bump_semver, compare_semver, parse_semver
+from codex_refactor_loop.release.versions import (
+    bump_semver,
+    compare_semver,
+    next_release_version,
+    parse_semver,
+    validate_release_version_coordinate,
+)
 
 
 class ReleaseVersionsTests(unittest.TestCase):
@@ -31,6 +37,30 @@ class ReleaseVersionsTests(unittest.TestCase):
     def test_invalid_semver_fails_closed(self) -> None:
         with self.assertRaises(ValueError):
             compare_semver("v1.0", "1.0.0")
+
+    def test_next_release_version_beta_stays_same_stage_for_patch_minor_major(self) -> None:
+        for bump_type in ("patch", "minor", "major"):
+            with self.subTest(bump_type=bump_type):
+                self.assertEqual("1.0.0-beta.4", next_release_version("1.0.0-beta.3", bump_type))
+
+    def test_next_release_version_rc_stays_same_stage(self) -> None:
+        self.assertEqual("1.0.0-rc.3", next_release_version("1.0.0-rc.2", "patch"))
+
+    def test_next_release_version_ga_preserves_core_bump_semantics(self) -> None:
+        self.assertEqual("1.0.1", next_release_version("1.0.0", "patch"))
+        self.assertEqual("1.1.0", next_release_version("1.0.0", "minor"))
+        self.assertEqual("2.0.0", next_release_version("1.0.0", "major"))
+
+    def test_next_release_version_malformed_prerelease_fails_closed(self) -> None:
+        with self.assertRaises(ValueError):
+            next_release_version("1.0.0-beta.x", "patch")
+
+    def test_validate_release_version_coordinate_rejects_off_ladder(self) -> None:
+        self.assertEqual(
+            "release_coordinate_off_ladder",
+            validate_release_version_coordinate("1.0.0-beta.3", "1.0.1", "patch"),
+        )
+        self.assertIsNone(validate_release_version_coordinate("1.0.0-beta.3", "1.0.0-beta.4", "patch"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

修复 #272:`release-gate` 计算下一发布版本时不遵循 CLAUDE.md「版本迭代」预发布阶梯,把 `1.0.0-beta.3` 误算成 GA `1.0.1`(三连跳阶位),会在 publish 边界产生不可逆的错误 tag。

- **Old**:bump 计算无视当前版本的 `-beta.N` / `-rc.N` 预发布坐标,直接按 commit 类型推 GA semver(`feat`→minor / 其余→patch),导致 `beta.3` → `1.0.1`。
- **New**:遵循 `X.Y.Z-beta.N → X.Y.Z-rc.N → X.Y.Z`(GA)阶梯——同阶位只递增 `N`(`beta.3`→`beta.4`),升阶位需 release gate 连续达标且无回归证据;不在预发布坐标上跳算 GA patch。

违反:CLAUDE.md「版本迭代(规范)」——预发布阶梯 `beta.N → rc.N → GA`、「不临时拍版本」、「坏版即弃,不动已发 tag」。

## 范围

`release/gate.py`、`release/publish_preflight.py`、`release/versions.py` + 4 个 release 测试文件(`test_auto_release_gate` / `test_release_versions` / `test_release_gate_module` / `test_release_publish_preflight`)+ SKILL.md。阶梯递推与回归由 behavior + source-regression test 锁定。

#272 经设计共识 r1→r3 converge→consensus 后实施。

<details><summary>本机调试线索</summary>

consensus plan:`.refactor-loop/runs/phase9-issue272-r3-judge.md`

</details>

🤖 controller / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
