### PR TITLE
#385: release publisher reentry since=None(消除 stale_required_checks 死锁)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publisher.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publisher.py
@@ -91,7 +91,7 @@ class ReleasePublisher:
             commit = self._run(["git", "commit", "-m", self._release_bump_subject(version)])
             self._ensure_success(commit, "git commit")
         release_target_ref = self._current_head_sha()
-        release_push_started_at = self.now()
+        release_push_started_at = None if state.skip_bump_commit else self.now()
         self._safe_push()
         self._ensure_fresh_release_commit_checks_green(release_target_ref, since=release_push_started_at)
         release_command = ["gh", "release", "create", tag, "--target", release_target_ref, "--generate-notes"]
@@ -230,7 +230,7 @@ class ReleasePublisher:
         push = self._run(["git", "push", "origin", "HEAD"])
         self._ensure_success(push, "git push")
 
-    def _ensure_fresh_release_commit_checks_green(self, release_target_ref: str, *, since: datetime) -> None:
+    def _ensure_fresh_release_commit_checks_green(self, release_target_ref: str, *, since: datetime | None) -> None:
         repo_slug = self._repo_slug()
         projection = ReleaseRequiredChecksProjection(
             runner=self._run_check_command,

--- a/skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_release_pipeline_contract.py
@@ -250,7 +250,9 @@ class ReleasePipelineContractTests(unittest.TestCase):
             "def _ensure_fresh_release_commit_checks_green",
             "GH_REPO_SLUG is required for fresh release commit check gate",
             "projection.check_ref(repo_slug, release_target_ref",
+            "release_push_started_at = None if state.skip_bump_commit else self.now()",
             "since=release_push_started_at",
+            "_ensure_fresh_release_commit_checks_green(release_target_ref, since=release_push_started_at)",
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.publisher)

--- a/skills/codex-refactor-loop/scripts/test_release_publisher.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publisher.py
@@ -84,6 +84,7 @@ class FakeRunner:
         self.head_sha = "bumpcommit456"
         self.head_subject = "Release v2.0.0-beta.4"
         self.check_status = "green"
+        self.check_completed_at = "2026-05-30T12:01:00Z"
 
     def __call__(self, cmd: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         command = list(cmd)
@@ -120,7 +121,7 @@ class FakeRunner:
                     "name": name,
                     "status": status,
                     "conclusion": conclusion,
-                    "completed_at": "2026-05-30T12:01:00Z",
+                    "completed_at": self.check_completed_at,
                 }
             )
         if self.check_status == "missing":
@@ -376,6 +377,45 @@ class ReleasePublisherTests(unittest.TestCase):
             self.assertIsInstance(payload, dict)
             assert isinstance(payload, dict)
             self.assertEqual(payload["target_ref"], "bumpcommit456")
+
+    def test_already_bumped_reentry_accepts_exact_sha_green_checks_completed_before_rerun_now(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            set_mapped_version(repo, "2.0.0-beta.4")
+            runner = FakeRunner()
+            runner.check_completed_at = "2026-05-30T11:59:00Z"
+            publisher = ReleasePublisher(
+                repo,
+                preflight=FakePreflight(manifest_mismatch_result(repo)),
+                runner=runner,
+                now=lambda: NOW,
+            )
+
+            result = publisher.publish(target_ref="abc123")
+
+            self.assertTrue(result.published)
+            self.assertEqual(result.target_ref, "bumpcommit456")
+            check_command = expected_check_runs_command("bumpcommit456")
+            release_command = expected_reentry_success_commands()[-1]
+            check_index = runner.commands.index(check_command)
+            release_index = runner.commands.index(release_command)
+            self.assertLess(check_index, release_index)
+            self.assertEqual(release_command[4:6], ["--target", "bumpcommit456"])
+            self.assertEqual(runner.commands, expected_reentry_success_commands())
+
+    def test_first_run_still_rejects_checks_older_than_push_started_at(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            runner = FakeRunner()
+            runner.check_completed_at = "2026-05-30T11:59:00Z"
+            publisher = ReleasePublisher(repo, preflight=FakePreflight(allowed_result(repo)), runner=runner, now=lambda: NOW)
+
+            with self.assertRaisesRegex(RuntimeError, "stale_required_checks"):
+                publisher.publish(target_ref="abc123")
+
+            self.assertIn(expected_check_runs_command("bumpcommit456"), runner.commands)
+            self.assertFalse(any(command[:3] == ["gh", "release", "create"] for command in runner.commands))
+            self.assertFalse((repo / ".refactor-loop/state/release-publish-result.json").exists())
 
     def test_already_bumped_reentry_denies_mixed_manifest_mismatch_reasons_without_commands(self) -> None:
         with copy_repo_fixture() as tmp:


### PR DESCRIPTION
## 摘要

修复 #385:`ReleasePublisher` 的 already-bumped reentry 永久 `stale_required_checks` 死锁(beta.5/beta.6 暴露,#341 残留)。

- **Old**:`publish()` 每次都 `release_push_started_at = self.now()`;reentry(skip_bump_commit,push 是 no-op)把本次 rerun `now()` 当 freshness cutoff → release commit 的 exact-SHA checks(早在过去 success)被判 stale → 自动 publisher 永远完不成 `gh release create`,每次发版需 controller hand-complete tag。
- **New**(#385 r3 consensus,minimal framing):`release_push_started_at = None if state.skip_bump_commit else self.now()`;`_ensure_fresh_release_commit_checks_green` 的 `since` 放宽为 `datetime | None`。reentry 传 `since=None` 不产生 rerun-time stale,**仍**对 exact release SHA 读 Checks API 且 pending/red/missing/API-fail fail-closed;first-run 保留 post-push freshness。

保持 `_current_head_sha() -> _safe_push() -> _ensure_fresh_release_commit_checks_green() -> gh release create -> write result` 顺序;保 #322/#334 exact-SHA-green 不变量;不改 SKILL.md/CLAUDE.md/host.env。

## 范围

3 文件 +45/-3:
- `release/publisher.py`:reentry `since=None` + `since: datetime | None`(~+1/-1)
- `test_release_publisher.py`:+`test_already_bumped_reentry_accepts_exact_sha_green_checks_completed_before_rerun_now` / +`test_first_run_still_rejects_checks_older_than_push_started_at`(保留 pending/red/missing/API-fail fail-closed tests)
- `test_release_pipeline_contract.py`:source-regression literal 锁条件分支 + gate 顺序

全 suite **970 tests OK**(279s)。`HOST_REFACTOR_COMMENT_POLICY=none`。

## 共识

design-consensus #385 r3 **consensus(minimal,3/3)**:minimal/structural 收敛同一 framing,delete abstain(Path A compatible-neutral 支持)。落地后未来发版全自动(消除 hand-complete),提升 GA(#110)可靠性。

Closes #385

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
