### PR TITLE
#267: review-fix FIX_OUTPUT_PATH 绑定 production render 边界

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -2065,7 +2065,7 @@ Policy: AI keeps iterating until the fixed Consensus-rnd Phase review-gate truth
 Loop:
 
 1. **Round entry** — derive the next fix round from review/fix artifacts. If `fix_round > max_fix_rounds`, escalate (see below).
-2. **Dispatch fix codex** in PR's own worktree:
+2. **Render and dispatch fix codex** in PR's own worktree. Before spawn, call `ControllerActions.render_review_fix_prompt(PR, N, env)` or an equivalent controller-internal render action; this binds `FIX_OUTPUT_PATH=.refactor-loop/runs/fix-pr${PR}-round-${N}-report.md` into the rendered prompt artifact:
    ```bash
    <skill-root>/scripts/consensus-rnd-cli spawn-codex \
      --cd "$PR_WORKTREE" --add-dir "$REPO_ROOT" \
@@ -2073,7 +2073,8 @@ Loop:
      --log .refactor-loop/logs/fix-pr${PR}-round-${N}.log \
      --stall 3600
    ```
-   Fix codex reads all 3 reviewer outputs, applies in-scope fixes, validates locally, writes `FIX_REPORT.md`, emits `FIX_DONE:${PR}:round-${N}:applied-<N>:rejected-<M>:blocked-<K>` OR `FIX_BLOCKED:${PR}:round-${N}:<reason>:<short>`.
+   <!-- Refactor (issue-267): Old: fix worker wrote root FIX_REPORT.md by convention. New: controller-rendered FIX_OUTPUT_PATH points to .refactor-loop/runs/. -->
+   Fix codex reads all 3 reviewer outputs, applies in-scope fixes, validates locally, writes `${FIX_OUTPUT_PATH}` under `.refactor-loop/runs/`, emits `FIX_DONE:${PR}:round-${N}:applied-<N>:rejected-<M>:blocked-<K>` OR `FIX_BLOCKED:${PR}:round-${N}:<reason>:<short>`.
 3. **Controller commits + pushes** the fix codex's changes to the PR's HEAD branch (codex itself doesn't push, per hard rule 4). Commit message includes round number and applied/blocked counts.
 4. **Re-dispatch all 3 reviewers** against the new HEAD SHA (drop prior consensus).
 5. **Re-evaluate**:
@@ -2152,7 +2153,7 @@ Required PR comments (controller posts via `gh pr comment <PR> --body-file <file
 | Consensus-rnd Phase review-gate event | PR comment content |
 |---|---|
 | Reviewer round N complete | 中文 table of 3 verdicts + reject demands per role + "next action" (fix-retry dispatched OR auto-merge OR escalation). Link to commit SHA reviewed. |
-| Fix codex round N complete (FIX_DONE) | 中文 FIX_REPORT excerpt: applied / rejected-as-false-positive / blocked counts, build+test status, files changed. Link to fix commit SHA. |
+| Fix codex round N complete (FIX_DONE) | 中文 fix artifact excerpt from `${FIX_OUTPUT_PATH}`: applied / rejected-as-false-positive / blocked counts, build+test status, files changed. Link to fix commit SHA. |
 | Fix codex blocked (FIX_BLOCKED) | 中文: which reason category (conflict / human-decision / build-broken), reviewer demand text, controller's escalation decision. |
 | Consensus reached (`MERGE` / `MERGE_WITH_COMMENTS`) | 中文: round count, final reviewer outputs, surfaced comment evidence when present, "auto-merging now". Then merge + a second "merged at <commit>" comment. |
 | Escalation triggered | Add `crnd:human:maintainer-decision` label. Comment includes: full round history, latest verdicts, why escalation criteria hit, what controller tried. PushNotification mirrors the headline. |

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -36,9 +36,9 @@ Categorize each demand into one of:
 
 - **(A) Fixable in-scope** — concrete code change within `scope_paths` of this cluster. Apply it.
 - **(B) Fixable but scope-extend** — concrete code change outside scope_paths. Record `scope-extend: <file> <reason>` in the fix report and apply it ONLY if rejecting this demand would block consensus AND the file is in the same logical refactor (e.g. add missing test file for the new public method).
-- **(C) False positive** — the reviewer mis-read (e.g. cited a file not in the PR, cited a deletion that never happened, demand contradicts `$PROJECT_RULES`). Do NOT apply. Record in `FIX_REPORT.md` with evidence proving it's a false positive.
-- **(D) Conflicting demands** — Architect demands X, Quality demands ¬X. Do NOT apply either side without resolution. Record both sides in `FIX_REPORT.md` and emit `FIX_BLOCKED:conflict:<short>` at the end.
-- **(E) Outside fix-codex authority** — demand requires a design decision (e.g. "delete this feature entirely" / "split this into 3 PRs" / "rename core type that other clusters depend on"). Record in `FIX_REPORT.md` and emit `FIX_BLOCKED:human-decision:<short>`.
+- **(C) False positive** — the reviewer mis-read (e.g. cited a file not in the PR, cited a deletion that never happened, demand contradicts `$PROJECT_RULES`). Do NOT apply. Record in the fix artifact at `${FIX_OUTPUT_PATH}` with evidence proving it's a false positive.
+- **(D) Conflicting demands** — Architect demands X, Quality demands ¬X. Do NOT apply either side without resolution. Record both sides in the fix artifact at `${FIX_OUTPUT_PATH}` and emit `FIX_BLOCKED:conflict:<short>` at the end.
+- **(E) Outside fix-codex authority** — demand requires a design decision (e.g. "delete this feature entirely" / "split this into 3 PRs" / "rename core type that other clusters depend on"). Record in the fix artifact at `${FIX_OUTPUT_PATH}` and emit `FIX_BLOCKED:human-decision:<short>`.
 
 ### Step 2 — Apply (A) and selected (B) fixes
 
@@ -61,7 +61,7 @@ cd $REPO_ROOT && \
 
 Pick the test projects whose code you changed; do NOT run the full solution test suite (too slow). If build fails → fix or `FIX_BLOCKED:build:<short>`.
 
-### Step 4 — Write FIX_REPORT
+### Step 4 — Write fix artifact
 
 Write `${FIX_OUTPUT_PATH}` with this structure:
 
@@ -112,8 +112,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 - **You do NOT install new packages.**
 - **You do NOT touch files outside the PR's diff unless emitting `SCOPE_EXTEND` first.**
 - **You do NOT modify other cluster's PRs** (only this PR's HEAD branch).
-- **False-positive demands must have proof** in FIX_REPORT — don't dismiss without evidence.
-- **FIX_REPORT 写入路径强制 `${FIX_OUTPUT_PATH}`**(典型 `.refactor-loop/runs/fix-pr<N>-r<N>.md`)— **禁止**写到 repo root `FIX_REPORT.md`(会污染 worktree + rebase conflict)。若 `${FIX_OUTPUT_PATH}` 空(env var 漏传),emit `FIX_BLOCKED:env-missing:FIX_OUTPUT_PATH` 不要瞎写默认路径。
+- **False-positive demands must have proof** in the fix artifact at `${FIX_OUTPUT_PATH}` — don't dismiss without evidence.
+- **Fix artifact 写入路径强制 `${FIX_OUTPUT_PATH}`**(典型 `.refactor-loop/runs/fix-pr<N>-round-<R>-report.md`)— **禁止**写到 repo root `FIX_REPORT.md`(会污染 worktree + rebase conflict)。若 `${FIX_OUTPUT_PATH}` 空(env var 漏传),emit `FIX_BLOCKED:env-missing:FIX_OUTPUT_PATH` 不要瞎写默认路径。
 - **A demand citing `$PROJECT_RULES` verbatim is presumed valid** — burden of proof is on you to show it's a misreading.
 
 ## Anti-patterns (forbidden — emit FIX_BLOCKED instead of doing these)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -18,6 +18,7 @@ from . import labels
 from .context import LoopContext
 from .github_body import GitHubBodyError, validate_self_contained_github_body
 from .release.publisher import ReleasePublishResult, ReleasePublisher
+from .review_fix_dispatch import ReviewFixDispatchSpec
 from .triage import apply_decision, load_triage_apply_config
 from .work_items import extract_closing_issue_numbers
 from .workflow_spec import WorkflowSpecError, load_validated_workflow_spec
@@ -541,6 +542,27 @@ class ControllerActions:
             template = template.replace("{{" + key + "}}", value)
         rendered = Template(template).safe_substitute(values)
         Path(output_path).write_text(rendered, encoding="utf-8")
+
+    def render_review_fix_prompt(
+        self,
+        pr_number: int,
+        round_number: int,
+        env: Mapping[str, str] | None = None,
+    ) -> ReviewFixDispatchSpec:
+        # Refactor (issue-267): Old: FIX_OUTPUT_PATH was a prompt-only oral
+        # variable and workers could drift to root FIX_REPORT.md. New:
+        # controller render binds the canonical runs artifact before dispatch.
+        spec = ReviewFixDispatchSpec.for_round(pr_number, round_number)
+        render_env = dict(env or {})
+        render_env.update(spec.as_render_env())
+        prompt_path = self.ctx.repo_root / spec.prompt_path
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        self.render_template(
+            str(self.ctx.skill_root / "prompts" / "review-fix.md"),
+            str(prompt_path),
+            env=render_env,
+        )
+        return spec
 
     def _resolve_template_input(self, input_path: str) -> Path:
         if not input_path.startswith("host:"):

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/review_fix_dispatch.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/review_fix_dispatch.py
@@ -1,0 +1,60 @@
+"""Review-fix prompt render boundary helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Mapping
+
+
+_POSITIVE_INT_RE = re.compile(r"^[1-9][0-9]*$")
+_FIX_OUTPUT_RE = re.compile(r"^\.refactor-loop/runs/fix-pr[1-9][0-9]*-round-[1-9][0-9]*-report\.md$")
+
+
+@dataclass(frozen=True)
+class ReviewFixDispatchSpec:
+    """Canonical review-fix prompt, log, and output artifact paths."""
+
+    prompt_path: str
+    log_path: str
+    fix_output_path: str
+
+    @classmethod
+    def for_round(cls, pr_number: int, round_number: int) -> "ReviewFixDispatchSpec":
+        pr = _validate_positive_int(pr_number, "pr_number")
+        round_no = _validate_positive_int(round_number, "round_number")
+        # Refactor (issue-267): Old: review-fix output was a prompt-only
+        # convention. New: controller render owns the canonical artifact path.
+        fix_output_path = f".refactor-loop/runs/fix-pr{pr}-round-{round_no}-report.md"
+        return cls(
+            prompt_path=f".refactor-loop/prompts/fixes/fix-pr{pr}-round-{round_no}.md",
+            log_path=f".refactor-loop/logs/fix-pr{pr}-round-{round_no}.log",
+            fix_output_path=cls.validate_fix_output_path(fix_output_path),
+        )
+
+    def as_render_env(self) -> Mapping[str, str]:
+        return {"FIX_OUTPUT_PATH": self.fix_output_path}
+
+    @staticmethod
+    def validate_fix_output_path(path: str) -> str:
+        value = str(path or "").strip()
+        pure = PurePosixPath(value)
+        if not value:
+            raise ValueError("FIX_OUTPUT_PATH is required")
+        if pure.is_absolute():
+            raise ValueError("FIX_OUTPUT_PATH must be repo-relative")
+        if "\\" in value or ".." in pure.parts:
+            raise ValueError("FIX_OUTPUT_PATH must not escape the repo")
+        if not _FIX_OUTPUT_RE.fullmatch(value):
+            raise ValueError(
+                "FIX_OUTPUT_PATH must match .refactor-loop/runs/fix-pr<N>-round-<R>-report.md"
+            )
+        return value
+
+
+def _validate_positive_int(value: int, label: str) -> str:
+    text = str(value)
+    if not _POSITIVE_INT_RE.fullmatch(text):
+        raise ValueError(f"{label} must be a positive decimal integer")
+    return text

--- a/skills/codex-refactor-loop/scripts/test_review_fix_dispatch.py
+++ b/skills/codex-refactor-loop/scripts/test_review_fix_dispatch.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Behavior tests for review-fix dispatch rendering."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.context import LoopContext
+from codex_refactor_loop.controller_actions import ControllerActions
+from codex_refactor_loop.review_fix_dispatch import ReviewFixDispatchSpec
+
+
+class ReviewFixDispatchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="review-fix-dispatch-test-"))
+        (self.tmp / ".refactor-loop").mkdir(parents=True)
+        (self.tmp / ".refactor-loop" / "host.env").write_text(
+            f'export REPO_ROOT="{self.tmp}"\n',
+            encoding="utf-8",
+        )
+        self.actions = ControllerActions(
+            LoopContext.load(
+                repo_root=self.tmp,
+                skill_root=SCRIPT_DIR.parent,
+                env={"REPO_ROOT": str(self.tmp)},
+            )
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_spec_for_round_uses_canonical_runs_report_path(self) -> None:
+        spec = ReviewFixDispatchSpec.for_round(269, 1)
+
+        self.assertEqual(spec.fix_output_path, ".refactor-loop/runs/fix-pr269-round-1-report.md")
+        self.assertEqual(spec.prompt_path, ".refactor-loop/prompts/fixes/fix-pr269-round-1.md")
+        self.assertEqual(spec.log_path, ".refactor-loop/logs/fix-pr269-round-1.log")
+        self.assertEqual(spec.as_render_env(), {"FIX_OUTPUT_PATH": ".refactor-loop/runs/fix-pr269-round-1-report.md"})
+
+    def test_validate_rejects_root_report_and_path_escape(self) -> None:
+        invalid = (
+            "FIX_REPORT.md",
+            "./FIX_REPORT.md",
+            "/tmp/FIX_REPORT.md",
+            ".refactor-loop/../FIX_REPORT.md",
+            ".refactor-loop/logs/fix-pr269-round-1-report.md",
+            ".refactor-loop/runs/fix-pr269-r1.md",
+        )
+        for value in invalid:
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    ReviewFixDispatchSpec.validate_fix_output_path(value)
+
+    def test_controller_render_review_fix_prompt_injects_fix_output_path(self) -> None:
+        spec = self.actions.render_review_fix_prompt(
+            269,
+            1,
+            env={
+                "PR_NUMBER": "269",
+                "PR_TITLE": "Review fix render",
+                "FIX_ROUND": "1",
+                "MAX_FIX_ROUNDS": "3",
+                "BASE_BRANCH": "dev",
+                "HEAD_BRANCH": "impl/issue269",
+                "REVIEW_ARCHITECT_PATH": ".refactor-loop/runs/review-pr269-architect-r1.md",
+                "REVIEW_TESTS_PATH": ".refactor-loop/runs/review-pr269-tests-r1.md",
+                "REVIEW_QUALITY_PATH": ".refactor-loop/runs/review-pr269-quality-r1.md",
+                "AUDIT_PATH": ".refactor-loop/runs/audit.md",
+                "IMPLEMENT_SUMMARY_PATH": ".refactor-loop/runs/implement.md",
+                "PROJECT_RULES": "CLAUDE.md",
+                "HOST_REFACTOR_COMMENT_POLICY": "self-doc-comment",
+            },
+        )
+
+        self.assertEqual(spec.fix_output_path, ".refactor-loop/runs/fix-pr269-round-1-report.md")
+        prompt = self.tmp / ".refactor-loop" / "prompts" / "fixes" / "fix-pr269-round-1.md"
+        rendered = prompt.read_text(encoding="utf-8")
+        self.assertIn(".refactor-loop/runs/fix-pr269-round-1-report.md", rendered)
+        self.assertNotIn("${FIX_OUTPUT_PATH}", rendered)
+        self.assertTrue(prompt.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_review_fix_prompt_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_review_fix_prompt_contract.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Source-regression tests for the review-fix prompt contract."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_ROOT = SCRIPT_DIR.parent
+
+
+class ReviewFixPromptContractTests(unittest.TestCase):
+    def test_review_fix_prompt_has_single_positive_report_destination(self) -> None:
+        text = (SKILL_ROOT / "prompts" / "review-fix.md").read_text(encoding="utf-8")
+
+        self.assertIn("Write fix artifact", text)
+        self.assertIn("`${FIX_OUTPUT_PATH}`", text)
+        self.assertIn(".refactor-loop/runs/", text)
+        self.assertIn("FIX_BLOCKED:env-missing:FIX_OUTPUT_PATH", text)
+        self.assertIn("repo root `FIX_REPORT.md`", text)
+        self.assertNotIn("Record in `FIX_REPORT.md`", text)
+        self.assertNotIn("Write FIX_REPORT", text)
+
+    def test_skill_fix_retry_loop_uses_rendered_fix_output_path(self) -> None:
+        text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+
+        self.assertIn("render_review_fix_prompt", text)
+        self.assertIn(".refactor-loop/runs/fix-pr${PR}-round-${N}-report.md", text)
+        self.assertIn("fix artifact excerpt from `${FIX_OUTPUT_PATH}`", text)
+        self.assertNotIn("writes `FIX_REPORT.md`", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

修 #267:review-fix 的 `FIX_OUTPUT_PATH` 之前只是 prompt 口头变量,fix codex 把 `FIX_REPORT.md` 落 worktree 根被提交进 PR(quality reviewer 反复 reject)。本 PR 把它升级为 controller render 边界绑定。

- **Old**:`FIX_OUTPUT_PATH` 是 prompt 口头约定,无 render 边界,fix worker 自行决定路径 → root `FIX_REPORT.md` 污染。
- **New**:新增 `ReviewFixDispatchSpec` + `ControllerActions.render_review_fix_prompt`,canonical path `.refactor-loop/runs/fix-pr<N>-round-<R>-report.md`,validator 拒绝 root/绝对/`..`/logs/旧式;`review-fix.md` 正向写入目标只剩 `${FIX_OUTPUT_PATH}`。

3/3 design-consensus(r5,structural framing)。

## 范围

3 文件改 + 1 新模块 + 2 新测试(5 behavior/source-regression,全绿)。

Closes #267

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
