### PR TITLE
#323: GitHub posting 命令 roster 收口到单一 shared contract

### DIFF
--- a/skills/codex-refactor-loop/prompts/_github-post-rules.md
+++ b/skills/codex-refactor-loop/prompts/_github-post-rules.md
@@ -54,9 +54,10 @@ escalation / consensus pick **必须**给清晰"方案 1/2/3"表格,cell 一行�
 
 ## 你不能调的(controller 边界)
 
-- 任何 `git commit` / `git push` / `git checkout` / `git branch`
+- 任何 git topology / history mutation: `git commit` / `git push` / `git checkout` / `git branch` / `git merge` / `git reset` / `git rebase`
 - `gh pr create`(controller 创 PR;你只 comment / edit body)
 - `gh pr merge` / `gh pr close` / `gh issue create` / `gh issue close`(lifecycle 决策归 controller)
+- `gh issue edit --add-label` / `gh issue edit --remove-label` / `gh pr edit --add-label` / `gh pr edit --remove-label`(label 决策归 controller)
 - 改源码 / scope_paths(若你是 reviewer 你只看;若 fix-codex 见自己 prompt)
 - 调度其他 codex
 

--- a/skills/codex-refactor-loop/prompts/design-issue-reply.md
+++ b/skills/codex-refactor-loop/prompts/design-issue-reply.md
@@ -76,8 +76,8 @@ NyxId API keys / secrets / 内部 URL 之类敏感信息绝对禁止出现在 re
 
 5. **输出**：
    - 把回复内容写到 `$REPO_ROOT/.refactor-loop/runs/design-issue-${ISSUE_NUMBER}-reply-$(date +%s).md`
-   - 末尾打印 `DESIGN_REPLY_READY:${ISSUE_NUMBER}:<short_one_line_summary>`
-   - controller 会读这个文件并 `gh issue comment ${ISSUE_NUMBER} --body-file <file>`
+   - 写完 archive 后直接按 `prompts/_github-post-rules.md` post GitHub 回复
+   - 成功打印 `POSTED:design-reply:${ISSUE_NUMBER}:<URL>:<headline>`；失败打印 `POST_FAILED:design-reply:${ISSUE_NUMBER}:<reason>`
 
 ## 红线
 
@@ -95,10 +95,7 @@ NyxId API keys / secrets / 内部 URL 之类敏感信息绝对禁止出现在 re
 - body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
 - 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`
 - 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
-- Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
-
-可调:`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`
-不可调:`git commit/push/checkout`、`gh pr create`、`gh pr merge`、`gh issue create/close`
+- Post 后打印 `POSTED:design-reply:${ISSUE_NUMBER}:<URL>:<headline>` 或 `POST_FAILED:design-reply:${ISSUE_NUMBER}:<reason>`
 
 
 ---

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -159,9 +159,6 @@ Refactor (iter6/issue-118):
 - 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
 - Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
 
-可调:`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`
-不可调:`git commit/push/checkout`、`gh pr create`、`gh pr merge`、`gh issue create/close`
-
 
 ---
 

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -134,9 +134,6 @@ Begin.
 - 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
 - Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
 
-可调:`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`
-不可调:`git commit/push/checkout`、`gh pr create`、`gh pr merge`、`gh issue create/close`
-
 
 ---
 

--- a/skills/codex-refactor-loop/prompts/reviewer-architect.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-architect.md
@@ -90,9 +90,6 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 - 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
 - Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
 
-可调:`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`
-不可调:`git commit/push/checkout`、`gh pr create`、`gh pr merge`、`gh issue create/close`
-
 
 ---
 

--- a/skills/codex-refactor-loop/prompts/reviewer-quality.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-quality.md
@@ -93,9 +93,6 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 - 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
 - Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
 
-可调:`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`
-不可调:`git commit/push/checkout`、`gh pr create`、`gh pr merge`、`gh issue create/close`
-
 
 ---
 

--- a/skills/codex-refactor-loop/prompts/reviewer-tests.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-tests.md
@@ -91,9 +91,6 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 - 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
 - Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
 
-可调:`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`
-不可调:`git commit/push/checkout`、`gh pr create`、`gh pr merge`、`gh issue create/close`
-
 
 ---
 

--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -138,9 +138,6 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 - 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
 - Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
 
-可调:`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`
-不可调:`git commit/push/checkout`、`gh pr create`、`gh pr merge`、`gh issue create/close`
-
 
 ---
 

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -120,9 +120,6 @@ Refactor (iter6/issue-118):
 - 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
 - Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
 
-可调:`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`
-不可调:`git commit/push/checkout`、`gh pr create`、`gh pr merge`、`gh issue create/close`
-
 
 ---
 

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -121,9 +121,6 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 - 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
 - Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
 
-可调:`gh issue/pr comment`、`gh pr edit --body-file`、`gh api .../reactions`、`mktemp`
-不可调:`git commit/push/checkout`、`gh pr create`、`gh pr merge`、`gh issue create/close`
-
 
 ---
 

--- a/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
@@ -43,7 +43,12 @@ FORBIDDEN_DIRECT_LIFECYCLE_SNIPPETS = (
     "gh issue edit --add-label",
     "gh issue edit --remove-label",
     "gh pr edit --add-label",
+    "gh pr edit --remove-label",
     "gh pr create",
+    "gh pr merge",
+    "gh pr close",
+    "gh issue create",
+    "gh issue close",
     "git commit",
     "git push",
     "git checkout",
@@ -56,6 +61,28 @@ AFFIRMATIVE_DIRECT_POST_SNIPPETS = (
     "You DO post to GitHub directly",
     "自己调 `gh` post",
     "Post 后打印 `POSTED:",
