### PR TITLE
test(release):publisher reentry fail-closed 测试 (#341/#352 gap)

### DIFF
--- a/skills/codex-refactor-loop/scripts/test_release_publisher.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publisher.py
@@ -400,6 +400,25 @@ class ReleasePublisherTests(unittest.TestCase):
             self.assertFalse(any(command[:3] == ["gh", "release", "create"] for command in runner.commands))
             self.assertFalse((repo / ".refactor-loop/state/release-publish-result.json").exists())
 
+    def test_manifest_mismatch_without_target_version_manifests_fails_closed(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            set_mapped_version(repo, "2.0.0-beta.3")
+            runner = FakeRunner()
+            publisher = ReleasePublisher(
+                repo,
+                preflight=FakePreflight(manifest_mismatch_result(repo, version="2.0.0-beta.4")),
+                runner=runner,
+                now=lambda: NOW,
+            )
+
+            result = publisher.publish(target_ref="abc123")
+
+            self.assertFalse(result.published)
+            self.assertEqual(result.reasons, ("manifest_version_mismatch",))
+            self.assertEqual(runner.commands, [])
+            self.assertFalse((repo / ".refactor-loop/state/release-publish-result.json").exists())
+
     def test_target_version_manifests_without_release_head_subject_fail_closed(self) -> None:
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"


### PR DESCRIPTION
## 摘要

补 #341 publisher 两阶段幂等的 **reentry classifier fail-closed 分支** behavior 测试 —— #352 rollup 的 tests reviewer 指出该 net-new 分支无测试覆盖(rollup 闸正确拦在 dev 前)。

- 仅改 `skills/codex-refactor-loop/scripts/test_release_publisher.py`(+19 行,纯测试)。
- 断言 reentry 证据不一致时的 fail-closed 行为。931 tests OK。

#341 的窄 follow-up 测试补全,使 ard→dev rollup 可通过 tests review。base=auto-refact-dev。

⟦AI:AUTO-LOOP⟧
