### PR TITLE
test(release):publisher reentry mixed-denial fail-closed 测试 (#341)

### DIFF
--- a/skills/codex-refactor-loop/scripts/test_release_publisher.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publisher.py
@@ -155,6 +155,21 @@ def manifest_mismatch_result(repo: Path, version: str = "2.0.0-beta.4") -> Publi
     )
 
 
+def mixed_manifest_mismatch_result(repo: Path, version: str = "2.0.0-beta.4") -> PublishPreflightResult:
+    result = allowed_result(repo, version=version)
+    return PublishPreflightResult(
+        allowed=False,
+        reasons=("manifest_version_mismatch", "host_opt_in_not_true"),
+        candidate=result.candidate,
+        decision=result.decision,
+        candidate_path=result.candidate_path,
+        decision_path=result.decision_path,
+        target_ref=result.target_ref,
+        version=result.version,
+        candidate_digest=result.candidate_digest,
+    )
+
+
 def set_mapped_version(repo: Path, version: str) -> None:
     mapping = read_json(repo / ".version-bump.json")
     assert isinstance(mapping, dict)
@@ -357,6 +372,26 @@ class ReleasePublisherTests(unittest.TestCase):
             self.assertIsInstance(payload, dict)
             assert isinstance(payload, dict)
             self.assertEqual(payload["target_ref"], "bumpcommit456")
+
+    def test_already_bumped_reentry_denies_mixed_manifest_mismatch_reasons_without_commands(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            set_mapped_version(repo, "2.0.0-beta.4")
+            runner = FakeRunner()
+            runner.head_subject = "Release v2.0.0-beta.4"
+            publisher = ReleasePublisher(
+                repo,
+                preflight=FakePreflight(mixed_manifest_mismatch_result(repo)),
+                runner=runner,
+                now=lambda: NOW,
+            )
+
+            result = publisher.publish(target_ref="abc123")
+
+            self.assertFalse(result.published)
+            self.assertEqual(result.reasons, ("manifest_version_mismatch", "host_opt_in_not_true"))
+            self.assertEqual(runner.commands, [])
+            self.assertFalse((repo / ".refactor-loop/state/release-publish-result.json").exists())
 
     def test_already_bumped_reentry_pending_fails_closed_without_result_and_can_retry_green(self) -> None:
         with copy_repo_fixture() as tmp:


### PR DESCRIPTION
## 摘要

补 #341 publisher 两阶段幂等 **reentry guard 的 mixed-denial fail-closed 测试**。

#355 rollup tests reviewer reject 指出:`publisher.py` reentry guard 用 `result.reasons == ("manifest_version_mismatch",)` 精确 tuple 相等判定是否允许 already-bumped reentry,但无测试覆盖 **mixed-denial** 案例(reasons 含 `manifest_version_mismatch` + 另一原因如 `host_opt_in_not_true`)。若 guard 退化成 membership-check(`in`),会在有额外 preflight denial 时仍放行 already-bumped 发布,而当前测试抓不到。

本 PR 补 behavior 测试:already-bumped 前置 + multi-reason denied preflight → `published=False`、保留完整 reasons tuple、不跑 git show/push/check/release、不写 release result artifact。release 安全关键。

## 范围

`test_release_publisher.py` +35 行(纯新增测试,不改 production)。

⟦AI:AUTO-LOOP⟧