+)
+
+LOCAL_COMMAND_ROSTER_SNIPPETS = (
+    "可调:",
+    "不可调:",
+    "你能调的 gh 命令",
+    "你不能调的(controller 边界)",
+)
+
+DIRECT_POST_COMMAND_ROSTER_SNIPPETS = (
+    "gh issue/pr comment",
+    "gh pr edit --body-file",
+    "gh api .../reactions",
+    "mktemp",
+    "git commit/push/checkout",
+    "git merge/reset/rebase",
+    "gh pr create/merge/close",
+    "gh issue create/close",
+    "gh issue edit --add-label",
+    "gh issue edit --remove-label",
+    "gh pr edit --add-label",
+    "gh pr edit --remove-label",
 )
 
 
@@ -74,6 +101,10 @@ def marker_only_prompt_paths() -> list[Path]:
     return [path for path in prompt_paths() if not re.search(r"(?m)^## GitHub post", path.read_text(encoding="utf-8"))]
 
 
+def direct_post_prompt_paths() -> list[Path]:
+    return [path for path in prompt_paths() if re.search(r"(?m)^## GitHub post", path.read_text(encoding="utf-8"))]
+
+
 def prompts_with_marker_only_ban() -> list[Path]:
     paths = []
     for path in marker_only_prompt_paths():
@@ -90,10 +121,20 @@ def ban_section(body: str) -> str:
     return body
 
 
+def github_post_section(body: str) -> str:
+    match = re.search(r"(?ms)^## GitHub post.*?(?=^## |\Z)", body)
+    if not match:
+        return ""
+    return match.group(0)
+
+
 class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
     # Refactor (iter6/issue-118):
     #   Old pattern: SKILL.md/REFERENCE.md 维护 posting-mode prompt filename roster,会漂移
     #   New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
+    # Refactor (iter1/issue-323):
+    #   Old pattern: posting-capable prompt 各自复制本地 GitHub 命令 allow/deny roster,弱于 marker-only ban 且与 shared _github-post-rules.md 漂移;design-issue-reply.md posting-path 自相矛盾
+    #   New principle: command roster 唯一 owner=prompts/_github-post-rules.md(补完整);7 个 direct-post prompt 删本地 可调/不可调 roster 只留 shared 引用;design-issue-reply.md 选 worker direct-post 唯一成功路径(POSTED/POST_FAILED,删 DESIGN_REPLY_READY relay);source-regression 从 prompt body 派生 posting mode;SKILL.md 不改、不新增 runtime wrapper/registry
     def test_marker_only_prompts_with_ban_block_have_complete_lifecycle_ban(self) -> None:
         paths = prompts_with_marker_only_ban()
         self.assertGreater(len(paths), 0)
@@ -162,6 +203,68 @@ class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
         }
         self.assertTrue(prompt_roles)
         self.assertFalse(prompt_roles & set(COMMANDS))
