### PR TITLE
#364: Path-A divergent-source contract-only locator

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -2301,7 +2301,15 @@ Policy: all three solver outputs are mandatory, and all implementation-bearing p
 
 ### Solver source contract
 
+<!--
+Refactor (iter364/issue364):
+  Old pattern: Path-A solvers dispatched with --cd $REPO_ROOT (integration checkout) can't see work-unit source when the issue references files on a divergent non-integration branch, emitting spurious no-plan and wasting rounds.
+  New principle: Contract-only source locator: SKILL solver source contract + 3 solver prompts document a read-only source-locator recipe (git show <ref>:<path> / raw URL / gh api / host.env), classify missing/invalid locator as source-location-missing-or-invalid; NO new projection/parser/header/module.
+-->
+
 Solver scope comes from the prompt header `WORK_UNIT_SOURCE_REF`, the work-unit `source_ref`, or a local source artifact explicitly pointed to by either field. For issue-driven / Path A work, `WORK_UNIT_PRODUCER=manual-issue (prompt-only provenance)` and `WORK_UNIT_SOURCE_REF=gh-issue-<N>` mean `gh issue view <N>` issue body/comments are the scope source. If an issue body or source_ref points to an existing audit artifact, solvers may read and verify that artifact; otherwise missing audit artifacts are valid for issue-driven work and must not be fabricated. For Path A greenfield identity, absence of existing local code to delete is neutral evidence for the delete solver and is compatible with `SOLVER_DONE:delete:abstain:<reason>` when deletion/collapse is not justified.
+
+For Path A issue body/comments that cite files absent from the current checkout, solvers must not directly emit a generic `no-plan`. The issue body/comments may carry a read-only source locator: `git show <ref>:<path>` for a named ref/path, a raw URL, `gh api` for a GitHub object, or a host-provided path from `.refactor-loop/host.env`. Use the locator only to read the cited source; do not fetch, checkout, switch, merge, rebase, reset, create a source worktree, or add a source directory. If the locator is missing or invalid and the current checkout cannot verify the cited source, classify the no-plan reason precisely as `source-location-missing-or-invalid`.
 
 Audit-backed sources require verification of the audit `evidence:` file:line. Issue-driven sources require verification of the cited files, symbols, problem statement, or repo rules present in the issue body/comments. A missing audit `evidence:` block is not by itself a defect for manual issues. The router renders the same producer/source-ref provenance into meta-judge prompts so the judge can recognize Path A greenfield framing instead of treating delete-solver abstain as a failed deletion proof.
 

--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -19,12 +19,19 @@ You explicitly resist adding code. If after honest evaluation the feature must s
 
 ## Inputs
 
+<!--
+Refactor (iter364/issue364):
+  Old pattern: Path-A solvers dispatched with --cd $REPO_ROOT (integration checkout) can't see work-unit source when the issue references files on a divergent non-integration branch, emitting spurious no-plan and wasting rounds.
+  New principle: Contract-only source locator: SKILL solver source contract + 3 solver prompts document a read-only source-locator recipe (git show <ref>:<path> / raw URL / gh api / host.env), classify missing/invalid locator as source-location-missing-or-invalid; NO new projection/parser/header/module.
+-->
+
 1. `gh issue view ${ISSUE_NUMBER}` — full body + comments.
 2. Work-unit scope source, by precedence:
    - Read the prompt header `WORK_UNIT_SOURCE_REF` / `source_ref` first.
    - Use only the router-injected validated transition projection lines (`TRANSITION_TYPE`, `TRANSITION_CONFIDENCE`, `TRANSITION_EVIDENCE_REFS`) for transition assessment context. Missing, malformed, or untrusted sidecars are projected as `unknown` with confidence `0`; the sidecar is not approval, not a consensus substitute, and cannot override the meta-judge truth table. `positive-discovery` is valid only with classifier-surface delta and `net_positive_signal=true`.
    - If it points to an existing local artifact or audit section, read that source and verify it.
    - If it is `gh-issue-<N>` or a referenced local artifact is missing, treat the GitHub issue body/comments from `gh issue view ${ISSUE_NUMBER}` as the scope spec.
