### PR TITLE
Release rollup

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -380,7 +380,7 @@ Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event
 10. Run controller wakeup step 1.5 for the concurrency floor before any `ScheduleWakeup`.
 11. Spawn the next codexes with harness background tasks if actionable work exists.
 12. Confirm the daemon-event Monitor bridge is still maintained; then confirm any in-flight background task notification or successfully registered ScheduleWakeup fallback that is being used for turn-level completion/fallback.
-13. Run `consensus-rnd-cli peek | tail -80` again after spawn, merge, banner, or close actions.
+13. Run `python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80` again after spawn, merge, banner, or close actions.
 
 `consensus-rnd-cli wakeup-plan` named read-only surface:
 
@@ -1251,7 +1251,7 @@ gh issue view <N> --json comments --jq '
 - **Controller 自己 post banner** 使用 `maintainer` 或 host 配置的安全称谓,不写裸人名。
 - **@-mention whitelist** 来自 `$MAINTAINER_WHITELIST`,并且必须经 git blame / host 配置验证。
 
-### Wakeup 第一动作:`bash <skill-root>/scripts/consensus-rnd-cli peek`(强制)
+### Wakeup 第一动作:`python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80`(强制)
 
 减少人工 grep / parse 错误。一眼看全:
 - 活跃 codex 数(只数本 loop:命令行含 `.refactor-loop/logs/` 或 `.refactor-loop/prompts/`)
@@ -1274,7 +1274,7 @@ gh issue view <N> --json comments --jq '
 
 **铁律**:任何 active phase issue/PR(`🔍 design-solving` / `🔧 fixing` / `👀 reviewing` / `🛠️ implementing`)存在时,**应至少有 1 个本 loop codex 在跑**。本 loop codex = `consensus-rnd-cli spawn-codex` 命令行含 `.refactor-loop/logs/` 或 `.refactor-loop/prompts/`。实际为 0 且 GitHub 有 active phase → **P0 bug**(no-gap-violation)。
 
-**Controller wakeup 第一动作**:`bash <skill-root>/scripts/consensus-rnd-cli peek`。如果活跃 codex == 0:
+**Controller wakeup 第一动作**:`python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80`。如果活跃 codex == 0:
 1. **不允许** `ScheduleWakeup` 后 end-turn — 必须派下一步 codex 才允许 ScheduleWakeup
 2. **不允许**只看 marker 不 sweep:必须扫所有刚 finished marker(implement/judge/reviewer/fix/reflector)并按 marker→spawn-next 表派至少 1 codex
 3. 如果所有 active issue/PR 都真在等 maintainer(全是 `crnd:human:maintainer-decision` / `crnd:phase:blocked`),那 0 codex 才 OK — 但仍要在 status 报告中说明 "0 codex by design:N issue 全等人"
@@ -1943,7 +1943,7 @@ dev sync stays with daemon; Consensus-rnd Phase design-consensus triplet/converg
 # Consensus-rnd Phase integration-sync 现在 controller 只读 daemon-maintained health/log surface
 python3 <skill-root>/scripts/consensus-rnd-cli restart-daemons
 python3 <skill-root>/scripts/consensus-rnd-cli concurrency --count-only >/dev/null
-bash <skill-root>/scripts/consensus-rnd-cli peek | tail -80
+python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80
 tail -10 .refactor-loop/logs/dev_sync_daemon.log | grep -E "(DEV_SYNC_BLOCKED|FAIL|FATAL)" | tail -3
 ```
 若 heartbeat stale/missing/malformed → 由 `consensus-rnd-cli restart-daemons` 按 canonical wrapper 重启。

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -2065,7 +2065,7 @@ Policy: AI keeps iterating until the fixed Consensus-rnd Phase review-gate truth
 Loop:
 
 1. **Round entry** — derive the next fix round from review/fix artifacts. If `fix_round > max_fix_rounds`, escalate (see below).
-2. **Dispatch fix codex** in PR's own worktree:
+2. **Render and dispatch fix codex** in PR's own worktree. Before spawn, call `ControllerActions.render_review_fix_prompt(PR, N, env)` or an equivalent controller-internal render action; this binds `FIX_OUTPUT_PATH=.refactor-loop/runs/fix-pr${PR}-round-${N}-report.md` into the rendered prompt artifact:
    ```bash
    <skill-root>/scripts/consensus-rnd-cli spawn-codex \
      --cd "$PR_WORKTREE" --add-dir "$REPO_ROOT" \
