### PR TITLE
Release rollup

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publish_preflight.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publish_preflight.py
@@ -196,25 +196,25 @@ class ReleasePublishPreflight:
         return next(iter(versions))
 
     def _validate_version(self, candidate: dict[str, Any], decision: dict[str, Any], version: str, reasons: list[str]) -> None:
-        # Refactor (iter272/issue-272):
-        #   Old pattern: release-gate semver 不遵循预发布阶梯:beta.3+patch commits → 误算 1.0.1(GA,三重越阶)
-        #   New principle: 结构化修复:新增 versions.next_release_version helper 按预发布阶梯递推(beta.N→beta.N+1,绝不自动升阶/off-ladder),preflight 增 off-ladder validation 拒绝越阶 target;不引入 schema v3 / ReleaseCoordinatePolicy
+        # Refactor (iter279/issue-279):
+        #   Old pattern: preflight compared pre-bump manifests against to_version and rejected valid beta.N to beta.N+1 candidates.
+        #   New principle: preflight validates current manifests against from_version, while coordinate validation still gates from_version to to_version.
         to_version = candidate.get("to_version")
         if not isinstance(to_version, str) or not to_version:
             reasons.append("candidate_version_missing")
             return
+        from_version = candidate.get("from_version")
+        if not isinstance(from_version, str) or not from_version:
+            reasons.append("candidate_from_version_missing")
+            return
         try:
-            versions_match = compare_semver(version, to_version) == 0
+            versions_match = compare_semver(version, from_version) == 0
         except ValueError:
             versions_match = False
         if not versions_match:
             reasons.append("manifest_version_mismatch")
         if decision and decision.get("to_version") != to_version:
             reasons.append("decision_version_mismatch")
-        from_version = candidate.get("from_version")
-        if not isinstance(from_version, str) or not from_version:
-            reasons.append("candidate_from_version_missing")
-            return
         coordinate_reason = validate_release_version_coordinate(from_version, to_version, candidate.get("bump_type"))
         if coordinate_reason is not None:
             reasons.append(coordinate_reason)

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -295,6 +295,8 @@ class ReleaseSemverLadderSourceTests(unittest.TestCase):
 
         self.assertIn("next_release_version", gate_source)
         self.assertIn("validate_release_version_coordinate", preflight_source)
+        self.assertIn("compare_semver(version, from_version)", preflight_source)
+        self.assertNotIn("compare_semver(version, to_version)", preflight_source)
         self.assertNotIn("bump_semver(from_version, bump_type)", gate_source)
         self.assertIn("same-stage `N+1`", skill)
         self.assertIn("`bump_type` is commit-impact metadata, not promotion authority", skill)

--- a/skills/codex-refactor-loop/scripts/test_release_publish_preflight.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publish_preflight.py
@@ -113,7 +113,7 @@ def write_ready_artifacts(
     expires_at: datetime | None = None,
     signals: dict[str, object] | None = None,
 ) -> None:
-    set_mapped_version(repo, version)
+    set_mapped_version(repo, from_version)
     decision = {
         "from_version": from_version,
         "to_version": version,
@@ -356,8 +356,8 @@ class ReleasePublishPreflightTests(unittest.TestCase):
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"
             write_host_opt_in(repo)
-            write_ready_artifacts(repo, version="2.0.0")
-            set_mapped_version(repo, "1.9.9")
+            write_ready_artifacts(repo, from_version="1.9.9", version="1.9.10")
+            set_mapped_version(repo, "1.9.8")
 
             result = ReleasePublishPreflight(repo, now=lambda: NOW).validate(target_ref="abc123")
 
@@ -369,7 +369,7 @@ class ReleasePublishPreflightTests(unittest.TestCase):
             repo = Path(tmp) / "repo"
             write_host_opt_in(repo)
             write_ready_artifacts(repo, from_version="1.9.9", version="1.9.10+candidate")
-            set_mapped_version(repo, "1.9.10+manifest")
+            set_mapped_version(repo, "1.9.9+manifest")
 
             result = ReleasePublishPreflight(repo, now=lambda: NOW).validate(target_ref="abc123")
 
@@ -391,9 +391,9 @@ class ReleasePublishPreflightTests(unittest.TestCase):
                 current = current[int(part)] if isinstance(current, list) else current[part]
             last = parts[-1]
             if isinstance(current, list):
-                current[int(last)] = "1.9.9"
+                current[int(last)] = "1.9.8"
             else:
-                current[last] = "1.9.9"
+                current[last] = "1.9.8"
             write_json(path, data)
 
             self.assert_preflight_denies_with_reason(repo, "manifest_versions_not_synchronized")

--- a/skills/codex-refactor-loop/scripts/test_release_publisher.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publisher.py
@@ -54,10 +54,16 @@ def copy_repo_fixture() -> tempfile.TemporaryDirectory[str]:
 class FakePreflight:
     def __init__(self, result: PublishPreflightResult) -> None:
         self.result = result
-        self.calls: list[tuple[str | Path, str]] = []
+        self.calls: list[dict[str, str | Path | None]] = []
 
     def validate(self, *, candidate_path: str | Path, target_ref: str, manifest_version: str | None = None) -> PublishPreflightResult:
-        self.calls.append((candidate_path, target_ref))
+        self.calls.append(
+            {
+                "candidate_path": candidate_path,
+                "target_ref": target_ref,
+                "manifest_version": manifest_version,
+            }
+        )
         return self.result
 
 
@@ -140,7 +146,16 @@ class ReleasePublisherTests(unittest.TestCase):
             result = publisher.publish(target_ref="abc123")
 
             self.assertTrue(result.published)
-            self.assertEqual(preflight.calls, [(".refactor-loop/state/release-candidate.json", "abc123")])
+            self.assertEqual(
+                preflight.calls,
+                [
+                    {
+                        "candidate_path": ".refactor-loop/state/release-candidate.json",
+                        "target_ref": "abc123",
+                        "manifest_version": None,
+                    }
+                ],
+            )
             self.assertEqual(runner.commands, expected_success_commands())
 
     def test_publisher_records_result_and_uses_bump_commit_tag_target(self) -> None:


### PR DESCRIPTION
## Release rollup — auto-refact-dev → dev

把 `auto-refact-dev` 累积内容滚动到 `dev`,为发布 **1.0.0-beta.4** 做准备。

本批内容:
- **#280 / #279**:release publisher preflight 改为对 `from_version` 校验当前 manifest,解除 `manifest_version_mismatch` 对 beta.4 publish 的阻塞(#272 的 decider/publisher 边界回归修复)。

合并后:重跑 `release-commits` + `release-gate`(8 信号),preflight 现对 from_version 校验(manifest=beta.3 通过)→ ReleasePublisher 发布 `v1.0.0-beta.4`。

🤖 Auto-loop / codex-refactor-loop release rollup

⟦AI:AUTO-LOOP⟧