+   - If issue body/comments cite files absent from the current checkout, look for a read-only source locator in that source: `git show <ref>:<path>`, raw URL, `gh api`, or a host-provided path from `.refactor-loop/host.env`. Use it only to read source; must not fetch/checkout/switch/merge/rebase/reset; must not create source worktree/add-dir. If the locator is missing or invalid and the current checkout cannot verify the cited source, emit `SOLVER_DONE:delete:escalate:no-plan:source-location-missing-or-invalid` instead of a generic no-plan.
    - `audit-iter-${ITERATION}.md if present` is an audit-backed source only when the current `WORK_UNIT_SOURCE_REF` / `source_ref` points to it; do not fabricate audit artifacts.
    - For issue-driven / Path A greenfield work, `WORK_UNIT_PRODUCER=manual-issue (prompt-only provenance)` with `WORK_UNIT_SOURCE_REF=gh-issue-<N>` means absence of existing local code to delete is neutral evidence: classify as genuinely needed/no current deletion dependency and abstain when deletion/collapse is not justified.
 3. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` "删除优先" clause; "Deletion-first" principle. `$REPO_ROOT/AGENTS.md` is supporting input when present.

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -8,12 +8,19 @@ Your bias: **smallest viable change** that resolves the audit's flagged violatio
 
 ## Inputs
 
+<!--
+Refactor (iter364/issue364):
+  Old pattern: Path-A solvers dispatched with --cd $REPO_ROOT (integration checkout) can't see work-unit source when the issue references files on a divergent non-integration branch, emitting spurious no-plan and wasting rounds.
+  New principle: Contract-only source locator: SKILL solver source contract + 3 solver prompts document a read-only source-locator recipe (git show <ref>:<path> / raw URL / gh api / host.env), classify missing/invalid locator as source-location-missing-or-invalid; NO new projection/parser/header/module.
+-->
+
 1. `gh issue view ${ISSUE_NUMBER}` — full body + comments (skip controller `## 🤖` markers).
 2. Work-unit scope source, by precedence:
    - Read the prompt header `WORK_UNIT_SOURCE_REF` / `source_ref` first.
    - Use only the router-injected validated transition projection lines (`TRANSITION_TYPE`, `TRANSITION_CONFIDENCE`, `TRANSITION_EVIDENCE_REFS`) for transition assessment context. Missing, malformed, or untrusted sidecars are projected as `unknown` with confidence `0`; the sidecar is not approval, not a consensus substitute, and cannot override the meta-judge truth table. `positive-discovery` is valid only with classifier-surface delta and `net_positive_signal=true`.
    - If it points to an existing local artifact or audit section, read that source and verify it.
    - If it is `gh-issue-<N>` or a referenced local artifact is missing, treat the GitHub issue body/comments from `gh issue view ${ISSUE_NUMBER}` as the scope spec.
+   - If issue body/comments cite files absent from the current checkout, look for a read-only source locator in that source: `git show <ref>:<path>`, raw URL, `gh api`, or a host-provided path from `.refactor-loop/host.env`. Use it only to read source; must not fetch/checkout/switch/merge/rebase/reset; must not create source worktree/add-dir. If the locator is missing or invalid and the current checkout cannot verify the cited source, emit `SOLVER_DONE:minimal:escalate:no-plan:source-location-missing-or-invalid` instead of a generic no-plan.
    - `audit-iter-${ITERATION}.md if present` is an audit-backed source only when the current `WORK_UNIT_SOURCE_REF` / `source_ref` points to it; do not fabricate audit artifacts.
 3. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` — primary rules that frame the violation; `$REPO_ROOT/AGENTS.md` — supporting rules when present.
 4. The actual source files cited by the current work-unit source (issue body/comments, local artifact, audit evidence, or repo rules). Open them; do NOT trust line numbers without verifying.

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -8,12 +8,19 @@ Your bias: **CLAUDE-philosophy-aligned, structurally clean**. You accept higher 
 
 ## Inputs
 
+<!--
+Refactor (iter364/issue364):
+  Old pattern: Path-A solvers dispatched with --cd $REPO_ROOT (integration checkout) can't see work-unit source when the issue references files on a divergent non-integration branch, emitting spurious no-plan and wasting rounds.
+  New principle: Contract-only source locator: SKILL solver source contract + 3 solver prompts document a read-only source-locator recipe (git show <ref>:<path> / raw URL / gh api / host.env), classify missing/invalid locator as source-location-missing-or-invalid; NO new projection/parser/header/module.
+-->
+
 1. `gh issue view ${ISSUE_NUMBER}` — full body + comments (skip controller `## 🤖` markers).
 2. Work-unit scope source, by precedence:
    - Read the prompt header `WORK_UNIT_SOURCE_REF` / `source_ref` first.
    - Use only the router-injected validated transition projection lines (`TRANSITION_TYPE`, `TRANSITION_CONFIDENCE`, `TRANSITION_EVIDENCE_REFS`) for transition assessment context. Missing, malformed, or untrusted sidecars are projected as `unknown` with confidence `0`; the sidecar is not approval, not a consensus substitute, and cannot override the meta-judge truth table. `positive-discovery` is valid only with classifier-surface delta and `net_positive_signal=true`.
    - If it points to an existing local artifact or audit section, read that source and verify it.
    - If it is `gh-issue-<N>` or a referenced local artifact is missing, treat the GitHub issue body/comments from `gh issue view ${ISSUE_NUMBER}` as the scope spec.
