### PR TITLE
#262: read-only transition_assessment sidecar reader + ranking/prompt projection

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -3053,7 +3053,22 @@ Policy: **源文件内部 English-only;源文件之外的 user-facing artifact �
 
 The work-unit contract describes the fields carried through audit artifacts, GitHub design issues,
 prompt artifacts, and implementation/review run artifacts. Do not add migrated queue containers,
-envelope wrappers, a normalizer helper, or a root state migration for this contract.
+normalizer helpers, root state migrations, producer abstractions, registry helpers, or envelope
+wrappers, except the optional read-only `transition_assessment` sidecar documented here.
+<!-- Refactor (issue-262): Old/New
+Old: transition ranking and prompt context had no narrow checked-in sidecar boundary.
+New: optional read-only transition_assessment is the only sidecar exception for ranking/prompt projection.
+-->
+
+The optional read-only `transition_assessment` sidecar is a ranking/prompt projection fact keyed
+by `work_unit_id` and `source_ref`. It is not stable candidate NDJSON, not a work-unit envelope wrapper,
+and not a WorkUnit producer. Missing/malformed/untrusted -> unknown with confidence 0.
+The only canonical path is `.refactor-loop/runs/transition-assessments/<safe-work-unit-id>.json`,
+where `<safe-work-unit-id>` matches `[A-Za-z0-9._-]+`; no explicit path, directory scan, writer,
+controller alias, host command, host lens, `bedc_ci.py` call, marker change, branch change, or
+work-unit token change is part of this sidecar. Transition bucket order is
+`positive-discovery > classifier-shift > formal-hardening > ledger-repair > record-growth > unknown`.
+`positive-discovery` requires both classifier-surface delta and `net_positive_signal=true`.
 
 Naming policy: this engine's public product identity is Consensus R&D, and `codex-refactor-loop`
 remains the stable installed skill entrypoint. `refactor` is a valid development/work-unit
@@ -3105,6 +3120,10 @@ The controller recognizes exactly these producer values:
 This is a documented normalization boundary, not a new producer framework. Do not add new
 producer abstractions, registry helpers, envelope wrappers, or migrated work-unit state containers
 for this contract.
+
+The sidecar `producer` field is assessment provenance only and does not extend the WorkUnit
+producer enum. The only allowed sidecar provenance values are `audit` and `manual-issue`;
+`host:<slug>` is not allowed in the first version.
 
 ### `audit` producer
 
@@ -3198,9 +3217,12 @@ Goal: parallel safety. Two clusters can be in the same batch **only if** all fou
 
 Greedy bin-packing:
 
-1. Sort candidate work units by `risk` (low first), then `leverage` (high first).
-2. For each cluster, assign to first batch where it's compatible with every existing member.
-3. Each batch has at most `max_parallel_clusters`.
+1. For checked-in callers that read the optional `transition_assessment` sidecar, sort by
+   transition bucket before `risk` and `leverage`; missing/malformed/untrusted sidecars are
+   `unknown, confidence=0`, preserving existing ordering among units with no sidecar.
+2. Sort candidate work units by `risk` (low first), then `leverage` (high first).
+3. For each cluster, assign to first batch where it's compatible with every existing member.
+4. Each batch has at most `max_parallel_clusters`.
 
 If a cluster cannot fit in any new batch ≤ `max_parallel_clusters`, start a new batch for it.
 

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -17,6 +17,7 @@ Policy: **3/3 unanimous + meta-judge consensus** is the sole gate. Anything less
 3. `${SOLVER_DELETE_PATH}` — solver-delete output
 4. `gh issue view ${ISSUE_NUMBER}` — original cluster spec + maintainer comments
 5. Convergence round count: `${CONVERGENCE_ROUND}`
+6. Router-validated transition projection: `${TRANSITION_TYPE}`, `${TRANSITION_CONFIDENCE}`, `${TRANSITION_EVIDENCE_REFS}`
 
 ## Router-scoped input boundary
 
@@ -24,6 +25,8 @@ When this prompt is rendered by the router, the only local solver artifacts in s
 `${SOLVER_MINIMAL_PATH}`, `${SOLVER_STRUCTURAL_PATH}`, and `${SOLVER_DELETE_PATH}`. You may also read `gh issue view ${ISSUE_NUMBER}`. Do not search for, infer from, or copy sibling judge artifacts, other issue artifacts, other round artifacts, or unlisted solver outputs.
 
 Fail closed if any solver frontmatter `issue` is not `${ISSUE_NUMBER}`, or if any listed solver path is not exactly for issue `${ISSUE_NUMBER}`, convergence round `${CONVERGENCE_ROUND}`, and its named role. Fail closed if `${META_JUDGE_OUTPUT_PATH}` is not the judge output path for issue `${ISSUE_NUMBER}` and round `${CONVERGENCE_ROUND}`.
