### PR TITLE
#332: peek lens 输出 closed-item cleanup 改为 fact-only 字段

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/peek.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/peek.py
@@ -59,7 +59,7 @@ class PeekStatusLens:
         lines.extend(self._spawn_drop())
         lines.extend(["", "▍Drift (label vs codex mismatch):"])
         lines.extend(self._drift())
-        lines.extend(["", "▍Stale worktree (branch merged and should be cleaned):"])
+        lines.extend(["", "▍Stale worktree (remote branch missing; cleanup is controller-owned):"])
         lines.extend(self._stale_worktrees())
         lines.extend(["", "▍Stuck too long (>6h without maintainer reply; consider 4h reflector re-evaluation):"])
         lines.extend(self._stuck_too_long())
@@ -258,6 +258,9 @@ class PeekStatusLens:
         return ManagedWorkProjection(items)
 
     def _stale_worktrees(self) -> list[str]:
+        # Refactor (iter/issue-332):
+        #   Old pattern: peek 只读 status lens 在输出里打印可复制的破坏性 lifecycle cleanup 命令(git worktree remove --force && git branch -D)
+        #   New principle: read-only lens 只报 fact 字段(path/branch/remote_missing/cleanup_owner/no_lifecycle_authority),lifecycle cleanup 命令只属授权 controller runbook;保留 stale worktree 只读检测
         out = []
         result = subprocess.run(["git", "-C", str(self.ctx.repo_root), "worktree", "list", "--porcelain"], capture_output=True, text=True, check=False)
         current: Path | None = None
@@ -273,7 +276,10 @@ class PeekStatusLens:
             branch = line.removeprefix("branch refs/heads/")
             remote = subprocess.run(["git", "-C", str(self.ctx.repo_root), "ls-remote", "--exit-code", "--heads", "origin", branch], capture_output=True, text=True, check=False)
             if remote.returncode != 0:
-                out.append(f"  ⚠️ {current}  branch={branch}(remote no longer exists — git worktree remove {current} --force && git branch -D {branch})")
+                out.append(
+                    f"  ⚠️ path={current} branch={branch} remote_missing=true "
+                    "cleanup_owner=controller-runbook no_lifecycle_authority=true"
+                )
         return out
 
     def _stuck_too_long(self) -> list[str]:

--- a/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
+++ b/skills/codex-refactor-loop/scripts/test_peek_status_lens.py
@@ -50,8 +50,12 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
                   if [[ "${PEEK_TEST_UNPUSHED:-}" == "1" ]]; then
                     printf 'worktree %s/.worktrees/pr%s\nbranch refs/heads/refactor/iter%s-worker\n\n' "$REPO_ROOT" "$PEEK_TEST_PR" "$PEEK_TEST_PR"
                   fi
+                  if [[ "${PEEK_TEST_STALE_WORKTREE:-}" == "1" ]]; then
+                    printf 'worktree %s/.worktrees/impl-issue332\nbranch refs/heads/impl/issue332-peek-fact-only\n\n' "$REPO_ROOT"
+                  fi
                   exit 0
                 fi
+                if [[ "$args" == *"ls-remote --exit-code --heads origin impl/issue332-peek-fact-only"* ]]; then exit 2; fi
                 if [[ "$args" == *"rev-parse --verify HEAD"* ]]; then printf 'local-sha\n'; exit 0; fi
                 if [[ "$args" == *"rev-parse --verify refs/remotes/origin/refactor/iter"* ]]; then printf 'remote-sha\n'; exit 0; fi
                 if [[ "$args" == *"rev-list --count refs/remotes/origin/refactor/iter"* ]]; then printf '3\n'; exit 0; fi
@@ -200,6 +204,7 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
         pr: int | None = None,
         milestone_fixtures: bool = False,
         unpushed: bool = False,
+        stale_worktree: bool = False,
         pr_open_issue: bool = False,
         represented_parent: bool = False,
         missing_link_pr: bool = False,
@@ -218,6 +223,8 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
             env["PEEK_TEST_MILESTONE_FIXTURES"] = "1"
         if unpushed:
             env["PEEK_TEST_UNPUSHED"] = "1"
