### PR TITLE
#276: controller lifecycle target 规范化,空/非法号 fail-closed

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1363,6 +1363,11 @@ documented as public consensus-rnd-cli/controller-actions shell commands.
 New principle: lifecycle operations are controller-internal ControllerActions
 methods/direct package calls, never worker-visible public CLI verbs. -->
 
+<!-- Refactor (issue-276): Old pattern: controller lifecycle PR/issue targets
+could be empty, inferred, or non-canonical GitHub identifiers before gh/git
+side effects. New principle: lifecycle targets are normalized through a private
+canonical positive-decimal boundary before any lifecycle side effect. -->
+
 7 个曾发生的 bug 都来自 controller boilerplate 重复 + shell 变量传值 bug。统一用 controller-internal `ControllerActions` primitives, not public CLI commands:
 
 ```python
@@ -1379,6 +1384,7 @@ actions.apply_human_label_or_skip(pr_number, source_marker, reason)
 - merge PR 必须用 internal `merge_pr(pr)` — auto-close + label cleanup,不留尾巴。`merge_pr` is a post-decision lifecycle primitive: call it only after the controller has already decided `MERGE` or `MERGE_WITH_COMMENTS`; it never computes Consensus-rnd Phase review-gate reviewer policy.
 - worktree 创建必须用 internal `safe_worktree(iteration, cluster, base)` — 处理 "already exists" race
 - PR 号捕获必须用 internal `open_pr_with_label(...)` returned tuple — **禁止** shell `pr_num=$(...grep -oE...)` 这种 subshell 变量传值模式
+- Lifecycle PR/issue targets entering `apply_human_label_or_skip`, `merge_pr`, `open_pr_with_label`, or `record_recent_pr_merge` must pass `_normalize_lifecycle_target` and become canonical positive decimals before any `gh` or `git` side effect; empty, blank, zero, negative, non-digit, leading-zero, URL, branch, and current-PR inference inputs fail closed and write `CONTROLLER_ACTION_BLOCKED:invalid-github-target:<action>:<kind>:<source>` to the controller pending-event log. PR creation target capture stays limited to `open_pr_with_label(...)` URL extraction followed by the same normalization.
 - `safe_push`, `safe_sync_main`, triage apply, and human-label apply are internal primitives/direct package calls only; `consensus-rnd-cli merge-pr/open-pr/open-release-rollup-pr/apply-human-label/safe-push/safe-sync-main/apply-sync/apply-triage` must fail closed as unknown public commands.
 
 **Label 生命周期(强制状态机)**:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -38,6 +38,7 @@ ISSUE_LABELS_REMOVE = (
 )
 SAFE_WORKTREE_ITERATION_RE = re.compile(r"^[0-9]+$")
 SAFE_WORKTREE_CLUSTER_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+GITHUB_LIFECYCLE_TARGET_RE = re.compile(r"^[1-9][0-9]*$")
 
 
 class ControllerActions:
@@ -77,8 +78,15 @@ class ControllerActions:
     def apply_human_label_or_skip(self, pr_number: str, source_marker: str = "", reason: str = "") -> int:
         if not self._require_owner_or_return("controller-label", code=3):
             return 3
-        if not pr_number:
-            sys.stderr.write("apply_human_label_or_skip: missing pr_number\n")
+        pr_target = self._normalize_lifecycle_target_or_block(
+            pr_number,
+            kind="pr",
+            action="apply-human-label",
+            source="argument",
+        )
+        if pr_target is None:
+            if not pr_number:
+                sys.stderr.write("apply_human_label_or_skip: missing pr_number\n")
             return 2
         env_marker = os.environ.get("HUMAN_LABEL_SOURCE_MARKER", "")
         if not source_marker.startswith("META_RESOLVED:escalate-human:") and env_marker.startswith(
@@ -91,7 +99,7 @@ class ControllerActions:
             sys.stderr.write("ERROR: apply_human_label_or_skip requires META_RESOLVED:escalate-human marker source\n")
             return 2
 
-        result = self.gh(["pr", "edit", pr_number, "--add-label", labels.HUMAN_MAINTAINER_DECISION], check=False)
+        result = self.gh(["pr", "edit", pr_target, "--add-label", labels.HUMAN_MAINTAINER_DECISION], check=False)
         return result.returncode
 
     def _current_branch(self) -> str:
@@ -196,36 +204,57 @@ class ControllerActions:
     def merge_pr(self, pr: str, linked_issue: str = "") -> int:
         if not self._require_owner_or_return("merge-pr", code=3):
             return 3
-        if not pr:
-            sys.stderr.write("merge_pr: missing pr number\n")
+        pr_target = self._normalize_lifecycle_target_or_block(pr, kind="pr", action="merge-pr", source="argument")
+        if pr_target is None:
             return 1
+        issue_target = ""
+        if linked_issue:
+            normalized = self._normalize_lifecycle_target_or_block(
+                linked_issue,
+                kind="issue",
+                action="merge-pr",
+                source="argument",
+            )
+            if normalized is None:
+                return 1
+            issue_target = normalized
         if not linked_issue:
-            body = self.gh(["pr", "view", pr, "--json", "body", "--jq", ".body"], check=False).stdout
+            body = self.gh(["pr", "view", pr_target, "--json", "body", "--jq", ".body"], check=False).stdout
             linked_issue = _single_linked_issue(body)
-        merge = self.gh(["pr", "merge", pr, "--admin", "--squash", "--delete-branch"], check=False)
+            if linked_issue:
+                normalized = self._normalize_lifecycle_target_or_block(
+                    linked_issue,
+                    kind="issue",
+                    action="merge-pr",
+                    source="pr-body",
+                )
+                if normalized is None:
+                    return 1
+                issue_target = normalized
+        merge = self.gh(["pr", "merge", pr_target, "--admin", "--squash", "--delete-branch"], check=False)
         if merge.stdout:
             print(merge.stdout.splitlines()[-1])
         elif merge.stderr:
             print(merge.stderr.splitlines()[-1])
         if merge.returncode != 0:
             return merge.returncode
-        self.record_recent_pr_merge(pr)
-        args = ["pr", "edit", pr]
+        self.record_recent_pr_merge(pr_target)
+        args = ["pr", "edit", pr_target]
         for label in PR_LABELS_REMOVE:
             args.extend(["--remove-label", label])
         args.extend(["--add-label", labels.PHASE_MERGED])
         self.gh(args, check=False)
-        if linked_issue:
-            comment = f"✅ Auto-merged via PR #{pr}.\n\n⟦AI:AUTO-LOOP⟧"
-            close = self.gh(["issue", "close", linked_issue, "--reason", "completed", "--comment", comment], check=False)
+        if issue_target:
+            comment = f"✅ Auto-merged via PR #{pr_target}.\n\n⟦AI:AUTO-LOOP⟧"
+            close = self.gh(["issue", "close", issue_target, "--reason", "completed", "--comment", comment], check=False)
             if close.stdout:
                 print(close.stdout.splitlines()[-1])
-            args = ["issue", "edit", linked_issue]
+            args = ["issue", "edit", issue_target]
             for label in ISSUE_LABELS_REMOVE:
                 args.extend(["--remove-label", label])
             args.extend(["--add-label", labels.PHASE_MERGED])
             self.gh(args, check=False)
-        head = self.gh(["pr", "view", pr, "--json", "headRefName", "--jq", ".headRefName"], check=False).stdout.strip()
+        head = self.gh(["pr", "view", pr_target, "--json", "headRefName", "--jq", ".headRefName"], check=False).stdout.strip()
         if head:
             wt = self._worktree_for_branch(head)
             if wt and wt != self.ctx.repo_root:
@@ -239,24 +268,38 @@ class ControllerActions:
             raise RuntimeError("open_pr_with_label: head branch required (avoid gh fallback to current branch = base)")
         self._validate_pr_body_file(body_file)
         linked_issue = _single_linked_issue(self._read_body_file(body_file))
+        issue_target = ""
+        if linked_issue:
+            issue_target = self._normalize_lifecycle_target_or_raise(
+                linked_issue,
+                kind="issue",
+                action="open-pr",
+                source="pr-body",
+            )
         created = self.gh(["pr", "create", "--base", base, "--head", head, "--title", title, "--body-file", body_file], check=False)
         output = created.stdout + created.stderr
         match = re.search(r"https://github\.com/[^/]+/[^/]+/pull/([0-9]+)", output)
         if not match:
+            self._normalize_lifecycle_target_or_raise("", kind="pr", action="open-pr", source="github-pr-create-url")
             raise RuntimeError(f"open_pr_with_label: failed to extract PR num from: {output.strip()}")
-        pr_num = int(match.group(1))
+        pr_target = self._normalize_lifecycle_target_or_raise(
+            match.group(1),
+            kind="pr",
+            action="open-pr",
+            source="github-pr-create-url",
+        )
         self.gh(
             [
                 "pr",
                 "edit",
-                str(pr_num),
+                pr_target,
                 "--add-label",
                 ",".join((labels.MANAGED, labels.PHASE_REVIEWING, labels.HUMAN_AUTO)),
             ],
             check=False,
         )
-        if linked_issue:
-            args = ["issue", "edit", linked_issue]
+        if issue_target:
+            args = ["issue", "edit", issue_target]
             for label in ISSUE_LABELS_REMOVE:
                 args.extend(["--remove-label", label])
             args.extend(
@@ -266,7 +309,7 @@ class ControllerActions:
                 ]
             )
             self.gh(args, check=False)
-        return pr_num, match.group(0)
+        return int(pr_target), match.group(0)
 
     def _validate_pr_body_file(self, body_file: str) -> None:
         body_path = Path(body_file)
@@ -329,9 +372,15 @@ class ControllerActions:
         return self.open_pr_with_label(title, body_file, base=review_base_branch, head=rollup_head)
 
     def record_recent_pr_merge(self, pr: str) -> None:
+        pr_target = self._normalize_lifecycle_target_or_raise(
+            pr,
+            kind="pr",
+            action="record-recent-pr-merge",
+            source="argument",
+        )
         fact_json = ""
         for attempt in range(3):
-            result = self.gh(["pr", "view", pr, "--json", "number,mergedAt,mergeCommit,baseRefName,headRefName"], check=False)
+            result = self.gh(["pr", "view", pr_target, "--json", "number,mergedAt,mergeCommit,baseRefName,headRefName"], check=False)
             fact_json = result.stdout
             try:
                 facts = json.loads(fact_json)
@@ -346,7 +395,12 @@ class ControllerActions:
         merge_commit = facts.get("mergeCommit") if isinstance(facts, dict) else None
         sha = merge_commit.get("oid") if isinstance(merge_commit, dict) else None
         merged_at = facts.get("mergedAt") if isinstance(facts, dict) else None
-        pr_num = facts.get("number") or pr
+        pr_num = self._normalize_lifecycle_target_or_raise(
+            facts.get("number") or pr_target,
+            kind="pr",
+            action="record-recent-pr-merge",
+            source="github-facts",
+        )
         if not pr_num or not sha or not merged_at:
             raise RuntimeError(
                 "merge_pr: recent-pr-merges projection failed: missing mergedAt or mergeCommit.oid after retry; "
@@ -472,6 +526,29 @@ class ControllerActions:
         if not decision.allowed:
             raise RuntimeError(f"active_controller=noop:not-owner action={action} owner={decision.owner_device}")
 
+    def _normalize_lifecycle_target_or_block(self, value: object, *, kind: str, action: str, source: str) -> str | None:
+        # Refactor (iter276/issue-276): Old pattern: controller lifecycle
+        # targets accepted empty or non-canonical GitHub ids before gh calls.
+        # New principle: require canonical positive decimal target ids and
+        # record invalid target blocks before lifecycle side effects.
+        try:
+            return _normalize_lifecycle_target(value, kind=kind, action=action, source=source)
+        except ValueError as exc:
+            self._append_invalid_github_target_event(kind=kind, action=action, source=source)
+            sys.stderr.write(str(exc) + "\n")
+            return None
+
+    def _normalize_lifecycle_target_or_raise(self, value: object, *, kind: str, action: str, source: str) -> str:
+        target = self._normalize_lifecycle_target_or_block(value, kind=kind, action=action, source=source)
+        if target is None:
+            raise RuntimeError(f"{action}: invalid {kind} target from {source}")
+        return target
+
+    def _append_invalid_github_target_event(self, *, kind: str, action: str, source: str) -> None:
+        self.ctx.paths.pending_events.parent.mkdir(parents=True, exist_ok=True)
+        with self.ctx.paths.pending_events.open("a", encoding="utf-8") as handle:
+            handle.write(f"CONTROLLER_ACTION_BLOCKED:invalid-github-target:{action}:{kind}:{source}\n")
+
 
 def _parse_time(value: object) -> datetime | None:
     if not isinstance(value, str) or not value:
@@ -483,6 +560,14 @@ def _parse_time(value: object) -> datetime | None:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+def _normalize_lifecycle_target(value: object, *, kind: str, action: str, source: str) -> str:
+    """refactor helper, no behavior change except rejecting unsafe GitHub target ids."""
+    target = "" if value is None else str(value)
+    if not GITHUB_LIFECYCLE_TARGET_RE.fullmatch(target):
+        raise ValueError(f"{action}: invalid {kind} target from {source}: {target!r}")
+    return target
 
 
 def _single_linked_issue(body: str) -> str:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -39,6 +39,7 @@ ISSUE_LABELS_REMOVE = (
 SAFE_WORKTREE_ITERATION_RE = re.compile(r"^[0-9]+$")
 SAFE_WORKTREE_CLUSTER_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 GITHUB_LIFECYCLE_TARGET_RE = re.compile(r"^[1-9][0-9]*$")
+BODY_CLOSING_ISSUE_TARGET_RE = re.compile(r"(?im)\bCloses\s+#([^\s,;:.)\]}]*)")
 
 
 class ControllerActions:
@@ -220,13 +221,15 @@ class ControllerActions:
             issue_target = normalized
         if not linked_issue:
             body = self.gh(["pr", "view", pr_target, "--json", "body", "--jq", ".body"], check=False).stdout
-            linked_issue = _single_linked_issue(body)
+            linked_issue = self._single_body_linked_issue_or_block(body, action="close")
+            if linked_issue is None:
+                return 1
             if linked_issue:
                 normalized = self._normalize_lifecycle_target_or_block(
                     linked_issue,
                     kind="issue",
-                    action="merge-pr",
-                    source="pr-body",
+                    action="close",
+                    source="body-link",
                 )
                 if normalized is None:
                     return 1
@@ -267,14 +270,14 @@ class ControllerActions:
         if not head:
             raise RuntimeError("open_pr_with_label: head branch required (avoid gh fallback to current branch = base)")
         self._validate_pr_body_file(body_file)
-        linked_issue = _single_linked_issue(self._read_body_file(body_file))
+        linked_issue = self._single_body_linked_issue_or_raise(self._read_body_file(body_file), action="open-pr")
         issue_target = ""
         if linked_issue:
             issue_target = self._normalize_lifecycle_target_or_raise(
                 linked_issue,
                 kind="issue",
                 action="open-pr",
-                source="pr-body",
+                source="body-link",
             )
         created = self.gh(["pr", "create", "--base", base, "--head", head, "--title", title, "--body-file", body_file], check=False)
         output = created.stdout + created.stderr
@@ -549,6 +552,29 @@ class ControllerActions:
         with self.ctx.paths.pending_events.open("a", encoding="utf-8") as handle:
             handle.write(f"CONTROLLER_ACTION_BLOCKED:invalid-github-target:{action}:{kind}:{source}\n")
 
+    def _single_body_linked_issue_or_block(self, body: str, *, action: str) -> str | None:
+        # Refactor (issue-276): Old pattern: body-derived `Closes #...`
+        # targets used the read-only projection parser, so malformed body links
+        # looked identical to no link and skipped lifecycle target validation.
+        # New principle: body-link lifecycle targets fail closed before any
+        # gh side effect; absent or ambiguous valid links still mean no issue
+        # lifecycle mutation.
+        for target in _body_closing_issue_targets(body):
+            if self._normalize_lifecycle_target_or_block(
+                target,
+                kind="issue",
+                action=action,
+                source="body-link",
+            ) is None:
+                return None
+        return _single_linked_issue(body)
+
+    def _single_body_linked_issue_or_raise(self, body: str, *, action: str) -> str:
+        target = self._single_body_linked_issue_or_block(body, action=action)
+        if target is None:
+            raise RuntimeError(f"{action}: invalid issue target from body-link")
+        return target
+
 
 def _parse_time(value: object) -> datetime | None:
     if not isinstance(value, str) or not value:
