### PR TITLE
#275: 删除 SKILL.md 可被 clobber 的 positional-shell 探针,改指 canonical CLI

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1836,26 +1836,11 @@ PR_NUMBER=$(gh pr list --head "<trunk_branch>" --json number --jq '.[0].number')
 
 If no open PR → skip Consensus-rnd Phase ci-watch (local CI is sufficient).
 
-### Arm the watch
+### Read the watch
 
-```bash
-# Poll every 60s; emit one event per failed check; exit when all checks settled.
-prev=""
-while true; do
-  state=$(gh pr checks "$PR_NUMBER" --json name,bucket,state)
-  cur=$(jq -r '.[] | "\(.name)\t\(.bucket)\t\(.state)"' <<<"$state" | sort)
-  comm -13 <(printf '%s\n' "$prev") <(printf '%s\n' "$cur") | awk -F'\t' '$2=="fail"{print $0}'
-  prev=$cur
-  if jq -e 'all(.bucket != "pending")' <<<"$state" >/dev/null; then
-    failed=$(jq -r '[.[] | select(.bucket=="fail") | .name] | length' <<<"$state")
-    echo "REMOTE_CI_DONE:failed=$failed"
-    break
-  fi
-  sleep 60
-done
-```
+Do not run a controller-authored shell poller for remote CI. Every controller wakeup first reads `python3 <skill-root>/scripts/consensus-rnd-cli wakeup-plan --repo-root "$REPO_ROOT"` and handles any structured action with `kind: "ci-red"`. For each red PR, the controller then reads the failed check details with `gh pr checks "$PR_NUMBER" --json name,bucket,state,link`, selects `bucket: fail`, and uses the check `name` plus `link` for the focused remote-CI fix route.
 
-Arm as a Monitor with `persistent: true`. Each emitted line is a notification you wake on. Stop only on the `REMOTE_CI_DONE:` line.
+The persistent daemon-event Monitor bridge remains the wake source for pending controller events; remote CI triage is driven by `consensus-rnd-cli wakeup-plan` output, not by an executable fenced shell watch in SKILL.md.
 
 ### Triage on failure
 
@@ -2653,8 +2638,8 @@ codex 偶发 `ERROR: stream disconnected before completion` 且 exit 1,尤其同
 ```bash
 source .refactor-loop/host.env                              # 取 REPO_ROOT / CODEX_FLOOR
 FLOOR=$(( ${CODEX_FLOOR:-5} < 2 ? 2 : ${CODEX_FLOOR:-5} ))   # 硬下限 2
-# 只数本仓库 codex:含 consensus-rnd-cli spawn-codex 且含本仓库绝对路径 $REPO_ROOT(scope,防同机多 loop 过计)
-ACTIVE=$(ps -eo command= | awk -v r="$REPO_ROOT" 'r!="" && /spawn-codex[.]sh/ && index($0,r) && index($0," -c ")==0 { n++ } END { print n+0 }')
+# 只数本仓库 codex:使用 canonical CLI 计数;diagnostic 明细可用 --list-codex
+ACTIVE=$(python3 <skill-root>/scripts/consensus-rnd-cli concurrency --count-only)
 NEEDED=$(( FLOOR - ACTIVE ))
 [ "$NEEDED" -le 0 ] && return  # floor 已满(本仓库 codex 已 >= FLOOR)
 

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1838,6 +1838,7 @@ If no open PR → skip Consensus-rnd Phase ci-watch (local CI is sufficient).
 
 ### Read the watch
 
+<!-- Refactor (issue-275): Old pattern: SKILL.md fenced shell 探针含 raw positional $0/$1/$2,skill 带参加载被 clobber。 New principle: 删可执行探针改指 canonical CLI(wakeup-plan ci-red + concurrency --count-only),不在文档放可被位置参数 clobber 的 inline shell。 -->
 Do not run a controller-authored shell poller for remote CI. Every controller wakeup first reads `python3 <skill-root>/scripts/consensus-rnd-cli wakeup-plan --repo-root "$REPO_ROOT"` and handles any structured action with `kind: "ci-red"`. For each red PR, the controller then reads the failed check details with `gh pr checks "$PR_NUMBER" --json name,bucket,state,link`, selects `bucket: fail`, and uses the check `name` plus `link` for the focused remote-CI fix route.
 
 The persistent daemon-event Monitor bridge remains the wake source for pending controller events; remote CI triage is driven by `consensus-rnd-cli wakeup-plan` output, not by an executable fenced shell watch in SKILL.md.
@@ -2635,6 +2636,7 @@ codex 偶发 `ERROR: stream disconnected before completion` 且 exit 1,尤其同
 
 **判定脚本**(controller wakeup step 1.5):
 
+<!-- Refactor (issue-275): Old pattern: SKILL.md fenced shell 探针含 raw positional $0/$1/$2,skill 带参加载被 clobber。 New principle: 删可执行探针改指 canonical CLI(wakeup-plan ci-red + concurrency --count-only),不在文档放可被位置参数 clobber 的 inline shell。 -->
 ```bash
 source .refactor-loop/host.env                              # 取 REPO_ROOT / CODEX_FLOOR
 FLOOR=$(( ${CODEX_FLOOR:-5} < 2 ? 2 : ${CODEX_FLOOR:-5} ))   # 硬下限 2

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -366,6 +366,36 @@ class SkillEntrypointContractTests(unittest.TestCase):
         self.assertNotIn("peek --json", self.skill)
         self.assertNotIn("`--json`", read(SKILL_ROOT / "scripts" / "codex_refactor_loop" / "peek.py"))
 