+        if stale_worktree:
+            env["PEEK_TEST_STALE_WORKTREE"] = "1"
         if pr_open_issue:
             env["PEEK_TEST_PR_OPEN_ISSUE"] = "1"
         if represented_parent:
@@ -358,6 +365,32 @@ class PeekStatusLensBehaviorTests(unittest.TestCase):
         self.assertNotIn("safe-push origin refactor/iter77-worker", result.stdout)
         self.assertNotIn('"actions"', result.stdout)
         self.assertNotIn('"schema": "wakeup-plan"', result.stdout)
+
+    def test_peek_stale_worktree_reports_fact_without_cleanup_command(self) -> None:
+        result = self.run_peek(stale_worktree=True)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Stale worktree (remote branch missing; cleanup is controller-owned)", result.stdout)
+        self.assertIn(f"path={self.root}/.worktrees/impl-issue332", result.stdout)
+        self.assertIn("branch=impl/issue332-peek-fact-only", result.stdout)
+        self.assertIn("remote_missing=true", result.stdout)
+        self.assertIn("cleanup_owner=controller-runbook", result.stdout)
+        self.assertIn("no_lifecycle_authority=true", result.stdout)
+        for token in ("git worktree remove", "--force", "git branch -D", "&&", "suggested_command"):
+            with self.subTest(token=token):
+                self.assertNotIn(token, result.stdout)
+
+    def test_peek_source_has_no_stale_worktree_lifecycle_cleanup_command(self) -> None:
+        source = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "peek.py").read_text(encoding="utf-8")
+        executable_source = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
+
+        for token in ("git worktree remove", "--force", "git branch -D", "suggested_command"):
+            with self.subTest(token=token):
+                self.assertNotIn(token, executable_source)
+        self.assertIn("_stale_worktrees", source)
+        self.assertIn('"worktree", "list", "--porcelain"', source)
+        self.assertIn('"ls-remote", "--exit-code", "--heads"', source)
+        self.assertIn("no_lifecycle_authority", source)
 
     def test_peek_closed_label_projection_has_no_remediation_text(self) -> None:
         text = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "peek.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## 摘要

cluster-004(#332):`peek` 只读 status lens 输出过 closed-item cleanup 的**可复制 remediation 命令**(`git worktree remove --force` / `git branch -D`),违反 peek 只读 observability 边界 —— peek 只能展示状态,不得渲染可执行 lifecycle 命令。

- **Old**:peek 对 closed managed item 渲染可复制的 `git worktree remove --force <path>` / `git branch -D <branch>` cleanup 命令。
- **New**:改为只读 fact 字段(`path` / `branch` / `remote_missing` / `cleanup_owner` / `no_lifecycle_authority`),只陈述事实,不给可执行命令;cleanup 决策权留给 owner。

违反:peek 是 observability-only status lens(SKILL「Claude Code statusline」/「peek 是 observability-only status lens…不显示 generic marker-to-route recommendation」),不得持 lifecycle authority 或渲染 remediation。

## 范围

- `skills/codex-refactor-loop/scripts/codex_refactor_loop/peek.py`(+10/-2):cleanup 命令渲染 → fact-only 字段。
- `skills/codex-refactor-loop/scripts/test_peek_status_lens.py`(+33):2 个 behavior + source-regression 测试,锁住 fact-only 输出且无可执行命令字面。

## 验证

- `python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'`:**Ran 896 tests, OK (skipped=1)**。
- `test_peek_status_lens.py`:15 tests pass。
- architecture guard(`$CI_GUARDS` empty):no-op pass。

## 设计来源

走完整 Consensus-rnd Phase design-consensus(issue #332,r2 共识,structural fact-only framing)。本 PR 落地共识方案,无新增抽象、无 schema/protocol 改动。

<details><summary>本机调试线索</summary>

- 共识 artifact:`.refactor-loop/runs/phase9-issue332-r2-judge.md`
- implement summary:`.refactor-loop/runs/implement-issue-332.md`
</details>

Closes #332

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