@@ -2073,7 +2073,8 @@ Loop:
      --log .refactor-loop/logs/fix-pr${PR}-round-${N}.log \
      --stall 3600
    ```
-   Fix codex reads all 3 reviewer outputs, applies in-scope fixes, validates locally, writes `FIX_REPORT.md`, emits `FIX_DONE:${PR}:round-${N}:applied-<N>:rejected-<M>:blocked-<K>` OR `FIX_BLOCKED:${PR}:round-${N}:<reason>:<short>`.
+   <!-- Refactor (issue-267): Old: fix worker wrote root FIX_REPORT.md by convention. New: controller-rendered FIX_OUTPUT_PATH points to .refactor-loop/runs/. -->
+   Fix codex reads all 3 reviewer outputs, applies in-scope fixes, validates locally, writes `${FIX_OUTPUT_PATH}` under `.refactor-loop/runs/`, emits `FIX_DONE:${PR}:round-${N}:applied-<N>:rejected-<M>:blocked-<K>` OR `FIX_BLOCKED:${PR}:round-${N}:<reason>:<short>`.
 3. **Controller commits + pushes** the fix codex's changes to the PR's HEAD branch (codex itself doesn't push, per hard rule 4). Commit message includes round number and applied/blocked counts.
 4. **Re-dispatch all 3 reviewers** against the new HEAD SHA (drop prior consensus).
 5. **Re-evaluate**:
@@ -2152,7 +2153,7 @@ Required PR comments (controller posts via `gh pr comment <PR> --body-file <file
 | Consensus-rnd Phase review-gate event | PR comment content |
 |---|---|
 | Reviewer round N complete | 中文 table of 3 verdicts + reject demands per role + "next action" (fix-retry dispatched OR auto-merge OR escalation). Link to commit SHA reviewed. |