+    def test_executable_shell_blocks_do_not_embed_raw_positional_parameters(self) -> None:
+        fenced_bash_blocks = re.findall(r"```(?:bash|sh|shell)\n(.*?)```", self.skill, flags=re.DOTALL)
+        self.assertTrue(fenced_bash_blocks)
+        for index, block in enumerate(fenced_bash_blocks):
+            with self.subTest(block=index):
+                self.assertNotRegex(block, r"(?<!\\)\$[0-9]")
+
+    def test_issue275_shell_clobber_patterns_are_removed_from_skill(self) -> None:
+        forbidden = (
+            "comm -13",
+            "awk -F'\\t' '$2==\"fail\"",
+            "ps -eo command= | awk",
+            "index($0,r)",
+            "REMOTE_CI_DONE",
+        )
+        for needle in forbidden:
+            with self.subTest(needle=needle):
+                self.assertNotIn(needle, self.skill)
+
+        required = (
+            "kind: \"ci-red\"",
+            'gh pr checks "$PR_NUMBER" --json name,bucket,state,link',
+            "concurrency --count-only",
+            "--list-codex",
+            "ACTIVE=$(python3 <skill-root>/scripts/consensus-rnd-cli concurrency --count-only)",
+        )
+        for needle in required:
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.skill)
+
     def test_root_state_json_contract_deleted_but_specialized_artifacts_remain(self) -> None:
         forbidden = (
             "Write initial state.json",

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -373,6 +373,7 @@ class SkillEntrypointContractTests(unittest.TestCase):
             with self.subTest(block=index):
                 self.assertNotRegex(block, r"(?<!\\)\$[0-9]")
 
+    # Refactor (issue-275): Old pattern: SKILL.md executable probes could carry raw positional shell parameters and clobber skill loading. New principle: source-regression locks the removal and the canonical CLI replacement wording.
     def test_issue275_shell_clobber_patterns_are_removed_from_skill(self) -> None:
         forbidden = (
             "comm -13",

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -416,6 +416,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         kinds = [action["kind"] for action in plan["actions"]]
         self.assertLess(kinds.index("ci-red"), kinds.index("no-gap-violation"))
 
+    # Refactor (issue-275): Old pattern: remote CI routing depended on inline shell poller marker text. New principle: behavior tests assert wakeup-plan emits structured ci-red actions without marker coupling.
     def test_ci_red_check_projection_requests_triage_fields_without_remote_ci_done_marker(self) -> None:
         plan = self.run_plan(fixture="ci_red")
 

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -412,8 +412,16 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         self.assertEqual(plan["actions"][0]["kind"], "ci-red")
         self.assertEqual(plan["actions"][0]["item"], "PR #31")
+        self.assertEqual(plan["actions"][0]["actor"], "remote-ci-fix-codex")
         kinds = [action["kind"] for action in plan["actions"]]
         self.assertLess(kinds.index("ci-red"), kinds.index("no-gap-violation"))
+
+    def test_ci_red_check_projection_requests_triage_fields_without_remote_ci_done_marker(self) -> None:
+        plan = self.run_plan(fixture="ci_red")
+
+        self.assertEqual(plan["actions"][0]["kind"], "ci-red")
+        self.assertEqual(plan["actions"][0]["actor"], "remote-ci-fix-codex")
+        self.assertNotIn("REMOTE_CI_DONE", json.dumps(plan))
 
     def test_no_gap_routes_before_milestone(self) -> None:
         (self.repo / ".refactor-loop" / ".concurrency-alert.log").write_text(


### PR DESCRIPTION
## Summary / 摘要

#275(SKILL.md fenced shell 的 positional `$0/$1/$2` 被 skill-arg 加载时 clobber)。

- **Old**:SKILL.md 正文可执行 shell 片段(CI-watch fail 检测的 `comm|awk '$2=="fail"'`、并发计数的 `ps -eo command=|awk index($0,r)`)含 raw positional 变量,skill 带参加载时被位置参数替换成乱码。
- **New**(design-consensus r3 structural,删除优先):删除这些 clobber-prone 可执行 shell 探针,改 prose 指 canonical CLI —— CI-watch 读 `consensus-rnd-cli wakeup-plan` 的 `kind: ci-red` + `gh pr checks --json`;并发 floor 用 `concurrency --count-only`(`--list-codex` 作 diagnostic);移除 `REMOTE_CI_DONE` required stop marker。补 source-regression 锁 fenced bash 无 raw `$0..$9` / 无 clobber 探针 / count-only 在档。

不新增生产模块/marker/schema。

## Scope / 范围

3 files(SKILL.md −20、test_skill_entrypoint_contract +30、test_wakeup_plan +8)。验证:targeted 54 OK;全量 OK(1 skipped)。

Closes #275

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