+
+Use only the router-injected validated transition projection for transition assessment context. Missing, malformed, or untrusted sidecars are projected as `unknown` with confidence `0`; the sidecar is not approval, not a consensus substitute, and cannot override this prompt's truth table. `positive-discovery` is valid only with classifier-surface delta and `net_positive_signal=true`.
 
 ## Procedure
 

--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -22,6 +22,7 @@ You explicitly resist adding code. If after honest evaluation the feature must s
 1. `gh issue view ${ISSUE_NUMBER}` — full body + comments.
 2. Work-unit scope source, by precedence:
    - Read the prompt header `WORK_UNIT_SOURCE_REF` / `source_ref` first.
+   - Use only the router-injected validated transition projection lines (`TRANSITION_TYPE`, `TRANSITION_CONFIDENCE`, `TRANSITION_EVIDENCE_REFS`) for transition assessment context. Missing, malformed, or untrusted sidecars are projected as `unknown` with confidence `0`; the sidecar is not approval, not a consensus substitute, and cannot override the meta-judge truth table. `positive-discovery` is valid only with classifier-surface delta and `net_positive_signal=true`.
    - If it points to an existing local artifact or audit section, read that source and verify it.
    - If it is `gh-issue-<N>` or a referenced local artifact is missing, treat the GitHub issue body/comments from `gh issue view ${ISSUE_NUMBER}` as the scope spec.
    - `audit-iter-${ITERATION}.md if present` is an audit-backed source only when the current `WORK_UNIT_SOURCE_REF` / `source_ref` points to it; do not fabricate audit artifacts.

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -11,6 +11,7 @@ Your bias: **smallest viable change** that resolves the audit's flagged violatio
 1. `gh issue view ${ISSUE_NUMBER}` — full body + comments (skip controller `## 🤖` markers).
 2. Work-unit scope source, by precedence:
    - Read the prompt header `WORK_UNIT_SOURCE_REF` / `source_ref` first.
+   - Use only the router-injected validated transition projection lines (`TRANSITION_TYPE`, `TRANSITION_CONFIDENCE`, `TRANSITION_EVIDENCE_REFS`) for transition assessment context. Missing, malformed, or untrusted sidecars are projected as `unknown` with confidence `0`; the sidecar is not approval, not a consensus substitute, and cannot override the meta-judge truth table. `positive-discovery` is valid only with classifier-surface delta and `net_positive_signal=true`.
    - If it points to an existing local artifact or audit section, read that source and verify it.
    - If it is `gh-issue-<N>` or a referenced local artifact is missing, treat the GitHub issue body/comments from `gh issue view ${ISSUE_NUMBER}` as the scope spec.
    - `audit-iter-${ITERATION}.md if present` is an audit-backed source only when the current `WORK_UNIT_SOURCE_REF` / `source_ref` points to it; do not fabricate audit artifacts.

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -11,6 +11,7 @@ Your bias: **CLAUDE-philosophy-aligned, structurally clean**. You accept higher 
 1. `gh issue view ${ISSUE_NUMBER}` — full body + comments (skip controller `## 🤖` markers).
 2. Work-unit scope source, by precedence:
    - Read the prompt header `WORK_UNIT_SOURCE_REF` / `source_ref` first.
+   - Use only the router-injected validated transition projection lines (`TRANSITION_TYPE`, `TRANSITION_CONFIDENCE`, `TRANSITION_EVIDENCE_REFS`) for transition assessment context. Missing, malformed, or untrusted sidecars are projected as `unknown` with confidence `0`; the sidecar is not approval, not a consensus substitute, and cannot override the meta-judge truth table. `positive-discovery` is valid only with classifier-surface delta and `net_positive_signal=true`.
    - If it points to an existing local artifact or audit section, read that source and verify it.
    - If it is `gh-issue-<N>` or a referenced local artifact is missing, treat the GitHub issue body/comments from `gh issue view ${ISSUE_NUMBER}` as the scope spec.
    - `audit-iter-${ITERATION}.md if present` is an audit-backed source only when the current `WORK_UNIT_SOURCE_REF` / `source_ref` points to it; do not fabricate audit artifacts.

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -31,6 +31,7 @@ from typing import Callable, Iterable, Literal, cast
 from ..active_controller import require_active_controller, write_active_controller_status
 from ..context import LoopContext
 from ..heartbeat import DaemonHeartbeatLease
+from ..transition_assessment import TransitionAssessment, TransitionAssessmentReader, projection_lines
 from ..workflow_stages import format_stage
 
 
@@ -131,11 +132,14 @@ class Phase9SourceIssueDecision:
 
 @dataclass(frozen=True)
 class MetaJudgePromptContext:
-    # refactor helper, no behavior change outside meta-judge prompt rendering.
+    # Refactor (issue-262): Old: meta-judge prompt context had no validated
+    # transition projection. New: carry the same read-only sidecar projection
+    # used by solver headers without creating a second prompt injection path.
     issue: str
     round: int
     solver_paths: dict[str, str]
     output_path: str