+
+    def test_direct_post_prompts_reference_shared_contract_without_local_roster(self) -> None:
+        paths = direct_post_prompt_paths()
+        self.assertGreater(len(paths), 0)
+        for path in paths:
+            body = path.read_text(encoding="utf-8")
+            section = github_post_section(body)
+            with self.subTest(prompt=path.name):
+                self.assertIn("prompts/_github-post-rules.md", section)
+                for snippet in LOCAL_COMMAND_ROSTER_SNIPPETS:
+                    self.assertNotIn(snippet, section)
+
+    def test_direct_post_prompts_do_not_copy_command_tokens(self) -> None:
+        paths = direct_post_prompt_paths()
+        self.assertGreater(len(paths), 0)
+        for path in paths:
+            section = github_post_section(path.read_text(encoding="utf-8"))
+            with self.subTest(prompt=path.name):
+                for snippet in DIRECT_POST_COMMAND_ROSTER_SNIPPETS:
+                    self.assertNotIn(snippet, section)
+
+    def test_shared_github_post_rules_own_complete_command_roster(self) -> None:
+        body = (PROMPTS_DIR / "_github-post-rules.md").read_text(encoding="utf-8")
+        allowed = re.search(r"(?ms)^## 你能调的 gh 命令.*?(?=^## |\Z)", body)
+        forbidden = re.search(r"(?ms)^## 你不能调的\(controller 边界\).*?(?=^## |\Z)", body)
+        self.assertIsNotNone(allowed)
+        self.assertIsNotNone(forbidden)
+
+        for needle in (
+            "gh issue view",
+            "gh issue comment",
+            "gh pr view",
+            "gh pr comment",
+            "gh pr edit --body-file",
+            "gh api ...",
+            "mktemp",
+        ):
+            with self.subTest(section="allowed", needle=needle):
+                self.assertIn(needle, allowed.group(0))
+        for needle in (
+            "git merge",
+            "git reset",
+            "git rebase",
+            "gh pr close",
+            "gh issue edit --add-label",
+            "gh issue edit --remove-label",
+            "gh pr edit --add-label",
+            "gh pr edit --remove-label",
+        ):
+            with self.subTest(section="forbidden", needle=needle):
+                self.assertIn(needle, forbidden.group(0))
+
+    def test_design_issue_reply_has_single_worker_post_success_path(self) -> None:
+        body = (PROMPTS_DIR / "design-issue-reply.md").read_text(encoding="utf-8")
+        section = github_post_section(body)
+        self.assertIn("## GitHub post", body)
+        self.assertIn("prompts/_github-post-rules.md", section)
+        self.assertNotIn("controller 会读这个文件", body)
+        self.assertNotIn("DESIGN_REPLY_READY", body)
+        self.assertIn("POSTED:design-reply", body)
+        self.assertIn("POST_FAILED:design-reply", body)
+        self.assertIn("DESIGN_REPLY_SKIPPED", body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary / 摘要

#323:把所有 posting-capable prompt 的本地 GitHub 命令 roster 收口到单一 shared contract `prompts/_github-post-rules.md`,消除「单一主干 / 事实源唯一 / 窄运行时授权」违反。

- **Old**:8 个 posting-capable prompt(meta-judge / review-fix / reviewer-{architect,tests,quality} / solver-{minimal,structural,delete})在 reference shared post contract 之后又各自复制一份本地命令 allow/deny roster;这些副本弱于 shared contract(漏 `git merge/reset/rebase`、`gh pr close`、label mutation),与单一 post contract 漂移。`design-issue-reply.md` posting-path 自相矛盾(controller-relay vs worker-direct)。
- **New**(consensus:`META_JUDGE_DONE:consensus:structural:shared_github_post_rules_only_no_SKILL_change_delete_local_rosters`):删除 8 个 prompt 的本地 roster,折叠为对 `_github-post-rules.md` 的单一引用;修正 `design-issue-reply.md` 为 worker-direct-post(`POSTED`/`POST_FAILED`,删 `DESIGN_REPLY_READY` relay);新增 `test_marker_only_prompts_gh_ban.py` source-regression 锁住「prompt 不得在 shared contract + marker-only 例外块之外增长本地 GitHub 命令 roster」。**不**改 SKILL.md,**不**新增 prompt registry 或第二套 posting system。

违反:R01-single-mainline / R04-fact-source-unique / R06-narrow-runtime-authority。

## Scope / 范围

- 收口:`_github-post-rules.md`(承载唯一命令 roster)。
- 删本地 roster:`meta-judge.md` / `review-fix.md` / `reviewer-architect.md` / `reviewer-tests.md` / `reviewer-quality.md` / `solver-minimal.md` / `solver-structural.md` / `solver-delete.md`。
- 修 posting-path 矛盾:`design-issue-reply.md` → worker-direct-post。
- 新增:`test_marker_only_prompts_gh_ban.py`(source-regression,body-derived posting-mode 防漂移)。

## 验证

- 全量套件 post-merge(已并 hotfix degradation 修复的 `auto-refact-dev`):`Ran 882 tests, OK (skipped=1)`。
- `git diff --check` OK;`CI_GUARDS` unset → guards skipped。

Closes #323

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
