### PR TITLE
#304: judge stalled 输出权威下放为 router predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 不是"多跑几遍取多数",而是**偏置独立的多角度逼近**:
 
 - **多 solver,先验对立**:每个 solver 带不同立场(如 minimal 最小改动 / structural 架构洁净 / delete 质疑必要性),且**互相看不到对方输出**,各自独立得出结论。
-- **meta-judge 仲裁**:把分歧收敛成 `consensus` / `converge` / `stalled` 三个出口,不达成一致就继续收敛,直到真停滞才升 reflector 调和。
+- **meta-judge 仲裁**:把分歧收敛成 `consensus` / `converge`;产品层仍有 `stalled` 出口,但它由 router 在 qualifying `converge` 后按 deterministic predicate 派生,真停滞才升 reflector 调和。
+<!-- Refactor (issue-304): Old: README described stalled as a judge-owned third exit. New: stalled is product-level router-derived continuation after converge. -->
 - **任何 concrete plan 都必须过这道闸**:哪怕方向已明确,也不允许单个 agent 直接落地 —— 用多角度验证把"明显方向"证成"明显方案"。
 - **验证侧同构**:产物再经多 reviewer(架构 / 质量 / 测试)共识 gate 才允许合并。
 - **controller 纯编排**:所有思考、分析、诊断、验证都 delegate 给 agent;确定性脚本可按 allowlist 读 marker 并派发下一 actor;LLM controller 保留语义 fallback、未知状态、git 与状态面。

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -30,7 +30,8 @@ Use intra-file anchors when a phase needs the detailed body, such as [host runti
 | Work unit state | The work-unit contract is stable; do not rename, migrate, or wrap it. Root `.refactor-loop/state.json` is not a contract surface. | Use GitHub labels/comments, clean `EXIT=0` logs, prompt artifacts, git topology, and named specialized state artifacts; export `WORK_UNIT_ID=$CLUSTER_ID` for audit-backed units. | [work-unit contract](#work-unit-contract), [specialized state artifacts](#specialized-state-artifacts) | `.refactor-loop/state/*.json`, daemon-owned state files |
 | Phase routing | Markers route immediately to the next actor in the same wakeup. | Sweep `EXIT=0` logs, parse verdict markers only after clean exit, then spawn next work if actionable. | [phase routing details](#phase-routing-details) | logs, prompts |
 | Operational names | Parsed or cross-agent names are operational interfaces with owner-local fact sources. | Keep each parser/generator in its owner surface; do not add a production registry or whole-repo naming lint. | [operational names](#operational-names) | router/progress/concurrency/git/controller actions/labels/cli/stages |
-| 3/3 consensus | Concrete plans require Consensus-rnd Phase design-consensus multi-solver consensus and meta-judge consensus. | Dispatch minimal, structural, delete solvers; meta-judge may return only consensus, converge, or stalled-style escalation path. | [design-consensus details](#design-consensus-details) | `solver-*.md`, `meta-judge.md` |
+| 3/3 consensus | Concrete plans require Consensus-rnd Phase design-consensus multi-solver consensus and meta-judge consensus. | Dispatch minimal, structural, delete solvers; meta-judge returns consensus/converge only; router-owned stalled predicate may route qualifying converge to reflector, with legacy stalled markers read-only compatible. | [design-consensus details](#design-consensus-details) | `solver-*.md`, `meta-judge.md` |
+<!-- Refactor (issue-304): Old: meta-judge owned a fresh stalled output. New: stalled is a router predicate continuation; legacy stalled markers are compatibility input only. -->
 | Floor | Keep `$CODEX_FLOOR` host-scoped codexes, default 5, hard lower bound 2. | Count only this loop's `consensus-rnd-cli spawn-codex` processes containing absolute `$REPO_ROOT`; top up before ScheduleWakeup. | [concurrency floor details](#concurrency-floor-details) | `consensus-rnd-cli concurrency`, `consensus-rnd-cli peek` |
 | Labels | Every issue/PR has exactly one phase label and one human label. | Sync labels and banner together; `crnd:human:maintainer-decision` only after allowed meta-layer routes. | [label bootstrap loops](#label-bootstrap-loops) | controller-internal `ControllerActions`, GitHub labels |
 | Spawn | Mainline codex spawn uses harness background tasks, not detached nohup. | Use one background task per codex; if detached already happened, preserve work and rely on log sweep plus wake source. | [codex invocation details](#codex-invocation-details) | `consensus-rnd-cli spawn-codex` |
@@ -360,7 +361,7 @@ These are local controller contract rules learned from dogfood incidents:
 
 ## Wakeup Skeleton
 
-Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event wakeup follows this skeleton. Each controller session must arm or confirm the mounted persistent Monitor bridge before pending-event sweep, marker parsing, concurrency-floor handling, or dispatch/spawn. Daemon pending-event wakeups are valid only through that Monitor or equivalent harness bridge; daemon alone is not a wake source. The Consensus-rnd Phase design-consensus router daemon may replace controller dispatch for SOLVER_DONE triplets, converge, and valid stalled continuation; controller fallback sweep remains authoritative for every other marker.
+Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event wakeup follows this skeleton. Each controller session must arm or confirm the mounted persistent Monitor bridge before pending-event sweep, marker parsing, concurrency-floor handling, or dispatch/spawn. Daemon pending-event wakeups are valid only through that Monitor or equivalent harness bridge; daemon alone is not a wake source. The Consensus-rnd Phase design-consensus router daemon may replace controller dispatch for SOLVER_DONE triplets, converge, and router-derived stalled continuation; legacy stalled judge markers are read-only compatibility input under the same gates; controller fallback sweep remains authoritative for every other marker.
 
 <!-- Refactor (issue-277): Old: 并发 floor 把 audit fallback 当成无限可重复派发,会和 #205 单 active audit 规则冲突。New: floor 无通用豁免,`AUDIT_DONE:none:0` 仍不豁免;但同一 iteration ordinary audit fallback 只有一个 active slot,slot 占用且无其他合法 work 时输出 WAIT + blocked_deficit,不重复 audit。 -->
 
@@ -442,8 +443,8 @@ Routing is marker-driven, but markers are trusted only after `EXIT=0` at the tai
 | `AUDIT_DONE` | Create design issues for `requires_design` units; dispatch direct implement work where allowed. |
 | `SOLVER_DONE` from minimal, structural, and delete for same issue/round | Spawn same issue/round meta-judge; this triplet route may be executed directly by `consensus-rnd-cli phase9-router`. |
 | `META_JUDGE_DONE:consensus:<framing>` | Post consensus card, move labels, dispatch implement codex. |
-| `META_JUDGE_DONE:converge:round-N` | Canonical clean rS judge payload is source round `round-S`; legacy adjacent `round-(S+1)` is accepted temporarily; both dispatch r(S+1) solvers, while any non-adjacent payload mismatch falls back; no hard round cap; this route may be executed directly by `consensus-rnd-cli phase9-router`. |
-| `META_JUDGE_DONE:escalate:stalled` | Dispatch meta-reflector only when the stalled predicate holds; no-framing evidence must be evaluated through the stalled reflector template and preferentially dropped; do not label human directly; this route may be executed directly by `consensus-rnd-cli phase9-router`. |
+| `META_JUDGE_DONE:converge:round-N` | Canonical clean rS judge payload is source round `round-S`; legacy adjacent `round-(S+1)` is accepted temporarily; before dispatching r(S+1), the router-owned stalled predicate may route qualifying r3+ no-progress converge to the stalled reflector and suppress next solvers; non-adjacent payload mismatch falls back; no hard round cap; this route may be executed directly by `consensus-rnd-cli phase9-router`. |
+| legacy `META_JUDGE_DONE:escalate:stalled` | Read-only compatibility input only: dispatch meta-reflector only when the same judge-role/source-OPEN/stalled-predicate gates hold; no-framing evidence must be evaluated through the stalled reflector template and preferentially dropped; do not label human directly; this route may be executed directly by `consensus-rnd-cli phase9-router`. |
 | `META_RESOLVED:retry-fix` | Dispatch fix with reflector constraints and bounded retry window. |
 | `META_RESOLVED:re-design` | Close/withdraw current path and restart Consensus-rnd Phase design-consensus only for concrete new framing or a cited current maintainer directive/current authorization artifact. |
 | `META_RESOLVED:re-cluster` | Close current PR/issue path and queue re-split. |
@@ -513,7 +514,7 @@ Controller duties:
 - Spawn codex workers.
 - Own git topology: commit, merge, push, PR create/merge/close.
 - Maintain wake source and concurrency floor.
-- Named exception: `consensus-rnd-cli phase9-router` owns only the narrow Consensus-rnd Phase design-consensus allowlist (`SOLVER_DONE` triplet, `META_JUDGE_DONE:converge`, valid `META_JUDGE_DONE:escalate:stalled`) and appends fallback pending events for everything else.
+- Named exception: `consensus-rnd-cli phase9-router` owns only the narrow Consensus-rnd Phase design-consensus allowlist (`SOLVER_DONE` triplet, `META_JUDGE_DONE:converge` including router-derived stalled continuation, and legacy read-only `META_JUDGE_DONE:escalate:stalled`) and appends fallback pending events for everything else.
 
 Controller non-duties:
 
@@ -669,7 +670,7 @@ Consensus-rnd Phase design-consensus is the sole authorization gate for concrete
 2. A meta-judge reads all three solver outputs.
 3. Concrete implementation authorization requires 3/3 solver convergence plus meta-judge `consensus`.
 4. `converge:round-N` uses canonical source-round payload from the judge log; source round S and legacy adjacent S+1 both route to r(S+1), while non-adjacent mismatch falls back; no hard round cap.
-5. `escalate:stalled` routes to reflector, not directly to human.
+5. Qualifying r3+ no-progress `converge` routes to reflector via router-owned stalled predicate, not directly to human; legacy `escalate:stalled` markers are compatibility input only.
 6. Maintainer replies reset the round when they materially change framing.
 7. Any concrete plan bypassing Consensus-rnd Phase design-consensus is invalid.
 8. Full consensus card template and solver rules are in [design-consensus details](#design-consensus-details).
@@ -1289,8 +1290,8 @@ Controller wakeup 处理 markers 后,**必须在同 turn 内派出下一步 code
 |---|---|
 | SOLVER_DONE × 3(同 issue 同 round)| 同 issue 同 round meta-judge |
 | META_JUDGE_DONE:consensus | implement codex |
-| META_JUDGE_DONE:converge:rS | r(S+1) 三 solver; legacy r(S+1) payload remains compatible |
-| META_JUDGE_DONE:escalate:stalled | reflector(per Consensus-rnd Phase design-consensus 路由表) |
+| META_JUDGE_DONE:converge:rS | r(S+1) 三 solver unless router-owned stalled predicate dispatches round-S reflector; legacy r(S+1) payload remains compatible |
+| legacy META_JUDGE_DONE:escalate:stalled | reflector only as read-only compatibility and only if the stalled predicate holds |
 | META_RESOLVED:re-design | fresh round 三 solver with new framing |
 | IMPLEMENT_DONE:ok | controller commit/push/open PR + Consensus-rnd Phase review-gate reviewer × 3 |
 | REVIEW_DONE × 3 + any reject | fix codex r+1 |
@@ -1313,15 +1314,15 @@ controller 严格按 judge marker 判 escalate,**不允许**自己以"累了/rou
 
 | Judge marker | Controller 动作 | 不允许 |
 |---|---|---|
-| `converge:round-N` | clean rS judge 的 canonical payload 是 round-S; legacy round-(S+1) 也派 r(S+1);非相邻 payload mismatch fallback | ❌ "round 多了"自升 escalate |
-| `escalate:stalled` | 派 reflector codex | ❌ 直接 label `crnd:human:maintainer-decision` |
-| `escalate:philosophy:<reason>` / `escalate:gpg-ratification:<reason>` / `escalate:<其他>` | 视为 legacy judge 输出:重派 judge 或派 reflector,要求回到 consensus / converge / stalled 三出口 | ❌ 因 CLAUDE.md / Tier I/II / GPG / reinstall 直接 label 人 |
+| `converge:round-N` | clean rS judge 的 canonical payload 是 round-S; legacy round-(S+1) 也派 r(S+1);若 router-owned stalled predicate 成立则改派 round-S reflector;非相邻 payload mismatch fallback | ❌ "round 多了"自升 escalate |
+| legacy `escalate:stalled` | read-only compatibility: predicate/source gates 成立才派 reflector codex | ❌ 直接 label `crnd:human:maintainer-decision` |
+| `escalate:philosophy:<reason>` / `escalate:gpg-ratification:<reason>` / `escalate:<其他>` | 视为 legacy judge 输出:重派 judge 或派 reflector,要求回到 consensus / converge;stalled 只能由 router predicate 派生 | ❌ 因 CLAUDE.md / Tier I/II / GPG / reinstall 直接 label 人 |
 | `consensus` | 派 implement | — |
 | 无 judge marker / judge crash | 重派 judge | ❌ 自判 escalate |
 
 **正确"label 人"的唯一路径**:`reflector` 输出 `META_RESOLVED:escalate-human:<reason>` → controller 才允许 label `crnd:human:maintainer-decision` + ASCII A/B/C reason banner。该路径只表示**共识机制本身无法收敛**,不是因为触及 Tier I/II、CLAUDE.md、核心抽象、GPG 或 reinstall。
 
-结构性教训:controller 曾把多数 issue 误升为人工等待,根因是没有严格区分 `converge`、`stalled`、`philosophy` 三类 judge marker。只有 reflector 输出 `META_RESOLVED:escalate-human:<reason>` 后才允许 label 人;`converge` 继续派 solver,`stalled` 先派 reflector,可由 reflector 处理的 philosophy 分歧不得直接升人。
+结构性教训:controller 曾把多数 issue 误升为人工等待,根因是没有严格区分 `converge`、router-derived `stalled`、`philosophy` 三类路由。只有 reflector 输出 `META_RESOLVED:escalate-human:<reason>` 后才允许 label 人;`converge` 继续派 solver或由 router predicate 改派 reflector,可由 reflector 处理的 philosophy 分歧不得直接升人。
 
 ### Spawn / merge / banner 后必须 peek(强制 — 防 maintainer 漏读)
 
@@ -1931,13 +1932,13 @@ Verification: `test_phase9_router_open_state_gate.py`, `test_phase9_router_daemo
 One-shot:`python3 <skill-root>/scripts/consensus-rnd-cli phase9-router --once --repo-root "$REPO_ROOT"`; dry-run:`python3 <skill-root>/scripts/consensus-rnd-cli phase9-router --once --dry-run --repo-root "$REPO_ROOT"`; monitor:`tail -50 .refactor-loop/logs/phase9-router-daemon.log`。
 Allowlist(唯一 direct spawn authority):
 - `SOLVER_DONE:<minimal|structural|delete>:*` x3, same issue/round, clean `^EXIT=0`, non-placeholder, not ledgered, not in-flight → render full `prompts/meta-judge.md` with router-scoped inputs and spawn same-round meta-judge.
-- `META_JUDGE_DONE:converge:round-<N>:*`, clean exit, not ledgered/in-flight → clean rS judge canonical payload is `round-S`; legacy `round-(S+1)` is temporarily accepted; both spawn r(S+1) minimal/structural/delete solvers; non-adjacent payload mismatch falls back.
-- `META_JUDGE_DONE:escalate:stalled:*`, clean exit + stalled predicate(`round >= 3` and solver verdict text unchanged across 3 rounds) → spawn reflector with the full `prompts/meta-reflector-stalled.md` template plus the 3 recent rounds x 3 solver log path evidence; template read failure must fail closed in the spawned prompt, not fall back to a generic route.
+- `META_JUDGE_DONE:converge:round-<N>:*`, clean exit, not ledgered/in-flight → clean rS judge canonical payload is `round-S`; legacy `round-(S+1)` is temporarily accepted; before spawning r(S+1) minimal/structural/delete solvers, run the router-owned stalled predicate(`round >= 3` and solver verdict text unchanged across 3 rounds); if it holds, spawn round-S reflector with the full `prompts/meta-reflector-stalled.md` template and suppress next solvers; non-adjacent payload mismatch falls back.
+- legacy `META_JUDGE_DONE:escalate:stalled:*`, clean exit + stalled predicate + judge-role/source-OPEN gates → read-only compatibility replay that spawns reflector with the full `prompts/meta-reflector-stalled.md` template plus the 3 recent rounds x 3 solver log path evidence; template read failure must fail closed in the spawned prompt, not fall back to a generic route.
 HostWorkflowSpec is not a phase9 direct-spawn authority: host `roles`, `dispatch`, and `consensus_policies` are validation/display/data-only projection surfaces and must not alter this allowlist or block the built-in router routes.
 Input filename dialect allowlist:`phase9-issue<N>-r<R>-<minimal|structural|delete|judge|reflector>.log`,`solver-issue<N>-r<R>-<minimal|structural|delete>.log`,`meta-judge-issue<N>-r<R>.log`。issue/round 来自 filename identity,public marker payload remains role-local(`SOLVER_DONE:<role>:...`); must not introduce public marker aliases, migrated work-unit schema, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority. daemon-owned output logs remain `phase9-issue...`;legacy input logs 只作为读取兼容面。daemon startup / first wakeup 文本必须与 `consensus-rnd-cli restart-daemons` 的 6-daemon restart-helper-managed 面一致,包含 Consensus-rnd Phase design-consensus router; persistent daemon-event Monitor bridge 单独由 controller arm。
 Fallback/ledger/recovery: lifecycle/unknown markers append `.refactor-loop/.controller-pending-events.log`; no spawn beyond the allowlisted worker dispatches, no direct resolution, no git, no GitHub lifecycle mutation, no label, no lifecycle authority(no close/merge/release). Append-only `.refactor-loop/phase9-router-ledger.jsonl` records base dispatch fields `{key, marker, log_path, dispatched_at}`; successful solver-triplet-to-judge rows may add row-level router-private provenance fields `{route, issue, round, target_actor, clean_exit_solver_logs, solver_input_prompts, judge_input_solver_logs, judge_prompt_path, judge_prompt_template_path, judge_prompt_scope, independence_check}`. Router recovery/idempotency reads only `key`, and meta-judge decisions read solver logs, not ledger evidence. If router-visible solver prompts explicitly reference same-round peer solver logs/prompts/run artifacts, the router fails closed before judge dispatch and appends an existing-format pending event with reason `phase9-triplet-evidence-invalid`; if full `prompts/meta-judge.md` rendering is unavailable or any solver/judge path falls outside same issue/round/role scope, the router fails closed before judge dispatch and appends an existing-format `phase9-router-fallback` event. Fallback events use prefix `phase9-router-fallback`. A solver-triplet-to-judge duplicate with `key` already in the ledger is silent; when the triplet is not ledgered but target log / equivalent legacy judge log / in-flight target suppresses dispatch, append one existing-format `phase9-router-fallback` event with key prefix `phase9-triplet-suppression:` and reason exactly one of `phase9-triplet-target-log-exists`, `phase9-triplet-equivalent-log-exists`, or `phase9-triplet-in-flight`. The state-only source-OPEN gate must not use gh issue close, gh issue edit, gh label, gh pr merge, gh release, or any label/close/merge/release lifecycle flag. In-flight target logs or live `consensus-rnd-cli spawn-codex --log <target>` suppress re-dispatch, `.refactor-loop/phase9-router.lock` enforces singleton, and duplicate ledger rows never delete logs. Staged expansion requires route-ledger evidence and must not introduce ControllerEvent, ControllerCommand, ControllerOrchestrator, migrated work-unit schema, public marker aliases, or lifecycle authority.
 ### Daemon vs controller 分工
-dev sync stays with daemon; Consensus-rnd Phase design-consensus triplet/converge/valid-stalled continuation may use **consensus-rnd-cli phase9-router** narrow allowlist with controller fallback sweep retained; design/consensus/implement/review/fix/liveness/escalation stay with controller wakeups.
+dev sync stays with daemon; Consensus-rnd Phase design-consensus triplet/converge/router-derived stalled continuation and legacy stalled compatibility may use **consensus-rnd-cli phase9-router** narrow allowlist with controller fallback sweep retained; design/consensus/implement/review/fix/liveness/escalation stay with controller wakeups.
 ### Controller 每 wakeup 责任(只 verify daemon)
 ```bash
 # Consensus-rnd Phase integration-sync 现在 controller 只读 daemon-maintained health/log surface
@@ -2278,13 +2279,13 @@ Meta-judge emits `META_JUDGE_DONE:<decision>:<...>`,**controller 路由表(强�
 | Decision | Category | Controller 动作 |
 |---|---|---|
 | `consensus:<framing>:<summary>` | — | auto-applies(派 implement,见 "Consensus action";implement 可改 Tier I/II/CLAUDE.md/SPEC/核心抽象) |
-| `converge:round-N:<question>` | — | clean rS judge canonical payload is `round-S`; legacy `round-(S+1)` also派 r(S+1) 三 solver(把 convergence question prepend prompt); non-adjacent payload mismatch falls back; `consensus-rnd-cli phase9-router` may direct-dispatch this route |
-| `escalate:stalled:<...>` | `CONVERGENCE_ROUND >= 3` 且 3+ round 无 maintainer input 且 solver verdict 文本连续无变化 | **必须先派 reflector codex**(走完整 stalled reflector template + 9 个 solver log path evidence);no-framing evidence 优先 drop,`re-design` 仅用于 concrete new framing/directive artifact;**禁止**直接 label 人; `consensus-rnd-cli phase9-router` may direct-dispatch only when the stalled predicate holds |
-| `escalate:<其他 category>` | legacy / judge 异常 | 重派 judge 或派 reflector,要求归一到 `consensus` / `converge` / `escalate:stalled`;**禁止**直接 label 人 |
+| `converge:round-N:<question>` | — | clean rS judge canonical payload is `round-S`; legacy `round-(S+1)` also派 r(S+1) 三 solver unless router-owned stalled predicate first派 round-S reflector; non-adjacent payload mismatch falls back; `consensus-rnd-cli phase9-router` may direct-dispatch this route |
+| legacy `escalate:stalled:<...>` | compatibility only | read-only replay path: predicate/source gates 成立才派 reflector codex(走完整 stalled reflector template + 9 个 solver log path evidence);no-framing evidence 优先 drop,`re-design` 仅用于 concrete new framing/directive artifact;**禁止**直接 label 人 |
+| `escalate:<其他 category>` | legacy / judge 异常 | 重派 judge 或派 reflector,要求归一到 `consensus` / `converge`;**禁止**直接 label 人 |
 
-结构性教训:曾出现多个 `escalate:stalled` 被直接 label 人,**没派 reflector**。原因是路由只写了"escalate → label",没有明确 `stalled` 子类必须 reflector 优先。上表 `escalate:stalled` 行强制 reflector。
+结构性教训:曾出现多个 `escalate:stalled` 被直接 label 人,**没派 reflector**。现在 fresh judge 不再授权 stalled 输出;router predicate 从 clean converge 历史派生 stalled,legacy stalled marker 只读兼容且仍必须 reflector 优先。
 
-**stalled 判据铁律**:`stalled` 只能在 `CONVERGENCE_ROUND >= 3` 且 solver verdict 文本连续无变化时成立。round 1 / round 2 不可能 stalled;此时 solver 分歧应判 `converge` 并继续派下一轮,不能接受 meta-judge 在 r1/r2 输出的 `escalate:stalled` 作为事实。若 r1/r2 judge 输出 `escalate:stalled`,controller 必须按 judge 异常处理:重派 judge(同输入,提示 stalled 最小轮次约束),而不是派 reflector 或 label 人。
+**stalled 判据铁律**:`stalled` 只能由 router 在 `CONVERGENCE_ROUND >= 3` 且 solver verdict 文本连续无变化时从 clean `converge` 派生。round 1 / round 2 不可能 stalled;此时 solver 分歧应判 `converge` 并继续派下一轮,不能接受 meta-judge 在 r1/r2 输出的 `escalate:stalled` 作为事实。若 r1/r2 judge 输出 `escalate:stalled`,controller 必须按 legacy judge 异常处理:重派 judge(同输入,提示 fresh stalled 禁止),而不是派 reflector 或 label 人。
 
 **反面(❌ 严禁)**:
 - ❌ r1 三 solver 分歧,meta-judge 输出 `escalate:stalled`,controller 直接派 reflector。
@@ -2510,7 +2511,7 @@ These are first-class consensus scope, not escalation triggers. Meta-judge MUST 
 7. **Performance constraint unverifiable** — solver claims latency/memory bound but only prod can verify
 8. **Issue body's `human_brief.why_needs_design`** contains: `rule-boundary` / `architecture-change` / `philosophy` / `CLAUDE.md` / `canon-vocabulary`
 
-If the above makes the current framing underspecified, route `converge` with the missing exact text or evidence question. If solvers repeat unchanged text for ≥3 rounds, route `escalate:stalled` to reflector. Do not create `escalate:gpg-ratification` or `escalate:philosophy`.
+If the above makes the current framing underspecified, route `converge` with the missing exact text or evidence question. If solvers repeat unchanged text for ≥3 rounds, the router-owned stalled predicate may route that `converge` to reflector. Do not create fresh `escalate:stalled`, `escalate:gpg-ratification`, or `escalate:philosophy`.
 
 ### GitHub traceability (mandatory per SKILL.md "GitHub traceability" — same standard as Consensus-rnd Phase review-gate)
 
@@ -2521,10 +2522,10 @@ Every Consensus-rnd Phase design-consensus action posts a 中文 comment to the 
 | Round N solvers dispatched | 中文: "Consensus-rnd Phase design-consensus round N — minimal/structural/delete codex in flight. 3/3 unanimous required to auto-implement; otherwise iterate." |
 | Maintainer reply detected mid-Phase-9 | 中文: "Halted in-flight round; resetting with maintainer comment as new constraint. New round dispatched. Old round outputs preserved for solver context." |
 | **Each individual solver completes** | Post FULL solver output as its own comment. Header: `## 🤖 Consensus-rnd Phase design-consensus Solver — \`<role>\` (round N)`. Body = verbatim solver output. One comment per solver, three comments per round. |
-| **Meta-judge completes** | Post FULL meta-judge output as its own comment. Header: `## 🤖 Consensus-rnd Phase design-consensus Meta-judge — round N verdict: \`<consensus\|converge\|escalate>\``. Body = verbatim judge output. |
+| **Meta-judge completes** | Post FULL meta-judge output as its own comment. Header: `## 🤖 Consensus-rnd Phase design-consensus Meta-judge — round N verdict: \`<consensus\|converge>\``. Body = verbatim judge output. |
 | Meta-judge → consensus | Same as above + then a follow-up controller comment: "`crnd:triage:resume-requested` label added; implement codex dispatched" |
 | Meta-judge → converge | Same as above + the round-(N+1) "solvers dispatched" comment that includes the convergence question for transparency |
-| Meta-judge → escalate:stalled | Same as above + label `crnd:lifecycle:stuck` + `## 🤖 Controller next-step` comment saying reflector is being dispatched for a no-progress stall |
+| Router-derived stalled converge | Same as above + `## 🤖 Controller next-step` comment saying reflector is being dispatched for a no-progress stall |
 | Legacy escalation category emitted | Post meta-judge output + summary "legacy escalation category normalized back into consensus loop"; re-dispatch judge or reflector; do not label human directly |
 
 **Forbidden**: posting a "summary" of solver outputs instead of the FULL outputs. The raw reasoning, evidence, and concrete plans are the audit record; a summary loses too much fidelity. The 3+ comments per round are intentional.

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -5,10 +5,11 @@ Artifact profile: phase9-meta-judge
 You are the **4th codex** for design-issue **${ISSUE_NUMBER}** (work unit `${WORK_UNIT_ID}`, audit cluster alias `${CLUSTER_ID}`). You did NOT propose a solution. Your job: read all 3 solver outputs and decide ONE of:
 
 1. **Consensus reached** → auto-dispatch implement (3/3 same framing; this is sufficient authorization for any file or tier)
-2. **Convergence round needed** → re-dispatch the 3 solvers with a narrowed question (no hard round cap; stall is evaluated after ≥3 no-progress rounds)
-3. **Escalate stalled** — the solver loop has truly stalled
+2. **Convergence round needed** → re-dispatch the 3 solvers with a narrowed question (no hard round cap; router evaluates stall after ≥3 no-progress rounds)
 
-Policy: **3/3 unanimous + meta-judge consensus** is the sole gate. Anything less goes through convergence (no hard round cap; loop iterates until consensus OR true stall). Every maintainer reply resets the round. Touching CLAUDE.md/L0/L1/L2, Tier I/II boundaries, core abstractions, architecture vocabulary, or philosophy keywords is NOT an escalation trigger by itself. Once deep consensus is reached, there is no post-consensus human approval, GPG ratification, reinstall ratification, or Tier ratification blocker; implement is authorized to land the agreed Tier I/II/CLAUDE.md/SPEC/core-abstraction change subject only to automatic tests, conformance, and review gates.
+<!-- Refactor (issue-304): Old: meta-judge had fresh stalled marker authority. New: meta-judge emits only consensus/converge; stalled is a router-owned predicate continuation after qualifying converge. -->
+
+Policy: **3/3 unanimous + meta-judge consensus** is the sole gate. Anything less goes through convergence (no hard round cap; loop iterates until consensus OR router-derived true stall). Every maintainer reply resets the round. Touching CLAUDE.md/L0/L1/L2, Tier I/II boundaries, core abstractions, architecture vocabulary, or philosophy keywords is NOT an escalation trigger by itself. Once deep consensus is reached, there is no post-consensus human approval, GPG ratification, reinstall ratification, or Tier ratification blocker; implement is authorized to land the agreed Tier I/II/CLAUDE.md/SPEC/core-abstraction change subject only to automatic tests, conformance, and review gates.
 
 ## Inputs
 
@@ -56,9 +57,7 @@ If the best plan requires changing philosophy/CLAUDE.md/SPEC/Tier boundaries, tr
 - why the change is worth the trusted-base cost
 - why deep consensus is reachable or already reached
 
-Only this is a real escalation exit:
-
-1. `escalate:stalled:<reason>` — after ≥3 convergence rounds, there is no material change in solver verdict text/framing, no new evidence, and no maintainer input.
+Stalled is not a fresh meta-judge output. After ≥3 convergence rounds, the router owns the deterministic stalled predicate from clean solver verdict history and may route a qualifying `converge` decision to the stalled reflector.
 
 If a solver emits `escalate:gpg-ratification`, `escalate:physical-ratification`, `escalate:reinstall`, `escalate:philosophy`, `escalate:top-level-claude-clause`, `escalate:new-core-abstraction`, `escalate:docs-canon-change`, or similar legacy category, do NOT forward it automatically. Reclassify it as a proposal gap and converge with a question asking the solvers to include the exact philosophy/CLAUDE.md/SPEC/Tier text change in their concrete plan. If 3/3 solvers agree on that concrete plan, output `consensus:<framing>` and let implement land it.
 
@@ -74,17 +73,14 @@ Take the 3 solvers' `verdict` + their `Recommended framing` summary:
 - **3/3 abstain**: cluster is not solvable as scoped yet; converge with a narrower question unless the stall trigger already applies.
 - **Anyone false-positive**: solver claims violation is gone; controller MUST verify by re-reading audit evidence before accepting. If verified, close issue as `wontfix:false-positive`. If contradicted by current code, treat as `abstain` and recompute.
 
-### Step 4 — Convergence vs escalate
+### Step 4 — Convergence
 
-**No hard round cap.** The loop iterates until 3/3 unanimous consensus, regardless of round count, UNLESS the stall trigger fires:
+**No hard round cap.** The loop iterates until 3/3 unanimous consensus. When repeated no-progress rounds satisfy the router-owned stalled predicate, the router routes the current `converge` decision to the stalled reflector instead of spawning another solver triplet.
 
-- **Stall trigger**: if `${CONVERGENCE_ROUND} >= 3` AND no maintainer comment landed since last round AND all 3 solvers' verdict text is essentially the same as last round (no new evidence, no shifted stance) → escalate as `stalled:no-progress-no-input` (controller will re-prompt maintainer).
-
-Otherwise:
 - If divergence is on a NAMED specific technical question and there's progress vs prior rounds → CONVERGENCE: write the `convergence_question`, controller dispatches another round.
 - → marker: `META_JUDGE_DONE:converge:round-${CONVERGENCE_ROUND}:<one-line question>` (canonical payload is the judge log source round; router dispatches the adjacent next solver round)
-- If divergence is named but no progress for 3+ rounds with no maintainer input → escalate as stalled (above).
-- If divergence is fundamental / unnamed AND not stalled → still converge (the next round may surface the right framing). Only true stall escalates.
+- If divergence is named but no progress for 3+ rounds with no maintainer input → still output converge; router will suppress solver churn and dispatch `meta-reflector-stalled.md` when its predicate holds.
+- If divergence is fundamental / unnamed → still converge (the next round may surface the right framing, or the router may derive stalled).
 
 ### Step 5 — Output the decision
 
@@ -99,7 +95,7 @@ solver_verdicts:
   minimal: propose | abstain | escalate | false-positive
   structural: ...
   delete: ...
-decision: consensus | converge | escalate
+decision: consensus | converge
 ---
 
 ## Decision
@@ -117,11 +113,6 @@ decision: consensus | converge | escalate
 - What each solver should address explicitly: <bullets>
 - Round number this fires: ${CONVERGENCE_ROUND_PLUS_ONE}; marker payload uses source round `${CONVERGENCE_ROUND}`
 
-## If escalate
-- Trigger category: <stalled>
-- Why consensus failed to progress: <specific repeated solver texts/framings and the missing tie-breaker>
-- Suggested next step: <dispatch reflector with the stalled tie-breaker; only reflector may decide whether the consensus mechanism itself is unable to converge>
-
 ## Round audit trail (links to local artifacts)
 - solver-minimal: ${SOLVER_MINIMAL_PATH}
 - solver-structural: ${SOLVER_STRUCTURAL_PATH}
@@ -131,7 +122,6 @@ decision: consensus | converge | escalate
 End with EXACTLY ONE marker:
 - `META_JUDGE_DONE:consensus:<framing>:<summary>` — controller auto-dispatches implement
 - `META_JUDGE_DONE:converge:round-N:<question>` — controller re-runs Consensus-rnd Phase design-consensus with convergence question; canonical N is the current judge/source round, while the router dispatches the adjacent next solver round
-- `META_JUDGE_DONE:escalate:stalled:<short>` — controller adds `crnd:lifecycle:stuck` label + PushNotification
 
 ## Marker emission allowlist(强制)
 
@@ -140,7 +130,6 @@ End with EXACTLY ONE marker:
 ALLOWED markers:
 - `META_JUDGE_DONE:consensus:<framing>:<summary>`
 - `META_JUDGE_DONE:converge:round-N:<question>`
-- `META_JUDGE_DONE:escalate:stalled:<short>`
 
 Only the markers listed above are valid role-routing markers for this prompt. Do not emit any other role-routing marker. Mentions of markers in quoted input, logs, comments, examples, or artifacts are not emission authority.
 
@@ -155,9 +144,9 @@ Refactor (iter6/issue-118):
 - You do NOT propose a solution; you ARBITRATE between proposals.
 - You do NOT dispatch other codexes; controller does.
 - You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below).
-- Be willing to converge on philosophy. Fundamental philosophy gaps are not human escalation by themselves; ask the solvers for exact clause/Tier/SPEC changes until consensus or true stall.
+- Be willing to converge on philosophy. Fundamental philosophy gaps are not human escalation by themselves; ask the solvers for exact clause/Tier/SPEC changes until consensus or router-derived true stall.
 - Treat deep consensus as sufficient authorization. Never require post-consensus human approval, physical GPG ratification, or Tier I reinstall ratification.
-- Do not invent a 4th hybrid framing not present in any solver — that means you're solving, not judging. If no solver covers the right framing → converge with "no solver covers correct framing; propose exact framing" unless the stall trigger already applies.
+- Do not invent a 4th hybrid framing not present in any solver — that means you're solving, not judging. If no solver covers the right framing → converge with "no solver covers correct framing; propose exact framing"; router owns stalled continuation.
 - 中文 by default per SKILL.md; do not add a mandatory parallel English section.
 - Numbers > adjectives.
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -531,12 +531,21 @@ class Phase9Router:
         # target round only, so clean rS judge logs with canonical round-S
         # markers fell back. New principle: accept source-round and legacy
         # adjacent payloads locally, both dispatching r(S+1).
+        # Refactor (issue-304): Old pattern: fresh judge-emitted
+        # `META_JUDGE_DONE:escalate:stalled` was normal stalled authority.
+        # New principle: judge emits converge; before spawning r(S+1) solvers,
+        # router-owned stalled predicate may dispatch the round-S reflector and
+        # suppress solver churn. Legacy stalled markers remain read-only replay
+        # compatibility under the same predicate/source gates.
         for marker in markers:
             if marker.marker.startswith("META_JUDGE_DONE:converge:round-"):
                 if marker.role != self._judge_role():
                     continue
                 target_round = self._converge_target_round(marker.marker, marker.round)
                 if target_round is None:
+                    continue
+                if self._stalled_predicate_holds(marker.issue, marker.round):
+                    self._dispatch_stalled_reflector(marker, ledger)
                     continue
                 for role in self._solver_roles():
                     key = self._key(marker.issue, target_round, role)
@@ -565,24 +574,7 @@ class Phase9Router:
             if marker.marker.startswith("META_JUDGE_DONE:escalate:stalled:"):
                 if marker.role != self._judge_role():
                     continue
-                key = self._key(marker.issue, marker.round, "reflector")
-                log_path = self._log_path(marker.issue, marker.round, "reflector")
-                if key in ledger or self._in_flight(log_path):
-                    continue
-                if not self._stalled_predicate_holds(marker.issue, marker.round):
-                    continue
-                if not self._require_open_source_issue(
-                    marker.issue,
-                    marker.round,
-                    "stalled_to_reflector",
-                    marker.marker,
-                    marker.log_path,
-                ):
-                    continue
-                prompt = self._write_prompt(marker.issue, marker.round, "reflector", self._reflector_prompt(marker))
-                if self._spawn(prompt, log_path):
-                    self._append_ledger(key, marker.marker, log_path)
-                    ledger.add(key)
+                self._dispatch_stalled_reflector(marker, ledger)
 
     def _append_fallbacks(self, markers: list[Marker], ledger: set[str]) -> None:
         # Refactor (iter4/skill-router-fallback-flood-fix): Old pattern: dedup
@@ -610,6 +602,10 @@ class Phase9Router:
             target_round = self._converge_target_round(marker.marker, marker.round)
             if target_round is None:
                 return False
+            if self._stalled_predicate_holds(marker.issue, marker.round):
+                if f"phase9-source-eligibility:{marker.issue}-{marker.round}-stalled_to_reflector" in self._fallback_seen:
+                    return True
+                return self._key(marker.issue, marker.round, "reflector") in ledger
             if f"phase9-source-eligibility:{marker.issue}-{target_round}-converge_to_next_solvers" in self._fallback_seen:
                 return True
             return all(self._key(marker.issue, target_round, role) in ledger for role in self._solver_roles())
@@ -633,6 +629,26 @@ class Phase9Router:
         if payload_round in {source_round, source_round + 1}:
             return source_round + 1
         return None
+
+    def _dispatch_stalled_reflector(self, marker: Marker, ledger: set[str]) -> None:
+        key = self._key(marker.issue, marker.round, "reflector")
+        log_path = self._log_path(marker.issue, marker.round, "reflector")
+        if key in ledger or self._in_flight(log_path):
+            return
+        if not self._stalled_predicate_holds(marker.issue, marker.round):
+            return
+        if not self._require_open_source_issue(
+            marker.issue,
+            marker.round,
+            "stalled_to_reflector",
+            marker.marker,
+            marker.log_path,
+        ):
+            return
+        prompt = self._write_prompt(marker.issue, marker.round, "reflector", self._reflector_prompt(marker))
+        if self._spawn(prompt, log_path):
+            self._append_ledger(key, marker.marker, log_path)
+            ledger.add(key)
 
     def _stalled_predicate_holds(self, issue: str, round_no: int) -> bool:
         if round_no < 3:

--- a/skills/codex-refactor-loop/scripts/test_marker_emission_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_emission_contract.py
@@ -90,7 +90,6 @@ PROMPT_ALLOWLISTS = {
     "meta-judge.md": (
         "META_JUDGE_DONE:consensus:<framing>:<summary>",
         "META_JUDGE_DONE:converge:round-N:<question>",
-        "META_JUDGE_DONE:escalate:stalled:<short>",
     ),
     "meta-reflector-stalled.md": (
         "META_RESOLVED:retry-fix:<reason>",
@@ -271,6 +270,18 @@ class MarkerEmissionContractTests(unittest.TestCase):
                     profile_tokens,
                     f"{filename} allowlist tokens must fit profile {profile}",
                 )
+
+    def test_meta_judge_prompt_does_not_authorize_fresh_stalled_marker(self) -> None:
+        # Refactor (issue-304): Old: meta-judge allowlist authorized a fresh
+        # `META_JUDGE_DONE:escalate:stalled` output. New: only router-owned
+        # predicate logic can derive the stalled reflector continuation.
+        body = (PROMPTS_DIR / "meta-judge.md").read_text(encoding="utf-8")
+        section = allowlist_section(body)
+
+        self.assertNotIn("META_JUDGE_DONE:escalate:stalled:<short>", section)
+        self.assertNotIn("Escalate stalled", body)
+        self.assertIn("meta-judge emits only consensus/converge", body)
+        self.assertIn("router-owned stalled predicate", body)
 
     def test_github_post_rules_declares_post_body_artifact_profile(self) -> None:
         body = (PROMPTS_DIR / "_github-post-rules.md").read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -952,7 +952,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.write_ledger_key("91-2-judge")
         self.write_log(
             "phase9-issue91-r3-judge.log",
-            "META_JUDGE_DONE:escalate:stalled:no-change",
+            "META_JUDGE_DONE:converge:round-3:no-change",
         )
 
         self.router.tick()
@@ -1067,17 +1067,22 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertFalse(any("reflector" in " ".join(command) for command in self.commands))
         self.assertNotIn("81-3-reflector", [entry["key"] for entry in self.ledger_entries()])
 
-    def test_phase9_router_stalled_requires_valid_predicate(self) -> None:
-        self.write_log("phase9-issue37-r2-judge.log", "META_JUDGE_DONE:escalate:stalled:no-change")
+    def test_phase9_router_converge_routes_to_stalled_reflector_when_predicate_holds(self) -> None:
+        # Refactor (issue-304): Old: fresh judge-emitted stalled markers were
+        # the normal happy path. New: a clean r3 converge marker checks the
+        # router-owned stalled predicate before spawning r4 solvers.
+        self.write_log("phase9-issue37-r2-judge.log", "META_JUDGE_DONE:converge:round-2:need-more")
         self.router.tick()
-        self.assertEqual(self.commands, [])
+        logs = " ".join(" ".join(command) for command in self.commands)
+        self.assertIn("phase9-issue37-r3-minimal.log", logs)
+        self.assertNotIn("phase9-issue37-r2-reflector.log", logs)
 
         self.commands.clear()
         for round_no in (1, 2, 3):
             self.solver_triplet(issue=38, round_no=round_no, verdict="same")
         self.write_ledger_key("38-1-judge")
         self.write_ledger_key("38-2-judge")
-        self.write_log("phase9-issue38-r3-judge.log", "META_JUDGE_DONE:escalate:stalled:no-change")
+        self.write_log("phase9-issue38-r3-judge.log", "META_JUDGE_DONE:converge:round-3:no-change")
         self.router.tick()
 
         reflector_commands = [
@@ -1086,6 +1091,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertEqual(len(reflector_commands), 1)
         self.assertEqual(len(self.commands), 1)
         self.assertIn("38-3-reflector", [entry["key"] for entry in self.ledger_entries()])
+        self.assertNotIn("38-4-minimal", [entry["key"] for entry in self.ledger_entries()])
 
     def test_phase9_router_closed_issue_suppresses_stalled_reflector_dispatch(self) -> None:
         self.source_issue_states["38"] = "CLOSED"
@@ -1093,7 +1099,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             self.solver_triplet(issue=38, round_no=round_no, verdict="same")
         self.write_ledger_key("38-1-judge")
         self.write_ledger_key("38-2-judge")
-        self.write_log("phase9-issue38-r3-judge.log", "META_JUDGE_DONE:escalate:stalled:no-change")
+        self.write_log("phase9-issue38-r3-judge.log", "META_JUDGE_DONE:converge:round-3:no-change")
 
         self.router.tick()
 
@@ -1113,7 +1119,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertEqual(by_key["phase9-triplet-suppression:38-3-judge"]["reason"], "phase9-triplet-target-log-exists")
         self.assertEqual(by_key["phase9-triplet-suppression:38-3-judge"]["route"], "solver_triplet_to_judge")
 
-    def test_phase9_router_accepts_meta_judge_issue_log_for_stalled(self) -> None:
+    def test_phase9_router_accepts_meta_judge_issue_log_for_router_derived_stalled(self) -> None:
         for round_no in (1, 2, 3):
             for role in ("minimal", "structural", "delete"):
                 self.write_log(
@@ -1122,7 +1128,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
                 )
         self.write_ledger_key("100-1-judge")
         self.write_ledger_key("100-2-judge")
-        self.write_log("meta-judge-issue100-r3.log", "META_JUDGE_DONE:escalate:stalled:no-change")
+        self.write_log("meta-judge-issue100-r3.log", "META_JUDGE_DONE:converge:round-3:no-change")
 
         self.router.tick()
 
@@ -1133,12 +1139,25 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertEqual(len(self.commands), 1)
         self.assertIn("100-3-reflector", [entry["key"] for entry in self.ledger_entries()])
 
+    def test_phase9_router_accepts_legacy_stalled_marker_read_only_compatibility(self) -> None:
+        for round_no in (1, 2, 3):
+            self.solver_triplet(issue=101, round_no=round_no, verdict="same")
+        self.write_ledger_key("101-1-judge")
+        self.write_ledger_key("101-2-judge")
+        self.write_log("phase9-issue101-r3-judge.log", "META_JUDGE_DONE:escalate:stalled:legacy-replay")
+
+        self.router.tick()
+
+        self.assertEqual(len(self.commands), 1)
+        self.assertIn("phase9-issue101-r3-reflector.log", " ".join(self.commands[0]))
+        self.assertIn("101-3-reflector", [entry["key"] for entry in self.ledger_entries()])
+
     def test_stalled_reflector_prompt_uses_full_template_and_evidence(self) -> None:
         for round_no in (1, 2, 3):
             self.solver_triplet(issue=85, round_no=round_no, verdict="same")
         self.write_ledger_key("85-1-judge")
         self.write_ledger_key("85-2-judge")
-        stalled_marker = "META_JUDGE_DONE:escalate:stalled:no-actionable-framing"
+        stalled_marker = "META_JUDGE_DONE:converge:round-3:no-actionable-framing"
         self.write_log("phase9-issue85-r3-judge.log", stalled_marker)
 
         self.router.tick()
@@ -1180,7 +1199,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             self.solver_triplet(issue=86, round_no=round_no, verdict="same")
         self.write_ledger_key("86-1-judge")
         self.write_ledger_key("86-2-judge")
-        stalled_marker = "META_JUDGE_DONE:escalate:stalled:no-actionable-framing"
+        stalled_marker = "META_JUDGE_DONE:converge:round-3:no-actionable-framing"
         self.write_log("phase9-issue86-r3-judge.log", stalled_marker)
 
         original_read_text = Path.read_text
@@ -1213,13 +1232,14 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             self.solver_triplet(issue=39, round_no=round_no, verdict=verdict)
         self.write_ledger_key("39-1-judge")
         self.write_ledger_key("39-2-judge")
-        self.write_log("phase9-issue39-r3-judge.log", "META_JUDGE_DONE:escalate:stalled:no-change")
+        self.write_log("phase9-issue39-r3-judge.log", "META_JUDGE_DONE:converge:round-3:no-change")
 
         self.router.tick()
 
         self.assertFalse(any("reflector" in " ".join(command) for command in self.commands))
         self.assertNotIn("39-3-reflector", [entry["key"] for entry in self.ledger_entries()])
-        self.assertIn("META_JUDGE_DONE:escalate:stalled:no-change", self.pending_events())
+        logs = " ".join(" ".join(command) for command in self.commands)
+        self.assertIn("phase9-issue39-r4-minimal.log", logs)
 
     def test_phase9_router_lifecycle_markers_never_spawn(self) -> None:
         markers = (

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
@@ -217,11 +217,14 @@ class Phase9RouterPackageTests(unittest.TestCase):
         self.assertEqual(event["marker"], "SOMETHING_DONE:surprise:payload")
         self.assertEqual(self.ledger_entries(), [])
 
-    def test_package_router_stalled_dispatches_reflector_when_predicate_holds(self) -> None:
+    def test_package_router_converge_dispatches_stalled_reflector_when_predicate_holds(self) -> None:
+        # Refactor (issue-304): Old: package smoke used a fresh stalled judge
+        # marker. New: r3 converge plus unchanged solver history renders the
+        # stalled reflector template and suppresses r4 solver dispatch.
         for round_no in (1, 2, 3):
             for role in ("minimal", "structural", "delete"):
                 self.write_log(f"phase9-issue160-r{round_no}-{role}.log", f"SOLVER_DONE:{role}:same:summary")
-        self.write_log("phase9-issue160-r3-judge.log", "META_JUDGE_DONE:escalate:stalled:no-change")
+        self.write_log("phase9-issue160-r3-judge.log", "META_JUDGE_DONE:converge:round-3:no-change")
 
         self.router.tick()
 
@@ -230,6 +233,11 @@ class Phase9RouterPackageTests(unittest.TestCase):
         ]
         self.assertEqual(len(reflector_commands), 1)
         self.assertIn("160-3-reflector", [entry["key"] for entry in self.ledger_entries()])
+        self.assertNotIn("160-4-minimal", [entry["key"] for entry in self.ledger_entries()])
+        prompt = (self.repo / ".refactor-loop" / "prompts" / "phase9" / "phase9-issue160-r3-reflector.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("# Role: Meta-reflector - stalled route resolver", prompt)
 
     def test_router_ignores_host_policy_roles_and_dispatch_for_active_spawn_allowlist(self) -> None:
         ctx = self.write_host_policy()

--- a/skills/codex-refactor-loop/scripts/test_role_artifact_profiles.py
+++ b/skills/codex-refactor-loop/scripts/test_role_artifact_profiles.py
@@ -83,8 +83,8 @@ PROFILES = {
     ),
     "phase9-meta-judge": ArtifactProfile(
         required_metadata=("issue", "cluster", "convergence_round", "solver_verdicts", "decision"),
-        required_sections=("Decision", "If consensus", "If converge", "If escalate", "Round audit trail"),
-        final_marker_patterns=(r"^META_JUDGE_DONE:(consensus|converge|escalate):.+$",),
+        required_sections=("Decision", "If consensus", "If converge", "Round audit trail"),
+        final_marker_patterns=(r"^META_JUDGE_DONE:(consensus|converge):.+$",),
         forbidden_marker_tokens=tuple(token for token in ROLE_MARKER_TOKENS if token != "META_JUDGE_DONE"),
         sentinel_policy="penultimate-before-final-marker",
     ),
@@ -211,9 +211,6 @@ Consensus reached on test-only profile fixtures.
 - Chosen framing: test-only
 
 ## If converge
-- Not applicable.
-
-## If escalate
 - Not applicable.
 
 ## Round audit trail
@@ -457,6 +454,20 @@ class RoleArtifactProfileTests(unittest.TestCase):
         artifact = VALID_META_JUDGE.replace("\n## Round audit trail\n- solver-minimal: path\n", "\n")
 
         self.assertInvalidBecause("phase9-meta-judge", artifact, "missing sections")
+
+    def test_meta_judge_rejects_fresh_stalled_marker_fixture(self) -> None:
+        # Refactor (issue-304): Old: phase9-meta-judge profile accepted
+        # escalate markers. New: fresh meta-judge artifacts are limited to
+        # consensus/converge; stalled is a router-owned derived route.
+        artifact = VALID_META_JUDGE.replace(
+            "META_JUDGE_DONE:consensus:test-only:all solvers aligned",
+            "META_JUDGE_DONE:escalate:stalled:no-change",
+        ).replace(
+            "decision: consensus",
+            "decision: converge",
+        )
+
+        self.assertInvalidBecause("phase9-meta-judge", artifact, "final line does not match")
 
     def test_reviewer_with_wrong_marker_fails(self) -> None:
         artifact = VALID_REVIEWER.replace("REVIEW_DONE:42:architect:approve", "SOLVER_DONE:minimal:propose:no")

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -365,6 +365,9 @@ class SkillEntrypointContractTests(unittest.TestCase):
         self.assertIn("SOLVER_DONE", self.skill)
         self.assertIn("META_JUDGE_DONE:converge", self.skill)
         self.assertIn("META_JUDGE_DONE:escalate:stalled", self.skill)
+        self.assertIn("router-derived stalled continuation", self.skill)
+        self.assertIn("legacy read-only `META_JUDGE_DONE:escalate:stalled`", self.skill)
+        self.assertIn("meta-judge returns consensus/converge only", self.skill)
         self.assertIn("do not introduce migrated work-unit schema, public marker aliases, ControllerOrchestrator, ControllerEvent, ControllerCommand, or lifecycle authority", self.skill)
 
     def test_issue276_lifecycle_target_normalization_contract_is_documented(self) -> None:

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -692,7 +692,9 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             "host `roles`, `dispatch`, and `consensus_policies` are validation/display/data-only projection surfaces",
             "must not alter this allowlist or block the built-in router routes",
             "SOLVER_DONE:<minimal|structural|delete>:*",
-            "both spawn r(S+1) minimal/structural/delete solvers",
+            "before spawning r(S+1) minimal/structural/delete solvers",
+            "router-owned stalled predicate",
+            "suppress next solvers",
         ):
             with self.subTest(token=token):
                 self.assertIn(token, contract_section)
@@ -752,6 +754,39 @@ class SkillReferenceAnchorTests(unittest.TestCase):
         self.assertNotIn("target_round <= marker.round", router)
         self.assertFalse((router_path.parent / "decision.py").exists())
         self.assertNotIn("MetaJudgeRouteProjection", combined)
+
+    def test_phase9_stalled_is_router_owned_predicate_source_regression(self) -> None:
+        # Refactor (issue-304): Old: fresh phase9 meta-judge artifacts could
+        # authorize `META_JUDGE_DONE:escalate:stalled`. New: prompt/profile
+        # allow only consensus/converge; router checks stalled predicate before
+        # r(S+1) solver dispatch, while legacy stalled markers are read-only.
+        router = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "phase9" / "router.py").read_text(encoding="utf-8")
+        meta_judge = (SKILL_ROOT / "prompts" / "meta-judge.md").read_text(encoding="utf-8")
+        marker_contract = (SKILL_ROOT / "scripts" / "test_marker_emission_contract.py").read_text(encoding="utf-8")
+        profile_contract = (SKILL_ROOT / "scripts" / "test_role_artifact_profiles.py").read_text(encoding="utf-8")
+        combined = "\n".join((self.skill, meta_judge, router, marker_contract, profile_contract))
+
+        for token in (
+            "Refactor (issue-304)",
+            "meta-judge emits only consensus/converge",
+            "router-owned stalled predicate",
+            "_dispatch_stalled_reflector",
+            "legacy read-only `META_JUDGE_DONE:escalate:stalled`",
+            "r(S+1)",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, combined)
+
+        allowlist = re.search(
+            r'    "meta-judge\.md": \(\n(?P<body>.*?)\n    \),',
+            marker_contract,
+            flags=re.S,
+        )
+        self.assertIsNotNone(allowlist)
+        assert allowlist is not None
+        self.assertNotIn("META_JUDGE_DONE:escalate:stalled:<short>", allowlist.group("body"))
+        self.assertIn(r"^META_JUDGE_DONE:(consensus|converge):.+$", profile_contract)
+        self.assertNotIn(r"^META_JUDGE_DONE:(consensus|converge|escalate):.+$", profile_contract)
 
     def test_phase9_solver_triplet_suppression_fallback_contract_source_regression(self) -> None:
         router = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "phase9" / "router.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## 摘要

修 #304:meta-judge 在 round<3 仍能输出 `escalate:stalled`,造成无尽 stalled-churn(router 反复 fallback)。

- **Old**:meta-judge 拥有 fresh `escalate:stalled` 输出权威,无最小轮次门。
- **New**:judge 只出 `consensus`/`converge`;stalled 改由 router-owned predicate 在 r3+ converge 后派生(派 meta-reflector-stalled 并 suppress 下一轮 solver);legacy `escalate:stalled` marker 仅 read-only 兼容。

3/3 design-consensus(r6,delete framing)。这条修复终止本会话反复出现的 r1/r2 stalled 异常 churn。

## 范围

meta-judge.md / router.py / SKILL.md / README + 6 测试(含 negative source-regression)。全套 **841 tests OK**。

Closes #304

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