+    transition_assessment: TransitionAssessment
 
     @property
     def work_unit_id(self) -> str:
@@ -160,6 +164,9 @@ class MetaJudgePromptRenderer:
         "SOLVER_STRUCTURAL_PATH",
         "SOLVER_DELETE_PATH",
         "META_JUDGE_OUTPUT_PATH",
+        "TRANSITION_TYPE",
+        "TRANSITION_CONFIDENCE",
+        "TRANSITION_EVIDENCE_REFS",
     }
 
     def __init__(self, template_path: Path) -> None:
@@ -177,6 +184,9 @@ class MetaJudgePromptRenderer:
             "SOLVER_STRUCTURAL_PATH": context.solver_paths["structural"],
             "SOLVER_DELETE_PATH": context.solver_paths["delete"],
             "META_JUDGE_OUTPUT_PATH": context.output_path,
+            "TRANSITION_TYPE": context.transition_assessment.transition_type,
+            "TRANSITION_CONFIDENCE": f"{context.transition_assessment.confidence:g}",
+            "TRANSITION_EVIDENCE_REFS": context.transition_assessment.evidence_refs_text,
         }
         rendered = template
         for key in self.PLACEHOLDERS:
@@ -955,11 +965,13 @@ class Phase9Router:
                 f"SOLVER_STRUCTURAL_PATH={context.solver_paths['structural']}",
                 f"SOLVER_DELETE_PATH={context.solver_paths['delete']}",
                 f"META_JUDGE_OUTPUT_PATH={context.output_path}",