-| Fix codex round N complete (FIX_DONE) | 中文 FIX_REPORT excerpt: applied / rejected-as-false-positive / blocked counts, build+test status, files changed. Link to fix commit SHA. |
+| Fix codex round N complete (FIX_DONE) | 中文 fix artifact excerpt from `${FIX_OUTPUT_PATH}`: applied / rejected-as-false-positive / blocked counts, build+test status, files changed. Link to fix commit SHA. |
 | Fix codex blocked (FIX_BLOCKED) | 中文: which reason category (conflict / human-decision / build-broken), reviewer demand text, controller's escalation decision. |
 | Consensus reached (`MERGE` / `MERGE_WITH_COMMENTS`) | 中文: round count, final reviewer outputs, surfaced comment evidence when present, "auto-merging now". Then merge + a second "merged at <commit>" comment. |
 | Escalation triggered | Add `crnd:human:maintainer-decision` label. Comment includes: full round history, latest verdicts, why escalation criteria hit, what controller tried. PushNotification mirrors the headline. |

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1542,7 +1542,7 @@ The default work-unit producer is `audit`. Producer normalization is documented 
 triage and must already be reshaped before Consensus-rnd Phase design-consensus.
 
 1. Copy `prompts/audit.md` (this skill's template) to `.refactor-loop/prompts/audit-iter-N.md`.
-2. Replace `{{iteration}}` placeholder.
+2. Replace the literal `${ITERATION}` placeholders with N using a targeted replacement; leave runtime placeholders such as `$REPO_ROOT`, `${PROJECT_RULES:-CLAUDE.md}`, and `$SOURCE_GLOBS` intact for the audit codex runtime.
 3. Dispatch:
 
    ```bash

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -36,9 +36,9 @@ Categorize each demand into one of:
 
 - **(A) Fixable in-scope** — concrete code change within `scope_paths` of this cluster. Apply it.
 - **(B) Fixable but scope-extend** — concrete code change outside scope_paths. Record `scope-extend: <file> <reason>` in the fix report and apply it ONLY if rejecting this demand would block consensus AND the file is in the same logical refactor (e.g. add missing test file for the new public method).
-- **(C) False positive** — the reviewer mis-read (e.g. cited a file not in the PR, cited a deletion that never happened, demand contradicts `$PROJECT_RULES`). Do NOT apply. Record in `FIX_REPORT.md` with evidence proving it's a false positive.
-- **(D) Conflicting demands** — Architect demands X, Quality demands ¬X. Do NOT apply either side without resolution. Record both sides in `FIX_REPORT.md` and emit `FIX_BLOCKED:conflict:<short>` at the end.
-- **(E) Outside fix-codex authority** — demand requires a design decision (e.g. "delete this feature entirely" / "split this into 3 PRs" / "rename core type that other clusters depend on"). Record in `FIX_REPORT.md` and emit `FIX_BLOCKED:human-decision:<short>`.
+- **(C) False positive** — the reviewer mis-read (e.g. cited a file not in the PR, cited a deletion that never happened, demand contradicts `$PROJECT_RULES`). Do NOT apply. Record in the fix artifact at `${FIX_OUTPUT_PATH}` with evidence proving it's a false positive.
+- **(D) Conflicting demands** — Architect demands X, Quality demands ¬X. Do NOT apply either side without resolution. Record both sides in the fix artifact at `${FIX_OUTPUT_PATH}` and emit `FIX_BLOCKED:conflict:<short>` at the end.
+- **(E) Outside fix-codex authority** — demand requires a design decision (e.g. "delete this feature entirely" / "split this into 3 PRs" / "rename core type that other clusters depend on"). Record in the fix artifact at `${FIX_OUTPUT_PATH}` and emit `FIX_BLOCKED:human-decision:<short>`.
 
 ### Step 2 — Apply (A) and selected (B) fixes
 
@@ -61,7 +61,7 @@ cd $REPO_ROOT && \
 
 Pick the test projects whose code you changed; do NOT run the full solution test suite (too slow). If build fails → fix or `FIX_BLOCKED:build:<short>`.
 
-### Step 4 — Write FIX_REPORT
+### Step 4 — Write fix artifact
 
 Write `${FIX_OUTPUT_PATH}` with this structure:
 
@@ -112,8 +112,8 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 - **You do NOT install new packages.**
 - **You do NOT touch files outside the PR's diff unless emitting `SCOPE_EXTEND` first.**
 - **You do NOT modify other cluster's PRs** (only this PR's HEAD branch).
-- **False-positive demands must have proof** in FIX_REPORT — don't dismiss without evidence.
-- **FIX_REPORT 写入路径强制 `${FIX_OUTPUT_PATH}`**(典型 `.refactor-loop/runs/fix-pr<N>-r<N>.md`)— **禁止**写到 repo root `FIX_REPORT.md`(会污染 worktree + rebase conflict)。若 `${FIX_OUTPUT_PATH}` 空(env var 漏传),emit `FIX_BLOCKED:env-missing:FIX_OUTPUT_PATH` 不要瞎写默认路径。
+- **False-positive demands must have proof** in the fix artifact at `${FIX_OUTPUT_PATH}` — don't dismiss without evidence.
+- **Fix artifact 写入路径强制 `${FIX_OUTPUT_PATH}`**(典型 `.refactor-loop/runs/fix-pr<N>-round-<R>-report.md`)— **禁止**写到 repo root `FIX_REPORT.md`(会污染 worktree + rebase conflict)。若 `${FIX_OUTPUT_PATH}` 空(env var 漏传),emit `FIX_BLOCKED:env-missing:FIX_OUTPUT_PATH` 不要瞎写默认路径。
 - **A demand citing `$PROJECT_RULES` verbatim is presumed valid** — burden of proof is on you to show it's a misreading.
 
 ## Anti-patterns (forbidden — emit FIX_BLOCKED instead of doing these)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -18,6 +18,7 @@ from . import labels
 from .context import LoopContext
 from .github_body import GitHubBodyError, validate_self_contained_github_body
 from .release.publisher import ReleasePublishResult, ReleasePublisher
+from .review_fix_dispatch import ReviewFixDispatchSpec
 from .triage import apply_decision, load_triage_apply_config
 from .work_items import extract_closing_issue_numbers
 from .workflow_spec import WorkflowSpecError, load_validated_workflow_spec
@@ -541,6 +542,27 @@ class ControllerActions:
             template = template.replace("{{" + key + "}}", value)
         rendered = Template(template).safe_substitute(values)
         Path(output_path).write_text(rendered, encoding="utf-8")
+
+    def render_review_fix_prompt(
+        self,
+        pr_number: int,
+        round_number: int,
+        env: Mapping[str, str] | None = None,
+    ) -> ReviewFixDispatchSpec:
+        # Refactor (issue-267): Old: FIX_OUTPUT_PATH was a prompt-only oral
+        # variable and workers could drift to root FIX_REPORT.md. New:
+        # controller render binds the canonical runs artifact before dispatch.
+        spec = ReviewFixDispatchSpec.for_round(pr_number, round_number)
+        render_env = dict(env or {})
+        render_env.update(spec.as_render_env())
+        prompt_path = self.ctx.repo_root / spec.prompt_path
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        self.render_template(
+            str(self.ctx.skill_root / "prompts" / "review-fix.md"),
+            str(prompt_path),
+            env=render_env,
+        )
+        return spec
 
     def _resolve_template_input(self, input_path: str) -> Path:
         if not input_path.startswith("host:"):

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/review_fix_dispatch.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/review_fix_dispatch.py
@@ -1,0 +1,60 @@
+"""Review-fix prompt render boundary helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Mapping
+
+
+_POSITIVE_INT_RE = re.compile(r"^[1-9][0-9]*$")
+_FIX_OUTPUT_RE = re.compile(r"^\.refactor-loop/runs/fix-pr[1-9][0-9]*-round-[1-9][0-9]*-report\.md$")
+
+
+@dataclass(frozen=True)
+class ReviewFixDispatchSpec:
+    """Canonical review-fix prompt, log, and output artifact paths."""
+
+    prompt_path: str
+    log_path: str
+    fix_output_path: str
+
+    @classmethod
+    def for_round(cls, pr_number: int, round_number: int) -> "ReviewFixDispatchSpec":
+        pr = _validate_positive_int(pr_number, "pr_number")
+        round_no = _validate_positive_int(round_number, "round_number")
+        # Refactor (issue-267): Old: review-fix output was a prompt-only
+        # convention. New: controller render owns the canonical artifact path.
+        fix_output_path = f".refactor-loop/runs/fix-pr{pr}-round-{round_no}-report.md"
+        return cls(
+            prompt_path=f".refactor-loop/prompts/fixes/fix-pr{pr}-round-{round_no}.md",
+            log_path=f".refactor-loop/logs/fix-pr{pr}-round-{round_no}.log",
+            fix_output_path=cls.validate_fix_output_path(fix_output_path),
+        )
+
+    def as_render_env(self) -> Mapping[str, str]:
+        return {"FIX_OUTPUT_PATH": self.fix_output_path}
+
+    @staticmethod
+    def validate_fix_output_path(path: str) -> str:
+        value = str(path or "").strip()
+        pure = PurePosixPath(value)
+        if not value:
+            raise ValueError("FIX_OUTPUT_PATH is required")
+        if pure.is_absolute():
+            raise ValueError("FIX_OUTPUT_PATH must be repo-relative")
+        if "\\" in value or ".." in pure.parts:
+            raise ValueError("FIX_OUTPUT_PATH must not escape the repo")
+        if not _FIX_OUTPUT_RE.fullmatch(value):
+            raise ValueError(
+                "FIX_OUTPUT_PATH must match .refactor-loop/runs/fix-pr<N>-round-<R>-report.md"
+            )
+        return value
+
+
+def _validate_positive_int(value: int, label: str) -> str:
+    text = str(value)
+    if not _POSITIVE_INT_RE.fullmatch(text):
+        raise ValueError(f"{label} must be a positive decimal integer")
+    return text

--- a/skills/codex-refactor-loop/scripts/test_cli_daemon_help_smoke.py
+++ b/skills/codex-refactor-loop/scripts/test_cli_daemon_help_smoke.py
@@ -52,6 +52,21 @@ class CliDaemonHelpSmokeTests(unittest.TestCase):
                 offenders.append(f"{op}: {reason}")
         self.assertEqual(offenders, [], f"command main() import errors: {offenders}")
 
+    def test_peek_python_invocation_parses_help(self) -> None:
+        # Refactor (issue-303): controller docs invoke the Python CLI directly,
+        # so keep the targeted `python3 consensus-rnd-cli peek --help` path
+        # covered even if the broader operation list changes.
+        result = subprocess.run(
+            [sys.executable, str(CLI), "peek", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        blob = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 0, blob)
+        self.assertIn("usage:", blob)
+        self.assertIn("peek", blob)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_review_fix_dispatch.py
+++ b/skills/codex-refactor-loop/scripts/test_review_fix_dispatch.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Behavior tests for review-fix dispatch rendering."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.context import LoopContext
+from codex_refactor_loop.controller_actions import ControllerActions
+from codex_refactor_loop.review_fix_dispatch import ReviewFixDispatchSpec
+
+
+class ReviewFixDispatchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="review-fix-dispatch-test-"))
+        (self.tmp / ".refactor-loop").mkdir(parents=True)
+        (self.tmp / ".refactor-loop" / "host.env").write_text(
+            f'export REPO_ROOT="{self.tmp}"\n',
+            encoding="utf-8",
+        )
+        self.actions = ControllerActions(
+            LoopContext.load(
+                repo_root=self.tmp,
+                skill_root=SCRIPT_DIR.parent,
+                env={"REPO_ROOT": str(self.tmp)},
+            )
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_spec_for_round_uses_canonical_runs_report_path(self) -> None:
+        spec = ReviewFixDispatchSpec.for_round(269, 1)
+
+        self.assertEqual(spec.fix_output_path, ".refactor-loop/runs/fix-pr269-round-1-report.md")
+        self.assertEqual(spec.prompt_path, ".refactor-loop/prompts/fixes/fix-pr269-round-1.md")
+        self.assertEqual(spec.log_path, ".refactor-loop/logs/fix-pr269-round-1.log")
+        self.assertEqual(spec.as_render_env(), {"FIX_OUTPUT_PATH": ".refactor-loop/runs/fix-pr269-round-1-report.md"})
+
+    def test_validate_rejects_root_report_and_path_escape(self) -> None:
+        invalid = (
+            "FIX_REPORT.md",
+            "./FIX_REPORT.md",
+            "/tmp/FIX_REPORT.md",
+            ".refactor-loop/../FIX_REPORT.md",
+            ".refactor-loop/logs/fix-pr269-round-1-report.md",
+            ".refactor-loop/runs/fix-pr269-r1.md",
+        )
+        for value in invalid:
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    ReviewFixDispatchSpec.validate_fix_output_path(value)
+
+    def test_controller_render_review_fix_prompt_injects_fix_output_path(self) -> None:
+        spec = self.actions.render_review_fix_prompt(
+            269,
+            1,
+            env={
+                "PR_NUMBER": "269",
+                "PR_TITLE": "Review fix render",
+                "FIX_ROUND": "1",
+                "MAX_FIX_ROUNDS": "3",
+                "BASE_BRANCH": "dev",
+                "HEAD_BRANCH": "impl/issue269",
+                "REVIEW_ARCHITECT_PATH": ".refactor-loop/runs/review-pr269-architect-r1.md",
+                "REVIEW_TESTS_PATH": ".refactor-loop/runs/review-pr269-tests-r1.md",
+                "REVIEW_QUALITY_PATH": ".refactor-loop/runs/review-pr269-quality-r1.md",
+                "AUDIT_PATH": ".refactor-loop/runs/audit.md",
+                "IMPLEMENT_SUMMARY_PATH": ".refactor-loop/runs/implement.md",
+                "PROJECT_RULES": "CLAUDE.md",
+                "HOST_REFACTOR_COMMENT_POLICY": "self-doc-comment",
+            },
+        )
+
+        self.assertEqual(spec.fix_output_path, ".refactor-loop/runs/fix-pr269-round-1-report.md")
+        prompt = self.tmp / ".refactor-loop" / "prompts" / "fixes" / "fix-pr269-round-1.md"
+        rendered = prompt.read_text(encoding="utf-8")
+        self.assertIn(".refactor-loop/runs/fix-pr269-round-1-report.md", rendered)
+        self.assertNotIn("${FIX_OUTPUT_PATH}", rendered)
+        self.assertTrue(prompt.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_review_fix_prompt_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_review_fix_prompt_contract.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Source-regression tests for the review-fix prompt contract."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_ROOT = SCRIPT_DIR.parent
+
+
+class ReviewFixPromptContractTests(unittest.TestCase):
+    def test_review_fix_prompt_has_single_positive_report_destination(self) -> None:
+        text = (SKILL_ROOT / "prompts" / "review-fix.md").read_text(encoding="utf-8")
+
+        self.assertIn("Write fix artifact", text)
+        self.assertIn("`${FIX_OUTPUT_PATH}`", text)
+        self.assertIn(".refactor-loop/runs/", text)
+        self.assertIn("FIX_BLOCKED:env-missing:FIX_OUTPUT_PATH", text)
+        self.assertIn("repo root `FIX_REPORT.md`", text)
+        self.assertNotIn("Record in `FIX_REPORT.md`", text)
+        self.assertNotIn("Write FIX_REPORT", text)
+
+    def test_skill_fix_retry_loop_uses_rendered_fix_output_path(self) -> None:
+        text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+
+        self.assertIn("render_review_fix_prompt", text)
+        self.assertIn(".refactor-loop/runs/fix-pr${PR}-round-${N}-report.md", text)
+        self.assertIn("fix artifact excerpt from `${FIX_OUTPUT_PATH}`", text)
+        self.assertNotIn("writes `FIX_REPORT.md`", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -214,6 +214,56 @@ class SkillEntrypointContractTests(unittest.TestCase):
             r"Confirm a wake source: an active daemon-event Monitor bridge,.*or.*ScheduleWakeup",
         )
 
+    def test_controller_cli_invocation_contract_forbids_bash_interpreter(self) -> None:
+        # Refactor (issue-303):
+        #   Old pattern: controller-actionable runbooks invoked the Python CLI
+        #   with `bash <skill-root>/scripts/consensus-rnd-cli peek`, so wakeup
+        #   docs looked executable but selected the wrong interpreter.
+        #   New principle: controller-actionable CLI examples spell the Python
+        #   interpreter explicitly; shell wrappers may only source env and exec
+        #   python3.
+        canonical = "python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80"
+        self.assertNotIn("bash <skill-root>/scripts/consensus-rnd-cli", self.skill)
+        self.assertIn(canonical, self.skill)
+
+    def test_wakeup_peek_uses_python_cli_invocation(self) -> None:
+        # Refactor (issue-303): lock the controller-actionable peek callsites to
+        # the Python CLI contract without rewriting conceptual command mentions.
+        canonical = "python3 <skill-root>/scripts/consensus-rnd-cli peek | tail -80"
+        skeleton = section_between(
+            self.skill,
+            r"^## Wakeup Skeleton$",
+            r"^## Workflow Stage Index$",
+        )
+        first_action = section_between(
+            self.skill,
+            r"^### Wakeup 第一动作:",
+            r"^<a id=\"wake-source-rules\"></a>$",
+        )
+        wake_source = section_between(
+            self.skill,
+            r"^## Wake source rules and no-gap details$",
+            r"^### Controller 每 wakeup 必派",
+        )
+        dev_sync = section_between(
+            self.skill,
+            r"^### Controller 每 wakeup 责任",
+            r"^### 反面",
+        )
+        self.assertTrue(skeleton)
+        self.assertTrue(first_action)
+        self.assertTrue(wake_source)
+        self.assertTrue(dev_sync)
+        self.assertIn(f"### Wakeup 第一动作:`{canonical}`(强制)", self.skill)
+        for label, section, needle in (
+            ("wakeup skeleton final peek", skeleton, f"Run `{canonical}` again after spawn, merge, banner, or close actions."),
+            ("wakeup first action body", first_action, canonical),
+            ("zero-codex first action", wake_source, f"**Controller wakeup 第一动作**:`{canonical}`。如果活跃 codex == 0:"),
+            ("dev-sync controller responsibility", dev_sync, canonical),
+        ):
+            with self.subTest(label=label):
+                self.assertIn(needle, section)
+
     def test_wakeup_plan_entrypoint_contract_is_read_only_and_authorized(self) -> None:
         skeleton = section_between(
             self.skill,

--- a/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_entrypoint_contract.py
@@ -661,6 +661,34 @@ class SkillEntrypointContractTests(unittest.TestCase):
             with self.subTest(needle=needle):
                 self.assertIn(needle, section)
 
+    def test_audit_work_intake_iteration_placeholder_matches_audit_prompt(self) -> None:
+        # Refactor (issue-307): keep work-intake rendering contract aligned with
+        # prompts/audit.md while preserving runtime shell placeholders.
+        section = section_between(
+            self.skill,
+            r"^## Consensus-rnd Phase work-intake .+$",
+            r"^## ",
+        )
+        self.assertTrue(section)
+        self.assertNotIn("{{iteration}}", section)
+        for needle in (
+            "Replace the literal `${ITERATION}` placeholders with N using a targeted replacement",
+            "leave runtime placeholders such as `$REPO_ROOT`, `${PROJECT_RULES:-CLAUDE.md}`, and `$SOURCE_GLOBS` intact",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, section)
+
+        audit_prompt = read(SKILL_ROOT / "prompts" / "audit.md")
+        rendered = audit_prompt.replace("${ITERATION}", "307")
+        self.assertIn("audit-iter-307", rendered)
+        for runtime_placeholder in (
+            "$REPO_ROOT",
+            "${PROJECT_RULES:-CLAUDE.md}",
+            "$SOURCE_GLOBS",
+        ):
+            with self.subTest(runtime_placeholder=runtime_placeholder):
+                self.assertIn(runtime_placeholder, rendered)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Release rollup — auto-refact-dev → dev

本轮 `auto-refact-dev` 领先 `dev` 3 个提交,滚动到 review base:

- **#267**:review-fix `FIX_OUTPUT_PATH` 绑定到 production render 边界(ReviewFixDispatchSpec)
- **#303**:SKILL controller-actionable peek 调用统一为 `python3 …cli peek` + source-regression
- **#307**:audit work-intake 占位符统一 `${ITERATION}`,删 unsupported `{{iteration}}` + contract test

三者均经 3/3 design-consensus + review-gate 共识合入 ard。进入既有 review-gate + CI/merge policy。

🤖 Auto-loop / codex-refactor-loop release rollup

⟦AI:AUTO-LOOP⟧
