### PR TITLE
#391: source-language guard 覆盖 degradation.py(删整文件排除+owner-literal allowlist)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/checks/degradation.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/checks/degradation.py
@@ -18,16 +18,9 @@ from typing import Iterable
 from ..context import LoopContext
 
 
-# Refactor (issue160-p3-checks):
-#   Old: scripts/check_skill_degradation.py owned the static issue #66 drift
-#   gate as a top-level script.
-#   New: expose the same read-only checks from codex_refactor_loop.checks while
-#   preserving every marker, required check name, authorization path, and narrow
-#   allowlist literal for future CLI import.
-# Refactor (impl/issue235-delete-downstream-watch): Old pattern: the checker required downstream runtime watch hooks and alert surfaces. New principle: skill-degradation is source-repo CI/release validation only; downstream hosts have no runtime watch surface.
-# Refactor (iter259/issue-259):
-#   Old pattern: check-degradation --static 把 downstream/plugin host root 当 source tree 扫描,吐 skills/codex-refactor-loop/... required-file false-positive(每 tick rc=1)
-#   New principle: degradation.py 内加私有 not-source-repo guard:无 source sentinels 时 rc=0 + reason not-source-repo;source repo candidate 仍 fail-closed;不新增 SourceRepoValidationContext,不改 manifest.py
+# Static checks preserve the existing CLI markers, check names, authorization
+# paths, and narrow allowlist literals while staying read-only.
+# Non-source repo roots are accepted as no-op plugin-installed host roots.
 
 CHECK_NAME = "skill-degradation"
 SKILL_RELATIVE = Path("skills/codex-refactor-loop")
@@ -262,9 +255,8 @@ class SkillDriftChecker:
         )
 
     def single_file_reference_contract_present(self) -> list[Finding]:
-        # Refactor (iter319/issue-319):
-        #   Old pattern: CLAUDE.md 把『重型参考必须物理拆 REFERENCE.md』当宪法,audit 据此反复把单文件 SKILL.md 判 R02/R03 违规
-        #   New principle: 改哲学:单文件 SKILL.md + intra-file anchors 是被认可的 canonical reference surface;衡量标准从『必须物理拆文件』改为『事实源唯一+owner surface 清楚+anchor 可验证』
+        # The single-file reference contract intentionally allows intra-file
+        # anchors when they are the skill's clearest reference surface.
         return self.require_markers(
             SKILL_RELATIVE / "SKILL.md",
             REQUIRED_DETAILED_REFERENCE_MARKERS,
@@ -275,9 +267,8 @@ class SkillDriftChecker:
         return self.require_markers(CI_WORKFLOW, REQUIRED_CI_MARKERS, "ci-job")
 
     def release_workflow_required_check_present(self) -> list[Finding]:
-        # Refactor (iter217/issue-217):
-        #   Old pattern: release.yml 保留 tag/release mutation,无法可靠读本地 runtime fact,绕过 release-gate decider-only 边界
-        #   New principle: controller-only publication:新增 ReleasePublishPreflight+ReleasePublisher 替代 workflow 发布权;release.yml 降为 read-only preview(contents:read,禁 gh release create)。严格按 plan 'Concrete plan' 逐条改。
+        # Release workflow validation keeps publication authority out of the
+        # read-only workflow preview path.
         findings = self.require_markers(RELEASE_WORKFLOW, REQUIRED_RELEASE_MARKERS, "release-workflow")
         text = self.read(RELEASE_WORKFLOW)
         if "push:" in text:

--- a/skills/codex-refactor-loop/scripts/test_source_language_policy.py
+++ b/skills/codex-refactor-loop/scripts/test_source_language_policy.py
@@ -60,6 +60,7 @@ ALLOWLIST: tuple[AllowlistEntry, ...] = (
     AllowlistEntry("skills/codex-refactor-loop/scripts/codex_refactor_loop/project_rules.py", "OLD_CANONICAL_BODY", "legacy project-rules fixed point text is intentionally Chinese host-facing policy"),
     AllowlistEntry("skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py", "comment", "#238 reconciliation refactor self-documents per review gate policy"),
     AllowlistEntry("skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_phase_labels.py", "comment", "#238 phase helper refactor self-documents per review gate policy"),
+    AllowlistEntry("skills/codex-refactor-loop/scripts/codex_refactor_loop/checks/degradation.py", "DOC_FORBIDDEN_CONTEXT", "static checker recognizes Chinese forbidden-context terms in docs"),
 )
 
 
@@ -81,7 +82,7 @@ def source_files(repo_root: Path = REPO_ROOT) -> list[Path]:
     for root in python_source_roots:
         if not root.exists():
             continue
-        files.extend(path for path in root.rglob("*.py") if path.name != "degradation.py")
+        files.extend(root.rglob("*.py"))
     return sorted(files)
 
 
@@ -226,6 +227,19 @@ def is_allowlisted(finding: Finding) -> bool:
 
 
 class SourceLanguagePolicyTests(unittest.TestCase):
+    def test_source_files_includes_degradation_checker(self) -> None:
+        expected = (
+            REPO_ROOT
+            / "skills"
+            / "codex-refactor-loop"
+            / "scripts"
+            / "codex_refactor_loop"
+            / "checks"
+            / "degradation.py"
+        )
+
+        self.assertIn(expected, source_files(REPO_ROOT))
+
     def test_scan_python_source_language_is_clean(self) -> None:
         findings = scan_python_source_language(REPO_ROOT)
         details = "\n".join(f"{f.relative_path}:{f.line}:{f.owner}:{f.reason}:{f.text}" for f in findings[:50])


### PR DESCRIPTION
## 摘要

修复 #391:source-language English-only guard 整文件排除 `degradation.py`(`test_source_language_policy.py:84` 的 `if path.name != "degradation.py"`),使该生产源文件的中文/refactor-history 注释绕过 English-only source 契约。

**design-consensus r1→r2 consensus(structural framing)**:删除整文件排除,让 `source_files()` 覆盖 degradation.py;清理其 refactor-history/中文源码注释为短英文;仅对仍 load-bearing 的 `DOC_FORBIDDEN_CONTEXT` 中文 literal 用现有 owner-level `ALLOWLIST` 窄授权(非整文件豁免)。

## 范围(2 文件 +22/-17)

- `test_source_language_policy.py`:`source_files()` 收录所有 `*.py`(删 degradation.py 排除);新增 `AllowlistEntry(checks/degradation.py, DOC_FORBIDDEN_CONTEXT, ...)`;新增 `test_source_files_includes_degradation_checker`
- `checks/degradation.py`:删 refactor-history/中文源注释为短英文;保留 `DOC_FORBIDDEN_CONTEXT` 的 `拒绝`/`禁止` 作文档 forbidden-context 匹配 literal

不新增 whole-file allowlist、新抽象、CLAUDE.md/SPEC/Tier/host.env 变更(承 r2 consensus 边界)。既有 `test_scan_python_source_language_is_clean` 自然覆盖 degradation.py。全 suite **993 OK**。`HOST_REFACTOR_COMMENT_POLICY=none`。

## 共识

design-consensus #391:r1 三 solver propose → judge converge(整文件 exclude vs 分层)→ r2 三 solver propose → judge **consensus(structural)**:删 exclude + source_files 覆盖 + owner-literal allowlist。

Closes #391

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
