### PR TITLE
docs:README 英文 canonical + 中文 companion (#343)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 本文件给**在本仓库内工作的 agent**(增改 skill、维护清单、发版)看;不是给 host 项目运行时用的。host 运行时事实由 `host.env` 注入,见各 skill 的 SKILL.md。
 
-仓库定位与共识引擎设计哲学见 [`README.md`](./README.md);本文件是 agent 工作宪法,与 README 不重复。术语定义与项目当前状态归各 skill 的 SKILL.md / REFERENCE.md,不在本文件维护。
+仓库定位与共识引擎设计哲学见英文 canonical [`README.md`](./README.md);中文 companion 见 [`README.zh-CN.md`](./README.zh-CN.md)。本文件是 agent 工作宪法,与 README pair 不重复。术语定义与项目当前状态归各 skill 的 SKILL.md / REFERENCE.md,不在本文件维护。
 
 ## 仓库性质
 
@@ -18,6 +18,7 @@
 ├── gemini-extension.json + GEMINI.md   # Gemini:扩展清单 + 上下文入口
 ├── package.json           # npm 风格元数据 / 版本锚点
 ├── AGENTS.md → CLAUDE.md  # 跨 agent 约定(符号链接)
+├── README.md + README.zh-CN.md  # 英文 canonical 公开身份文档 + 中文 companion
 ├── LICENSE                # MIT
 ├── skills/<name>/         # 各 skill(SKILL.md 必备)
 └── .version-bump.json     # 版本号同步映射
@@ -47,7 +48,7 @@ New principle: 改哲学:单文件 SKILL.md + intra-file anchors 是被认可的
 
 ## 共识引擎哲学(本仓库唯一产品身份)
 
-权威表述见 [`README.md`](./README.md)「核心」段;此处只述跨 skill 不动点:
+权威表述见英文 canonical [`README.md`](./README.md)「Core」段;[`README.zh-CN.md`](./README.zh-CN.md) 是中文 companion。此处只述跨 skill 不动点:
 
 - **偏置独立多角度**:同一决策点的多 solver / 多 reviewer **互相看不到对方输出**,各自带先验立场独立得出结论;禁止串行"先看 A 再写 B"或单源冒充多源。
 - **meta-judge 收敛**:分歧只收敛到固定数量的出口语义(达成 / 接近 / 真停滞);真停滞才升级到 meta-layer 调和,不直接升级到人。
@@ -84,6 +85,12 @@ New principle: 改哲学:单文件 SKILL.md + intra-file anchors 是被认可的
 - **artifact 路径相对 `$REPO_ROOT`**:不硬编码 host 路径,不引入具体 host 事实。
 - **controller worktree 统一位置**:放在 `<repo-root>/.worktrees/<name>/`(gitignored),**不**创建 sibling `<repo>-wt-*` 目录。
 - **最小权限动作**:没有明确授权时,agent 不修改 host 配置、不发布 release、不关闭外部状态面、不执行不可逆生命周期动作。
+<!--
+Refactor (iter343/issue-343):
+  Old pattern: README 单一(非英文默认),CLAUDE.md 文档分层称 README 为权威源;无英文 canonical + 中文 companion 双文件,语言策略未给 README pair carve-out
+  New principle: README.md 英文 canonical 公开身份文档 + README.zh-CN.md 中文 companion(双向交叉链接,大段顺序对齐不要求逐句对等);CLAUDE.md 文档分层/根.md收口/语言 carve-out 与 SKILL.md 语言策略窄改:README pair 是唯一英文-canonical 公开文档 carve-out,GitHub issue/PR/commit/design artifact 等工作态仍中文默认。严格按 DESIGN_DECISION_PATH verbatim Concrete plan;不碰 .version-bump.json/额外根文档/runtime/host.env/marker/daemon/workflow
+-->
+- **公开身份文档语言例外**:README pair 是唯一英文 canonical 公开文档 carve-out(only English-canonical public-doc carve-out):`README.md` 用英文作为 canonical public identity document,`README.zh-CN.md` 是中文 companion,二者双向交叉链接且大段顺序对齐即可,不要求逐句对等。GitHub issue/PR/commit/design artifact 等工作态仍按 skill 语言策略中文默认。
 
 ## 版本同步(强制)
 
@@ -101,8 +108,8 @@ New principle: 改哲学:单文件 SKILL.md + intra-file anchors 是被认可的
 
 ## 工程约定(精简)
 
-- **文档分层**:`README.md` 是仓库定位与共识引擎设计哲学权威源;`CLAUDE.md` 是 agent 工作宪法;`skills/<name>/SKILL.md` 是该 skill 的契约;`skills/<name>/REFERENCE.md` 是可选重型参考层;未使用 `REFERENCE.md` 时,SKILL.md 的详细参考区是该 skill 的权威参考层。三者职责不重叠:README 写产品身份,CLAUDE.md 写仓库宪法,skill 自己维护行为合同/参考。
-- **根目录 `.md` 收口**:仅保留 `CLAUDE.md`、`README.md`、`AGENTS.md`(符号链接,内容同 `CLAUDE.md`)、`LICENSE`、`GEMINI.md`、`CHANGELOG.md`(若有)。
+- **文档分层**:`README.md` 是英文 canonical 仓库定位与共识引擎设计哲学权威源;`README.zh-CN.md` 是中文 companion,用于公开中文阅读入口,大段顺序对齐即可;`CLAUDE.md` 是 agent 工作宪法;`skills/<name>/SKILL.md` 是该 skill 的契约;`skills/<name>/REFERENCE.md` 是可选重型参考层;未使用 `REFERENCE.md` 时,SKILL.md 的详细参考区是该 skill 的权威参考层。职责不重叠:README pair 写产品身份,CLAUDE.md 写仓库宪法,skill 自己维护行为合同/参考。
+- **根目录 `.md` 收口**:仅保留 `CLAUDE.md`、`README.md`、`README.zh-CN.md`、`AGENTS.md`(符号链接,内容同 `CLAUDE.md`)、`LICENSE`、`GEMINI.md`、`CHANGELOG.md`(若有)。
 - **不保留历史副本**:废弃文件直接删除,不留 `.bak/.old/.deprecated`;历史由 git 保留。
 - **Git**:分支名描述意图;提交信息祈使句聚焦单一目的;PR 写明动机、影响范围、验证命令与结果。
 - **CI / 守卫**:任何 controller-runtime 例外(narrow allowlist daemon、observability、decision-artifact 等)必须配套机械验证手段(behavior test + source-regression test)。

--- a/README.md
+++ b/README.md
@@ -2,38 +2,67 @@
 
 English canonical public identity document. 中文 companion: [README.zh-CN.md](./README.zh-CN.md).
 
-`consensus-rnd` is a cross-platform Agent Skills repository for **consensus-driven R&D**: a reusable multi-perspective decision and verification engine that any host repository can inject into its own development loop.
+`consensus-rnd` is a cross-platform Agent Skills publication repository. Its product identity is a **consensus engine** for repository work: biased independent solvers produce candidate plans, a meta-judge converges them into one concrete plan, implementation runs, independent reviewers apply the same consensus discipline, and only then may the work proceed to merge.
 
-## Positioning
+This repository is not an application runtime. Its deliverables are skills under `skills/<name>/` plus the platform manifests that expose the same skill tree to Claude Code, Codex, Cursor, and Gemini.
 
-Here, "R&D" has the broadest meaning: any sustained activity that commits state back to a repository. Code changes, documentation, marketing assets, research notes, configuration maintenance, and release work all fit the same shape when the output lands in git, needs review, and needs quality control.
+## What It Provides
 
-This repository is not bound to one host project. A host injects loop runtime facts through `host.env`: repository root, integration branch, project rules, build and test commands, GitHub slug, and related surfaces. The engine must not hardcode host project facts. `.refactor-loop/` is skill runtime state; host-owned config may be located through `CONSENSUS_RND_HOST_ENV`.
-
-## Core: Consensus-Building Engine
-
-This is not "run the same prompt several times and take a majority vote." The core is **biased, independent, multi-angle convergence**:
-
-- **Multiple solvers with opposing priors**: each solver carries a different stance, such as minimal change, structural cleanliness, or deletion pressure, and cannot see the other solvers' outputs before forming its own conclusion.
-- **Meta-judge arbitration**: disagreement is reduced to `consensus` or `converge`; product-level `stalled` remains a router-derived continuation after qualifying `converge`, not a fresh judge-owned verdict.
-<!--
-Refactor (iter343/issue-343):
-  Old pattern: README 单一(非英文默认),CLAUDE.md 文档分层称 README 为权威源;无英文 canonical + 中文 companion 双文件,语言策略未给 README pair carve-out
-  New principle: README.md 英文 canonical 公开身份文档 + README.zh-CN.md 中文 companion(双向交叉链接,大段顺序对齐不要求逐句对等);CLAUDE.md 文档分层/根.md收口/语言 carve-out 与 SKILL.md 语言策略窄改:README pair 是唯一英文-canonical 公开文档 carve-out,GitHub issue/PR/commit/design artifact 等工作态仍中文默认。严格按 DESIGN_DECISION_PATH verbatim Concrete plan;不碰 .version-bump.json/额外根文档/runtime/host.env/marker/daemon/workflow
--->
-- **Every concrete plan passes the gate**: even when the direction is obvious, a single agent does not implement directly. The gate turns an obvious direction into an evidenced plan.
-- **Symmetric verification**: implementation output goes through a multi-reviewer consensus gate before merge.
-- **Pure orchestration controller**: analysis, design, implementation, and verification are delegated to workers; deterministic scripts may read markers and dispatch allowlisted next actors; the LLM controller keeps semantic fallback, unknown states, git, and state surfaces.
-
-## Skills
-
-| skill | Description | Status |
+| skill | What it is for | Runtime shape |
 |---|---|---|
-| `codex-refactor-loop` | Stable Consensus R&D loop entrypoint; keeps audit/refactor as the compatibility intake and producer, uses Codex CLI workers, and treats GitHub as the visible state surface. | Ported from the original host project; `refactor` remains the accepted work-unit metaphor because the maintainer treats refactor as general development. |
+| `codex-refactor-loop` | Heavy autonomous loop for ongoing repository work: daemon supervision, Codex workers, GitHub orchestration, review gates, and automated release publication when the host opts in. | Uses checked-in scripts, `.refactor-loop/` state, GitHub, git, and host-provided `host.env` facts. |
+| `sshx` | Lightweight prompt-only consensus methodology for high-risk decisions or implementation plans that need isolated perspectives but do not need daemon, GitHub, or git orchestration. | Pure prompt contract: no daemon, no lifecycle authority, no runtime control plane. |
 
-## Repository Structure
+## Core
 
-This is a **cross-platform Agent Skills repository**. The same `skills/` tree is shared by Claude Code, Codex, Cursor, and Gemini; each platform points at it through root manifests:
+The engine is not "run the same prompt several times and vote." It is biased, independent, multi-angle convergence:
+
+- **Biased independent perspectives**: solver and reviewer roles start from different priors, such as minimal change, structural integrity, deletion pressure, architecture, quality, and tests. Same-round peers must not read one another's output before sealing their own verdicts.
+- **Meta-judge convergence**: disagreement is reduced into fixed exits: reached consensus, close enough to converge into one concrete plan, or truly stalled and escalated to a meta layer.
+- **Concrete plans pass the gate**: even when a direction looks obvious, one agent does not skip directly to implementation. The gate turns an obvious direction into an evidenced plan.
+- **Symmetric verification**: the finished work goes through independent reviewers and a fixed review truth table before merge.
+- **Pure orchestration controller**: the controller routes, posts, labels, spawns, commits, pushes, merges, and publishes only through narrow allowed surfaces; design, implementation, verification, and repair are delegated to workers or deterministic scripts.
+
+## Risks
+
+`codex-refactor-loop` is an experimental autonomous R&D system. Enable it only after the host repository explicitly opts in and the maintainers understand these risks:
+
+- **Autonomous writes**: when enabled, the loop can run unattended. It may let agent workers commit/push work, and the controller may open or close issues and PRs, merge PRs, create tags, and publish releases without per-action human confirmation.
+- **API and compute cost**: continuous Codex worker dispatch plus six GitHub-polling daemons can continuously consume API quota, model tokens, and local compute.
+- **Automatic releases**: with `RELEASE_AUTO_ENABLE=true`, the release gate may automatically bump manifests, commit, push, tag, and publish a GitHub release after required checks pass. Bad published tags are abandoned and superseded by the next version; they are not moved or rolled back.
+- **Host boundary**: skills have no authority to edit host configuration outside the surfaces exposed through `host.env`. The active-controller lease still creates a single writer that can mutate GitHub and already-pushed git surfaces within its narrow authorization.
+- **Experimental scope**: this is dogfood-stage infrastructure, not a production stability guarantee. Downstream hosts must opt in before autonomous surfaces do anything.
+
+## Quick Start
+
+### Claude Code
+
+```bash
+/plugin marketplace add ChronoAIProject/consensus-rnd
+/plugin install consensus-rnd@consensus-rnd
+```
+
+### Codex / Cursor
+
+Point the platform plugin mechanism at this repository. `.codex-plugin/plugin.json` and `.cursor-plugin/plugin.json` expose skills through `"skills": "./skills/"`.
+
+### Gemini CLI
+
+Install as an extension. `gemini-extension.json` uses `GEMINI.md` as the context entrypoint, lists available skills, and instructs the agent to read them on demand.
+
+### Direct Copy
+
+Copy `skills/<name>/` into the agent's personal skills directory, such as Claude Code's `~/.claude/skills/`.
+
+### Downstream Host Setup
+
+The host installation sequence for `codex-refactor-loop` is centralized in the [`Downstream install walkthrough`](./skills/codex-refactor-loop/SKILL.md#downstream-install-walkthrough). Use that walkthrough to install the skill, copy and fill the host-owned `host.env`, configure user-level cron or launchd, and connect the Claude Code `statusLine`; this README does not duplicate the command matrix.
+
+## Architecture
+
+`skills/` is the shared product surface. Each skill owns its contract in `SKILL.md`; heavy references may live beside it, and mechanical behavior lives under that skill's `scripts/` tree.
+
+Platform manifests point different agents at the same skills:
 
 ```text
 .
@@ -51,42 +80,11 @@ This is a **cross-platform Agent Skills repository**. The same `skills/` tree is
 └── .version-bump.json     # Manifest version synchronization map
 ```
 
-Rules for adding or changing skills, plus version synchronization requirements, live in [CLAUDE.md](./CLAUDE.md).
+Host projects inject runtime facts through `host.env`: repository root, GitHub slug, review and integration branches, project rules, build/test commands, release opt-in, and related surfaces. The skill repository must not hardcode host facts or modify host configuration directly.
 
-## Install
+## Roadmap
 
-### Claude Code
-
-```bash
-/plugin marketplace add ChronoAIProject/consensus-rnd
-/plugin install consensus-rnd@consensus-rnd
-```
-
-### Codex / Cursor
-
-Point the platform plugin mechanism at this repository. `.codex-plugin/plugin.json` and `.cursor-plugin/plugin.json` expose skills through `"skills": "./skills/"`.
-
-### Gemini CLI
-
-Install as an extension. `gemini-extension.json` uses `GEMINI.md` as the context entrypoint, lists available skills, and instructs the agent to read them on demand.
-
-### Direct Copy, Any Agent
-
-Copy `skills/<name>/` into the agent's personal skills directory, such as Claude Code's `~/.claude/skills/`.
-
-### Downstream Host Quickstart
-
-The host installation sequence for `codex-refactor-loop` is centralized in the [`Downstream install walkthrough`](./skills/codex-refactor-loop/SKILL.md#downstream-install-walkthrough). Use that walkthrough to install the skill, copy and fill the host-owned `host.env`, configure user-level cron or launchd, and connect the Claude Code `statusLine`; this README does not duplicate the command matrix.
-
-## Generalization Roadmap
-
-The first shipped skill is a direct port and still carries the "refactor" shell plus a few host-shaped assumptions. The intended evolution is:
-
-1. **Extract the engine spine**: make `solve -> consensus -> implement -> verify` reusable while allowing the seed producer to change from audit output to any work-unit source, such as a design proposal, documentation task, marketing asset, or spec change.
-2. **Parameterize leaked host assumptions**: policies such as work language should be host-injected where appropriate, not hardcoded.
-3. **Keep "Consensus R&D" as the public product identity**: retain `codex-refactor-loop` as the stable skill entrypoint until there is a real discovery or installation reason to add another alias.
-
-The engine should generalize through its own consensus gate: use the engine to generalize the engine.
+The public product identity is Consensus R&D. `codex-refactor-loop` remains the heavy autonomous loop entrypoint, while `sshx` carries the same consensus philosophy as a lightweight prompt-only method. Future work should generalize the engine spine, parameterize host assumptions where appropriate, and keep runtime authority narrow enough to verify mechanically.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The engine is not "run the same prompt several times and vote." It is biased, in
 
 `codex-refactor-loop` is an experimental autonomous R&D system. Enable it only after the host repository explicitly opts in and the maintainers understand these risks:
 
-- **Autonomous writes**: when enabled, the loop can run unattended. It may let agent workers commit/push work, and the controller may open or close issues and PRs, merge PRs, create tags, and publish releases without per-action human confirmation.
+- **Autonomous writes**: when enabled, the loop can run unattended. Controller-owned paths may commit, push, open PRs, merge PRs, and publish releases after their respective gates and allowlists pass, without per-action human confirmation. Agent workers only produce implementation diffs in isolated worktrees; they do not commit or push.
 - **API and compute cost**: continuous Codex worker dispatch plus six GitHub-polling daemons can continuously consume API quota, model tokens, and local compute.
 - **Automatic releases**: with `RELEASE_AUTO_ENABLE=true`, the release gate may automatically bump manifests, commit, push, tag, and publish a GitHub release after required checks pass. Bad published tags are abandoned and superseded by the next version; they are not moved or rolled back.
 - **Host boundary**: skills have no authority to edit host configuration outside the surfaces exposed through `host.env`. The active-controller lease still creates a single writer that can mutate GitHub and already-pushed git surfaces within its narrow authorization.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,59 @@
 # consensus-rnd
 
-通用**共识式研发** skills 库 —— 可被任意 host 仓库注入的多角度共识构建引擎。
+English canonical public identity document. 中文 companion: [README.zh-CN.md](./README.zh-CN.md).
 
-## 定位
+`consensus-rnd` is a cross-platform Agent Skills repository for **consensus-driven R&D**: a reusable multi-perspective decision and verification engine that any host repository can inject into its own development loop.
 
-这里的"研发"取最广义:**任何持续向仓库提交状态的活动都是研发** —— 写代码是研发,写文档是研发,做 marketing、整理资料、维护配置同样是研发。只要产物落进 git、需要被审查、需要质量保证,就适用同一套引擎。
+## Positioning
 
-本库不绑定任何具体项目。host 通过 `host.env` 注入自己的 loop runtime 事实(仓库根、集成分支、规则文档、构建/测试命令、GitHub slug 等),引擎本身不写死任一项目。`.refactor-loop/` 是 skill runtime state;host-owned config 可通过 `CONSENSUS_RND_HOST_ENV` 指向。
+Here, "R&D" has the broadest meaning: any sustained activity that commits state back to a repository. Code changes, documentation, marketing assets, research notes, configuration maintenance, and release work all fit the same shape when the output lands in git, needs review, and needs quality control.
 
-## 核心:共识构建引擎
+This repository is not bound to one host project. A host injects loop runtime facts through `host.env`: repository root, integration branch, project rules, build and test commands, GitHub slug, and related surfaces. The engine must not hardcode host project facts. `.refactor-loop/` is skill runtime state; host-owned config may be located through `CONSENSUS_RND_HOST_ENV`.
 
-不是"多跑几遍取多数",而是**偏置独立的多角度逼近**:
+## Core: Consensus-Building Engine
 
-- **多 solver,先验对立**:每个 solver 带不同立场(如 minimal 最小改动 / structural 架构洁净 / delete 质疑必要性),且**互相看不到对方输出**,各自独立得出结论。
-- **meta-judge 仲裁**:把分歧收敛成 `consensus` / `converge`;产品层仍有 `stalled` 出口,但它由 router 在 qualifying `converge` 后按 deterministic predicate 派生,真停滞才升 reflector 调和。
-<!-- Refactor (issue-304): Old: README described stalled as a judge-owned third exit. New: stalled is product-level router-derived continuation after converge. -->
-- **任何 concrete plan 都必须过这道闸**:哪怕方向已明确,也不允许单个 agent 直接落地 —— 用多角度验证把"明显方向"证成"明显方案"。
-- **验证侧同构**:产物再经多 reviewer(架构 / 质量 / 测试)共识 gate 才允许合并。
-- **controller 纯编排**:所有思考、分析、诊断、验证都 delegate 给 agent;确定性脚本可按 allowlist 读 marker 并派发下一 actor;LLM controller 保留语义 fallback、未知状态、git 与状态面。
+This is not "run the same prompt several times and take a majority vote." The core is **biased, independent, multi-angle convergence**:
 
-## skills
+- **Multiple solvers with opposing priors**: each solver carries a different stance, such as minimal change, structural cleanliness, or deletion pressure, and cannot see the other solvers' outputs before forming its own conclusion.
+- **Meta-judge arbitration**: disagreement is reduced to `consensus` or `converge`; product-level `stalled` remains a router-derived continuation after qualifying `converge`, not a fresh judge-owned verdict.
+<!--
+Refactor (iter343/issue-343):
+  Old pattern: README 单一(非英文默认),CLAUDE.md 文档分层称 README 为权威源;无英文 canonical + 中文 companion 双文件,语言策略未给 README pair carve-out
+  New principle: README.md 英文 canonical 公开身份文档 + README.zh-CN.md 中文 companion(双向交叉链接,大段顺序对齐不要求逐句对等);CLAUDE.md 文档分层/根.md收口/语言 carve-out 与 SKILL.md 语言策略窄改:README pair 是唯一英文-canonical 公开文档 carve-out,GitHub issue/PR/commit/design artifact 等工作态仍中文默认。严格按 DESIGN_DECISION_PATH verbatim Concrete plan;不碰 .version-bump.json/额外根文档/runtime/host.env/marker/daemon/workflow
+-->
+- **Every concrete plan passes the gate**: even when the direction is obvious, a single agent does not implement directly. The gate turns an obvious direction into an evidenced plan.
+- **Symmetric verification**: implementation output goes through a multi-reviewer consensus gate before merge.
+- **Pure orchestration controller**: analysis, design, implementation, and verification are delegated to workers; deterministic scripts may read markers and dispatch allowlisted next actors; the LLM controller keeps semantic fallback, unknown states, git, and state surfaces.
 
-| skill | 说明 | 状态 |
+## Skills
+
+| skill | Description | Status |
 |---|---|---|
-| `codex-refactor-loop` | Consensus R&D 循环的稳定 skill 入口;默认以 audit/refactor 作为兼容 intake / producer,codex CLI 驱动,GitHub 为状态面 | 自 host 项目移植,verbatim;保留 refactor 作为合法 work-unit 隐喻 |
+| `codex-refactor-loop` | Stable Consensus R&D loop entrypoint; keeps audit/refactor as the compatibility intake and producer, uses Codex CLI workers, and treats GitHub as the visible state surface. | Ported from the original host project; `refactor` remains the accepted work-unit metaphor because the maintainer treats refactor as general development. |
 
-## 仓库结构
+## Repository Structure
 
-本库是一个**跨平台 Agent Skills 仓库**,同一份 `skills/` 被多个 coding agent 共享,各平台靠根目录的清单文件指向它:
+This is a **cross-platform Agent Skills repository**. The same `skills/` tree is shared by Claude Code, Codex, Cursor, and Gemini; each platform points at it through root manifests:
 
-```
+```text
 .
-├── .claude-plugin/        # Claude Code:plugin.json + marketplace.json
-├── .codex-plugin/         # Codex:plugin.json
-├── .cursor-plugin/        # Cursor:plugin.json
-├── gemini-extension.json  # Gemini:扩展清单(配 GEMINI.md 上下文入口)
-├── package.json           # npm 风格元数据 / 版本锚点
-├── AGENTS.md → CLAUDE.md   # 跨 agent 约定(符号链接)
-├── CLAUDE.md              # 本仓库内工作的 agent 指南
+├── .claude-plugin/        # Claude Code: plugin.json + marketplace.json
+├── .codex-plugin/         # Codex: plugin.json
+├── .cursor-plugin/        # Cursor: plugin.json
+├── gemini-extension.json + GEMINI.md   # Gemini: extension manifest + context entry
+├── package.json           # npm-style metadata / version anchor
+├── AGENTS.md -> CLAUDE.md # Cross-agent rules, symlinked
+├── CLAUDE.md              # Agent guide for work inside this repository
+├── README.md              # English canonical public identity document
+├── README.zh-CN.md        # Chinese companion public identity document
 ├── LICENSE                # MIT
-├── skills/<name>/         # 各 skill(SKILL.md 必备)
-└── .version-bump.json     # 各清单版本号同步映射
+├── skills/<name>/         # Each skill; SKILL.md is required
+└── .version-bump.json     # Manifest version synchronization map
 ```
 
-新增 / 修改 skill 的约定与版本同步规则见 [`CLAUDE.md`](./CLAUDE.md)。
+Rules for adding or changing skills, plus version synchronization requirements, live in [CLAUDE.md](./CLAUDE.md).
 
-## 安装
+## Install
 
 ### Claude Code
 
@@ -56,37 +64,29 @@
 
 ### Codex / Cursor
 
-按各自插件机制指向本仓库;`.codex-plugin/plugin.json` 与 `.cursor-plugin/plugin.json` 已通过 `"skills": "./skills/"` 暴露 skills。
+Point the platform plugin mechanism at this repository. `.codex-plugin/plugin.json` and `.cursor-plugin/plugin.json` expose skills through `"skills": "./skills/"`.
 
 ### Gemini CLI
 
-作为扩展安装,`gemini-extension.json` 以 `GEMINI.md` 为上下文入口,列出可用 skills 并指引按需读取。
+Install as an extension. `gemini-extension.json` uses `GEMINI.md` as the context entrypoint, lists available skills, and instructs the agent to read them on demand.
 
-### 直接拷贝(任意 agent)
+### Direct Copy, Any Agent
 
-把 `skills/<name>/` 拷进 agent 的个人 skills 目录(如 Claude Code 的 `~/.claude/skills/`)即可。
+Copy `skills/<name>/` into the agent's personal skills directory, such as Claude Code's `~/.claude/skills/`.
 
-### 下游 host quickstart
+### Downstream Host Quickstart
 
-<!--
-Refactor (iter1/issue-141):
-  Old pattern: 下游没有 installer 时,装机步骤散落在 README、SKILL statusline 段和 restart helper 段,缺乏从安装 skill 到配置 host.env、调度守护进程、接入 statusLine 的单步 walkthrough。
-  New principle: Downstream install walkthrough 是唯一装机主段;README 链到 SKILL 锚点,SKILL 内部段落互链;source-regression 锁住单文件链接与必备 surface,bounded scheduler behavior test 锁住 restart-daemons.sh 不无限阻塞。
--->
+The host installation sequence for `codex-refactor-loop` is centralized in the [`Downstream install walkthrough`](./skills/codex-refactor-loop/SKILL.md#downstream-install-walkthrough). Use that walkthrough to install the skill, copy and fill the host-owned `host.env`, configure user-level cron or launchd, and connect the Claude Code `statusLine`; this README does not duplicate the command matrix.
 
-`codex-refactor-loop` 的 host 安装顺序集中在
-[`Downstream install walkthrough`](./skills/codex-refactor-loop/SKILL.md#downstream-install-walkthrough)。
-按该 walkthrough 安装 skill、复制并填写 host-owned `host.env`、配置用户级 cron/launchd 和 Claude Code `statusLine`;README 不复制命令矩阵。
+## Generalization Roadmap
 
-## 泛化路线(待迭代)
+The first shipped skill is a direct port and still carries the "refactor" shell plus a few host-shaped assumptions. The intended evolution is:
 
-第一块是直接移植,仍带"重构"外壳与少量 host 主张。后续迭代方向:
+1. **Extract the engine spine**: make `solve -> consensus -> implement -> verify` reusable while allowing the seed producer to change from audit output to any work-unit source, such as a design proposal, documentation task, marketing asset, or spec change.
+2. **Parameterize leaked host assumptions**: policies such as work language should be host-injected where appropriate, not hardcoded.
+3. **Keep "Consensus R&D" as the public product identity**: retain `codex-refactor-loop` as the stable skill entrypoint until there is a real discovery or installation reason to add another alias.
 
-1. **抽出引擎脊柱**(`solve → consensus → implement → verify`),让 audit 这一步(产生工作单元的种子)可替换 —— 换成任意 work-unit 来源(设计提案 / 文档任务 / 营销产出 / spec 变更),其余整套共识机制原样复用。
-2. **参数化漏入的 host 主张**:如"工作语言规则"应成为可注入的 host policy,而非写死。
-3. 对外以 "Consensus R&D" 为主产品身份; 保留 codex-refactor-loop 作为稳定 skill 入口,因为 maintainer 已接受 "refactor = development" 通用隐喻; 不新增重复 alias skill,除非未来出现真实平台发现/安装问题。
-
-> 泛化引擎本身宜走引擎自己那套共识 gate —— 用这个引擎来通用化这个引擎。
+The engine should generalize through its own consensus gate: use the engine to generalize the engine.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@
 
 `codex-refactor-loop` 是实验性自治研发系统。下游仓库必须显式 opt in,且 maintainer 理解以下风险后再启用:
 
-- **自治写操作**:启用后 loop 可无人值守运行。它可能让 agent worker commit/push 工作,controller 可能开关 issue/PR、merge PR、打 tag、发 release,且没有逐动作人工确认。
+- **自治写操作**:启用后 loop 可无人值守运行。controller-owned 路径在相应 gate 与 allowlist 通过后,可执行 commit、push、open PR、merge PR、release publish,且没有逐动作人工确认。agent worker 只在隔离 worktree 产出实现 diff,不 commit/push。
 - **API/算力成本**:持续派发 Codex worker 加上 6 个 daemon 轮询 GitHub,会持续消耗 API quota、model token 和本机算力。
 - **自动发版**:`RELEASE_AUTO_ENABLE=true` 时,release gate 可在 required checks 全绿后自动 bump manifest、commit、push、tag 并发布 GitHub release。坏版即弃,用下一个版本取代;已发布 tag 不移动、不回滚。
 - **host 边界**:skill 无权修改 host 暴露面之外的配置,只在 `host.env` 暴露的 surface 工作。但 active-controller lease 会形成单写者,在窄授权内写 GitHub/已 push git 面。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,53 +2,38 @@
 
 中文 companion public identity document. English canonical: [README.md](./README.md).
 
-`consensus-rnd` 是一个跨平台 Agent Skills 仓库,提供**共识式研发**引擎:任意 host 仓库都可注入的多角度决策与验证循环。
+`consensus-rnd` 是一个跨平台 Agent Skills 发布仓库。它的产品身份是**共识引擎**:偏置独立的多角度 solver 先给出候选方案,meta-judge 收敛成一个 concrete plan,随后实现,再由多 reviewer 过同构共识 gate,最后才进入 merge。
 
-## 定位
+本仓库不是应用运行时代码。唯一产物是 `skills/<name>/` 下的 skill 及根目录中让 Claude Code / Codex / Cursor / Gemini 指向同一份 `skills/` 的平台清单。
 
-这里的"研发"取最广义:任何持续向仓库提交状态的活动都是研发。写代码、写文档、做 marketing、整理研究资料、维护配置、发版,只要产物落进 git、需要被审查、需要质量保证,就适用同一套引擎。
+## 提供什么
 
-本库不绑定任何具体 host 项目。host 通过 `host.env` 注入 loop runtime 事实:仓库根、集成分支、项目规则、构建/测试命令、GitHub slug 等。引擎本身不得写死 host 项目事实。`.refactor-loop/` 是 skill runtime state;host-owned config 可通过 `CONSENSUS_RND_HOST_ENV` 定位。
+| skill | 用途 | 运行形态 |
+|---|---|---|
+| `codex-refactor-loop` | 重型自治 loop:daemon 监督、Codex worker、GitHub 编排、review gate,以及 host opt-in 后的自动发版。 | 使用 checked-in scripts、`.refactor-loop/` state、GitHub、git 和 host 通过 `host.env` 注入的事实。 |
+| `sshx` | 轻量纯 prompt 共识方法论:高风险决策或实现方案需要隔离多角度判断,但不需要 daemon/GitHub/git 编排时使用。 | 纯 prompt contract:无 daemon、无 lifecycle authority、无 runtime control plane。 |
 
-## 核心:共识构建引擎
+## 核心
 
 这不是"多跑几遍取多数",而是**偏置独立的多角度逼近**:
 
-- **多 solver,先验对立**:每个 solver 带不同立场,如 minimal 最小改动、structural 架构洁净、delete 质疑必要性,且在形成结论前互相看不到对方输出。
-- **meta-judge 仲裁**:把分歧收敛成 `consensus` / `converge`;产品层仍有 `stalled` 出口,但它由 router 在 qualifying `converge` 后按 deterministic predicate 派生,不是 judge 新增 verdict。
-- **任何 concrete plan 都必须过闸**:哪怕方向已明确,也不允许单个 agent 直接落地;用多角度验证把"明显方向"证成"明显方案"。
-- **验证侧同构**:实现产物再经多 reviewer 共识 gate 才允许合并。
-- **controller 纯编排**:所有分析、设计、实现、验证都 delegate 给 worker;确定性脚本可按 allowlist 读 marker 并派发下一 actor;LLM controller 保留语义 fallback、未知状态、git 与状态面。
+- **偏置独立多角度**:solver / reviewer 带不同先验,如 minimal 最小改动、structural 架构完整、delete 质疑必要性、architecture、quality、tests;同一轮 peer 在 sealed verdict 前不得读取彼此输出。
+- **meta-judge 收敛**:分歧只收敛到固定出口:达成共识、足够接近并收敛成一个 concrete plan、或真停滞后升级 meta-layer。
+- **concrete plan 必过共识闸**:哪怕方向明显,也不允许单个 agent 跳过共识直接实现;gate 把"明显方向"证成"明确方案"。
+- **验证侧同构**:实现产物再经独立 reviewer 和固定 review truth table 才允许 merge。
+- **controller 纯编排**:controller 只通过窄授权 surface route / post / label / spawn / commit / push / merge / publish;设计、实现、验证、修复交给 worker 或确定性脚本。
 
-## skills
+## ⚠️ 风险提示
 
-| skill | 说明 | 状态 |
-|---|---|---|
-| `codex-refactor-loop` | Consensus R&D 循环的稳定 skill 入口;默认以 audit/refactor 作为兼容 intake / producer,由 Codex CLI worker 执行,GitHub 是可见状态面。 | 自原 host 项目移植;保留 refactor 作为合法 work-unit 隐喻,因为 maintainer 接受 "refactor = development" 的通用解释。 |
+`codex-refactor-loop` 是实验性自治研发系统。下游仓库必须显式 opt in,且 maintainer 理解以下风险后再启用:
 
-## 仓库结构
+- **自治写操作**:启用后 loop 可无人值守运行。它可能让 agent worker commit/push 工作,controller 可能开关 issue/PR、merge PR、打 tag、发 release,且没有逐动作人工确认。
+- **API/算力成本**:持续派发 Codex worker 加上 6 个 daemon 轮询 GitHub,会持续消耗 API quota、model token 和本机算力。
+- **自动发版**:`RELEASE_AUTO_ENABLE=true` 时,release gate 可在 required checks 全绿后自动 bump manifest、commit、push、tag 并发布 GitHub release。坏版即弃,用下一个版本取代;已发布 tag 不移动、不回滚。
+- **host 边界**:skill 无权修改 host 暴露面之外的配置,只在 `host.env` 暴露的 surface 工作。但 active-controller lease 会形成单写者,在窄授权内写 GitHub/已 push git 面。
+- **适用范围**:这是 dogfood 阶段的实验性研发基础设施,不是生产稳定保证;下游 host 未 opt in 时自治 surface 应保持 noop。
 
-本库是一个**跨平台 Agent Skills 仓库**。同一份 `skills/` 被 Claude Code / Codex / Cursor / Gemini 共享,各平台靠根目录的清单文件指向它:
-
-```text
-.
-├── .claude-plugin/        # Claude Code: plugin.json + marketplace.json
-├── .codex-plugin/         # Codex: plugin.json
-├── .cursor-plugin/        # Cursor: plugin.json
-├── gemini-extension.json + GEMINI.md   # Gemini: extension manifest + context entry
-├── package.json           # npm 风格元数据 / 版本锚点
-├── AGENTS.md -> CLAUDE.md # 跨 agent 约定(符号链接)
-├── CLAUDE.md              # 本仓库内工作的 agent 指南
-├── README.md              # 英文 canonical public identity document
-├── README.zh-CN.md        # 中文 companion public identity document
-├── LICENSE                # MIT
-├── skills/<name>/         # 各 skill,SKILL.md 必备
-└── .version-bump.json     # 各清单版本号同步映射
-```
-
-新增 / 修改 skill 的约定与版本同步规则见 [CLAUDE.md](./CLAUDE.md)。
-
-## 安装
+## 快速开始
 
 ### Claude Code
 
@@ -65,23 +50,41 @@
 
 作为扩展安装。`gemini-extension.json` 以 `GEMINI.md` 为上下文入口,列出可用 skills 并指引按需读取。
 
-### 直接拷贝(任意 agent)
+### 直接拷贝
 
 把 `skills/<name>/` 拷进 agent 的个人 skills 目录,如 Claude Code 的 `~/.claude/skills/`。
 
-### 下游 host quickstart
+### 下游 host 设置
 
-`codex-refactor-loop` 的 host 安装顺序集中在英文 canonical README 的 "Downstream Host Quickstart" 和 skill 内的 walkthrough。按该 walkthrough 安装 skill、复制并填写 host-owned `host.env`、配置用户级 cron/launchd 和 Claude Code `statusLine`;本 companion 不复制命令矩阵。
+`codex-refactor-loop` 的 host 安装顺序集中在英文 canonical README 的 "Downstream Host Setup" 和 skill 内的 walkthrough。按该 walkthrough 安装 skill、复制并填写 host-owned `host.env`、配置用户级 cron/launchd 和 Claude Code `statusLine`;本 companion 不复制命令矩阵。
 
-## 泛化路线
+## 架构
 
-第一块 skill 是直接移植,仍带"重构"外壳与少量 host 主张。后续迭代方向:
+`skills/` 是共享产品 surface。每个 skill 在自己的 `SKILL.md` 维护契约;重型参考可放在同目录,机械行为放在该 skill 的 `scripts/` 树下。
 
-1. **抽出引擎脊柱**:让 `solve -> consensus -> implement -> verify` 可复用,把 seed producer 从 audit 输出替换为任意 work-unit 来源,如设计提案、文档任务、marketing 产出或 spec 变更。
-2. **参数化漏入的 host 主张**:如工作语言策略应在合适边界由 host 注入,而非写死。
-3. **对外以 "Consensus R&D" 为主产品身份**:保留 `codex-refactor-loop` 作为稳定 skill 入口,直到未来出现真实平台发现或安装问题再考虑新增 alias。
+各平台清单把不同 agent 指向同一份 skills:
 
-泛化引擎本身宜走引擎自己的共识 gate:用这个引擎来通用化这个引擎。
+```text
+.
+├── .claude-plugin/        # Claude Code: plugin.json + marketplace.json
+├── .codex-plugin/         # Codex: plugin.json
+├── .cursor-plugin/        # Cursor: plugin.json
+├── gemini-extension.json + GEMINI.md   # Gemini: extension manifest + context entry
+├── package.json           # npm 风格元数据 / 版本锚点
+├── AGENTS.md -> CLAUDE.md # 跨 agent 约定,符号链接
+├── CLAUDE.md              # 本仓库内工作的 agent 指南
+├── README.md              # 英文 canonical public identity document
+├── README.zh-CN.md        # 中文 companion public identity document
+├── LICENSE                # MIT
+├── skills/<name>/         # 各 skill;SKILL.md 必备
+└── .version-bump.json     # 各清单版本号同步映射
+```
+
+host 项目通过 `host.env` 注入运行时事实:仓库根、GitHub slug、review/integration 分支、项目规则、构建/测试命令、release opt-in 等。skill 仓库不得硬编码 host 事实,也不得直接修改 host 配置。
+
+## 路线
+
+公开产品身份是 Consensus R&D。`codex-refactor-loop` 保留为重型自治 loop 入口,`sshx` 则把同一套共识哲学压缩成轻量纯 prompt 方法。后续工作应继续抽出 engine spine、把 host 主张参数化,并把 runtime authority 收窄到可机械验证的边界。
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,88 @@
+# consensus-rnd
+
+中文 companion public identity document. English canonical: [README.md](./README.md).
+
+`consensus-rnd` 是一个跨平台 Agent Skills 仓库,提供**共识式研发**引擎:任意 host 仓库都可注入的多角度决策与验证循环。
+
+## 定位
+
+这里的"研发"取最广义:任何持续向仓库提交状态的活动都是研发。写代码、写文档、做 marketing、整理研究资料、维护配置、发版,只要产物落进 git、需要被审查、需要质量保证,就适用同一套引擎。
+
+本库不绑定任何具体 host 项目。host 通过 `host.env` 注入 loop runtime 事实:仓库根、集成分支、项目规则、构建/测试命令、GitHub slug 等。引擎本身不得写死 host 项目事实。`.refactor-loop/` 是 skill runtime state;host-owned config 可通过 `CONSENSUS_RND_HOST_ENV` 定位。
+
+## 核心:共识构建引擎
+
+这不是"多跑几遍取多数",而是**偏置独立的多角度逼近**:
+
+- **多 solver,先验对立**:每个 solver 带不同立场,如 minimal 最小改动、structural 架构洁净、delete 质疑必要性,且在形成结论前互相看不到对方输出。
+- **meta-judge 仲裁**:把分歧收敛成 `consensus` / `converge`;产品层仍有 `stalled` 出口,但它由 router 在 qualifying `converge` 后按 deterministic predicate 派生,不是 judge 新增 verdict。
+- **任何 concrete plan 都必须过闸**:哪怕方向已明确,也不允许单个 agent 直接落地;用多角度验证把"明显方向"证成"明显方案"。
+- **验证侧同构**:实现产物再经多 reviewer 共识 gate 才允许合并。
+- **controller 纯编排**:所有分析、设计、实现、验证都 delegate 给 worker;确定性脚本可按 allowlist 读 marker 并派发下一 actor;LLM controller 保留语义 fallback、未知状态、git 与状态面。
+
+## skills
+
+| skill | 说明 | 状态 |
+|---|---|---|
+| `codex-refactor-loop` | Consensus R&D 循环的稳定 skill 入口;默认以 audit/refactor 作为兼容 intake / producer,由 Codex CLI worker 执行,GitHub 是可见状态面。 | 自原 host 项目移植;保留 refactor 作为合法 work-unit 隐喻,因为 maintainer 接受 "refactor = development" 的通用解释。 |
+
+## 仓库结构
+
+本库是一个**跨平台 Agent Skills 仓库**。同一份 `skills/` 被 Claude Code / Codex / Cursor / Gemini 共享,各平台靠根目录的清单文件指向它:
+
+```text
+.
+├── .claude-plugin/        # Claude Code: plugin.json + marketplace.json
+├── .codex-plugin/         # Codex: plugin.json
+├── .cursor-plugin/        # Cursor: plugin.json
+├── gemini-extension.json + GEMINI.md   # Gemini: extension manifest + context entry
+├── package.json           # npm 风格元数据 / 版本锚点
+├── AGENTS.md -> CLAUDE.md # 跨 agent 约定(符号链接)
+├── CLAUDE.md              # 本仓库内工作的 agent 指南
+├── README.md              # 英文 canonical public identity document
+├── README.zh-CN.md        # 中文 companion public identity document
+├── LICENSE                # MIT
+├── skills/<name>/         # 各 skill,SKILL.md 必备
+└── .version-bump.json     # 各清单版本号同步映射
+```
+
+新增 / 修改 skill 的约定与版本同步规则见 [CLAUDE.md](./CLAUDE.md)。
+
+## 安装
+
+### Claude Code
+
+```bash
+/plugin marketplace add ChronoAIProject/consensus-rnd
+/plugin install consensus-rnd@consensus-rnd
+```
+
+### Codex / Cursor
+
+按各自插件机制指向本仓库;`.codex-plugin/plugin.json` 与 `.cursor-plugin/plugin.json` 已通过 `"skills": "./skills/"` 暴露 skills。
+
+### Gemini CLI
+
+作为扩展安装。`gemini-extension.json` 以 `GEMINI.md` 为上下文入口,列出可用 skills 并指引按需读取。
+
+### 直接拷贝(任意 agent)
+
+把 `skills/<name>/` 拷进 agent 的个人 skills 目录,如 Claude Code 的 `~/.claude/skills/`。
+
+### 下游 host quickstart
+
+`codex-refactor-loop` 的 host 安装顺序集中在英文 canonical README 的 "Downstream Host Quickstart" 和 skill 内的 walkthrough。按该 walkthrough 安装 skill、复制并填写 host-owned `host.env`、配置用户级 cron/launchd 和 Claude Code `statusLine`;本 companion 不复制命令矩阵。
+
+## 泛化路线
+
+第一块 skill 是直接移植,仍带"重构"外壳与少量 host 主张。后续迭代方向:
+
+1. **抽出引擎脊柱**:让 `solve -> consensus -> implement -> verify` 可复用,把 seed producer 从 audit 输出替换为任意 work-unit 来源,如设计提案、文档任务、marketing 产出或 spec 变更。
+2. **参数化漏入的 host 主张**:如工作语言策略应在合适边界由 host 注入,而非写死。
+3. **对外以 "Consensus R&D" 为主产品身份**:保留 `codex-refactor-loop` 作为稳定 skill 入口,直到未来出现真实平台发现或安装问题再考虑新增 alias。
+
+泛化引擎本身宜走引擎自己的共识 gate:用这个引擎来通用化这个引擎。
+
+## License
+
+[MIT](./LICENSE) © ChronoAIProject

--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -36,7 +36,7 @@ Use intra-file anchors when a phase needs the detailed body, such as [host runti
 | Labels | Every issue/PR has exactly one phase label and one human label. | Sync labels and banner together; `crnd:human:maintainer-decision` only after allowed meta-layer routes. | [label bootstrap loops](#label-bootstrap-loops) | controller-internal `ControllerActions`, GitHub labels |
 | Spawn | Mainline codex spawn uses harness background tasks, not detached nohup. | Use one background task per codex; if detached already happened, preserve work and rely on log sweep plus wake source. | [codex invocation details](#codex-invocation-details) | `consensus-rnd-cli spawn-codex` |
 | Hard rules | All worker prompts inherit controller-level hard rules. | Include scope, git, test, language, and no-scope-creep constraints in every spawned prompt. | [hard rules details](#hard-rules-details) | prompt templates |
-| Language | Source files are English-only; external user-facing artifacts are 中文 by default. No mandatory parallel English section. | Enforce on prompts, GitHub posts, commits, docs, source comments/logs. | [language policy details](#language-policy-details), [historical bilingual notes](#historical-bilingual-notes) | prompts, docs, commit text |
+| Language | Source files are English-only; external user-facing artifacts are 中文 by default. README.md + README.zh-CN.md is the only English-canonical public-doc carve-out. No mandatory parallel English section. | Enforce on prompts, GitHub posts, commits, docs, source comments/logs. | [language policy details](#language-policy-details), [historical bilingual notes](#historical-bilingual-notes) | prompts, docs, commit text |
 
 ## Two entry modes
 
@@ -737,14 +737,19 @@ Policy:the loop continues until an explicit stop condition or a visible `crnd:hu
 5. No sleep/delay-based test pacing; use deterministic awaiters.
 6. No `[Skip]`, disabled tests, ignored tests, or manual category escapes to make CI green.
 7. No scope creep; workers must print `SCOPE_EXTEND: <file> <reason>` before touching outside authorized scope.
-8. Source files are English-only; external user-facing artifacts are 中文 by default. No mandatory parallel English section.
+8. Source files are English-only; external user-facing artifacts are 中文 by default. The root README pair is the only English-canonical public-doc carve-out: `README.md` is English canonical, `README.zh-CN.md` is the 中文 companion, and GitHub issue/PR/commit/design artifacts remain 中文 by default. No mandatory parallel English section.
 10. Do not hardcode host facts into this cross-platform skill.
 
 Details are in [hard rules details](#hard-rules-details).
 
 ## 工作语言规则(源码内英文,源码外中文)
 
-Policy: Source files are English-only; external user-facing artifacts are 中文 by default. No mandatory parallel English section.
+<!--
+Refactor (iter343/issue-343):
+  Old pattern: README 单一(非英文默认),CLAUDE.md 文档分层称 README 为权威源;无英文 canonical + 中文 companion 双文件,语言策略未给 README pair carve-out
+  New principle: README.md 英文 canonical 公开身份文档 + README.zh-CN.md 中文 companion(双向交叉链接,大段顺序对齐不要求逐句对等);CLAUDE.md 文档分层/根.md收口/语言 carve-out 与 SKILL.md 语言策略窄改:README pair 是唯一英文-canonical 公开文档 carve-out,GitHub issue/PR/commit/design artifact 等工作态仍中文默认。严格按 DESIGN_DECISION_PATH verbatim Concrete plan;不碰 .version-bump.json/额外根文档/runtime/host.env/marker/daemon/workflow
+-->
+Policy: Source files are English-only; external user-facing artifacts are 中文 by default. The root README pair is the only English-canonical public-doc carve-out. No mandatory parallel English section.
 Operational details live in [language policy details](#language-policy-details); historical bilingual notes live in [historical bilingual notes](#historical-bilingual-notes).
 
 ## Files
@@ -3041,13 +3046,13 @@ Bash(
 5. **No `sleep/delay`-based test pacing** — tests must use deterministic awaiters.
 6. **No `[Skip]` / disabled tests** as a way to make CI green.
 7. **No scope creep** — codex must print `SCOPE_EXTEND: <file> <reason>` before touching anything outside `scope_paths`.
-8. **Source files are English-only; external user-facing artifacts are 中文 by default**. Inside `.rs` / `.lua` / `.sh` / `.py` / `.ts`, comments, docstrings, `log.{info,warn,error}` strings, error/panic text, identifiers, and code-built commit-body templates are English. Outside source files, GitHub issue bodies, PR descriptions, design notifications, git commit messages written by the controller/codex, docs, TODO markers, and natural-language artifacts use 中文. English may appear inline when quoting (a) a CLAUDE.md / AGENTS.md clause, (b) source error messages, (c) test names — quote verbatim, do not translate. No mandatory parallel English section.
+8. **Source files are English-only; external user-facing artifacts are 中文 by default**. Inside `.rs` / `.lua` / `.sh` / `.py` / `.ts`, comments, docstrings, `log.{info,warn,error}` strings, error/panic text, identifiers, and code-built commit-body templates are English. Outside source files, GitHub issue bodies, PR descriptions, design notifications, git commit messages written by the controller/codex, docs, TODO markers, and natural-language artifacts use 中文. `README.md` + `README.zh-CN.md` is the only English-canonical public-doc carve-out: `README.md` is English canonical, `README.zh-CN.md` is the 中文 companion, and large-section order alignment is enough. English may appear inline when quoting (a) a CLAUDE.md / AGENTS.md clause, (b) source error messages, (c) test names — quote verbatim, do not translate. No mandatory parallel English section.
 
 ## 工作语言规则(源码内英文,源码外中文)
 
 Policy: **源文件内部 English-only;源文件之外的 user-facing artifact 默认 中文**。
 
-中文适用对象:GitHub issue body、PR description、PR comments、design issue auto-loop 评论、scorecard docs (`docs/audit-scorecard/`)、escalation 文案、cross-post 通知、controller / codex 写出的 git commit message、`docs/*.md`、TODO 标记。Internal artifact(`.refactor-loop/runs/*.md` and named daemon state artifacts)仍是英文(只要 grep / 调试用)。
+中文适用对象:GitHub issue body、PR description、PR comments、design issue auto-loop 评论、scorecard docs (`docs/audit-scorecard/`)、escalation 文案、cross-post 通知、controller / codex 写出的 git commit message、`docs/*.md`、TODO 标记。`README.md` + `README.zh-CN.md` 是唯一英文 canonical 公开文档 carve-out:`README.md` 英文 canonical,`README.zh-CN.md` 中文 companion,双向交叉链接且大段顺序对齐即可,不要求逐句对等。Internal artifact(`.refactor-loop/runs/*.md` and named daemon state artifacts)仍是英文(只要 grep / 调试用)。
 
 英文适用对象:所有源文件(`.rs` / `.lua` / `.sh` / `.py` / `.ts`)内部自然语言与代码元素,包括注释、docstring、`log.{info,warn,error}` 字符串、error / panic 文本、代码 identifier、代码内构造的 commit-body 模板字符串。fkst 是 substrate,无 end-user UI;人读 `git log` / `journalctl` / source,英文 log 与注释强制英文同理,保持 LLM 语料一致、跨工程 reuse、无 encoding / 字体问题。
 
@@ -3062,6 +3067,7 @@ Policy: **源文件内部 English-only;源文件之外的 user-facing artifact �
 | GitHub PR title / body / 评论 | **中文** |
 | Git commit message | **中文**(包括 controller 写的 fix/merge/squash 等) |
 | Push notification | **中文** |
+| Public identity README pair | `README.md` is **English canonical**; `README.zh-CN.md` is the **中文 companion**. This is the only English-canonical public-doc carve-out. |
 | Skill 文档 / $REPO_ROOT 的架构/词汇文档(若有) /audit 报告 | 维持现状(中英混排已存在) |
 | **代码内 `// Refactor (iterN/cluster-XXX):` 注释** | **英文**(production code 跨团队读) |
 | **代码内 doc comment / xmldoc / 其他注释** | **英文** |

--- a/skills/codex-refactor-loop/scripts/test_repository_public_docs.py
+++ b/skills/codex-refactor-loop/scripts/test_repository_public_docs.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Repository public documentation boundary tests."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__)
+REPO_ROOT = SCRIPT_PATH.parents[3]
+README = REPO_ROOT / "README.md"
+README_ZH = REPO_ROOT / "README.zh-CN.md"
+CLAUDE = REPO_ROOT / "CLAUDE.md"
+AGENTS = REPO_ROOT / "AGENTS.md"
+SKILL = REPO_ROOT / "skills" / "codex-refactor-loop" / "SKILL.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def heading_order(markdown: str) -> list[str]:
+    return [line.strip() for line in markdown.splitlines() if line.startswith("## ")]
+
+
+class RepositoryPublicDocsTests(unittest.TestCase):
+    def test_readme_pair_exists_and_cross_links(self) -> None:
+        self.assertTrue(README.exists())
+        self.assertTrue(README_ZH.exists())
+        self.assertIn("[README.zh-CN.md](./README.zh-CN.md)", read(README))
+        self.assertIn("[README.md](./README.md)", read(README_ZH))
+        self.assertIn("English canonical public identity document", read(README))
+        self.assertIn("中文 companion public identity document", read(README_ZH))
+
+    def test_language_boundary_visible(self) -> None:
+        skill = read(SKILL)
+        for needle in (
+            "README.md` is English canonical",
+            "README.zh-CN.md` is the 中文 companion",
+            "GitHub issue/PR/commit/design artifacts remain 中文 by default",
+            "Public identity README pair",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, skill)
+
+    def test_root_markdown_closure_and_agents_symlink(self) -> None:
+        allowed = {
+            "AGENTS.md",
+            "CLAUDE.md",
+            "GEMINI.md",
+            "README.md",
+            "README.zh-CN.md",
+        }
+        if (REPO_ROOT / "CHANGELOG.md").exists():
+            allowed.add("CHANGELOG.md")
+        actual = {path.name for path in REPO_ROOT.glob("*.md")}
+        self.assertEqual(actual, allowed)
+        self.assertTrue(AGENTS.is_symlink())
+        self.assertEqual(AGENTS.readlink(), Path("CLAUDE.md"))
+        self.assertIn("README.zh-CN.md", read(CLAUDE))
+
+    def test_public_identity_carveout_bounded_in_claude_and_skill(self) -> None:
+        claude = read(CLAUDE)
+        skill = read(SKILL)
+        for text in (claude, skill):
+            with self.subTest(document=("CLAUDE.md" if text == claude else "SKILL.md")):
+                self.assertIn("README pair", text)
+                self.assertIn("only English-canonical public-doc carve-out", text)
+                self.assertIn("GitHub issue/PR/commit/design artifact", text)
+        self.assertNotIn("INSTALL.md", read(README))
+        self.assertEqual(1, read(README).count("SKILL.md#downstream-install-walkthrough"))
+
+    def test_readme_links_downstream_walkthrough_once(self) -> None:
+        readme = read(README)
+        self.assertEqual(1, readme.count("./skills/codex-refactor-loop/SKILL.md#downstream-install-walkthrough"))
+        self.assertIn("Downstream Host Quickstart", readme)
+        self.assertEqual(
+            heading_order(readme),
+            [
+                "## Positioning",
+                "## Core: Consensus-Building Engine",
+                "## Skills",
+                "## Repository Structure",
+                "## Install",
+                "## Generalization Roadmap",
+                "## License",
+            ],
+        )
+        self.assertEqual(
+            heading_order(read(README_ZH)),
+            [
+                "## 定位",
+                "## 核心:共识构建引擎",
+                "## skills",
+                "## 仓库结构",
+                "## 安装",
+                "## 泛化路线",
+                "## License",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_repository_public_docs.py
+++ b/skills/codex-refactor-loop/scripts/test_repository_public_docs.py
@@ -110,6 +110,9 @@ class RepositoryPublicDocsTests(unittest.TestCase):
         self.assertIn("## ⚠️ 风险提示", readme_zh)
         for needle in (
             "Autonomous writes",
+            "Controller-owned paths may commit, push, open PRs, merge PRs, and publish releases",
+            "after their respective gates and allowlists pass",
+            "Agent workers only produce implementation diffs in isolated worktrees; they do not commit or push",
             "without per-action human confirmation",
             "API and compute cost",
             "six GitHub-polling daemons",
@@ -125,6 +128,9 @@ class RepositoryPublicDocsTests(unittest.TestCase):
                 self.assertIn(needle, readme)
         for needle in (
             "自治写操作",
+            "controller-owned 路径在相应 gate 与 allowlist 通过后",
+            "可执行 commit、push、open PR、merge PR、release publish",
+            "agent worker 只在隔离 worktree 产出实现 diff,不 commit/push",
             "没有逐动作人工确认",
             "API/算力成本",
             "6 个 daemon 轮询 GitHub",
@@ -138,6 +144,10 @@ class RepositoryPublicDocsTests(unittest.TestCase):
         ):
             with self.subTest(readme_zh_risk=needle):
                 self.assertIn(needle, readme_zh)
+        self.assertNotIn("agent workers commit/push", readme)
+        self.assertNotIn("let agent workers commit/push", readme)
+        self.assertNotIn("agent worker commit/push", readme_zh)
+        self.assertNotIn("让 agent worker commit/push", readme_zh)
 
     def test_readme_links_downstream_walkthrough_once(self) -> None:
         readme = read(README)

--- a/skills/codex-refactor-loop/scripts/test_repository_public_docs.py
+++ b/skills/codex-refactor-loop/scripts/test_repository_public_docs.py
@@ -71,31 +71,100 @@ class RepositoryPublicDocsTests(unittest.TestCase):
         self.assertNotIn("INSTALL.md", read(README))
         self.assertEqual(1, read(README).count("SKILL.md#downstream-install-walkthrough"))
 
+    def test_readme_pair_introduces_consensus_engine_and_skills(self) -> None:
+        readme = read(README)
+        readme_zh = read(README_ZH)
+        for needle in (
+            "cross-platform Agent Skills publication repository",
+            "product identity is a **consensus engine**",
+            "biased independent solvers",
+            "meta-judge converges",
+            "implementation runs",
+            "independent reviewers",
+            "`codex-refactor-loop`",
+            "`sshx`",
+            "Claude Code, Codex, Cursor, and Gemini",
+            "host-provided `host.env` facts",
+        ):
+            with self.subTest(readme_needle=needle):
+                self.assertIn(needle, readme)
+        for needle in (
+            "跨平台 Agent Skills 发布仓库",
+            "产品身份是**共识引擎**",
+            "偏置独立的多角度 solver",
+            "meta-judge 收敛",
+            "随后实现",
+            "多 reviewer",
+            "`codex-refactor-loop`",
+            "`sshx`",
+            "Claude Code / Codex / Cursor / Gemini",
+            "host 通过 `host.env` 注入",
+        ):
+            with self.subTest(readme_zh_needle=needle):
+                self.assertIn(needle, readme_zh)
+
+    def test_readme_pair_has_prominent_risk_warning(self) -> None:
+        readme = read(README)
+        readme_zh = read(README_ZH)
+        self.assertIn("## Risks", readme)
+        self.assertIn("## ⚠️ 风险提示", readme_zh)
+        for needle in (
+            "Autonomous writes",
+            "without per-action human confirmation",
+            "API and compute cost",
+            "six GitHub-polling daemons",
+            "Automatic releases",
+            "RELEASE_AUTO_ENABLE=true",
+            "Bad published tags are abandoned",
+            "Host boundary",
+            "active-controller lease",
+            "Experimental scope",
+            "opt in",
+        ):
+            with self.subTest(readme_risk=needle):
+                self.assertIn(needle, readme)
+        for needle in (
+            "自治写操作",
+            "没有逐动作人工确认",
+            "API/算力成本",
+            "6 个 daemon 轮询 GitHub",
+            "自动发版",
+            "RELEASE_AUTO_ENABLE=true",
+            "坏版即弃",
+            "host 边界",
+            "active-controller lease",
+            "适用范围",
+            "opt in",
+        ):
+            with self.subTest(readme_zh_risk=needle):
+                self.assertIn(needle, readme_zh)
+
     def test_readme_links_downstream_walkthrough_once(self) -> None:
         readme = read(README)
         self.assertEqual(1, readme.count("./skills/codex-refactor-loop/SKILL.md#downstream-install-walkthrough"))
-        self.assertIn("Downstream Host Quickstart", readme)
+        self.assertEqual(0, read(README_ZH).count("SKILL.md#downstream-install-walkthrough"))
+        self.assertIn("Downstream Host Setup", readme)
         self.assertEqual(
             heading_order(readme),
             [
-                "## Positioning",
-                "## Core: Consensus-Building Engine",
-                "## Skills",
-                "## Repository Structure",
-                "## Install",
-                "## Generalization Roadmap",
+                "## What It Provides",
+                "## Core",
+                "## Risks",
+                "## Quick Start",
+                "## Architecture",
+                "## Roadmap",
                 "## License",
             ],
         )
         self.assertEqual(
             heading_order(read(README_ZH)),
             [
-                "## 定位",
-                "## 核心:共识构建引擎",
-                "## skills",
-                "## 仓库结构",
-                "## 安装",
-                "## 泛化路线",
+                "## 提供什么",
+                "## 核心",
+                "## ⚠️ 风险提示",
+                "## 快速开始",
+                "## 架构",
+                "## 路线",
                 "## License",
             ],
         )


### PR DESCRIPTION
## 摘要

仓库对外建设(#343):README 英文 canonical + 中文 companion + 语言策略窄 carve-out。

- **Old**:README 单一非英文默认,CLAUDE.md 文档分层称 README 为权威源;无英文-canonical + 中文 companion 双文件;语言策略未给 README pair carve-out。
- **New**:`README.md` 英文 canonical 公开身份文档 + `README.zh-CN.md` 中文 companion(双向交叉链接,大段对齐不逐句对等);CLAUDE.md 文档分层/根.md收口/语言 carve-out + SKILL.md 语言策略窄改 —— README pair 是唯一英文-canonical 公开文档 carve-out,GitHub issue/PR/commit/design artifact 等工作态仍中文默认。

## 范围

README.md(重写)· README.zh-CN.md(新增)· CLAUDE.md · SKILL.md(语言段窄改)· test_repository_public_docs.py(新增,5 behavior)。927 tests OK。不碰 .version-bump.json/runtime/host.env/marker/daemon/workflow。

按 design-consensus r4 共识(3/3 + meta-judge)落地。Closes #343

⟦AI:AUTO-LOOP⟧