@@ -578,6 +604,10 @@ def _single_linked_issue(body: str) -> str:
     #   mutate a parent issue when there is exactly one durable PR-body link.
     numbers = extract_closing_issue_numbers(body)
     return str(numbers[0]) if len(numbers) == 1 else ""
+
+
+def _body_closing_issue_targets(body: str) -> tuple[str, ...]:
+    return tuple(match.group(1) for match in BODY_CLOSING_ISSUE_TARGET_RE.finditer(body or ""))
 
 
 def _validate_safe_worktree_fields(iteration: str, cluster: str) -> None:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -39,7 +39,8 @@ ISSUE_LABELS_REMOVE = (
 SAFE_WORKTREE_ITERATION_RE = re.compile(r"^[0-9]+$")
 SAFE_WORKTREE_CLUSTER_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 GITHUB_LIFECYCLE_TARGET_RE = re.compile(r"^[1-9][0-9]*$")
-BODY_CLOSING_ISSUE_TARGET_RE = re.compile(r"(?im)\bCloses\s+#([^\s,;:.)\]}]*)")
+# Refactor (issue-276): validate body-linked lifecycle targets without swallowing escaped line boundaries.
+BODY_CLOSING_ISSUE_TARGET_RE = re.compile(r"(?im)\bCloses\s+#([^\s,;:.)\]}\\]*)")
 
 
 class ControllerActions:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -284,7 +284,7 @@ class ControllerActions:
         output = created.stdout + created.stderr
         match = re.search(r"https://github\.com/[^/]+/[^/]+/pull/([0-9]+)", output)
         if not match:
-            self._normalize_lifecycle_target_or_raise("", kind="pr", action="open-pr", source="github-pr-create-url")
+            # Refactor (issue-276): preserve the PR-create parse failure instead of routing it through target normalization.
             raise RuntimeError(f"open_pr_with_label: failed to extract PR num from: {output.strip()}")
         pr_target = self._normalize_lifecycle_target_or_raise(
             match.group(1),

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import ast
 import shutil
 import subprocess
 import tempfile
@@ -51,6 +52,99 @@ class ControllerActionsTests(unittest.TestCase):
         data = json.loads((self.tmp / ".refactor-loop" / "state" / "recent-pr-merges.json").read_text(encoding="utf-8"))
         self.assertEqual(data["count"], 1)
         self.assertEqual(data["merges"][0]["sha"], "abc123")
+
+    def pending_events(self) -> str:
+        path = self.tmp / ".refactor-loop" / ".controller-pending-events.log"
+        return path.read_text(encoding="utf-8") if path.exists() else ""
+
+    # Refactor (iter276/issue-276): Old pattern: controller lifecycle targets
+    # accepted empty or non-canonical GitHub ids before gh calls. New principle:
+    # fail closed on non-canonical GitHub ids and leave a pending-event audit.
+    def test_merge_pr_rejects_invalid_pr_targets_before_gh_or_git(self) -> None:
+        invalid_targets = ("", " ", "0", "-1", "abc", "01", "https://github.com/owner/repo/pull/77")
+        for target in invalid_targets:
+            with self.subTest(target=target):
+                (self.tmp / ".refactor-loop" / ".controller-pending-events.log").unlink(missing_ok=True)
+                with mock.patch.object(self.actions, "gh", side_effect=AssertionError("gh should not be called")):
+                    with mock.patch.object(self.actions, "git", side_effect=AssertionError("git should not be called")):
+                        self.assertEqual(1, self.actions.merge_pr(target))
+                self.assertIn(
+                    "CONTROLLER_ACTION_BLOCKED:invalid-github-target:merge-pr:pr:argument",
+                    self.pending_events(),
+                )
+
+    def test_apply_human_label_rejects_invalid_pr_targets_before_gh_or_git(self) -> None:
+        with mock.patch.object(self.actions, "gh", side_effect=AssertionError("gh should not be called")):
+            with mock.patch.object(self.actions, "git", side_effect=AssertionError("git should not be called")):
+                self.assertEqual(2, self.actions.apply_human_label_or_skip("01", "META_RESOLVED:escalate-human:reason"))
+        self.assertIn(
+            "CONTROLLER_ACTION_BLOCKED:invalid-github-target:apply-human-label:pr:argument",
+            self.pending_events(),
+        )
+
+    def test_merge_pr_rejects_invalid_linked_issue_before_gh_or_git(self) -> None:
+        with mock.patch.object(self.actions, "gh", side_effect=AssertionError("gh should not be called")):
+            with mock.patch.object(self.actions, "git", side_effect=AssertionError("git should not be called")):
+                self.assertEqual(1, self.actions.merge_pr("77", linked_issue="01"))
+        self.assertIn(
+            "CONTROLLER_ACTION_BLOCKED:invalid-github-target:merge-pr:issue:argument",
+            self.pending_events(),
+        )
+
+    def test_open_pr_with_label_rejects_malformed_create_url_before_post_create_edit(self) -> None:
+        cases = (
+            ("missing-url", "created pull request 77\n"),
+            ("zero-pr", "https://github.com/owner/repo/pull/0\n"),
+            ("leading-zero-pr", "https://github.com/owner/repo/pull/077\n"),
+        )
+        for name, output in cases:
+            with self.subTest(name=name):
+                (self.tmp / ".refactor-loop" / ".controller-pending-events.log").unlink(missing_ok=True)
+                gh_calls: list[list[str]] = []
+
+                def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+                    gh_calls.append(args)
+                    if args[:2] == ["pr", "create"]:
+                        return mock.Mock(returncode=0, stdout=output, stderr="")
+                    raise AssertionError(f"unexpected post-create gh call: {args}")
+
+                with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+                    with self.assertRaisesRegex(RuntimeError, "invalid pr target|failed to extract PR num"):
+                        self.actions.open_pr_with_label("title", str(self.pr_body), head="refactor/branch")
+
+                self.assertEqual(1, sum(1 for call in gh_calls if call[:2] == ["pr", "create"]))
+                self.assertFalse(any(call[:2] == ["pr", "edit"] for call in gh_calls), gh_calls)
+                self.assertIn(
+                    "CONTROLLER_ACTION_BLOCKED:invalid-github-target:open-pr:pr:github-pr-create-url",
+                    self.pending_events(),
+                )
+
+    def test_record_recent_pr_merge_rejects_invalid_argument_before_gh_or_projection(self) -> None:
+        with mock.patch.object(self.actions, "gh", side_effect=AssertionError("gh should not be called")):
+            with self.assertRaisesRegex(RuntimeError, "invalid pr target"):
+                self.actions.record_recent_pr_merge("01")
+        self.assertFalse((self.tmp / ".refactor-loop" / "state" / "recent-pr-merges.json").exists())
+        self.assertIn(
+            "CONTROLLER_ACTION_BLOCKED:invalid-github-target:record-recent-pr-merge:pr:argument",
+            self.pending_events(),
+        )
+
+    def test_record_recent_pr_merge_rejects_invalid_github_fact_number_before_projection(self) -> None:
+        facts = {
+            "number": "01",
+            "mergedAt": "2026-05-29T00:00:00Z",
+            "mergeCommit": {"oid": "abc123"},
+            "baseRefName": "dev",
+            "headRefName": "feature",
+        }
+        with mock.patch.object(self.actions, "gh", return_value=mock.Mock(returncode=0, stdout=json.dumps(facts), stderr="")):
+            with self.assertRaisesRegex(RuntimeError, "invalid pr target"):
+                self.actions.record_recent_pr_merge("7")
+        self.assertFalse((self.tmp / ".refactor-loop" / "state" / "recent-pr-merges.json").exists())
+        self.assertIn(
+            "CONTROLLER_ACTION_BLOCKED:invalid-github-target:record-recent-pr-merge:pr:github-facts",
+            self.pending_events(),
+        )
 
     # Refactor (impl/issue191-single-active-controller): Old pattern:
     # lifecycle helpers could mutate GitHub/git from any controller device. New
@@ -564,9 +658,55 @@ class ControllerActionsSourceRegressionTests(unittest.TestCase):
 
     def test_merge_pr_uses_single_linked_issue_parser_for_body_linkage(self) -> None:
         text = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")
-        self.assertIn('body = self.gh(["pr", "view", pr, "--json", "body", "--jq", ".body"], check=False).stdout', text)
+        self.assertIn('body = self.gh(["pr", "view", pr_target, "--json", "body", "--jq", ".body"], check=False).stdout', text)
         self.assertIn("linked_issue = _single_linked_issue(body)", text)
         self.assertIn("return str(numbers[0]) if len(numbers) == 1 else \"\"", text)
+
+    def test_lifecycle_gh_subject_slots_use_normalized_target_locals(self) -> None:
+        source = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        allowed = {"pr_target", "issue_target"}
+        raw = {"pr", "pr_number", "linked_issue", "pr_num"}
+        offenders: list[str] = []
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "gh"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+            ):
+                continue
+            if not node.args or not isinstance(node.args[0], ast.List):
+                continue
+            items = node.args[0].elts
+            if len(items) < 3:
+                continue
+            first = items[0].value if isinstance(items[0], ast.Constant) else None
+            second = items[1].value if isinstance(items[1], ast.Constant) else None
+            if (first, second) not in {
+                ("pr", "view"),
+                ("pr", "edit"),
+                ("pr", "merge"),
+                ("issue", "close"),
+                ("issue", "edit"),
+            }:
+                continue
+            subject = items[2]
+            if isinstance(subject, ast.Name):
+                if subject.id not in allowed:
+                    offenders.append(f"line {node.lineno}: {first} {second} uses {subject.id}")
+            elif isinstance(subject, ast.Call) and isinstance(subject.func, ast.Name) and subject.func.id == "str":
+                if subject.args and isinstance(subject.args[0], ast.Name):
+                    offenders.append(f"line {node.lineno}: {first} {second} uses str({subject.args[0].id})")
+            else:
+                offenders.append(f"line {node.lineno}: {first} {second} uses non-local subject")
+
+        for name in raw:
+            self.assertFalse(any(f"uses {name}" in offender or f"str({name})" in offender for offender in offenders))
+        self.assertEqual([], offenders)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -91,6 +91,41 @@ class ControllerActionsTests(unittest.TestCase):
             self.pending_events(),
         )
 
