### PR TITLE
#331: daemon-name 事实源收口到 restart_managed_daemon_names()

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/gate.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/gate.py
@@ -380,8 +380,13 @@ class AutoReleaseGate:
 
     def fresh_heartbeats(self) -> dict[str, Any]:
         # Refactor (iterissue-331/issue-331):
-        #   Old pattern: release gate 与 wakeup_plan 各自维护本地 daemon-name literal(5/EXPECTED_DAEMONS),与 restart.py DAEMON_COMMANDS 漂移,违反事实源唯一
-        #   New principle: restart.py::restart_managed_daemon_names() 作唯一 canonical daemon-name projection;release 保留 DAEMON_NAMES 仅 derived alias;wakeup 删 EXPECTED_DAEMONS;health 收紧为每个 restart-managed heartbeat 都 fresh
+        #   Old pattern: release gate and wakeup_plan each kept local
+        #   daemon-name literals, drifting from restart.py DAEMON_COMMANDS and
+        #   duplicating the source of truth.
+        #   New principle: restart.py::restart_managed_daemon_names() is the
+        #   canonical daemon-name projection; release keeps DAEMON_NAMES only
+        #   as a derived alias, wakeup deletes EXPECTED_DAEMONS, and health
+        #   requires every restart-managed heartbeat to be fresh.
         now = self.now()
         required_names = restart_managed_daemon_names()
         fresh: dict[str, bool] = {}

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/gate.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/gate.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Mapping, Sequence
 
 from .. import labels as label_catalog
 from ..context import HostEnvLocator, parse_host_env
+from ..restart import restart_managed_daemon_names
 from ..state import read_json, write_json
 from .required_checks import REQUIRED_RELEASE_CHECKS, ReleaseRequiredChecksProjection
 from .versions import SEMVER_RE, bump_semver, compare_semver, next_release_version, parse_semver
@@ -48,13 +49,7 @@ SIGNAL_NAMES = (
     "fresh_heartbeats",
     "no_unresolved_human_escalation",
 )
-DAEMON_NAMES = (
-    "concurrency_monitor",
-    "codex-progress-reporter",
-    "comment-monitor",
-    "dev_sync_daemon",
-    "phase9_router_daemon",
-)
+DAEMON_NAMES = restart_managed_daemon_names()
 REQUIRED_CHECKS = REQUIRED_RELEASE_CHECKS
 HEARTBEAT_FRESH_SECONDS = 90
 
@@ -384,11 +379,11 @@ class AutoReleaseGate:
         return signal
 
     def fresh_heartbeats(self) -> dict[str, Any]:
-        # Refactor (iter1/issue-154):
-        #   Old pattern: release gate read phantom daemon-heartbeats.json.
-        #   New principle: read real .refactor-loop/heartbeats/*.ts while
-        #   preserving >=5 fresh @ HEARTBEAT_FRESH_SECONDS=90 semantics.
+        # Refactor (iterissue-331/issue-331):
+        #   Old pattern: release gate 与 wakeup_plan 各自维护本地 daemon-name literal(5/EXPECTED_DAEMONS),与 restart.py DAEMON_COMMANDS 漂移,违反事实源唯一
+        #   New principle: restart.py::restart_managed_daemon_names() 作唯一 canonical daemon-name projection;release 保留 DAEMON_NAMES 仅 derived alias;wakeup 删 EXPECTED_DAEMONS;health 收紧为每个 restart-managed heartbeat 都 fresh
         now = self.now()
+        required_names = restart_managed_daemon_names()
         fresh: dict[str, bool] = {}
         if self.heartbeat_dir.is_dir():
             for heartbeat_file in sorted(self.heartbeat_dir.glob("*.ts")):
@@ -401,7 +396,9 @@ class AutoReleaseGate:
                     heartbeat
                     and timedelta(0) <= now - heartbeat <= timedelta(seconds=HEARTBEAT_FRESH_SECONDS)
                 )
-        passed = sum(1 for ok in fresh.values() if ok) >= 5
+        for name in required_names:
+            fresh.setdefault(name, False)
+        passed = all(fresh[name] for name in required_names)
         reason = None if passed else "heartbeat_stale"
         return {"passed": passed, "reason": reason, "heartbeats": fresh, "source": "heartbeats/*.ts"}
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/restart.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/restart.py
@@ -37,6 +37,13 @@ DAEMON_COMMANDS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("closed_label_reconciler", ("python3", "{skill_root}/scripts/consensus-rnd-cli", "closed-label-reconciler", "--daemon")),
 )
 
