### PR TITLE
#303: SKILL peek 调用统一为 python3 CLI

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -380,7 +380,7 @@ Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event
 10. Run controller wakeup step 1.5 for the concurrency floor before any `ScheduleWakeup`.
 11. Spawn the next codexes with harness background tasks if actionable work exists.
 12. Confirm the daemon-event Monitor bridge is still maintained; then confirm any in-flight background task notification or successfully registered ScheduleWakeup fallback that is being used for turn-level completion/fallback.
-13. Run `consensus-rnd-cli peek | tail -80` again after spawn, merge, banner, or close actions.
+13. Run `python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80` again after spawn, merge, banner, or close actions.
 
 `consensus-rnd-cli wakeup-plan` named read-only surface:
 
@@ -1251,7 +1251,7 @@ gh issue view <N> --json comments --jq '
 - **Controller 自己 post banner** 使用 `maintainer` 或 host 配置的安全称谓,不写裸人名。
 - **@-mention whitelist** 来自 `$MAINTAINER_WHITELIST`,并且必须经 git blame / host 配置验证。
 
-### Wakeup 第一动作:`bash <skill-root>/scripts/consensus-rnd-cli peek`(强制)
+### Wakeup 第一动作:`python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80`(强制)
 
 减少人工 grep / parse 错误。一眼看全:
 - 活跃 codex 数(只数本 loop:命令行含 `.refactor-loop/logs/` 或 `.refactor-loop/prompts/`)
@@ -1274,7 +1274,7 @@ gh issue view <N> --json comments --jq '
 
 **铁律**:任何 active phase issue/PR(`🔍 design-solving` / `🔧 fixing` / `👀 reviewing` / `🛠️ implementing`)存在时,**应至少有 1 个本 loop codex 在跑**。本 loop codex = `consensus-rnd-cli spawn-codex` 命令行含 `.refactor-loop/logs/` 或 `.refactor-loop/prompts/`。实际为 0 且 GitHub 有 active phase → **P0 bug**(no-gap-violation)。
 
-**Controller wakeup 第一动作**:`bash <skill-root>/scripts/consensus-rnd-cli peek`。如果活跃 codex == 0:
+**Controller wakeup 第一动作**:`python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80`。如果活跃 codex == 0:
 1. **不允许** `ScheduleWakeup` 后 end-turn — 必须派下一步 codex 才允许 ScheduleWakeup
 2. **不允许**只看 marker 不 sweep:必须扫所有刚 finished marker(implement/judge/reviewer/fix/reflector)并按 marker→spawn-next 表派至少 1 codex
 3. 如果所有 active issue/PR 都真在等 maintainer(全是 `crnd:human:maintainer-decision` / `crnd:phase:blocked`),那 0 codex 才 OK — 但仍要在 status 报告中说明 "0 codex by design:N issue 全等人"
@@ -1943,7 +1943,7 @@ dev sync stays with daemon; Consensus-rnd Phase design-consensus triplet/converg
 # Consensus-rnd Phase integration-sync 现在 controller 只读 daemon-maintained health/log surface
 python3 <skill-root>/scripts/consensus-rnd-cli restart-daemons
 python3 <skill-root>/scripts/consensus-rnd-cli concurrency --count-only >/dev/null
