### PR TITLE
#357: Downstream walkthrough guided setup 小节

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -183,6 +183,19 @@ export CONSENSUS_RND_HOST_ENV=.config/consensus-rnd/host.env
 
 Fill the host-owned `host.env` according to the Host env surface matrix: required values must be set, defaulted values may keep their template defaults, optional/noop values may stay empty, and conditional fail-closed surfaces such as `MAINTAINER_WHITELIST` are required only when their surface is enabled. The optional `HOST_*` language-policy variables are empty by default and may stay empty unless the host has explicit policy text to inject. Legacy `.refactor-loop/host.env` remains a compatibility read fallback only.
 
+### Guided GitHub consensus workflow setup
+
+When a host user asks for guided setup, do not add a renderer, CLI command, setup skill, installer, template directory, or root install document. Follow this walkthrough and write advisory artifacts by hand under `.refactor-loop/runs/github-workflow-setup/<timestamp>/`:
+
+- `host-env.patch.md`: derive a suggested host-owned `.config/consensus-rnd/host.env` patch from the Host env surface matrix and `host.env.example`; `.refactor-loop/host.env` remains only a legacy/runtime read fallback.
+- `labels-plan.json`: derive the label plan from `scripts/codex_refactor_loop/labels.py`; do not run `gh label create`, `gh label edit`, or `gh label delete`.
+- `scheduler.md`: point at the existing cron/launchd `consensus-rnd-cli restart-daemons` examples below; do not install a scheduler.
+- `statusline.json`: point at the existing read-only `consensus-rnd-cli statusline`; do not write Claude Code settings.
+- `host-workflow-spec.json`: optional data-only `HOST_WORKFLOW_SPEC` draft when the host needs workflow invariants; use the existing `workflow_spec.py` / `WorkflowInvariantValidator` contract, `host:` namespace entries, repo-relative paths, and no command, git, label, merge, or lifecycle fields.
+- `walkthrough.md`: summarize what the host still needs to review and apply.
+
+Do not produce `summary.json` or `host-workflow-spec.example.json`. These artifacts are advisory only: they must not modify host `.git`, `.github`, CI, policy, branch protection, GitHub labels, issues, PRs, commits, pushes, merges, closes, tags, releases, installers, settings, or any lifecycle surface.
+
 ### Keep existing daemons alive
 
 Install exactly one user-level scheduler. The command must `source "${CONSENSUS_RND_HOST_ENV:-.refactor-loop/host.env}"` before it execs the checked-in helper; this preserves values with spaces and keeps all loop runtime facts in the host env file.

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -275,6 +275,66 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             walkthrough,
         )
 
+    def test_guided_github_consensus_workflow_setup_is_artifact_only(self) -> None:
+        walkthrough = section_after_anchor(self.skill, "downstream-install-walkthrough")
+        self.assertIn("This walkthrough is the only downstream install runbook", walkthrough)
+        self.assertIn("### Guided GitHub consensus workflow setup", walkthrough)
+        for needle in (
+            ".refactor-loop/runs/github-workflow-setup/<timestamp>/",
+            "host-env.patch.md",
+            "labels-plan.json",
+            "scheduler.md",
+            "statusline.json",
+            "host-workflow-spec.json",
+            "walkthrough.md",
+            "Host env surface matrix",
+            "host.env.example",
+            "scripts/codex_refactor_loop/labels.py",
+            "consensus-rnd-cli restart-daemons",
+            "consensus-rnd-cli statusline",
+            "workflow_spec.py",
+            "WorkflowInvariantValidator",
+            "`host:` namespace",
+            "repo-relative paths",
+            "advisory only",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, walkthrough)
+
+        for forbidden in (
+            "summary.json",
+            "host-workflow-spec.example.json",
+            "renderer",
+            "CLI command",
+            "setup skill",
+            "installer",
+            "template directory",
+            "root install document",
+            "host `.git`",
+            "`.github`",
+            "CI",
+            "policy",
+            "branch protection",
+            "GitHub labels",
+            "issues",
+            "PRs",
+            "commits",
+            "pushes",
+            "merges",
+            "closes",
+            "tags",
+            "releases",
+            "settings",
+            "lifecycle surface",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertIn(forbidden, walkthrough)
+
+        self.assertNotIn("GuidedWorkflowSetupBundle", self.skill)
+        self.assertFalse((REPO_ROOT / "skills" / "github-workflow-setup").exists())
+        self.assertFalse((SKILL_ROOT / "scripts" / "codex_refactor_loop" / "setup.py").exists())
+        self.assertEqual(0, len(list((SKILL_ROOT / "scripts" / "codex_refactor_loop").glob("*setup*"))))
+
     def test_skill_documents_update_check_notify_only_contract(self) -> None:
         section = section_after_heading(self.skill, "Notify-only update check(per #231)")
         for needle in (


### PR DESCRIPTION
## 摘要

#357 design-consensus r3 共识(delete):**首版不新增独立 renderer/CLI/skill**,仅在 codex-refactor-loop 唯一 Downstream install walkthrough 内新增 guided setup 小节(帮 host 用户配置 GitHub 共识工作流模版/host.env/labels),并补 source-regression test 锁住该小节。

- **Old**:无引导式配置入口,host 用户手动拼 host.env/labels。
- **New**:walkthrough 内 guided setup 小节给出分步配置引导;不引入新文件/CLI/skill(最小面)。

## 范围

2 files (+73):SKILL.md downstream-install-walkthrough 段 + test_skill_reference_anchors.py source-regression。

Closes #357

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
