### PR TITLE
#307: audit 占位符统一 ${ITERATION}

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1542,7 +1542,7 @@ The default work-unit producer is `audit`. Producer normalization is documented 
 triage and must already be reshaped before Consensus-rnd Phase design-consensus.
 
 1. Copy `prompts/audit.md` (this skill's template) to `.refactor-loop/prompts/audit-iter-N.md`.
-2. Replace `{{iteration}}` placeholder.
+2. Replace the literal `${ITERATION}` placeholders with N using a targeted replacement; leave runtime placeholders such as `$REPO_ROOT`, `${PROJECT_RULES:-CLAUDE.md}`, and `$SOURCE_GLOBS` intact for the audit codex runtime.
 3. Dispatch:
 
    ```bash

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -611,6 +611,34 @@ class SkillEntrypointContractTests(unittest.TestCase):
             with self.subTest(needle=needle):
                 self.assertIn(needle, section)
 
+    def test_audit_work_intake_iteration_placeholder_matches_audit_prompt(self) -> None:
+        # Refactor (issue-307): keep work-intake rendering contract aligned with
+        # prompts/audit.md while preserving runtime shell placeholders.
+        section = section_between(
+            self.skill,
+            r"^## Consensus-rnd Phase work-intake .+$",
+            r"^## ",
+        )
+        self.assertTrue(section)
+        self.assertNotIn("{{iteration}}", section)
+        for needle in (
+            "Replace the literal `${ITERATION}` placeholders with N using a targeted replacement",
+            "leave runtime placeholders such as `$REPO_ROOT`, `${PROJECT_RULES:-CLAUDE.md}`, and `$SOURCE_GLOBS` intact",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
+
+        audit_prompt = read(SKILL_ROOT / "prompts" / "audit.md")
+        rendered = audit_prompt.replace("${ITERATION}", "307")
+        self.assertIn("audit-iter-307", rendered)
+        for runtime_placeholder in (
+            "$REPO_ROOT",
+            "${PROJECT_RULES:-CLAUDE.md}",
+            "$SOURCE_GLOBS",
+        ):
+            with self.subTest(runtime_placeholder=runtime_placeholder):
+                self.assertIn(runtime_placeholder, rendered)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

修 #307:SKILL work-intake 第 2 步指向不存在的 `{{iteration}}` 占位符(`audit.md` 实际用 `${ITERATION}`),首派 audit 必走错。

- **Old**:`Replace {{iteration}} placeholder.`(unsupported micro-protocol)。
- **New**:`${ITERATION}` targeted replacement 文案 + 1 条 contract test 锁住 drift;不新增 renderer CLI。

3/3 design-consensus(r4,hybrid-minimal-delete)。

## 范围

SKILL.md(2 行)+ 1 contract test(27 tests OK)。

Closes #307

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