+# Refactor (iterissue-331/issue-331):
+#   Old pattern: release gate 与 wakeup_plan 各自维护本地 daemon-name literal(5/EXPECTED_DAEMONS),与 restart.py DAEMON_COMMANDS 漂移,违反事实源唯一
+#   New principle: restart.py::restart_managed_daemon_names() 作唯一 canonical daemon-name projection;release 保留 DAEMON_NAMES 仅 derived alias;wakeup 删 EXPECTED_DAEMONS;health 收紧为每个 restart-managed heartbeat 都 fresh
+def restart_managed_daemon_names() -> tuple[str, ...]:
+    return tuple(name for name, _command in DAEMON_COMMANDS)
+
+
 FORBIDDEN_LIFECYCLE_AUTHORITY = (
     "create/merge/close PR",
     "open/close issue",

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/restart.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/restart.py
@@ -38,8 +38,13 @@ DAEMON_COMMANDS: tuple[tuple[str, tuple[str, ...]], ...] = (
 )
 
 # Refactor (iterissue-331/issue-331):
-#   Old pattern: release gate 与 wakeup_plan 各自维护本地 daemon-name literal(5/EXPECTED_DAEMONS),与 restart.py DAEMON_COMMANDS 漂移,违反事实源唯一
-#   New principle: restart.py::restart_managed_daemon_names() 作唯一 canonical daemon-name projection;release 保留 DAEMON_NAMES 仅 derived alias;wakeup 删 EXPECTED_DAEMONS;health 收紧为每个 restart-managed heartbeat 都 fresh
+#   Old pattern: release gate and wakeup_plan each kept local daemon-name
+#   literals, drifting from restart.py DAEMON_COMMANDS and duplicating the
+#   source of truth.
+#   New principle: restart.py::restart_managed_daemon_names() is the canonical
+#   daemon-name projection; release keeps DAEMON_NAMES only as a derived alias,
+#   wakeup deletes EXPECTED_DAEMONS, and health requires every restart-managed
+#   heartbeat to be fresh.
 def restart_managed_daemon_names() -> tuple[str, ...]:
     return tuple(name for name, _command in DAEMON_COMMANDS)
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -288,8 +288,13 @@ def concurrency_plan(repo_root: Path, *, fixed_point: bool, gh_items: list[GhIte
 
 def daemon_health(repo_root: Path, now: float | None = None) -> dict[str, Any]:
     # Refactor (iterissue-331/issue-331):
-    #   Old pattern: release gate 与 wakeup_plan 各自维护本地 daemon-name literal(5/EXPECTED_DAEMONS),与 restart.py DAEMON_COMMANDS 漂移,违反事实源唯一
-    #   New principle: restart.py::restart_managed_daemon_names() 作唯一 canonical daemon-name projection;release 保留 DAEMON_NAMES 仅 derived alias;wakeup 删 EXPECTED_DAEMONS;health 收紧为每个 restart-managed heartbeat 都 fresh
+    #   Old pattern: release gate and wakeup_plan each kept local daemon-name
+    #   literals, drifting from restart.py DAEMON_COMMANDS and duplicating the
+    #   source of truth.
+    #   New principle: restart.py::restart_managed_daemon_names() is the
+    #   canonical daemon-name projection; release keeps DAEMON_NAMES only as a
+    #   derived alias, wakeup deletes EXPECTED_DAEMONS, and health requires
+    #   every restart-managed heartbeat to be fresh.
     if now is None:
         now = time.time()
     heartbeat_dir = repo_root / ".refactor-loop" / "heartbeats"

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -41,6 +41,7 @@ from typing import Any
 from codex_refactor_loop import labels as label_catalog
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.pr_checks import PrChecksProjection
+from codex_refactor_loop.restart import restart_managed_daemon_names
 from codex_refactor_loop.transition_assessment import TransitionAssessmentReader, transition_rank_key
 from codex_refactor_loop.work_items import ManagedWorkProjection, open_actionable_managed_items
 from codex_refactor_loop.workflow_spec import WorkflowSpecError, load_validated_workflow_spec
@@ -48,13 +49,6 @@ from codex_refactor_loop.workflow_stages import assert_stage_slug
 
 
 STALE_SECONDS = 90
-EXPECTED_DAEMONS = (
-    "concurrency_monitor",
-    "comment-monitor",
-    "codex-progress-reporter",
-    "dev_sync_daemon",
-    "phase9_router_daemon",
-)
 DONE_PREFIXES = (
     "AUDIT_DONE",
     "SOLVER_DONE",
@@ -293,9 +287,9 @@ def concurrency_plan(repo_root: Path, *, fixed_point: bool, gh_items: list[GhIte
 
 
 def daemon_health(repo_root: Path, now: float | None = None) -> dict[str, Any]:
-    # Refactor (issue-162/wakeup-heartbeats-only):
-    #   Old pattern: daemon health could drift toward matching solver or log text.
-    #   New principle: health reads only actor-owned .refactor-loop/heartbeats/*.ts.
+    # Refactor (iterissue-331/issue-331):
+    #   Old pattern: release gate 与 wakeup_plan 各自维护本地 daemon-name literal(5/EXPECTED_DAEMONS),与 restart.py DAEMON_COMMANDS 漂移,违反事实源唯一
+    #   New principle: restart.py::restart_managed_daemon_names() 作唯一 canonical daemon-name projection;release 保留 DAEMON_NAMES 仅 derived alias;wakeup 删 EXPECTED_DAEMONS;health 收紧为每个 restart-managed heartbeat 都 fresh
     if now is None:
         now = time.time()
     heartbeat_dir = repo_root / ".refactor-loop" / "heartbeats"
@@ -313,7 +307,7 @@ def daemon_health(repo_root: Path, now: float | None = None) -> dict[str, Any]:
                 items.append({"name": name, "status": status, "age_seconds": age})
             except (OSError, ValueError):
                 items.append({"name": name, "status": "stale", "age_seconds": None})
-    for name in EXPECTED_DAEMONS:
+    for name in restart_managed_daemon_names():
         if name not in seen:
             items.append({"name": name, "status": "missing", "age_seconds": None})
     needs_restart = any(item["status"] in {"stale", "missing"} for item in items)

--- a/skills/codex-refactor-loop/scripts/test_auto_release_gate.py
+++ b/skills/codex-refactor-loop/scripts/test_auto_release_gate.py
@@ -19,6 +19,7 @@ NOW = datetime(2026, 5, 26, 12, 0, tzinfo=timezone.utc)
 sys.path.insert(0, str(SCRIPT_PATH.parent))
 
 from codex_refactor_loop import labels as label_catalog
+from codex_refactor_loop.restart import restart_managed_daemon_names
 from codex_refactor_loop.release.gate import AutoReleaseGate, CommitInfo, classify_bump
 from codex_refactor_loop.release.versions import next_release_version
 
@@ -184,13 +185,7 @@ def write_live_state(repo: Path) -> None:
     state = repo / ".refactor-loop/state"
     heartbeat_dir = repo / ".refactor-loop/heartbeats"
     heartbeat_dir.mkdir(parents=True, exist_ok=True)
-    for name in (
-        "concurrency_monitor",
-        "codex-progress-reporter",
-        "comment-monitor",
-        "dev_sync_daemon",
-        "phase9_router_daemon",
-    ):
+    for name in restart_managed_daemon_names():
         (heartbeat_dir / f"{name}.ts").write_text(f"{now}\n", encoding="utf-8")
     write_json(state / "phase8-review-state.json", {"max_consecutive_reject_rounds": 0})
     write_json(state / "meta-resolutions.json", {"unresolved_escalate_human": []})
@@ -584,13 +579,7 @@ class AutoReleaseGateBehaviorTests(unittest.TestCase):
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"
             stale = int((NOW - timedelta(seconds=91)).timestamp())
-            write_heartbeat_files(repo, {name: stale for name in (
-                "concurrency_monitor",
-                "codex-progress-reporter",
-                "comment-monitor",
-                "dev_sync_daemon",
-                "phase9_router_daemon",
-            )})
+            write_heartbeat_files(repo, {name: stale for name in restart_managed_daemon_names()})
             state = repo / ".refactor-loop/state"
             write_json(state / "phase8-review-state.json", {"max_consecutive_reject_rounds": 0})
             write_json(state / "meta-resolutions.json", {"unresolved_escalate_human": []})
@@ -605,60 +594,43 @@ class AutoReleaseGateBehaviorTests(unittest.TestCase):
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"
             fresh = int(NOW.timestamp())
-            write_heartbeat_files(repo, {name: fresh for name in (
-                "concurrency_monitor",
-                "codex-progress-reporter",
-                "comment-monitor",
-                "dev_sync_daemon",
-                "phase9_router_daemon",
-                "extra-observer",
-            )})
+            write_heartbeat_files(repo, {**{name: fresh for name in restart_managed_daemon_names()}, "extra-observer": fresh})
             gate = AutoReleaseGate(repo, now=lambda: NOW, runner=FakeRunner())
 
             signal = gate.fresh_heartbeats()
 
             self.assertTrue(signal["passed"])
             self.assertEqual(signal["source"], "heartbeats/*.ts")
-            self.assertEqual(sum(1 for value in signal["heartbeats"].values() if value), 6)
+            self.assertEqual(sum(1 for value in signal["heartbeats"].values() if value), 7)
             self.assertTrue(signal["heartbeats"]["concurrency_monitor"])
+            self.assertTrue(signal["heartbeats"]["closed_label_reconciler"])
 
-    def test_fail_closed_when_fewer_than_five_real_heartbeats_are_fresh(self) -> None:
+    def test_fail_closed_when_any_restart_managed_heartbeat_is_missing(self) -> None:
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"
             fresh = int(NOW.timestamp())
-            stale = int((NOW - timedelta(seconds=91)).timestamp())
-            write_heartbeat_files(repo, {
-                "concurrency_monitor": fresh,
-                "codex-progress-reporter": fresh,
-                "comment-monitor": fresh,
-                "dev_sync_daemon": fresh,
-                "phase9_router_daemon": stale,
-            })
+            write_heartbeat_files(repo, {name: fresh for name in restart_managed_daemon_names() if name != "closed_label_reconciler"})
             gate = AutoReleaseGate(repo, now=lambda: NOW, runner=FakeRunner())
 
             signal = gate.fresh_heartbeats()
 
             self.assertFalse(signal["passed"])
             self.assertIn("heartbeat_stale", signal["reason"])
-            self.assertEqual(sum(1 for value in signal["heartbeats"].values() if value), 4)
+            self.assertFalse(signal["heartbeats"]["closed_label_reconciler"])
 
     def test_fail_closed_when_real_heartbeat_file_is_malformed(self) -> None:
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"
             fresh = int(NOW.timestamp())
-            write_heartbeat_files(repo, {
-                "concurrency_monitor": fresh,
-                "codex-progress-reporter": fresh,
-                "comment-monitor": fresh,
-                "dev_sync_daemon": fresh,
-                "phase9_router_daemon": "not-an-epoch",
-            })
+            values: dict[str, int | str] = {name: fresh for name in restart_managed_daemon_names()}
+            values["closed_label_reconciler"] = "not-an-epoch"
+            write_heartbeat_files(repo, values)
             gate = AutoReleaseGate(repo, now=lambda: NOW, runner=FakeRunner())
 
             signal = gate.fresh_heartbeats()
 
             self.assertFalse(signal["passed"])
-            self.assertFalse(signal["heartbeats"]["phase9_router_daemon"])
+            self.assertFalse(signal["heartbeats"]["closed_label_reconciler"])
 
     def test_fail_closed_when_phase8_reject_churn_reaches_limit(self) -> None:
         with copy_repo_fixture() as tmp:

--- a/skills/codex-refactor-loop/scripts/test_release_gate_module.py
+++ b/skills/codex-refactor-loop/scripts/test_release_gate_module.py
@@ -20,6 +20,7 @@ NOW = datetime(2026, 5, 29, 12, 0, tzinfo=timezone.utc)
 sys.path.insert(0, str(SCRIPT_PATH.parent))
 
 from codex_refactor_loop import labels as label_catalog
+from codex_refactor_loop import restart
 from codex_refactor_loop.release import gate
 
 
@@ -30,6 +31,10 @@ def write_json(path: Path, data: object) -> None:
 
 def read_json(path: Path) -> object:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def executable_source(source: str) -> str:
+    return "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
 
 
 def copy_repo_fixture() -> tempfile.TemporaryDirectory[str]:
@@ -181,7 +186,8 @@ class ReleaseGateModuleTests(unittest.TestCase):
             self.assertIn(label_catalog.HUMAN_MAINTAINER_DECISION, labels)
             heartbeat_signal = stability.signals["fresh_heartbeats"]
             self.assertEqual(heartbeat_signal["source"], "heartbeats/*.ts")
-            self.assertEqual(sum(1 for value in heartbeat_signal["heartbeats"].values() if value), 5)
+            self.assertEqual(sum(1 for value in heartbeat_signal["heartbeats"].values() if value), 6)
+            self.assertTrue(heartbeat_signal["heartbeats"]["closed_label_reconciler"])
 
     def test_release_gate_blocks_on_legacy_blocked_and_human_labels(self) -> None:
         with copy_repo_fixture() as tmp:
@@ -272,7 +278,8 @@ class ReleaseGateModuleTests(unittest.TestCase):
 
             self.assertFalse(signal["passed"])
             self.assertEqual(signal["source"], "heartbeats/*.ts")
-            self.assertEqual(signal["heartbeats"], {})
+            self.assertTrue(all(value is False for value in signal["heartbeats"].values()))
+            self.assertEqual(set(signal["heartbeats"]), set(gate.DAEMON_NAMES))
 
     def test_source_has_no_release_lifecycle_or_daemon_event_authority(self) -> None:
         source = (SCRIPT_PATH.parent / "codex_refactor_loop/release/gate.py").read_text(encoding="utf-8")
@@ -306,13 +313,49 @@ class ReleaseGateModuleTests(unittest.TestCase):
     def test_required_check_names_and_daemon_heartbeat_allowlist_are_stable(self) -> None:
         self.assertEqual(gate.REQUIRED_CHECKS, ("contract-tests", "manifest-version-sync", "skill-degradation"))
         self.assertEqual(gate.HEARTBEAT_FRESH_SECONDS, 90)
-        self.assertEqual(gate.DAEMON_NAMES, (
-            "concurrency_monitor",
-            "codex-progress-reporter",
-            "comment-monitor",
-            "dev_sync_daemon",
-            "phase9_router_daemon",
-        ))
+        self.assertEqual(gate.DAEMON_NAMES, restart.restart_managed_daemon_names())
+        self.assertEqual(6, len(gate.DAEMON_NAMES))
+        self.assertIn("closed_label_reconciler", gate.DAEMON_NAMES)
+
+    def test_fresh_heartbeats_requires_each_restart_managed_daemon(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            heartbeat_dir = repo / ".refactor-loop/heartbeats"
+            heartbeat_dir.mkdir(parents=True, exist_ok=True)
+            fresh = int(NOW.timestamp())
+            for name in gate.DAEMON_NAMES:
+                if name != "closed_label_reconciler":
+                    (heartbeat_dir / f"{name}.ts").write_text(f"{fresh}\n", encoding="utf-8")
+            (heartbeat_dir / "extra-observer.ts").write_text(f"{fresh}\n", encoding="utf-8")
+            release_gate = gate.AutoReleaseGate(repo, now=lambda: NOW, runner=FakeRunner())
+
+            signal = release_gate.fresh_heartbeats()
+
+            self.assertFalse(signal["passed"])
+            self.assertFalse(signal["heartbeats"]["closed_label_reconciler"])
+            self.assertTrue(signal["heartbeats"]["extra-observer"])
+
+            (heartbeat_dir / "closed_label_reconciler.ts").write_text(f"{fresh}\n", encoding="utf-8")
+            signal = release_gate.fresh_heartbeats()
+
+            self.assertTrue(signal["passed"])
+            self.assertTrue(all(signal["heartbeats"][name] for name in restart.restart_managed_daemon_names()))
+
+    def test_daemon_name_source_contract_uses_restart_projection(self) -> None:
+        restart_source = (SCRIPT_PATH.parent / "codex_refactor_loop/restart.py").read_text(encoding="utf-8")
+        release_source = (SCRIPT_PATH.parent / "codex_refactor_loop/release/gate.py").read_text(encoding="utf-8")
+        wakeup_source = (SCRIPT_PATH.parent / "codex_refactor_loop/wakeup_plan.py").read_text(encoding="utf-8")
+
+        self.assertIn("def restart_managed_daemon_names(", restart_source)
+        self.assertIn("return tuple(name for name, _command in DAEMON_COMMANDS)", restart_source)
+        self.assertNotIn("RESTART_MANAGED_DAEMON_NAMES", restart_source)
+        release_executable = executable_source(release_source)
+        wakeup_executable = executable_source(wakeup_source)
+        self.assertIn("DAEMON_NAMES = restart_managed_daemon_names()", release_executable)
+        self.assertIn("required_names = restart_managed_daemon_names()", release_executable)
+        self.assertNotIn('DAEMON_NAMES = (\n    "concurrency_monitor"', release_executable)
+        self.assertIn("restart_managed_daemon_names()", wakeup_source)
+        self.assertNotIn("EXPECTED_DAEMONS", wakeup_executable)
 
     def test_blocked_release_does_not_write_artifacts(self) -> None:
         with copy_repo_fixture() as tmp:

--- a/skills/codex-refactor-loop/scripts/test_restart_daemons.py
+++ b/skills/codex-refactor-loop/scripts/test_restart_daemons.py
@@ -22,10 +22,10 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.daemon_status import DaemonStatusProjection, collect as collect_daemon_status
 from codex_refactor_loop import restart
-from codex_refactor_loop.restart import DAEMON_COMMANDS, DaemonProcess, DaemonProcessInventory, RestartConfig, RestartDaemons, daemon_targets
+from codex_refactor_loop.restart import DAEMON_COMMANDS, DaemonProcess, DaemonProcessInventory, RestartConfig, RestartDaemons, daemon_targets, restart_managed_daemon_names
 
 
-DAEMON_NAMES = tuple(name for name, _command in DAEMON_COMMANDS)
+DAEMON_NAMES = restart_managed_daemon_names()
 FAKE_DAEMON = """import os, signal, sys, time
 from pathlib import Path
 repo = Path(os.environ["REPO_ROOT"])
@@ -160,6 +160,17 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
             self.assertIn("--daemon", command)
         self.assertIn(("closed_label_reconciler", ("python3", "{skill_root}/scripts/consensus-rnd-cli", "closed-label-reconciler", "--daemon")), DAEMON_COMMANDS)
         self.assertEqual({name for name, _command in DAEMON_COMMANDS}, set(DAEMON_NAMES))
+
+    def test_restart_managed_daemon_names_projects_daemon_commands(self) -> None:
+        self.assertEqual(tuple(name for name, _command in DAEMON_COMMANDS), restart_managed_daemon_names())
+        self.assertEqual(6, len(restart_managed_daemon_names()))
+        self.assertIn("closed_label_reconciler", restart_managed_daemon_names())
+        patched = (
+            ("first", ("python3", "first")),
+            ("second", ("python3", "second")),
+        )
+        with mock.patch("codex_refactor_loop.restart.DAEMON_COMMANDS", patched):
+            self.assertEqual(("first", "second"), restart.restart_managed_daemon_names())
 
     def test_help_exits_without_starting_daemons(self) -> None:
         with mock.patch.object(restart.RestartDaemons, "run") as run:
@@ -506,10 +517,13 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
             "pid_alive(pid)",
             "actor-owned heartbeat",
             "FORBIDDEN_LIFECYCLE_AUTHORITY",
+            "def restart_managed_daemon_names(",
+            "return tuple(name for name, _command in DAEMON_COMMANDS)",
         ):
             self.assertIn(needle, source)
         for forbidden in ("gh issue", "gh pr", "git fetch", "git push", "git merge"):
             self.assertNotIn(forbidden, source)
+        self.assertNotIn("RESTART_MANAGED_DAEMON_NAMES", source)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -632,7 +632,10 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             actual = {
                 str(path.relative_to(SKILL_ROOT / "scripts" / "codex_refactor_loop"))
                 for path in production_files
-                if token in path.read_text(encoding="utf-8")
+                if token
+                in "\n".join(
+                    line for line in path.read_text(encoding="utf-8").splitlines() if not line.lstrip().startswith("#")
+                )
             }
             with self.subTest(token=token):
                 self.assertLessEqual(actual, allowed_paths, actual - allowed_paths)

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -20,6 +20,7 @@ WAKEUP_PLAN = SKILL_ROOT / "scripts" / "consensus-rnd-cli"
 sys.path.insert(0, str(SKILL_ROOT / "scripts"))
 
 from codex_refactor_loop import labels as label_catalog  # noqa: E402
+from codex_refactor_loop.restart import restart_managed_daemon_names  # noqa: E402
 from codex_refactor_loop.workflow_stages import assert_stage_slug  # noqa: E402
 from codex_refactor_loop.wakeup_plan import resolve_repo_root  # noqa: E402
 
@@ -272,13 +273,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         heartbeats = self.repo / ".refactor-loop" / "heartbeats"
         heartbeats.mkdir(parents=True, exist_ok=True)
         now = str(int(time.time()))
-        for name in (
-            "concurrency_monitor",
-            "comment-monitor",
-            "codex-progress-reporter",
-            "dev_sync_daemon",
-            "phase9_router_daemon",
-        ):
+        for name in restart_managed_daemon_names():
             (heartbeats / f"{name}.ts").write_text(now, encoding="utf-8")
 
     def run_plan(self, *, fixture: str = "empty", ps_count: int = 5, active_audit: bool = False) -> dict:
@@ -653,6 +648,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         health = plan["daemon_health"]
         self.assertTrue(all(item["name"] != "solver-output" for item in health["items"]))
         self.assertTrue(any(item["name"] == "concurrency_monitor" and item["status"] == "missing" for item in health["items"]))
+        self.assertTrue(any(item["name"] == "closed_label_reconciler" and item["status"] == "missing" for item in health["items"]))
 
     def test_daemon_health_reports_stale_and_missing_with_restart_hint(self) -> None:
         heartbeats = self.repo / ".refactor-loop" / "heartbeats"
@@ -667,6 +663,20 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(health["recommendation"], "consensus-rnd-cli restart-daemons")
         self.assertTrue(any(item["name"] == "concurrency_monitor" and item["status"] == "stale" for item in health["items"]))
         self.assertTrue(any(item["status"] == "missing" for item in health["items"]))
+
+    def test_daemon_health_reports_closed_label_reconciler_missing(self) -> None:
+        (self.repo / ".refactor-loop" / "heartbeats" / "closed_label_reconciler.ts").unlink()
+
+        plan = self.run_plan()
+
+        health = plan["daemon_health"]
+        self.assertFalse(health["ok"])
+        self.assertTrue(
+            any(
+                item["name"] == "closed_label_reconciler" and item["status"] == "missing"
+                for item in health["items"]
+            )
+        )
 
     def test_deficit_calculates_from_floor_when_actual_below_target(self) -> None:
         plan, stdout = self.run_plan_with_stdout(ps_count=2)


### PR DESCRIPTION
## 摘要

cluster-002(#331):`release/gate.py` 与 `wakeup_plan.py` 各自维护本地 daemon-name 清单(release 5-name `DAEMON_NAMES` literal、wakeup `EXPECTED_DAEMONS`),与 `restart.py` 的 `DAEMON_COMMANDS` 漂移 —— 6-daemon 健康事实源不唯一,违反「事实源唯一」。

- **Old**:release gate 与 wakeup 各自硬编码 daemon-name 清单,与 restart 真实 allowlist 漂移(release 仍写 5 个,漏 `closed_label_reconciler`)。
- **New**:`restart.py::restart_managed_daemon_names()` 作唯一 canonical daemon-name projection;`release/gate.py` 删本地 literal,`DAEMON_NAMES` 降为 derived alias,`fresh_heartbeats` 要求**每个** restart-managed daemon heartbeat fresh;`wakeup_plan.py` 删 `EXPECTED_DAEMONS`,health 遍历函数返回值。

违反:CLAUDE.md「事实源唯一:同一约束禁止在多处平行声明」。

## 范围

8 files(+123/-83):`restart.py`(+projection 函数)、`release/gate.py`、`wakeup_plan.py` + 5 test 文件(behavior + source-regression 锁反 drift)。

## 验证

- `python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'`:**Ran 901 tests, OK (skipped=1)**。
- source-regression:断言 release/wakeup 不含本地 daemon inventory,restart 含 `restart_managed_daemon_names`。

## 设计来源

Consensus-rnd Phase design-consensus issue #331,r4 共识(structural framing,3/3 unanimous)。

<details><summary>本机调试线索</summary>

- 共识 artifact:`.refactor-loop/runs/phase9-issue331-r4-judge.md`
</details>

Closes #331

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