-bash <skill-root>/scripts/consensus-rnd-cli peek | tail -80
+python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80
 tail -10 .refactor-loop/logs/dev_sync_daemon.log | grep -E "(DEV_SYNC_BLOCKED|FAIL|FATAL)" | tail -3
 ```
 若 heartbeat stale/missing/malformed → 由 `consensus-rnd-cli restart-daemons` 按 canonical wrapper 重启。

--- a/skills/codex-refactor-loop/scripts/test_cli_daemon_help_smoke.py
+++ b/skills/codex-refactor-loop/scripts/test_cli_daemon_help_smoke.py
@@ -52,6 +52,21 @@ class CliDaemonHelpSmokeTests(unittest.TestCase):
                 offenders.append(f"{op}: {reason}")
         self.assertEqual(offenders, [], f"command main() import errors: {offenders}")
 
+    def test_peek_python_invocation_parses_help(self) -> None:
+        # Refactor (issue-303): controller docs invoke the Python CLI directly,
+        # so keep the targeted `python3 consensus-rnd-cli peek --help` path
+        # covered even if the broader operation list changes.
+        result = subprocess.run(
+            [sys.executable, str(CLI), "peek", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        blob = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 0, blob)
+        self.assertIn("usage:", blob)
+        self.assertIn("peek", blob)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -214,6 +214,56 @@ class SkillEntrypointContractTests(unittest.TestCase):
             r"Confirm a wake source: an active daemon-event Monitor bridge,.*or.*ScheduleWakeup",
         )
 
+    def test_controller_cli_invocation_contract_forbids_bash_interpreter(self) -> None:
+        # Refactor (issue-303):
+        #   Old pattern: controller-actionable runbooks invoked the Python CLI
+        #   with `bash <skill-root>/scripts/consensus-rnd-cli peek`, so wakeup
+        #   docs looked executable but selected the wrong interpreter.
+        #   New principle: controller-actionable CLI examples spell the Python
+        #   interpreter explicitly; shell wrappers may only source env and exec
+        #   python3.
+        canonical = "python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80"
+        self.assertNotIn("bash <skill-root>/scripts/consensus-rnd-cli", self.skill)
+        self.assertIn(canonical, self.skill)
+
+    def test_wakeup_peek_uses_python_cli_invocation(self) -> None:
+        # Refactor (issue-303): lock the controller-actionable peek callsites to
+        # the Python CLI contract without rewriting conceptual command mentions.
+        canonical = "python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80"
+        skeleton = section_between(
+            self.skill,
+            r"^## Wakeup Skeleton$",
+            r"^## Workflow Stage Index$",
+        )
+        first_action = section_between(
+            self.skill,
+            r"^### Wakeup 第一动作:",
+            r"^<a id=\"wake-source-rules\"></a>$",
+        )
+        wake_source = section_between(
+            self.skill,
+            r"^## Wake source rules and no-gap details$",
+            r"^### Controller 每 wakeup 必派",
+        )
+        dev_sync = section_between(
+            self.skill,
+            r"^### Controller 每 wakeup 责任",
+            r"^### 反面",
+        )
+        self.assertTrue(skeleton)
+        self.assertTrue(first_action)
+        self.assertTrue(wake_source)
+        self.assertTrue(dev_sync)
+        self.assertIn(f"### Wakeup 第一动作:`{canonical}`(强制)", self.skill)
+        for label, section, needle in (
+            ("wakeup skeleton final peek", skeleton, f"Run `{canonical}` again after spawn, merge, banner, or close actions."),
+            ("wakeup first action body", first_action, canonical),
+            ("zero-codex first action", wake_source, f"**Controller wakeup 第一动作**:`{canonical}`。如果活跃 codex == 0:"),
+            ("dev-sync controller responsibility", dev_sync, canonical),
+        ):
+            with self.subTest(label=label):
+                self.assertIn(needle, section)
+
     def test_wakeup_plan_entrypoint_contract_is_read_only_and_authorized(self) -> None:
         skeleton = section_between(
             self.skill,


### PR DESCRIPTION
## 摘要

修 #303:SKILL.md 多处把 `consensus-rnd-cli peek`(Python CLI)写成 `bash consensus-rnd-cli peek` 或裸调用,误导 controller 把它当可执行 bash 跑。

- **Old**:controller-actionable peek 指令形态不一致(`bash …` / 裸 `…`)。
- **New**:统一为 `python3 <skill-root>/scripts/consensus-rnd-cli peek`,source-regression 锁住不再出现裸 bash peek 形态。

3/3 design-consensus(r2,structural framing)。

## 范围

SKILL.md(8 行)+ 2 个 source-regression 测试。targeted suite 65 tests OK。

Closes #303

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
