### PR TITLE
#300: PR 共识前一律 draft 防误合 (_ensure_pr_ready_for_merge + --draft)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1368,6 +1368,11 @@ could be empty, inferred, or non-canonical GitHub identifiers before gh/git
 side effects. New principle: lifecycle targets are normalized through a private
 canonical positive-decimal boundary before any lifecycle side effect. -->
 
+<!-- Refactor (issue-300): Old pattern: controller-opened PRs could be mergeable
+before the review-gate consensus decision. New principle: open PRs as draft by
+default and mark ready only inside post-decision merge_pr after MERGE or
+MERGE_WITH_COMMENTS has already been decided. -->
+
 7 个曾发生的 bug 都来自 controller boilerplate 重复 + shell 变量传值 bug。统一用 controller-internal `ControllerActions` primitives, not public CLI commands:
 
 ```python
@@ -1381,7 +1386,8 @@ actions.apply_human_label_or_skip(pr_number, source_marker, reason)
 
 **强制**:
 - 派 codex 前必须 validate rendered prompt output — 防 codex blocked on unresolved placeholder
-- merge PR 必须用 internal `merge_pr(pr)` — auto-close + label cleanup,不留尾巴。`merge_pr` is a post-decision lifecycle primitive: call it only after the controller has already decided `MERGE` or `MERGE_WITH_COMMENTS`; it never computes Consensus-rnd Phase review-gate reviewer policy.
+- Controller-opened PRs must use internal `open_pr_with_label(...)`; it creates open PRs as draft by default (`gh pr create --draft`) before labels are applied.
+- merge PR 必须用 internal `merge_pr(pr)` — post-decision ready+merge + auto-close + label cleanup,不留尾巴。`merge_pr` first checks draft state and, only when the controller has already decided `MERGE` or `MERGE_WITH_COMMENTS`, marks the PR ready before `gh pr merge`; it never computes Consensus-rnd Phase review-gate reviewer policy.
 - worktree 创建必须用 internal `safe_worktree(iteration, cluster, base)` — 处理 "already exists" race
 - PR 号捕获必须用 internal `open_pr_with_label(...)` returned tuple — **禁止** shell `pr_num=$(...grep -oE...)` 这种 subshell 变量传值模式
 - Lifecycle PR/issue targets entering `apply_human_label_or_skip`, `merge_pr`, `open_pr_with_label`, or `record_recent_pr_merge` must pass `_normalize_lifecycle_target` and become canonical positive decimals before any `gh` or `git` side effect; empty, blank, zero, negative, non-digit, leading-zero, URL, branch, and current-PR inference inputs fail closed and write `CONTROLLER_ACTION_BLOCKED:invalid-github-target:<action>:<kind>:<source>` to the controller pending-event log. PR creation target capture stays limited to `open_pr_with_label(...)` URL extraction followed by the same normalization.
@@ -2042,11 +2048,11 @@ Each reviewer outputs `REVIEW_DONE:${PR}:${role}:<approve|comment|reject>` marke
 
 | Preconditions | Latest complete required round | Controller action |
 |---|---|
-| CI green, PR mergeable, reviewed head SHA current, every required role has exactly one valid marker after `EXIT=0` | `reject=0`, `approve=R`, `comment=0` | `MERGE`: post 中文 merge comment, then call `merge_pr <pr>`. |
-| Same preconditions | `reject=0`, `approve>=1`, `comment>=1`, `approve+comment=R` | `MERGE_WITH_COMMENTS`: surface comment evidence, post 中文 merge comment, then call `merge_pr <pr>`. |
-| Same preconditions | `reject=0`, `approve=0`, `comment=R` | `WAIT_EXPLICIT_APPROVAL`: surface comments, do not merge, do not dispatch fix. |
-| Same preconditions | `reject>=1` | `FIX`: enter fix-retry loop; fix codex consumes reject evidence as blocking input and comments as context. Do NOT escalate to human on first reject. |
-| Any gate incomplete or invalid | missing role, duplicate/unknown verdict, no `EXIT=0`, stale head SHA, CI pending/fail, or non-mergeable PR | `WAIT_OR_REDISPATCH`: wait or re-dispatch invalid/missing reviewer once; never merge. |
+| CI green, PR mergeable, reviewed head SHA current, every required role has exactly one valid marker after `EXIT=0` | `reject=0`, `approve=R`, `comment=0` | `MERGE`: post 中文 merge comment, then call `merge_pr <pr>` for ready+merge. |
+| Same preconditions | `reject=0`, `approve>=1`, `comment>=1`, `approve+comment=R` | `MERGE_WITH_COMMENTS`: surface comment evidence, post 中文 merge comment, then call `merge_pr <pr>` for ready+merge. |
+| Same preconditions | `reject=0`, `approve=0`, `comment=R` | `WAIT_EXPLICIT_APPROVAL`: surface comments, do not ready, do not merge, do not dispatch fix. |
+| Same preconditions | `reject>=1` | `FIX`: enter fix-retry loop; do not ready, do not merge; fix codex consumes reject evidence as blocking input and comments as context. Do NOT escalate to human on first reject. |
+| Any gate incomplete or invalid | missing role, duplicate/unknown verdict, no `EXIT=0`, stale head SHA, CI pending/fail, or non-mergeable PR | `WAIT_OR_REDISPATCH`: wait or re-dispatch invalid/missing reviewer once; do not ready, never merge. |
 
 ### Fix-retry loop (AI iterates until consensus)
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -203,6 +203,19 @@ class ControllerActions:
         sys.stderr.write("\n".join(result.stderr.splitlines()[-2:]) + "\n")
         return wt_path, branch
 
+    def _ensure_pr_ready_for_merge(self, pr_target: str) -> int:
+        # Refactor (issue-300): PRs are opened as draft by default; merge_pr is
+        # the controller-owned post-decision boundary that marks them ready only
+        # after MERGE or MERGE_WITH_COMMENTS has already been decided.
+        draft = self.gh(["pr", "view", pr_target, "--json", "isDraft", "--jq", ".isDraft"], check=False)
+        if draft.returncode != 0:
+            return draft.returncode
+        if draft.stdout.strip() == "true":
+            ready = self.gh(["pr", "ready", pr_target], check=False)
+            if ready.returncode != 0:
+                return ready.returncode
+        return 0
+
     def merge_pr(self, pr: str, linked_issue: str = "") -> int:
         if not self._require_owner_or_return("merge-pr", code=3):
             return 3
@@ -235,6 +248,9 @@ class ControllerActions:
                 if normalized is None:
                     return 1
                 issue_target = normalized
+        ready = self._ensure_pr_ready_for_merge(pr_target)
+        if ready != 0:
+            return ready
         merge = self.gh(["pr", "merge", pr_target, "--admin", "--squash", "--delete-branch"], check=False)
         if merge.stdout:
             print(merge.stdout.splitlines()[-1])
@@ -280,7 +296,7 @@ class ControllerActions:
                 action="open-pr",
                 source="body-link",
             )
-        created = self.gh(["pr", "create", "--base", base, "--head", head, "--title", title, "--body-file", body_file], check=False)
+        created = self.gh(["pr", "create", "--draft", "--base", base, "--head", head, "--title", title, "--body-file", body_file], check=False)
         output = created.stdout + created.stderr
         match = re.search(r"https://github\.com/[^/]+/[^/]+/pull/([0-9]+)", output)
         if not match:

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -142,12 +142,109 @@ class ControllerActionsTests(unittest.TestCase):
         with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
             self.assertEqual(0, self.actions.merge_pr("77", linked_issue="239"))
 
+        ready_index = gh_calls.index(["pr", "view", "77", "--json", "isDraft", "--jq", ".isDraft"])
+        merge_index = gh_calls.index(["pr", "merge", "77", "--admin", "--squash", "--delete-branch"])
+        self.assertLess(ready_index, merge_index)
         self.assertIn(["pr", "merge", "77", "--admin", "--squash", "--delete-branch"], gh_calls)
         self.assertFalse(any(call[:5] == ["pr", "view", "77", "--json", "body"] for call in gh_calls), gh_calls)
         self.assertTrue(any(call[:3] == ["pr", "edit", "77"] for call in gh_calls), gh_calls)
         self.assertTrue(any(call[:3] == ["issue", "close", "239"] for call in gh_calls), gh_calls)
         issue_edit = next(call for call in gh_calls if call[:3] == ["issue", "edit", "239"])
         self.assertEqual(labels.PHASE_MERGED, issue_edit[issue_edit.index("--add-label") + 1])
+
+    def test_merge_pr_marks_draft_ready_before_merge(self) -> None:
+        gh_calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            gh_calls.append(args)
+            if args[:5] == ["pr", "view", "77", "--json", "body"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            if args[:5] == ["pr", "view", "77", "--json", "isDraft"]:
+                return mock.Mock(returncode=0, stdout="true\n", stderr="")
+            if args[:3] == ["pr", "ready", "77"]:
+                return mock.Mock(returncode=0, stdout="Ready\n", stderr="")
+            if args[:2] == ["pr", "merge"]:
+                return mock.Mock(returncode=0, stdout="Merged pull request #77\n", stderr="")
+            if args[:5] == ["pr", "view", "77", "--json", "number,mergedAt,mergeCommit,baseRefName,headRefName"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        {
+                            "number": 77,
+                            "mergedAt": "2026-05-29T00:00:00Z",
+                            "mergeCommit": {"oid": "abc123"},
+                            "baseRefName": "dev",
+                            "headRefName": "impl/issue300",
+                        }
+                    ),
+                    stderr="",
+                )
+            if args[:5] == ["pr", "view", "77", "--json", "headRefName"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+            self.assertEqual(0, self.actions.merge_pr("77"))
+
+        self.assertIn(["pr", "ready", "77"], gh_calls)
+        self.assertLess(gh_calls.index(["pr", "ready", "77"]), gh_calls.index(["pr", "merge", "77", "--admin", "--squash", "--delete-branch"]))
+
+    def test_merge_pr_ready_failure_fails_closed_before_merge_side_effects(self) -> None:
+        gh_calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            gh_calls.append(args)
+            if args[:5] == ["pr", "view", "77", "--json", "body"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            if args[:5] == ["pr", "view", "77", "--json", "isDraft"]:
+                return mock.Mock(returncode=0, stdout="true\n", stderr="")
+            if args[:3] == ["pr", "ready", "77"]:
+                return mock.Mock(returncode=9, stdout="", stderr="ready failed")
+            raise AssertionError(f"unexpected gh side effect after ready failure: {args}")
+
+        with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+            with mock.patch.object(self.actions, "git", side_effect=AssertionError("git should not be called")):
+                self.assertEqual(9, self.actions.merge_pr("77"))
+
+        self.assertIn(["pr", "ready", "77"], gh_calls)
+        self.assertFalse(any(call[:2] == ["pr", "merge"] for call in gh_calls), gh_calls)
+        self.assertFalse((self.tmp / ".refactor-loop" / "state" / "recent-pr-merges.json").exists())
+
+    def test_merge_pr_already_ready_merges_without_pr_ready_call(self) -> None:
+        gh_calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            gh_calls.append(args)
+            if args[:5] == ["pr", "view", "77", "--json", "body"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            if args[:5] == ["pr", "view", "77", "--json", "isDraft"]:
+                return mock.Mock(returncode=0, stdout="false\n", stderr="")
+            if args[:2] == ["pr", "merge"]:
+                return mock.Mock(returncode=0, stdout="Merged pull request #77\n", stderr="")
+            if args[:5] == ["pr", "view", "77", "--json", "number,mergedAt,mergeCommit,baseRefName,headRefName"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        {
+                            "number": 77,
+                            "mergedAt": "2026-05-29T00:00:00Z",
+                            "mergeCommit": {"oid": "abc123"},
+                            "baseRefName": "dev",
+                            "headRefName": "impl/issue300",
+                        }
+                    ),
+                    stderr="",
+                )
+            if args[:5] == ["pr", "view", "77", "--json", "headRefName"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+            self.assertEqual(0, self.actions.merge_pr("77"))
+
+        self.assertIn(["pr", "view", "77", "--json", "isDraft", "--jq", ".isDraft"], gh_calls)
+        self.assertFalse(any(call[:2] == ["pr", "ready"] for call in gh_calls), gh_calls)
+        self.assertIn(["pr", "merge", "77", "--admin", "--squash", "--delete-branch"], gh_calls)
 
     def test_open_pr_with_label_rejects_malformed_create_url_before_post_create_edit(self) -> None:
         cases = (
@@ -314,6 +411,7 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertEqual(77, pr_num)
         self.assertIn(["push", "origin", "abc123:refs/heads/rollup/abc123"], git_calls)
         create_call = next(call for call in gh_calls if call[:2] == ["pr", "create"])
+        self.assertIn("--draft", create_call)
         self.assertIn("--head", create_call)
         self.assertEqual("rollup/abc123", create_call[create_call.index("--head") + 1])
         self.assertNotEqual("auto-refact-dev", create_call[create_call.index("--head") + 1])
@@ -466,6 +564,8 @@ class ControllerActionsTests(unittest.TestCase):
 
         self.assertEqual(77, pr_num)
         self.assertTrue(any(call[:2] == ["pr", "create"] for call in gh_calls), gh_calls)
+        create_call = next(call for call in gh_calls if call[:2] == ["pr", "create"])
+        self.assertIn("--draft", create_call)
         edit_call = next(call for call in gh_calls if call[:2] == ["pr", "edit"])
         self.assertEqual("77", edit_call[2])
         self.assertEqual(
@@ -776,6 +876,18 @@ class ControllerActionsSourceRegressionTests(unittest.TestCase):
         self.assertIn("BODY_CLOSING_ISSUE_TARGET_RE", text)
         self.assertIn("source=\"body-link\"", text)
         self.assertIn("CONTROLLER_ACTION_BLOCKED:invalid-github-target:{action}:{kind}:{source}", text)
+
+    def test_issue_300_draft_pr_ready_before_merge_contract(self) -> None:
+        text = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")
+        self.assertIn("Refactor (issue-300)", text)
+        self.assertIn('"pr", "create", "--draft"', text)
+        self.assertIn('def _ensure_pr_ready_for_merge(self, pr_target: str) -> int:', text)
+        self.assertIn('"pr", "view", pr_target, "--json", "isDraft", "--jq", ".isDraft"', text)
+        self.assertIn('"pr", "ready", pr_target', text)
+        self.assertIn("ready = self._ensure_pr_ready_for_merge(pr_target)", text)
+        self.assertLess(text.index("ready = self._ensure_pr_ready_for_merge(pr_target)"), text.index('"pr", "merge", pr_target'))
+        self.assertNotIn("ReviewGateAction", text)
+        self.assertNotIn("review_gate.py", text)
 
     def test_lifecycle_gh_subject_slots_use_normalized_target_locals(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_controller_lib_label_helper.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_lib_label_helper.py
@@ -207,7 +207,16 @@ class ControllerLibRecentMergeProjectionTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.tmp.cleanup()
 
-    def _write_fake_gh(self, *, merge_exit: int, fact_json: str, body: str = "Closes #145\n", head: str = "refactor/issue145") -> None:
+    def _write_fake_gh(
+        self,
+        *,
+        merge_exit: int,
+        fact_json: str,
+        body: str = "Closes #145\n",
+        head: str = "refactor/issue145",
+        is_draft: str = "false",
+        ready_exit: int = 0,
+    ) -> None:
         fake_gh = self.root / "gh"
         fake_gh.write_text(
             f"""#!/usr/bin/env bash
@@ -215,6 +224,13 @@ printf '%s\\n' "$*" >> "$FAKE_GH_LOG"
 if [[ "$1 $2 $3" == "pr view 55" && "$*" == *"--json body"* ]]; then
   printf '%s\\n' {json.dumps(body)}
   exit 0
+fi
+if [[ "$1 $2 $3" == "pr view 55" && "$*" == *"--json isDraft"* ]]; then
+  printf '%s\\n' {json.dumps(is_draft)}
+  exit 0
+fi
+if [[ "$1 $2 $3" == "pr ready 55" ]]; then
+  exit {ready_exit}
 fi
 if [[ "$1 $2 $3" == "pr merge 55" ]]; then
   printf 'merge output\\n'
@@ -317,6 +333,8 @@ exit 0
         self.assertEqual(merges[0]["sha"], "abc123")
         self.assertEqual(merges[0]["merged_at"], "2026-05-29T01:02:03Z")
         calls = self.gh_calls()
+        self.assertIn("pr view 55 --repo test-owner/test-repo --json isDraft --jq .isDraft", calls)
+        self.assertNotIn("pr ready 55 --repo test-owner/test-repo", calls)
         self.assertIn("pr merge 55 --repo test-owner/test-repo --admin --squash --delete-branch", calls)
         expected_pr_edit = ["pr", "edit", "55", "--repo", "test-owner/test-repo"]
         for label in (
@@ -423,6 +441,43 @@ exit 0
         self.assertFalse((self.root / ".refactor-loop/state/recent-pr-merges.json").exists())
         calls = "\n".join(self.gh_calls())
         self.assertIn("pr merge 55", calls)
+        self.assertNotIn("pr edit 55", calls)
+        self.assertNotIn("issue close 145", calls)
+        self.assertNotIn("worktree remove", self.git_log.read_text(encoding="utf-8") if self.git_log.exists() else "")
+
+    def test_merge_pr_marks_draft_ready_before_merge(self) -> None:
+        self._write_fake_gh(
+            merge_exit=0,
+            fact_json=json.dumps({
+                "number": 55,
+                "mergedAt": "2026-05-29T01:02:03Z",
+                "mergeCommit": {"oid": "abc123"},
+                "baseRefName": "auto-refact-dev",
+                "headRefName": "refactor/issue145",
+            }),
+            is_draft="true",
+        )
+
+        result = self.run_merge_pr("55", "145")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.gh_calls()
+        ready_call = "pr ready 55 --repo test-owner/test-repo"
+        merge_call = "pr merge 55 --repo test-owner/test-repo --admin --squash --delete-branch"
+        self.assertIn(ready_call, calls)
+        self.assertIn(merge_call, calls)
+        self.assertLess(calls.index(ready_call), calls.index(merge_call))
+
+    def test_merge_pr_ready_failure_fails_closed_before_projection_or_cleanup(self) -> None:
+        self._write_fake_gh(merge_exit=0, fact_json="{}", is_draft="true", ready_exit=7)
+
+        result = self.run_merge_pr("55", "145")
+
+        self.assertEqual(result.returncode, 7, result.stderr)
+        self.assertFalse((self.root / ".refactor-loop/state/recent-pr-merges.json").exists())
+        calls = "\n".join(self.gh_calls())
+        self.assertIn("pr ready 55", calls)
+        self.assertNotIn("pr merge 55", calls)
         self.assertNotIn("pr edit 55", calls)
         self.assertNotIn("issue close 145", calls)
         self.assertNotIn("worktree remove", self.git_log.read_text(encoding="utf-8") if self.git_log.exists() else "")

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -265,14 +265,31 @@ class SkillReferenceAnchorTests(unittest.TestCase):
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, section)
-        for forbidden in (
-            "copy, overwrite, reinstall",
-            "run installers",
-            "mutate `.git`",
-            "touches the network",
+
+    def test_skill_documents_issue_300_draft_then_ready_merge_contract(self) -> None:
+        for needle in (
+            "Refactor (issue-300)",
+            "gh pr create --draft",
+            "open PRs as draft by default",
+            "post-decision ready+merge",
+            "only when the controller has already decided `MERGE` or `MERGE_WITH_COMMENTS`",
+            "marks the PR ready before `gh pr merge`",
+            "it never computes Consensus-rnd Phase review-gate reviewer policy",
         ):
-            with self.subTest(forbidden=forbidden):
-                self.assertIn(forbidden, section)
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.skill)
+        self.assertIn("`MERGE`: post 中文 merge comment, then call `merge_pr <pr>` for ready+merge.", self.skill)
+        self.assertIn(
+            "`MERGE_WITH_COMMENTS`: surface comment evidence, post 中文 merge comment, then call `merge_pr <pr>` for ready+merge.",
+            self.skill,
+        )
+        for needle in (
+            "`WAIT_EXPLICIT_APPROVAL`: surface comments, do not ready, do not merge",
+            "`FIX`: enter fix-retry loop; do not ready, do not merge",
+            "`WAIT_OR_REDISPATCH`: wait or re-dispatch invalid/missing reviewer once; do not ready, never merge",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.skill)
 
     def test_skill_documents_daemon_event_monitor_command(self) -> None:
         self.assertIn(


### PR DESCRIPTION
## Summary
#300(PR 共识前一律 draft 防误合)。新增 `ControllerActions._ensure_pr_ready_for_merge`(isDraft→gh pr ready,fail-closed);open_pr_with_label/rollup 默认 `--draft`;merge_pr 合前 ready;SKILL Consensus rules 表只在 MERGE/MERGE_WITH_COMMENTS 后 ready+merge。固化即刻 conduct。
Closes #300
🤖 Auto-loop · 本 PR draft 防误合,共识后 ready+merge

⟦AI:AUTO-LOOP⟧