+    def test_merge_pr_accepts_valid_explicit_linked_issue_target(self) -> None:
+        gh_calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            gh_calls.append(args)
+            if args[:2] == ["pr", "merge"]:
+                return mock.Mock(returncode=0, stdout="Merged pull request #77\n", stderr="")
+            if args[:5] == ["pr", "view", "77", "--json", "number,mergedAt,mergeCommit,baseRefName,headRefName"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        {
+                            "number": 77,
+                            "mergedAt": "2026-05-29T00:00:00Z",
+                            "mergeCommit": {"oid": "abc123"},
+                            "baseRefName": "dev",
+                            "headRefName": "impl/issue239",
+                        }
+                    ),
+                    stderr="",
+                )
+            if args[:5] == ["pr", "view", "77", "--json", "headRefName"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+            self.assertEqual(0, self.actions.merge_pr("77", linked_issue="239"))
+
+        self.assertIn(["pr", "merge", "77", "--admin", "--squash", "--delete-branch"], gh_calls)
+        self.assertFalse(any(call[:5] == ["pr", "view", "77", "--json", "body"] for call in gh_calls), gh_calls)
+        self.assertTrue(any(call[:3] == ["pr", "edit", "77"] for call in gh_calls), gh_calls)
+        self.assertTrue(any(call[:3] == ["issue", "close", "239"] for call in gh_calls), gh_calls)
+        issue_edit = next(call for call in gh_calls if call[:3] == ["issue", "edit", "239"])
+        self.assertEqual(labels.PHASE_MERGED, issue_edit[issue_edit.index("--add-label") + 1])
+
     def test_open_pr_with_label_rejects_malformed_create_url_before_post_create_edit(self) -> None:
         cases = (
             ("missing-url", "created pull request 77\n"),

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -151,11 +151,11 @@ class ControllerActionsTests(unittest.TestCase):
 
     def test_open_pr_with_label_rejects_malformed_create_url_before_post_create_edit(self) -> None:
         cases = (
-            ("missing-url", "created pull request 77\n"),
-            ("zero-pr", "https://github.com/owner/repo/pull/0\n"),
-            ("leading-zero-pr", "https://github.com/owner/repo/pull/077\n"),
+            ("missing-url", "created pull request 77\n", "failed to extract PR num", False),
+            ("zero-pr", "https://github.com/owner/repo/pull/0\n", "invalid pr target", True),
+            ("leading-zero-pr", "https://github.com/owner/repo/pull/077\n", "invalid pr target", True),
         )
-        for name, output in cases:
+        for name, output, expected_error, expects_invalid_target_event in cases:
             with self.subTest(name=name):
                 (self.tmp / ".refactor-loop" / ".controller-pending-events.log").unlink(missing_ok=True)
                 gh_calls: list[list[str]] = []
@@ -167,15 +167,16 @@ class ControllerActionsTests(unittest.TestCase):
                     raise AssertionError(f"unexpected post-create gh call: {args}")
 
                 with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
-                    with self.assertRaisesRegex(RuntimeError, "invalid pr target|failed to extract PR num"):
+                    with self.assertRaisesRegex(RuntimeError, expected_error):
                         self.actions.open_pr_with_label("title", str(self.pr_body), head="refactor/branch")
 
                 self.assertEqual(1, sum(1 for call in gh_calls if call[:2] == ["pr", "create"]))
                 self.assertFalse(any(call[:2] == ["pr", "edit"] for call in gh_calls), gh_calls)
-                self.assertIn(
-                    "CONTROLLER_ACTION_BLOCKED:invalid-github-target:open-pr:pr:github-pr-create-url",
-                    self.pending_events(),
-                )
+                invalid_target_event = "CONTROLLER_ACTION_BLOCKED:invalid-github-target:open-pr:pr:github-pr-create-url"
+                if expects_invalid_target_event:
+                    self.assertIn(invalid_target_event, self.pending_events())
+                else:
+                    self.assertNotIn(invalid_target_event, self.pending_events())
 
     def test_record_recent_pr_merge_rejects_invalid_argument_before_gh_or_projection(self) -> None:
         with mock.patch.object(self.actions, "gh", side_effect=AssertionError("gh should not be called")):

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -91,6 +91,29 @@ class ControllerActionsTests(unittest.TestCase):
             self.pending_events(),
         )
 
+    def test_merge_pr_rejects_invalid_body_linked_issue_before_merge_or_label_edit(self) -> None:
+        cases = ("Closes #abc\n", "Closes #\n", "Closes #0\n", "Closes #01\n")
+        for body in cases:
+            with self.subTest(body=body.strip()):
+                (self.tmp / ".refactor-loop" / ".controller-pending-events.log").unlink(missing_ok=True)
+                gh_calls: list[list[str]] = []
+
+                def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+                    gh_calls.append(args)
+                    if args[:5] == ["pr", "view", "77", "--json", "body"]:
+                        return mock.Mock(returncode=0, stdout=body, stderr="")
+                    raise AssertionError(f"unexpected gh side effect after invalid body link: {args}")
+
+                with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+                    with mock.patch.object(self.actions, "git", side_effect=AssertionError("git should not be called")):
+                        self.assertEqual(1, self.actions.merge_pr("77"))
+
+                self.assertEqual([["pr", "view", "77", "--json", "body", "--jq", ".body"]], gh_calls)
+                self.assertIn(
+                    "CONTROLLER_ACTION_BLOCKED:invalid-github-target:close:issue:body-link",
+                    self.pending_events(),
+                )
+
     def test_merge_pr_accepts_valid_explicit_linked_issue_target(self) -> None:
         gh_calls: list[list[str]] = []
 
@@ -498,6 +521,23 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertEqual(77, pr_num)
         self.assertFalse(any(call[:2] == ["issue", "edit"] for call in gh_calls), gh_calls)
 
+    def test_open_pr_with_label_rejects_invalid_body_linked_issue_before_create(self) -> None:
+        cases = ("Closes #abc\n", "Closes #\n", "Closes #0\n", "Closes #01\n")
+        for body_link in cases:
+            with self.subTest(body=body_link.strip()):
+                (self.tmp / ".refactor-loop" / ".controller-pending-events.log").unlink(missing_ok=True)
+                self.pr_body.write_text(
+                    f"## 🤖 PR ready\n\nSelf-contained body.\n\n{body_link}\n⟦AI:AUTO-LOOP⟧\n",
+                    encoding="utf-8",
+                )
+                with mock.patch.object(self.actions, "gh", side_effect=AssertionError("gh should not be called")):
+                    with self.assertRaisesRegex(RuntimeError, "invalid issue target from body-link"):
+                        self.actions.open_pr_with_label("title", str(self.pr_body), head="refactor/branch")
+                self.assertIn(
+                    "CONTROLLER_ACTION_BLOCKED:invalid-github-target:open-pr:issue:body-link",
+                    self.pending_events(),
+                )
+
     def test_merge_pr_closes_single_linked_issue_from_body(self) -> None:
         gh_calls: list[list[str]] = []
 
@@ -694,8 +734,14 @@ class ControllerActionsSourceRegressionTests(unittest.TestCase):
     def test_merge_pr_uses_single_linked_issue_parser_for_body_linkage(self) -> None:
         text = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")
         self.assertIn('body = self.gh(["pr", "view", pr_target, "--json", "body", "--jq", ".body"], check=False).stdout', text)
-        self.assertIn("linked_issue = _single_linked_issue(body)", text)
+        self.assertIn('linked_issue = self._single_body_linked_issue_or_block(body, action="close")', text)
         self.assertIn("return str(numbers[0]) if len(numbers) == 1 else \"\"", text)
+
+    def test_body_linked_issue_parser_validates_malformed_closing_refs(self) -> None:
+        text = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")
+        self.assertIn("BODY_CLOSING_ISSUE_TARGET_RE", text)
+        self.assertIn("source=\"body-link\"", text)
+        self.assertIn("CONTROLLER_ACTION_BLOCKED:invalid-github-target:{action}:{kind}:{source}", text)
 
     def test_lifecycle_gh_subject_slots_use_normalized_target_locals(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -573,6 +573,39 @@ class ControllerActionsTests(unittest.TestCase):
         issue_edit = next(call for call in gh_calls if call[:3] == ["issue", "edit", "239"])
         self.assertEqual(labels.PHASE_MERGED, issue_edit[issue_edit.index("--add-label") + 1])
 
+    def test_merge_pr_accepts_body_link_with_escaped_newline_boundary(self) -> None:
+        gh_calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            gh_calls.append(args)
+            if args[:5] == ["pr", "view", "77", "--json", "body"]:
+                return mock.Mock(returncode=0, stdout="Ready.\n\nCloses #239\\n", stderr="")
+            if args[:2] == ["pr", "merge"]:
+                return mock.Mock(returncode=0, stdout="Merged pull request #77\n", stderr="")
+            if args[:5] == ["pr", "view", "77", "--json", "number,mergedAt,mergeCommit,baseRefName,headRefName"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        {
+                            "number": 77,
+                            "mergedAt": "2026-05-29T00:00:00Z",
+                            "mergeCommit": {"oid": "abc123"},
+                            "baseRefName": "dev",
+                            "headRefName": "impl/issue239",
+                        }
+                    ),
+                    stderr="",
+                )
+            if args[:5] == ["pr", "view", "77", "--json", "headRefName"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+            self.assertEqual(0, self.actions.merge_pr("77"))
+
+        self.assertIn(["pr", "merge", "77", "--admin", "--squash", "--delete-branch"], gh_calls)
+        self.assertTrue(any(call[:3] == ["issue", "close", "239"] for call in gh_calls), gh_calls)
+
     def test_merge_pr_does_not_guess_issue_when_body_closes_multiple_issues(self) -> None:
         gh_calls: list[list[str]] = []
 

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -359,6 +359,26 @@ class SkillEntrypointContractTests(unittest.TestCase):
         self.assertIn("META_JUDGE_DONE:escalate:stalled", self.skill)
         self.assertIn("do not introduce migrated work-unit schema, public marker aliases, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority", self.skill)
 
+    def test_issue276_lifecycle_target_normalization_contract_is_documented(self) -> None:
+        section = section_between(
+            self.skill,
+            r"^### Controller-internal lifecycle primitives.+$",
+            r"^### ",
+        )
+        self.assertTrue(section)
+        for needle in (
+            "<!-- Refactor (issue-276): Old pattern:",
+            "`apply_human_label_or_skip`, `merge_pr`, `open_pr_with_label`, or `record_recent_pr_merge`",
+            "`_normalize_lifecycle_target`",
+            "canonical positive decimals",
+            "before any `gh` or `git` side effect",
+            "empty, blank, zero, negative, non-digit, leading-zero, URL, branch, and current-PR inference inputs fail closed",
+            "`CONTROLLER_ACTION_BLOCKED:invalid-github-target:<action>:<kind>:<source>`",
+            "`open_pr_with_label(...)` URL extraction followed by the same normalization",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
+
     def test_runtime_surface_boundary_keeps_peek_human_and_wakeup_plan_machine(self) -> None:
         self.assertIn("`consensus-rnd-cli wakeup-plan` is the prioritized-next-action reader", self.skill)
         self.assertIn("`consensus-rnd-cli peek` is a status lens, not routing authority", self.skill)


### PR DESCRIPTION
## Summary / 摘要
#276(空 PR/issue 号未 fail-closed,误贴 label 到 rollup 人审门 PR)。
- **New**(consensus):新增私有 `_normalize_lifecycle_target`(只接受 `^[1-9][0-9]*$`);`apply_human_label_or_skip`/`merge_pr`/`open_pr_with_label`/`record_recent_pr_merge` 入口规范 target;invalid 在任何 gh/git 前 fail-closed 并写 `CONTROLLER_ACTION_BLOCKED:invalid-github-target` pending event。含 self-doc 注释 + AST source-regression(gh subject slot 只用 normalized target)。
## Scope:2 files(controller_actions.py +127、test_controller_actions.py +142)。targeted 33 OK;remote CI 跑全量。
Closes #276
🤖 Auto-loop / codex-refactor-loop
⟦AI:AUTO-LOOP⟧