+   - If issue body/comments cite files absent from the current checkout, look for a read-only source locator in that source: `git show <ref>:<path>`, raw URL, `gh api`, or a host-provided path from `.refactor-loop/host.env`. Use it only to read source; must not fetch/checkout/switch/merge/rebase/reset; must not create source worktree/add-dir. If the locator is missing or invalid and the current checkout cannot verify the cited source, emit `SOLVER_DONE:structural:escalate:no-plan:source-location-missing-or-invalid` instead of a generic no-plan.
    - `audit-iter-${ITERATION}.md if present` is an audit-backed source only when the current `WORK_UNIT_SOURCE_REF` / `source_ref` points to it; do not fabricate audit artifacts.
 3. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` — primary rules that frame the violation; `$REPO_ROOT/AGENTS.md` — supporting rules when present.
 4. `$REPO_ROOT/$REPO_ROOT 的架构/词汇文档(若有)` — repo vocabulary (Module / Interface / Depth / Seam / Adapter / Leverage / Locality).

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -235,6 +235,9 @@ class SkillReferenceAnchorTests(unittest.TestCase):
         self.assertIn("Refactoring, issue-solving, and repository R&D are different entry surfaces", self.readme)
         self.assertIn("## Main path and fallback producer", self.skill)
 
+    # Refactor (iter364/issue364):
+    #   Old pattern: Path-A solvers dispatched with --cd $REPO_ROOT (integration checkout) can't see work-unit source when the issue references files on a divergent non-integration branch, emitting spurious no-plan and wasting rounds.
+    #   New principle: Contract-only source locator: SKILL solver source contract + 3 solver prompts document a read-only source-locator recipe (git show <ref>:<path> / raw URL / gh api / host.env), classify missing/invalid locator as source-location-missing-or-invalid; NO new projection/parser/header/module.
     def test_skill_documents_phase9_solver_source_contract(self) -> None:
         phase9 = section_after_heading(
             self.skill,
@@ -249,6 +252,14 @@ class SkillReferenceAnchorTests(unittest.TestCase):
             "issue body/comments are the scope source",
             "must not be fabricated",
             "A missing audit `evidence:` block is not by itself a defect for manual issues",
+            "Path A issue body/comments that cite files absent from the current checkout",
+            "read-only source locator",
+            "git show <ref>:<path>",
+            "raw URL",
+            "gh api",
+            ".refactor-loop/host.env",
+            "must not directly emit a generic `no-plan`",
+            "source-location-missing-or-invalid",
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, phase9)

--- a/skills/codex-refactor-loop/scripts/test_solver_prompt_scope_sources.py
+++ b/skills/codex-refactor-loop/scripts/test_solver_prompt_scope_sources.py
@@ -59,6 +59,27 @@ class SolverPromptScopeSourceTests(unittest.TestCase):
                 for needle in required:
                     self.assertIn(needle, prompt)
 
+    # Refactor (iter364/issue364):
+    #   Old pattern: Path-A solvers dispatched with --cd $REPO_ROOT (integration checkout) can't see work-unit source when the issue references files on a divergent non-integration branch, emitting spurious no-plan and wasting rounds.
+    #   New principle: Contract-only source locator: SKILL solver source contract + 3 solver prompts document a read-only source-locator recipe (git show <ref>:<path> / raw URL / gh api / host.env), classify missing/invalid locator as source-location-missing-or-invalid; NO new projection/parser/header/module.
+    def test_solver_prompts_document_divergent_source_locator_contract(self) -> None:
+        for prompt_name in SOLVER_PROMPTS:
+            prompt = (PROMPTS_DIR / prompt_name).read_text(encoding="utf-8")
+            with self.subTest(prompt=prompt_name):
+                for needle in (
+                    "source locator",
+                    "current checkout",
+                    "read-only",
+                    "git show <ref>:<path>",
+                    "raw URL",
+                    "gh api",
+                    ".refactor-loop/host.env",
+                    "must not fetch/checkout/switch/merge/rebase/reset",
+                    "must not create source worktree/add-dir",
+                    "source-location-missing-or-invalid",
+                ):
+                    self.assertIn(needle, prompt)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

Closes #364. Path-A solver 在 non-integration 分支看不到 work-unit source 的能力缺口,采用 **contract-only source locator** 修复(design-consensus r4 3/3 propose,structural winning plan)。

- **Old**:Path-A solver 以 `--cd $REPO_ROOT`(integration checkout)派发;当 issue 引用的源码在 divergent 非 integration 分支时看不到文件,误输出 generic `no-plan`,浪费多轮。
- **New**:SKILL `Solver source contract` + 三份 solver prompt 文档化只读 source-locator recipe(`git show <ref>:<path>` / raw URL / gh api / host.env),并把缺失/无效 locator 归类为 `source-location-missing-or-invalid`(no-plan reason vocabulary,非新 routing marker)。

## 范围(6 files, +61/-0)

- `SKILL.md`(+8):`### Solver source contract` 增 Path-A divergent-source 规则
- `prompts/solver-{minimal,structural,delete}.md`(各 +7):同步只读 locator 输入规则
- `scripts/test_solver_prompt_scope_sources.py`(+21)、`test_skill_reference_anchors.py`(+11):source-regression 锁定
- **无**新 module/parser/header;不改 router runtime;不改 CLAUDE.md;不动 3/3 consensus gate;不让 host.env 成为 branch-topology SSOT。

本地 `test_solver_prompt_scope_sources test_skill_reference_anchors` 49 tests OK。

🤖 Auto-loop / codex-refactor-loop issue-driven 364

⟦AI:AUTO-LOOP⟧
