### PR TITLE
#344: 发版目标 issue 默认进入版本倒计时

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -420,6 +420,7 @@ Every `/loop`, task notification, ScheduleWakeup resume, or daemon pending-event
 - **Allowed git topology observation(issue #190 only)**: `git fetch origin --quiet`, `git -C <repo-root> worktree list --porcelain`, `git -C <worktree> rev-parse --verify HEAD`, `git -C <worktree> rev-parse --verify refs/remotes/origin/<head>`, and `git -C <worktree> rev-list --count refs/remotes/origin/<head>..HEAD`, solely for committed-but-unpushed worker output detection on open auto-loop PR heads. Committed `FIX_DONE` / `IMPLEMENT_DONE` output is not reviewer/CI visible until `origin/<head>` contains it; ahead local output emits actionable `UNPUSHED_WORKER_OUTPUT:<pr>:<n>`.
 - **Forbidden / no lifecycle authority**: no restart, no spawn, no git lifecycle or mutation commands, no checkout/switch, no branch create/delete/update, no worktree add/remove/prune, no commit, no push, no reset, no rebase, no merge, no label mutation, no issue/PR create-close-edit, no tag/release, and no GitHub lifecycle mutation.
 - **Hard-gate**: computes canonical `actual`, `target=max(CODEX_FLOOR, expected_from_active_tasks)`, `deficit=max(0,target-actual)`, and when `deficit>0` emits `HARD_GATE:dispatch_required=N` plus structured `hard_gate`; this is not advisory and requires dispatching enough ordered actionable tasks or legal audit fallback before ending the wakeup. There is no general low-floor exemption, and `AUDIT_DONE:none:0` still does not exempt the floor. The only single active audit boundary is when no actionable open work and no queue candidate exists, expected is 0, and the same-iteration `audit-iter-N` is already active; then the plan emits `WAIT:single-active-audit`, `dispatch_required=0`, `reason=single_active_audit_in_flight`, and `blocked_deficit=N` instead of duplicating the same audit; no duplicate same-iteration audit.
+- **Release countdown**: `crnd:milestone:release-target` may add a `release-countdown` status action sourced from release-gate scoring; release-countdown status is status-only and not dispatchable.
 - Output priority order mirrors the controller checklist: bootstrap or missing wake source, maintainer comment, unpushed worker output, completed `EXIT=0` marker, CI red, no-gap violation, `crnd:milestone:current` open issue/PR, ordinary open existing issue/PR, then producer or audit fixed-point recommendation.
 - If no actionable open work exists, it emits `RECOMMEND:audit`; ordinary audit is the floor fallback only when no same-iteration audit is already active.
 
@@ -589,6 +590,10 @@ Authorization: `skills/codex-refactor-loop/authorizations/runtime-exceptions.md#
 
 GitHub label `crnd:milestone:current` marks issue/PRs related to the current period's main task. It is orthogonal third axis beside phase labels and human labels: it changes dispatch priority, not phase semantics, human escalation semantics, marker semantics, or label exclusivity for those axes. Legacy milestone labels are migration aliases only and must be normalized through `codex_refactor_loop.labels`.
 
+GitHub label `crnd:milestone:release-target` marks open catalog-managed issue/PRs whose existence should surface release countdown status. It is a non-exclusive milestone fact and may coexist with `crnd:milestone:current`; `crnd:milestone:current` remains dispatch priority only and must not trigger release countdown by itself.
+
+Release countdown is wakeup-plan-only and read-only. `consensus-rnd-cli wakeup-plan` may append a status-only, non-dispatchable `release-countdown` action only when an open actionable managed issue/PR has `crnd:milestone:release-target`. Its fields come from the release-gate scoring source, `.version-bump.json`, and the existing release commits projection: `targets`, `from_version`, `to_version`, `stability_score`, `ready`, `red_signals`, `blocked_reasons`, `no_lifecycle_authority`, and `source: "release-gate"`. It must not create a daemon, write state, update statusline, update peek, create a top-level duplicate object, write a release decision, mutate labels, tag, publish a release, or add lifecycle authority.
+
 Milestone active means at least one open catalog-managed issue/PR carries `crnd:milestone:current`. Before any non-milestone existing-issue work or ordinary audit fallback, controller MUST first dispatch the next-step actor for milestone-labeled issue/PRs that lack in-flight codex coverage for their current phase label. Non-milestone design/audit work is downgraded while milestone is active; do not kill already-running non-milestone codexes solely because milestone became active.
 
 Only these actions stay above milestone priority: bootstrap failure / missing wake source, maintainer comment, completed marker same-wakeup route, CI red, and no-gap violation. Correctness still wins: no-gap violation means an active item has no required worker and must be repaired before discretionary prioritization.
@@ -656,6 +661,11 @@ exactly-one phase/human, then remove aliases. Workers and daemons must not
 mutate labels except the #238 `closed-label-reconciler`, which may mutate only
 CLOSED `crnd:lifecycle:managed` item phase/cleanup/stuck labels into exactly
 one terminal phase, `crnd:phase:merged` or `crnd:phase:closed`.
+
+Label exclusivity is per `LabelSpec.exclusive_axis`, not per group. Phase and
+human labels remain exactly-one axes; non-exclusive catalog labels such as
+`crnd:milestone:current` and `crnd:milestone:release-target` may coexist when
+`LabelSpec.exclusive_axis is None`.
 
 ## `crnd:human:maintainer-decision` 严格语义(强制) <a id="human-label-strict-semantics"></a>
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/labels.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/labels.py
@@ -157,6 +157,7 @@ LABEL_SPECS: tuple[LabelSpec, ...] = (
     _spec("triage", "pending", "External issue is pending manual intake triage.", "fbca04", aliases=("auto-loop-triage",)),
     _spec("triage", "resume-requested", "Maintainer requested resumed implementation.", "1d76db", aliases=("auto-loop-resume",)),
     _spec("milestone", "current", "Milestone-priority item.", "f9d0c4", aliases=("🎯 milestone",)),
+    _spec("milestone", "release-target", "Release countdown target issue/PR.", "f9d0c4"),
 )
 
 CLEANUP_ONLY_ALIASES = frozenset({"🆘 human:卡死", "🆘 human:卡死-需-rework"})
@@ -187,6 +188,7 @@ NO_FRAMING = canonical_name("lifecycle", "no-framing")
 TRIAGE_PENDING = canonical_name("triage", "pending")
 TRIAGE_RESUME_REQUESTED = canonical_name("triage", "resume-requested")
 MILESTONE_CURRENT = canonical_name("milestone", "current")
+MILESTONE_RELEASE_TARGET = canonical_name("milestone", "release-target")
 HUMAN_AUTO = canonical_name("human", "auto")
 HUMAN_MAINTAINER_DECISION = canonical_name("human", "maintainer-decision")
 PHASE_DESIGN_SOLVING = canonical_name("phase", "design-solving")

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -41,6 +41,7 @@ from typing import Any
 from codex_refactor_loop import labels as label_catalog
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.pr_checks import PrChecksProjection
+from codex_refactor_loop.release.gate import decide_release_artifact
 from codex_refactor_loop.restart import restart_managed_daemon_names
 from codex_refactor_loop.transition_assessment import TransitionAssessmentReader, transition_rank_key
 from codex_refactor_loop.work_items import ManagedWorkProjection, open_actionable_managed_items
@@ -896,6 +897,46 @@ def existing_issue_actions(items: list[GhItem], repo_root: Path | None = None) -
     return actions
 
 
+def release_countdown_actions(repo_root: Path, items: list[GhItem], scorer: Any | None = None) -> list[dict[str, Any]]:
+    targets = []
+    for item in open_actionable_managed_items(_projection_items(items)):
+        projection = label_catalog.normalize_label_set(item.labels)
+        if label_catalog.MILESTONE_RELEASE_TARGET not in projection.canonical:
+            continue
+        targets.append(
+            {
+                "kind": "PR" if item.kind == "pr" else item.kind,
+                "number": item.number,
+                "item": f"{'PR' if item.kind == 'pr' else item.kind} #{item.number}",
+                "title": item.title,
+            }
+        )
+    if not targets:
+        return []
+
+    score = (scorer or decide_release_artifact)(repo_root)
+    signals = score.get("signals") if isinstance(score.get("signals"), dict) else {}
+    red_signals = [name for name, signal in signals.items() if isinstance(signal, dict) and not signal.get("passed")]
+    blocked = score.get("blocked_reasons")
+    blocked_reasons = [str(reason) for reason in blocked] if isinstance(blocked, list) else red_signals
+    return [
+        {
+            "priority": 7,
+            "kind": "release-countdown",
+            "status_only": True,
+            "no_lifecycle_authority": True,
+            "targets": targets,
+            "from_version": score.get("from_version"),
+            "to_version": score.get("to_version"),
+            "stability_score": score.get("stability_score"),
+            "ready": bool(score.get("ready")),
+            "red_signals": red_signals,
+            "blocked_reasons": blocked_reasons,
+            "source": "release-gate",
+        }
+    ]
+
+
 def has_dispatchable_action(actions: list[dict[str, Any]]) -> bool:
     dispatchable = {
         "maintainer-comment",
@@ -1043,6 +1084,7 @@ def build_plan(repo_root: Path) -> dict[str, Any]:
         )
     else:
         actions.extend(host_actions)
+    actions.extend(release_countdown_actions(repo_root, gh_items))
     actions.extend(existing_issue_actions(gh_items, repo_root))
     actions.sort(key=lambda action: action["priority"])
     restore_hard_gate_for_dispatchable_actions(concurrency, actions)

--- a/skills/codex-refactor-loop/scripts/test_label_contract_source.py
+++ b/skills/codex-refactor-loop/scripts/test_label_contract_source.py
@@ -102,6 +102,24 @@ class LabelContractSourceTests(unittest.TestCase):
         self.assertIn("Closed terminal protocol state", source)
         self.assertEqual(labels.PHASE_CLOSED, "crnd:phase:closed")
 
+    def test_release_target_label_contract_stays_in_milestone_catalog(self) -> None:
+        skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        labels_source = (SCRIPT_DIR / "codex_refactor_loop" / "labels.py").read_text(encoding="utf-8")
+        wakeup_source = (SCRIPT_DIR / "codex_refactor_loop" / "wakeup_plan.py").read_text(encoding="utf-8")
+        combined = "\n".join((skill, labels_source, wakeup_source))
+
+        self.assertEqual(labels.MILESTONE_RELEASE_TARGET, "crnd:milestone:release-target")
+        self.assertIn('_spec("milestone", "release-target", "Release countdown target issue/PR.", "f9d0c4")', labels_source)
+        self.assertIn('MILESTONE_RELEASE_TARGET = canonical_name("milestone", "release-target")', labels_source)
+        self.assertIn("crnd:milestone:release-target", skill)
+        self.assertIn("crnd:milestone:current` remains dispatch priority only and must not trigger release countdown by itself", skill)
+        self.assertIn("Label exclusivity is per `LabelSpec.exclusive_axis`, not per group", skill)
+        self.assertNotIn("crnd:release-target", combined)
+        self.assertNotIn('"release"', labels_source)
+        self.assertNotIn("release-countdown.json", combined)
+        self.assertIn("label_catalog.MILESTONE_RELEASE_TARGET", wakeup_source)
+        self.assertNotIn("label_catalog.MILESTONE_CURRENT in projection.canonical", wakeup_source)
+
     def test_runtime_code_has_no_legacy_routing_literals_outside_catalog(self) -> None:
         allow = {
             SCRIPT_DIR / "codex_refactor_loop" / "labels.py",

--- a/skills/codex-refactor-loop/scripts/test_label_taxonomy.py
+++ b/skills/codex-refactor-loop/scripts/test_label_taxonomy.py
@@ -38,10 +38,24 @@ class LabelTaxonomyTests(unittest.TestCase):
         self.assertEqual(labels.canonical_name("phase", "design-solving"), labels.PHASE_DESIGN_SOLVING)
         self.assertIn(labels.HUMAN_AUTO, labels.labels_for_group("human"))
         self.assertIn(labels.PHASE_CLOSED, labels.labels_for_group("phase"))
+        self.assertEqual(labels.MILESTONE_RELEASE_TARGET, "crnd:milestone:release-target")
+        self.assertIn(labels.MILESTONE_RELEASE_TARGET, labels.labels_for_group("milestone"))
         labels.PHASE_CLOSED.encode("ascii")
         self.assertEqual(labels.phase_expected_workers(labels.PHASE_FIXING), 1)
         self.assertEqual(labels.actor_for_phase(labels.PHASE_REVIEWING), "reviewer-codex")
         self.assertEqual(labels.actor_for_phase(labels.PHASE_CLOSED), "closed-label-reconciler")
+
+    def test_release_target_uses_existing_milestone_grammar_without_groupless_exception(self) -> None:
+        self.assertEqual(labels.LABEL_GROUPS, ("phase", "human", "lifecycle", "triage", "milestone"))
+        self.assertRegex(labels.MILESTONE_RELEASE_TARGET, labels.CANONICAL_RE)
+        self.assertIsNone(re.fullmatch(labels.CANONICAL_RE, "crnd:release-target"))
+
+        projection = labels.normalize_label_set([labels.MILESTONE_CURRENT, labels.MILESTONE_RELEASE_TARGET])
+
+        self.assertEqual(
+            projection.canonical,
+            frozenset({labels.MILESTONE_CURRENT, labels.MILESTONE_RELEASE_TARGET}),
+        )
 
     def test_managed_query_labels_include_canonical_and_legacy_aliases(self) -> None:
         self.assertEqual(

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -196,6 +196,49 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             with self.subTest(needle=needle):
                 self.assertIn(needle, phase9)
 
+    def test_release_countdown_contract_is_wakeup_plan_only_status_projection(self) -> None:
+        milestone = section_after_heading(self.skill, "Milestone priority(强制)")
+        wakeup = section_after_heading(self.skill, "Wakeup Skeleton")
+
+        for needle in (
+            "crnd:milestone:release-target",
+            "release countdown status",
+            "non-exclusive milestone fact",
+            "crnd:milestone:current` remains dispatch priority only and must not trigger release countdown by itself",
+            "wakeup-plan-only and read-only",
+            "status-only, non-dispatchable `release-countdown` action",
+            "release-gate scoring source",
+            ".version-bump.json",
+            "existing release commits projection",
+            "no_lifecycle_authority",
+            "targets",
+            "from_version",
+            "to_version",
+            "stability_score",
+            "ready",
+            "red_signals",
+            "blocked_reasons",
+            'source: "release-gate"',
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, milestone)
+        for forbidden in (
+            "create a daemon",
+            "write state",
+            "update statusline",
+            "update peek",
+            "create a top-level duplicate object",
+            "write a release decision",
+            "mutate labels",
+            "tag",
+            "publish a release",
+            "add lifecycle authority",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertIn(forbidden, milestone)
+        self.assertIn("release-countdown status is status-only", wakeup)
+        self.assertIn("not dispatchable", wakeup)
+
     def test_skill_documents_transition_assessment_sidecar_boundary(self) -> None:
         work_unit = section_after_anchor(self.skill, "work-unit-contract")
         producers = section_after_heading(self.skill, "Producers")

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -22,7 +22,13 @@ sys.path.insert(0, str(SKILL_ROOT / "scripts"))
 from codex_refactor_loop import labels as label_catalog  # noqa: E402
 from codex_refactor_loop.restart import restart_managed_daemon_names  # noqa: E402
 from codex_refactor_loop.workflow_stages import assert_stage_slug  # noqa: E402
-from codex_refactor_loop.wakeup_plan import resolve_repo_root  # noqa: E402
+from codex_refactor_loop.wakeup_plan import (  # noqa: E402
+    GhItem,
+    existing_issue_actions,
+    has_dispatchable_action,
+    release_countdown_actions,
+    resolve_repo_root,
+)
 
 
 class WakeupPlanBehaviorTests(unittest.TestCase):
@@ -669,6 +675,101 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(actions[1]["item"], "PR #30")
         self.assertTrue(actions[0]["milestone"])
         self.assertFalse(actions[-1]["milestone"])
+
+    def test_release_countdown_ignores_absent_or_current_only_milestone_labels(self) -> None:
+        def scorer(_: Path) -> dict:
+            raise AssertionError("release scorer should not run without crnd:milestone:release-target")
+
+        no_target = [
+            GhItem("issue", 10, "ordinary", (label_catalog.MANAGED, label_catalog.PHASE_IMPLEMENTING, label_catalog.HUMAN_AUTO)),
+            GhItem("issue", 20, "current", (label_catalog.MANAGED, label_catalog.PHASE_IMPLEMENTING, label_catalog.HUMAN_AUTO, label_catalog.MILESTONE_CURRENT)),
+        ]
+
+        self.assertEqual(release_countdown_actions(self.repo, no_target, scorer=scorer), [])
+
+    def test_release_countdown_projects_release_gate_score_without_dispatch_authority(self) -> None:
+        calls: list[Path] = []
+
+        def scorer(repo_root: Path) -> dict:
+            calls.append(repo_root)
+            return {
+                "from_version": "1.2.3-beta.4",
+                "to_version": "1.2.3-beta.5",
+                "stability_score": 75,
+                "ready": False,
+                "signals": {
+                    "required_checks_recent_green": {"passed": False, "reason": "pending_required_checks"},
+                    "fresh_heartbeats": {"passed": True},
+                },
+                "blocked_reasons": ["required_checks_recent_green", "min_interval"],
+            }
+
+        items = [
+            GhItem(
+                "issue",
+                344,
+                "release target",
+                (
+                    label_catalog.MANAGED,
+                    label_catalog.PHASE_IMPLEMENTING,
+                    label_catalog.HUMAN_AUTO,
+                    label_catalog.MILESTONE_CURRENT,
+                    label_catalog.MILESTONE_RELEASE_TARGET,
+                ),
+            ),
+            GhItem("PR", 345, "ordinary PR", (label_catalog.MANAGED, label_catalog.PHASE_REVIEWING, label_catalog.HUMAN_AUTO)),
+        ]
+
+        actions = release_countdown_actions(self.repo, items, scorer=scorer)
+
+        self.assertEqual(calls, [self.repo])
+        self.assertEqual(len(actions), 1)
+        action = actions[0]
+        self.assertEqual(action["kind"], "release-countdown")
+        self.assertTrue(action["status_only"])
+        self.assertTrue(action["no_lifecycle_authority"])
+        self.assertEqual(action["source"], "release-gate")
+        self.assertEqual(action["targets"], [{"kind": "issue", "number": 344, "item": "issue #344", "title": "release target"}])
+        self.assertEqual(action["from_version"], "1.2.3-beta.4")
+        self.assertEqual(action["to_version"], "1.2.3-beta.5")
+        self.assertEqual(action["stability_score"], 75)
+        self.assertFalse(action["ready"])
+        self.assertEqual(action["red_signals"], ["required_checks_recent_green"])
+        self.assertEqual(action["blocked_reasons"], ["required_checks_recent_green", "min_interval"])
+        self.assertFalse(has_dispatchable_action(actions))
+
+    def test_release_countdown_status_does_not_change_existing_issue_order(self) -> None:
+        def scorer(_: Path) -> dict:
+            return {
+                "from_version": "1.2.3-beta.4",
+                "to_version": "1.2.3-beta.4",
+                "stability_score": 100,
+                "ready": False,
+                "signals": {},
+                "blocked_reasons": ["no_commits_since_last_release"],
+            }
+
+        items = [
+            GhItem(
+                "issue",
+                20,
+                "current release target",
+                (
+                    label_catalog.MANAGED,
+                    label_catalog.PHASE_DESIGN_SOLVING,
+                    label_catalog.HUMAN_AUTO,
+                    label_catalog.MILESTONE_CURRENT,
+                    label_catalog.MILESTONE_RELEASE_TARGET,
+                ),
+            ),
+            GhItem("issue", 10, "ordinary", (label_catalog.MANAGED, label_catalog.PHASE_FIXING, label_catalog.HUMAN_AUTO)),
+        ]
+
+        combined = release_countdown_actions(self.repo, items, scorer=scorer) + existing_issue_actions(items, self.repo)
+        combined.sort(key=lambda action: action["priority"])
+
+        existing = [action for action in combined if action["kind"] == "existing-issue"]
+        self.assertEqual([action["item"] for action in existing], ["issue #20", "issue #10"])
 
     def test_existing_issue_routes_before_audit_fallback(self) -> None:
         plan = self.run_plan(fixture="existing")


### PR DESCRIPTION
## 摘要

#344 发版目标 issue 存在时默认进入版本倒计时状态。按 design-consensus r4 minimal 共识。

- **Old**:发版倒计时无机械标识,controller 靠记忆报。
- **New**:`crnd:milestone:release-target` label 标识发版目标 issue;release-gate / wakeup-plan 据此投影倒计时状态(机械事实源,非记忆)。

## 范围

7 files:SKILL.md(milestone 段)+ labels.py(catalog 加 release-target)+ wakeup_plan.py(倒计时投影)+ 配套 source-regression / label-taxonomy test。

Closes #344

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