+                *projection_lines(context.transition_assessment),
             )
         )
         return (
             f"# {format_stage('design-consensus')} meta-judge\n\n"
             f"## Router template bindings\n\n{bindings}\n\n"
+            f"## Validated transition projection\n\n{self._transition_projection_summary(context.transition_assessment)}\n\n"
             f"## Full meta-judge template\n\n{prompt}"
             + "\n\n## Router dispatch evidence\n\n"
             + f"Dispatch ledger evidence: .refactor-loop/phase9-router-ledger.jsonl key={self._key(issue, round_no, self._judge_role())}\n"
@@ -986,7 +998,13 @@ class Phase9Router:
         if set(solver_paths) != set(self._solver_roles()):
             return self._fail_meta_judge_scope(issue, round_no, "missing solver path")
         output_path = self._artifact_path(self.ctx.paths.runs / f"phase9-issue{issue}-r{round_no}-judge.md")
-        return MetaJudgePromptContext(issue=issue, round=round_no, solver_paths=solver_paths, output_path=output_path)
+        return MetaJudgePromptContext(
+            issue=issue,
+            round=round_no,
+            solver_paths=solver_paths,
+            output_path=output_path,
+            transition_assessment=self._transition_assessment(issue),
+        )
 
     def _fail_meta_judge_scope(self, issue: str, round_no: int, detail: str) -> None:
         self._append_meta_judge_prompt_fallback_event(
@@ -1012,6 +1030,7 @@ class Phase9Router:
     #   authority.
     def _solver_work_unit_header(self, issue: str, round_no: int, role: str) -> str:
         output_path = f".refactor-loop/runs/phase9-issue{issue}-r{round_no}-{role}.md"
+        transition_lines = "\n".join(projection_lines(self._transition_assessment(issue)))
         return (
             f"Issue: #{issue}\n"
             f"Round: {round_no}\n"
@@ -1021,10 +1040,28 @@ class Phase9Router:
             "WORK_UNIT_KIND=manual-work-unit\n"
             "WORK_UNIT_PRODUCER=manual-issue (prompt-only provenance)\n"
             f"WORK_UNIT_SOURCE_REF=gh-issue-{issue}\n"
+            f"{transition_lines}\n"
             f"SOLVER_OUTPUT_PATH={output_path}\n"
             f"Read `gh issue view {issue}` for the issue body/comments. "
             "The issue body/comments are the scope spec when no local audit artifact is provided; "
             "do not fabricate audit artifacts."
+        )
+
+    def _transition_assessment(self, issue: str) -> TransitionAssessment:
+        return TransitionAssessmentReader.load_for_work_unit(
+            self.repo_root,
+            work_unit_id=f"issue-{issue}",
+            source_ref=f"gh-issue-{issue}",
+        )
+
+    def _transition_projection_summary(self, assessment: TransitionAssessment) -> str:
+        return "\n".join(
+            (
+                "Use only this router-validated transition projection; missing/malformed/untrusted sidecars are unknown.",
+                f"- transition_type: {assessment.transition_type}",
+                f"- confidence: {assessment.confidence:g}",
+                f"- evidence_refs: {assessment.evidence_refs_text}",
+            )
         )
 
     # Refactor (iter5/issue-85-stalled-reflector-template):

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/transition_assessment.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/transition_assessment.py
@@ -1,0 +1,184 @@
+"""Read-only transition assessment sidecar projection."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+# Refactor (issue-262): Old: transition ranking/prompt facts had no checked-in
+# reader, so callers would need ad hoc sidecar parsing. New: this module is the
+# only read-only transition_assessment reader and fails closed to unknown.
+SAFE_WORK_UNIT_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+ALLOWED_PRODUCERS = frozenset({"audit", "manual-issue"})
+TRANSITION_BUCKET_ORDER = {
+    "positive-discovery": 0,
+    "classifier-shift": 1,
+    "formal-hardening": 2,
+    "ledger-repair": 3,
+    "record-growth": 4,
+    "unknown": 5,
+}
+TRANSITION_TYPES = frozenset(TRANSITION_BUCKET_ORDER)
+
+
+@dataclass(frozen=True)
+class TransitionAssessment:
+    transition_type: str
+    confidence: float
+    evidence_refs: tuple[str, ...] = ()
+    classifier_surface_delta: tuple[str, ...] = ()
+    ledger_delta: tuple[str, ...] = ()
+    formal_delta: tuple[str, ...] = ()
+    record_growth_delta: tuple[str, ...] = ()
+    net_positive_signal: bool = False
+    notes: str = ""
+    producer: str = ""
+    source_ref: str = ""
+    work_unit_id: str = ""
+
+    @property
+    def bucket(self) -> int:
+        return TRANSITION_BUCKET_ORDER.get(self.transition_type, TRANSITION_BUCKET_ORDER["unknown"])
+
+    @property
+    def evidence_refs_text(self) -> str:
+        return ",".join(self.evidence_refs) if self.evidence_refs else "none"
+
+
+def unknown_assessment(*, work_unit_id: str = "", source_ref: str = "") -> TransitionAssessment:
+    return TransitionAssessment(
+        transition_type="unknown",
+        confidence=0.0,
+        work_unit_id=work_unit_id,
+        source_ref=source_ref,
+    )
+
+
+class TransitionAssessmentReader:
+    """Load validated transition_assessment sidecars from the canonical path only."""
+
+    @staticmethod
+    def canonical_path(repo_root: Path, work_unit_id: str) -> Path | None:
+        if not SAFE_WORK_UNIT_ID_RE.fullmatch(work_unit_id):
+            return None
+        return repo_root / ".refactor-loop" / "runs" / "transition-assessments" / f"{work_unit_id}.json"
+
+    @classmethod
+    def load_for_work_unit(cls, repo_root: Path, work_unit_id: str, source_ref: str) -> TransitionAssessment:
+        path = cls.canonical_path(repo_root, work_unit_id)
+        if path is None:
+            return unknown_assessment(work_unit_id=work_unit_id, source_ref=source_ref)
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return unknown_assessment(work_unit_id=work_unit_id, source_ref=source_ref)
+        return transition_assessment_from_mapping(raw, work_unit_id=work_unit_id, source_ref=source_ref)
+
+
+def transition_assessment_from_mapping(
+    raw: Any,
+    *,
+    work_unit_id: str,
+    source_ref: str,
+) -> TransitionAssessment:
+    if not isinstance(raw, dict):
+        return unknown_assessment(work_unit_id=work_unit_id, source_ref=source_ref)
+    if raw.get("work_unit_id") != work_unit_id or raw.get("source_ref") != source_ref:
+        return unknown_assessment(work_unit_id=work_unit_id, source_ref=source_ref)
+    producer = raw.get("producer")
+    if producer not in ALLOWED_PRODUCERS:
+        return unknown_assessment(work_unit_id=work_unit_id, source_ref=source_ref)
+    confidence = _confidence(raw.get("confidence"))
+    if confidence is None:
+        return unknown_assessment(work_unit_id=work_unit_id, source_ref=source_ref)
+
+    transition_type = raw.get("transition_type")
+    if transition_type not in TRANSITION_TYPES:
+        return unknown_assessment(work_unit_id=work_unit_id, source_ref=source_ref)
+
+    evidence_refs = _string_tuple(raw.get("evidence_refs"))
+    classifier_surface_delta = _string_tuple(raw.get("classifier_surface_delta"))
+    ledger_delta = _string_tuple(raw.get("ledger_delta"))
+    formal_delta = _string_tuple(raw.get("formal_delta"))
+    record_growth_delta = _string_tuple(raw.get("record_growth_delta"))
+    if None in (evidence_refs, classifier_surface_delta, ledger_delta, formal_delta, record_growth_delta):
+        return unknown_assessment(work_unit_id=work_unit_id, source_ref=source_ref)
+    net_positive_signal = raw.get("net_positive_signal")
+    if not isinstance(net_positive_signal, bool):
+        return unknown_assessment(work_unit_id=work_unit_id, source_ref=source_ref)
+
+    normalized_type = _normalize_transition_type(
+        transition_type,
+        classifier_surface_delta=classifier_surface_delta,
+        net_positive_signal=net_positive_signal,
+    )
+    notes = raw.get("notes", "")
+    if not isinstance(notes, str):
+        return unknown_assessment(work_unit_id=work_unit_id, source_ref=source_ref)
+    return TransitionAssessment(
+        transition_type=normalized_type,
+        confidence=confidence if normalized_type != "unknown" else 0.0,
+        evidence_refs=evidence_refs,
+        classifier_surface_delta=classifier_surface_delta,
+        ledger_delta=ledger_delta,
+        formal_delta=formal_delta,
+        record_growth_delta=record_growth_delta,
+        net_positive_signal=net_positive_signal,
+        notes=notes,
+        producer=producer,
+        source_ref=source_ref,
+        work_unit_id=work_unit_id,
+    )
+
+
+def transition_rank_key(assessment: TransitionAssessment) -> tuple[int, float]:
+    return (assessment.bucket, -assessment.confidence)
+
+
+def projection_lines(assessment: TransitionAssessment) -> tuple[str, str, str]:
+    return (
+        f"TRANSITION_TYPE={assessment.transition_type}",
+        f"TRANSITION_CONFIDENCE={assessment.confidence:g}",
+        f"TRANSITION_EVIDENCE_REFS={assessment.evidence_refs_text}",
+    )
+
+
+def _normalize_transition_type(
+    transition_type: str,
+    *,
+    classifier_surface_delta: tuple[str, ...],
+    net_positive_signal: bool,
+) -> str:
+    if transition_type != "positive-discovery":
+        return transition_type
+    if classifier_surface_delta and net_positive_signal:
+        return "positive-discovery"
+    if classifier_surface_delta:
+        return "classifier-shift"
+    return "unknown"
+
+
+def _confidence(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    confidence = float(value)
+    if confidence < 0 or confidence > 1:
+        return None
+    return confidence
+
+
+def _string_tuple(value: Any) -> tuple[str, ...] | None:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        return None
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item:
+            return None
+        result.append(item)
+    return tuple(result)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -40,6 +40,7 @@ from typing import Any
 
 from codex_refactor_loop import labels as label_catalog
 from codex_refactor_loop.context import LoopContext
+from codex_refactor_loop.transition_assessment import TransitionAssessmentReader, transition_rank_key
 from codex_refactor_loop.work_items import ManagedWorkProjection
 from codex_refactor_loop.workflow_spec import WorkflowSpecError, load_validated_workflow_spec
 from codex_refactor_loop.workflow_stages import assert_stage_slug
@@ -727,10 +728,13 @@ def ci_red_actions(repo_root: Path, items: list[GhItem]) -> list[dict[str, Any]]
     return actions
 
 
-def existing_issue_actions(items: list[GhItem]) -> list[dict[str, Any]]:
+def existing_issue_actions(items: list[GhItem], repo_root: Path | None = None) -> list[dict[str, Any]]:
     actions: list[dict[str, Any]] = []
     represented = ManagedWorkProjection(_projection_items(items)).represented_issue_numbers()
-    ordered = sorted(items, key=lambda item: (not item.milestone, 0 if item.kind == "issue" else 1, item.number))
+    # Refactor (issue-262): Old: existing issue ranking only used milestone,
+    # kind, and number. New: a checked-in caller may use the validated
+    # transition_assessment sidecar bucket before the existing tie-breakers.
+    ordered = sorted(items, key=lambda item: _existing_issue_sort_key(item, repo_root))
     for item in ordered:
         if item.kind == "issue" and item.number in represented:
             continue
@@ -751,6 +755,20 @@ def existing_issue_actions(items: list[GhItem]) -> list[dict[str, Any]]:
             }
         )
     return actions
+
+
+def _existing_issue_sort_key(item: GhItem, repo_root: Path | None) -> tuple[bool, int, float, int, int]:
+    if repo_root is None:
+        transition_key = (0, -0.0)
+    else:
+        transition_key = transition_rank_key(
+            TransitionAssessmentReader.load_for_work_unit(
+                repo_root,
+                work_unit_id=f"issue-{item.number}",
+                source_ref=f"gh-issue-{item.number}",
+            )
+        )
+    return (not item.milestone, transition_key[0], transition_key[1], 0 if item.kind == "issue" else 1, item.number)
 
 
 def phase_from_labels(labels: tuple[str, ...]) -> str:
@@ -843,7 +861,7 @@ def build_plan(repo_root: Path) -> dict[str, Any]:
         )
     else:
         actions.extend(host_actions)
-    actions.extend(existing_issue_actions(gh_items))
+    actions.extend(existing_issue_actions(gh_items, repo_root))
     actions.sort(key=lambda action: action["priority"])
 
     recommendation: str | None = None

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -63,6 +63,29 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         path.write_text(body, encoding="utf-8")
         return path
 
+    def write_transition_assessment(self, issue: int, transition_type: str = "positive-discovery") -> None:
+        path = self.repo / ".refactor-loop" / "runs" / "transition-assessments" / f"issue-{issue}.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "transition_type": transition_type,
+                    "confidence": 0.75,
+                    "evidence_refs": [f".refactor-loop/runs/issue-{issue}.md"],
+                    "classifier_surface_delta": ["classifier delta"],
+                    "ledger_delta": [],
+                    "formal_delta": [],
+                    "record_growth_delta": [],
+                    "net_positive_signal": transition_type == "positive-discovery",
+                    "notes": "",
+                    "producer": "manual-issue",
+                    "source_ref": f"gh-issue-{issue}",
+                    "work_unit_id": f"issue-{issue}",
+                }
+            ),
+            encoding="utf-8",
+        )
+
     def ledger_entries(self) -> list[dict]:
         path = self.repo / ".refactor-loop" / "phase9-router-ledger.jsonl"
         if not path.exists():
@@ -493,6 +516,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertEqual(len(path.read_text(encoding="utf-8").splitlines()), 4)
 
     def test_phase9_router_judge_prompt_references_dispatch_ledger_evidence(self) -> None:
+        self.write_transition_assessment(169)
         self.solver_triplet(issue=169, round_no=8)
 
         self.router.tick()
@@ -512,6 +536,10 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             "Round number this fires: 9",
             "Write `.refactor-loop/runs/phase9-issue169-r8-judge.md`",
             "gh issue view 169",
+            "TRANSITION_TYPE=positive-discovery",
+            "TRANSITION_CONFIDENCE=0.75",
+            "TRANSITION_EVIDENCE_REFS=.refactor-loop/runs/issue-169.md",
+            "Use only this router-validated transition projection",
             "Router-scoped input boundary",
         ):
             with self.subTest(token=token):
@@ -787,6 +815,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertEqual(events[0]["marker"], "META_JUDGE_DONE:converge:round-5:need-more")
 
     def test_solver_prompt_for_issue_driven_converge_has_source_header(self) -> None:
+        self.write_transition_assessment(114)
         self.write_log("phase9-issue114-r1-judge.log", "META_JUDGE_DONE:converge:round-2:need-more")
 
         self.router.tick()
@@ -804,6 +833,9 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             "WORK_UNIT_KIND=manual-work-unit",
             "WORK_UNIT_PRODUCER=manual-issue (prompt-only provenance)",
             "WORK_UNIT_SOURCE_REF=gh-issue-114",
+            "TRANSITION_TYPE=positive-discovery",
+            "TRANSITION_CONFIDENCE=0.75",
+            "TRANSITION_EVIDENCE_REFS=.refactor-loop/runs/issue-114.md",
             "SOLVER_OUTPUT_PATH=.refactor-loop/runs/phase9-issue114-r2-structural.md",
             "gh issue view 114",
             "issue body/comments are the scope spec when no local audit artifact is provided",
@@ -814,6 +846,22 @@ class Phase9RouterDaemonTests(unittest.TestCase):
                 self.assertIn(needle, prompt)
         self.assertNotIn("$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md", prompt)
         self.assertNotIn("cluster spec", prompt)
+
+    def test_solver_prompt_for_missing_transition_assessment_uses_unknown_projection(self) -> None:
+        self.write_log("phase9-issue115-r1-judge.log", "META_JUDGE_DONE:converge:round-2:need-more")
+
+        self.router.tick()
+
+        prompt = (
+            self.repo
+            / ".refactor-loop"
+            / "prompts"
+            / "phase9"
+            / "phase9-issue115-r2-minimal.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("TRANSITION_TYPE=unknown", prompt)
+        self.assertIn("TRANSITION_CONFIDENCE=0", prompt)
+        self.assertIn("TRANSITION_EVIDENCE_REFS=none", prompt)
 
     def test_phase9_router_converge_accepts_non_ascii_reason(self) -> None:
         self.write_log(

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -168,6 +168,39 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             with self.subTest(needle=needle):
                 self.assertIn(needle, phase9)
 
+    def test_skill_documents_transition_assessment_sidecar_boundary(self) -> None:
+        work_unit = section_after_anchor(self.skill, "work-unit-contract")
+        producers = section_after_heading(self.skill, "Producers")
+        batching = section_after_anchor(self.skill, "batching-heuristics")
+        prompts = "\n".join(
+            (
+                read(SKILL_ROOT / "prompts" / "solver-minimal.md"),
+                read(SKILL_ROOT / "prompts" / "solver-structural.md"),
+                read(SKILL_ROOT / "prompts" / "solver-delete.md"),
+                read(SKILL_ROOT / "prompts" / "meta-judge.md"),
+            )
+        )
+
+        for needle in (
+            "optional read-only `transition_assessment` sidecar",
+            "not stable candidate NDJSON",
+            "not a work-unit envelope wrapper",
+            "not a WorkUnit producer",
+            "Missing/malformed/untrusted -> unknown",
+            ".refactor-loop/runs/transition-assessments/<safe-work-unit-id>.json",
+            "[A-Za-z0-9._-]+",
+            "positive-discovery > classifier-shift > formal-hardening > ledger-repair > record-growth > unknown",
+            "classifier-surface delta and `net_positive_signal=true`",
+            "marker change, branch change, or\nwork-unit token change",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, work_unit)
+        self.assertIn("does not extend the WorkUnit\nproducer enum", producers)
+        self.assertIn("transition bucket before `risk` and `leverage`", batching)
+        self.assertIn("Use only the router-injected validated transition projection", prompts)
+        self.assertIn("cannot override the meta-judge truth table", prompts)
+        self.assertNotIn("host:<slug>` is allowed", self.skill)
+
     def test_downstream_install_walkthrough_contract(self) -> None:
         # Refactor (iter1/issue-141):
         #   Old pattern: downstream install steps without an installer were split across README, SKILL statusline text, and restart helper text, with no one-step walkthrough.

--- a/skills/codex-refactor-loop/scripts/test_transition_assessment.py
+++ b/skills/codex-refactor-loop/scripts/test_transition_assessment.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Behavior tests for read-only transition assessment sidecar projection."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from codex_refactor_loop.transition_assessment import (  # noqa: E402
+    TRANSITION_BUCKET_ORDER,
+    TransitionAssessmentReader,
+    projection_lines,
+    transition_rank_key,
+)
+
+
+class TransitionAssessmentTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.assessment_dir = self.repo / ".refactor-loop" / "runs" / "transition-assessments"
+        self.assessment_dir.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write_assessment(self, work_unit_id: str = "issue-262", **overrides: object) -> None:
+        payload = {
+            "transition_type": "positive-discovery",
+            "confidence": 0.8,
+            "evidence_refs": [".refactor-loop/runs/example.md"],
+            "classifier_surface_delta": ["classifier added a new signal"],
+            "ledger_delta": [],
+            "formal_delta": [],
+            "record_growth_delta": [],
+            "net_positive_signal": True,
+            "notes": "validated",
+            "producer": "manual-issue",
+            "source_ref": "gh-issue-262",
+            "work_unit_id": work_unit_id,
+        }
+        payload.update(overrides)
+        (self.assessment_dir / f"{work_unit_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    def load(self, work_unit_id: str = "issue-262", source_ref: str = "gh-issue-262"):
+        return TransitionAssessmentReader.load_for_work_unit(self.repo, work_unit_id, source_ref)
+
+    def test_loads_valid_canonical_sidecar_projection(self) -> None:
+        self.write_assessment()
+
+        assessment = self.load()
+
+        self.assertEqual(assessment.transition_type, "positive-discovery")
+        self.assertEqual(assessment.confidence, 0.8)
+        self.assertEqual(assessment.evidence_refs, (".refactor-loop/runs/example.md",))
+        self.assertEqual(projection_lines(assessment), (
+            "TRANSITION_TYPE=positive-discovery",
+            "TRANSITION_CONFIDENCE=0.8",
+            "TRANSITION_EVIDENCE_REFS=.refactor-loop/runs/example.md",
+        ))
+
+    def test_missing_malformed_or_untrusted_sidecars_are_unknown(self) -> None:
+        cases = [
+            ("missing", None),
+            ("malformed", "{not-json"),
+            ("producer", {"producer": "host:newmath"}),
+            ("source", {"source_ref": "gh-issue-999"}),
+            ("work-unit", {"work_unit_id": "issue-999"}),
+            ("confidence", {"confidence": 1.5}),
+        ]
+        for name, override in cases:
+            with self.subTest(name=name):
+                self.tmp.cleanup()
+                self.setUp()
+                if isinstance(override, str):
+                    (self.assessment_dir / "issue-262.json").write_text(override, encoding="utf-8")
+                elif isinstance(override, dict):
+                    self.write_assessment(**override)
+
+                assessment = self.load()
+
+                self.assertEqual(assessment.transition_type, "unknown")
+                self.assertEqual(assessment.confidence, 0)
+
+    def test_unsafe_work_unit_id_never_escapes_canonical_directory(self) -> None:
+        outside = self.repo / ".refactor-loop" / "runs" / "transition-assessments" / ".." / "evil.json"
+        outside.parent.mkdir(parents=True, exist_ok=True)
+        outside.write_text("{}", encoding="utf-8")
+
+        assessment = TransitionAssessmentReader.load_for_work_unit(self.repo, "../evil", "gh-issue-262")
+
+        self.assertEqual(assessment.transition_type, "unknown")
+        self.assertIsNone(TransitionAssessmentReader.canonical_path(self.repo, "../evil"))
+
+    def test_bucket_order_and_rank_key(self) -> None:
+        self.assertEqual(
+            list(TRANSITION_BUCKET_ORDER),
+            ["positive-discovery", "classifier-shift", "formal-hardening", "ledger-repair", "record-growth", "unknown"],
+        )
+        for transition_type, expected_bucket in TRANSITION_BUCKET_ORDER.items():
+            with self.subTest(transition_type=transition_type):
+                self.write_assessment(transition_type=transition_type, confidence=0.25)
+                assessment = self.load()
+                self.assertEqual(transition_rank_key(assessment), (expected_bucket, -0.25 if transition_type != "unknown" else -0.0))
+
+    def test_positive_discovery_requires_classifier_delta_and_net_positive_signal(self) -> None:
+        cases = [
+            ({"classifier_surface_delta": [], "net_positive_signal": True}, "unknown", 0),
+            ({"classifier_surface_delta": ["delta"], "net_positive_signal": False}, "classifier-shift", 0.8),
+        ]
+        for override, expected_type, expected_confidence in cases:
+            with self.subTest(override=override):
+                self.tmp.cleanup()
+                self.setUp()
+                self.write_assessment(**override)
+
+                assessment = self.load()
+
+                self.assertEqual(assessment.transition_type, expected_type)
+                self.assertEqual(assessment.confidence, expected_confidence)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -89,6 +89,9 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                     existing)
                       printf '[{"number":10,"title":"ordinary issue","labels":[{"name":"auto-loop"},{"name":"🔧 phase:fixing"}]}]\n'
                       ;;
+                    transition_sort)
+                      printf '[{"number":60,"title":"unknown issue","labels":[{"name":"auto-loop"},{"name":"🔧 phase:fixing"}]},{"number":61,"title":"positive issue","labels":[{"name":"auto-loop"},{"name":"🔧 phase:fixing"}]},{"number":62,"title":"classifier issue","labels":[{"name":"auto-loop"},{"name":"🔧 phase:fixing"}]},{"number":63,"title":"confident classifier issue","labels":[{"name":"auto-loop"},{"name":"🔧 phase:fixing"}]}]\n'
+                      ;;
                     many_active)
                       printf '['
                       for i in 1 2 3 4 5 6; do
@@ -452,6 +455,42 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(plan["actions"][0]["kind"], "existing-issue")
         self.assertEqual(plan["actions"][0]["item"], "issue #10")
         self.assertNotEqual(plan.get("recommendation"), "RECOMMEND:audit")
+
+    def write_transition_assessment(self, number: int, transition_type: str, confidence: float) -> None:
+        path = self.repo / ".refactor-loop" / "runs" / "transition-assessments" / f"issue-{number}.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "transition_type": transition_type,
+                    "confidence": confidence,
+                    "evidence_refs": [f".refactor-loop/runs/issue-{number}.md"],
+                    "classifier_surface_delta": ["classifier delta"] if transition_type in {"positive-discovery", "classifier-shift"} else [],
+                    "ledger_delta": [],
+                    "formal_delta": [],
+                    "record_growth_delta": [],
+                    "net_positive_signal": transition_type == "positive-discovery",
+                    "notes": "",
+                    "producer": "manual-issue",
+                    "source_ref": f"gh-issue-{number}",
+                    "work_unit_id": f"issue-{number}",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_existing_issue_transition_bucket_sorts_before_kind_and_number(self) -> None:
+        self.write_transition_assessment(61, "positive-discovery", 0.1)
+        self.write_transition_assessment(62, "classifier-shift", 0.2)
+        self.write_transition_assessment(63, "classifier-shift", 0.9)
+
+        plan = self.run_plan(fixture="transition_sort")
+
+        actions = [action for action in plan["actions"] if action["kind"] == "existing-issue"]
+        self.assertEqual(
+            [action["item"] for action in actions],
+            ["issue #61", "issue #63", "issue #62", "issue #60"],
+        )
 
     def test_load_github_items_queries_canonical_and_legacy_managed_labels_once(self) -> None:
         plan = self.run_plan(fixture="managed_dual_read")


### PR DESCRIPTION
## Summary / 摘要
#262(loop ranking 加可选 transition_assessment sidecar)。
- **New**(consensus structural):唯一 read-only `transition_assessment.py` reader(JSON schema 校验 + source_ref/work_unit_id trust + unknown fallback + rank helper);phase9-router 注入 validated TRANSITION_* projection 到 solver/judge prompt;wakeup_plan existing-issue 排序加 `(not milestone, transition_bucket, -confidence, kind_order, number)`,无 sidecar 时 ordering 不变。sidecar 是 ranking/prompt projection fact,**非** candidate NDJSON/envelope,**不**扩 WorkUnit producer enum,missing/malformed/untrusted=unknown,非共识替代/不覆盖 truth table。
## Scope:12 files(transition_assessment.py +184 新 + router/wakeup_plan projection + 4 prompts 输入规则 + SKILL work-unit-contract 窄例外 + tests)。targeted 100 OK;remote CI 跑全量。
Closes #262
🤖 Auto-loop / codex-refactor-loop
⟦AI:AUTO-LOOP⟧
