### PR TITLE
fix(#372): wakeup-plan bootstrap host-env 检查下沉 LoopContext

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -532,10 +532,10 @@ def actor_from_marker(marker: str) -> str:
     return "controller"
 
 
-def pending_bootstrap_actions(repo_root: Path, health: dict[str, Any]) -> list[dict[str, Any]]:
+def pending_bootstrap_actions(ctx: LoopContext, health: dict[str, Any]) -> list[dict[str, Any]]:
     actions: list[dict[str, Any]] = []
-    host_env = repo_root / ".refactor-loop" / "host.env"
-    if not host_env.exists():
+    repo_root = ctx.repo_root
+    if not ctx.host_env:
         actions.append(
             {
                 "priority": 1,
@@ -543,7 +543,7 @@ def pending_bootstrap_actions(repo_root: Path, health: dict[str, Any]) -> list[d
                 "item": None,
                 "phase": "bootstrap",
                 "actor": "controller",
-                "reason": "missing .refactor-loop/host.env",
+                "reason": "missing host-owned consensus-rnd host.env; set CONSENSUS_RND_HOST_ENV to the runtime injection file",
             }
         )
     if health["recommendation"]:
@@ -995,7 +995,7 @@ def build_plan(repo_root: Path) -> dict[str, Any]:
     )
 
     actions: list[dict[str, Any]] = []
-    actions.extend(pending_bootstrap_actions(repo_root, health))
+    actions.extend(pending_bootstrap_actions(ctx, health))
     actions.extend(harness_spawn_intent_actions(repo_root, ctx, monitor))
     actions.extend(maintainer_comment_actions(repo_root, gh_items))
     actions.extend(unpushed_worker_output_actions(repo_root, gh_items))

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -325,6 +325,46 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             json_text = json_text.split("\nHARD_GATE:", 1)[0]
         return json.loads(json_text), result.stdout
 
+    def run_plan_with_env(
+        self,
+        env_updates: dict[str, str],
+        *,
+        fixture: str = "empty",
+        ps_count: int = 5,
+        active_audit: bool = False,
+    ) -> tuple[dict, str]:
+        # Refactor (iter372/issue-372):
+        #   Old pattern: wakeup_plan.py 硬编码检查 .refactor-loop/host.env 存在性,缺失即报 bootstrap-missing,即使 CONSENSUS_RND_HOST_ENV 才是当前 locator。
+        #   New principle: collapse wakeup-plan bootstrap host-env check into LoopContext/HostEnvLocator:删 wakeup_plan.py 内硬编码 host-env 存在性块,pending_bootstrap_actions 接收 ctx/host_env_available;无 host env 时 reason 指向 host-owned 注入文件;保留 legacy 仅 compatibility read;不改 CLAUDE.md/SKILL philosophy。
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.fakebin}{os.pathsep}{env.get('PATH', '')}",
+                "CODEX_FLOOR": "5",
+                "GH_REPO_SLUG": "owner/repo",
+                "WAKEUP_PLAN_GH_FIXTURE": fixture,
+                "WAKEUP_PLAN_PS_COUNT": str(ps_count),
+                "WAKEUP_PLAN_ACTIVE_AUDIT": "1" if active_audit else "0",
+                "WAKEUP_PLAN_REPO_ROOT": str(self.repo.resolve()),
+                "WAKEUP_PLAN_GIT_LOG": str(self.repo / "git-commands.log"),
+                "WAKEUP_PLAN_GH_QUERY_LOG": str(self.repo / "gh-query-labels.log"),
+            }
+        )
+        env.update(env_updates)
+        result = subprocess.run(
+            ["python3", str(WAKEUP_PLAN), "wakeup-plan", "--repo-root", str(self.repo)],
+            cwd=self.repo,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        json_text = result.stdout
+        if "\nHARD_GATE:" in json_text:
+            json_text = json_text.split("\nHARD_GATE:", 1)[0]
+        return json.loads(json_text), result.stdout
+
     def write_dispatch(self, priority: str, task_id: str) -> Path:
         priority_dir = self.repo / ".refactor-loop" / "dispatch-queue" / priority
         priority_dir.mkdir(parents=True, exist_ok=True)
@@ -564,6 +604,31 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertNotIn("def read_host_env", wakeup_source)
         self.assertNotIn("Path.cwd().resolve()", wakeup_source)
         self.assertIn("LoopContext.load(repo_root=arg_root", wakeup_source)
+
+    def test_wakeup_plan_bootstrap_uses_explicit_host_env_locator_not_legacy_path(self) -> None:
+        (self.repo / ".refactor-loop" / "host.env").unlink()
+        host_env = self.repo / ".config" / "consensus-rnd" / "host.env"
+        host_env.parent.mkdir(parents=True)
+        host_env.write_text(
+            f"REPO_ROOT={self.repo}\nGH_REPO_SLUG=owner/repo\nCODEX_FLOOR=5\n",
+            encoding="utf-8",
+        )
+
+        plan, _stdout = self.run_plan_with_env({"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"})
+
+        self.assertNotIn(
+            "bootstrap",
+            [action["kind"] for action in plan["actions"] if action.get("reason", "").startswith("missing")],
+        )
+        self.assertNotIn("bootstrap-missing", json.dumps(plan))
+        self.assertNotIn(".refactor-loop/host.env", json.dumps(plan))
+
+    def test_wakeup_plan_source_has_no_legacy_host_env_bootstrap_authority(self) -> None:
+        source = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "wakeup_plan.py").read_text(encoding="utf-8")
+
+        self.assertNotIn("missing .refactor-loop/host.env", source)
+        self.assertNotIn('repo_root / ".refactor-loop" / "host.env"', source)
+        self.assertIn("ctx.host_env", source)
 
     def test_unpushed_worker_output_routes_before_completed_marker_ci_and_existing_issue(self) -> None:
         self.write_completed_log("fix-pr77-r3.log", "FIX_DONE")


### PR DESCRIPTION
## Summary / 摘要

`wakeup_plan.py` 把 legacy `.refactor-loop/host.env` 当 bootstrap 必需(硬编码存在性检查),即使 host-owned `CONSENSUS_RND_HOST_ENV` 才是当前 config locator。

- **Old**:`wakeup_plan.py` 硬编码检查 `.refactor-loop/host.env` 存在,缺失即 emit `missing .refactor-loop/host.env` bootstrap reason。
- **New**:collapse 到 `LoopContext`/`HostEnvLocator` —— `pending_bootstrap_actions` 经 host_env_available 判定;无 host env 时 reason 指向 host-owned 注入文件(`CONSENSUS_RND_HOST_ENV` / `.config/consensus-rnd/host.env`);legacy 仅 compatibility read。

违反:SKILL host SSOT 边界(host 生产事实/config SSOT 不得住 `.refactor-loop/`)。

## Scope / 范围

2 files(+70/-5):`wakeup_plan.py`、`test_wakeup_plan.py`(+behavior test:`CONSENSUS_RND_HOST_ENV` 存在 + 无 legacy → 不 emit bootstrap-missing)。

本地全量:`Ran 970+ tests ... OK (skipped=1)`。

## 共识来源

design-consensus r1 **3/3 consensus:delete**(issue #372,audit iter 20260531213100 cluster-002)。

Closes #372.

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
