### PR TITLE
#393: sshx SKILL 增加 Goal Contract(用户输入即唯一 goal,目标迭代)

### DIFF
--- a/skills/sshx/SKILL.md
+++ b/skills/sshx/SKILL.md
@@ -24,13 +24,29 @@ Use this skill when:
 
 Do not use this skill for routine one-step answers where no separate perspectives would change the outcome.
 
+## Goal Contract
+
+`GoalArtifact` is a prompt-level record, not a runtime API. It is written during `intake` before worker mode selection or any worker dispatch.
+
+`GoalArtifact` has exactly these fields:
+
+- `raw_user_input`
+- `normalized_goal`
+- `constraints`
+- `success_criteria`
+- `iteration_question`
+
+The user's current input is the only source for the goal. `sshx` must not discover or infer the goal from `codex-refactor-loop` milestones, release state, `host.env`, GitHub issues, GitHub pull requests, labels, branches, or any other external lifecycle surface.
+
+`iteration_question` must ask what still differs from `GoalArtifact`, using the normalized goal, constraints, and success criteria as the fixed target. It must not broaden the task into a generic improvement search.
+
 ## InlineConsensusProtocol
 
 `InlineConsensusProtocol` is a prompt-level protocol, not a runtime API.
 
 Run the stages in this exact order:
 
-1. `intake`
+1. `intake` (write `GoalArtifact` and normalize the goal)
 2. `choose_worker_mode`
 3. `thinking_triplet_workers`
 4. `meta_judge`
@@ -48,6 +64,8 @@ Each thinking or review record must include these fields:
 - `verdict`
 
 Thinking, implementation, and review are worker dispatches. The caller context may intake the task, choose worker mode, dispatch workers, run the meta-judge over returned summaries/verdicts, summarize outcomes, and produce the final report.
+
+Each `visible_inputs` value must include the same `GoalArtifact.normalized_goal` and must not include same-round peer outputs.
 
 ## Worker Delegation
 
@@ -85,6 +103,8 @@ Run three biased perspectives before choosing a plan:
 - `structural`: architecture and contract integrity under future growth.
 - `delete`: whether the feature, abstraction, or work should be removed, collapsed, or avoided.
 
+Every perspective must frame `propose`, `revise`, `reject`, or `abstain` as an answer to the current `GoalArtifact`: what satisfies it, what still differs from it, or why it cannot be satisfied. `revise` must name the goal gap and a next iteration question; it must not open an unrelated design search.
+
 Each perspective returns one of:
 
 - `propose`
@@ -104,6 +124,8 @@ The meta-judge applies this fixed thinking truth table:
 | any attempt to use one perspective as consensus | `reject fake consensus` |
 
 `meta-layer convergence` must produce one concrete plan before implementation. If the bounded pass still cannot produce a concrete plan, stop with options instead of inventing agreement.
+
+The convergence question must be "what still differs from `GoalArtifact`?" expressed against the fixed normalized goal, constraints, and success criteria. Do not generalize the convergence pass beyond that goal gap.
 
 ## Implementation Worker
 
@@ -141,11 +163,11 @@ Advisory comments do not count as approval. A reject blocks done until the issue
 
 ## Fix Or Done
 
-If review exits `fix`, apply the smallest change that addresses the blocking finding and rerun the review triplet. Stop after a bounded number of fix passes and report remaining blockers honestly.
+If review exits `fix`, ask what still differs from `GoalArtifact`, apply the smallest change that addresses that blocking goal gap, and rerun the review triplet. Stop after a bounded number of fix passes and report remaining blockers honestly.
 
 If review exits `done with advisory surfaced`, summarize the final outcome and include any non-blocking advisory feedback.
 
-If review exits `explicit user decision or another bounded review pass`, either run one more bounded pass or ask the user to decide. Do not loop indefinitely.
+If review exits `explicit user decision or another bounded review pass`, either run one more bounded pass with a concrete next iteration question tied to `GoalArtifact`, or ask the user to decide. Do not loop indefinitely.
 
 ## Boundaries
 
@@ -183,7 +205,11 @@ Use this compact transcript shape when the decision is non-trivial:
 ```text
 intake:
   goal:
-  constraints:
+    raw_user_input:
+    normalized_goal:
+    constraints:
+    success_criteria:
+    iteration_question:
   strict_peer_invisibility_required:
 worker_delegation:
   worker_mode:
@@ -211,6 +237,8 @@ thinking_triplet_workers:
 meta_judge:
   exit:
   concrete_plan:
+  goal_gap:
+  next_iteration_question:
 implementation_worker:
   worker_mode:
   summary:

--- a/skills/sshx/tests/test_sshx_contract.py
+++ b/skills/sshx/tests/test_sshx_contract.py
@@ -42,6 +42,7 @@ class SshxContractTests(unittest.TestCase):
         text = read(SKILL)
         for anchor in [
             "## Trigger",
+            "## Goal Contract",
             "## InlineConsensusProtocol",
             "## Worker Delegation",
             "## No Context Pollution",
@@ -55,9 +56,50 @@ class SshxContractTests(unittest.TestCase):
         ]:
             self.assertIn(anchor, text)
         self.assertIn(
-            "`intake`\n2. `choose_worker_mode`\n3. `thinking_triplet_workers`\n4. `meta_judge`\n5. `implementation_worker`\n6. `review_triplet_workers`\n7. `fix_or_done`",
+            "`intake` (write `GoalArtifact` and normalize the goal)\n2. `choose_worker_mode`\n3. `thinking_triplet_workers`\n4. `meta_judge`\n5. `implementation_worker`\n6. `review_triplet_workers`\n7. `fix_or_done`",
             text,
         )
+
+    def test_sshx_goal_contract_source_regression(self) -> None:
+        text = read(SKILL)
+        self.assertIn("## Goal Contract", text)
+        self.assertIn("`GoalArtifact` is a prompt-level record, not a runtime API", text)
+        self.assertIn("It is written during `intake` before worker mode selection or any worker dispatch", text)
+        for field in [
+            "`raw_user_input`",
+            "`normalized_goal`",
+            "`constraints`",
+            "`success_criteria`",
+            "`iteration_question`",
+        ]:
+            self.assertIn(field, text)
+        self.assertIn("The user's current input is the only source for the goal", text)
+        self.assertIn(
+            "must not discover or infer the goal from `codex-refactor-loop` milestones, release state, `host.env`, GitHub issues, GitHub pull requests, labels, branches, or any other external lifecycle surface",
+            text,
+        )
+
+    def test_sshx_goal_iteration_behavior_contract(self) -> None:
+        text = read(SKILL)
+        self.assertIn("`intake` (write `GoalArtifact` and normalize the goal)", text)
+        self.assertIn(
+            "Each `visible_inputs` value must include the same `GoalArtifact.normalized_goal` and must not include same-round peer outputs",
+            text,
+        )
+        self.assertIn(
+            "`revise` must name the goal gap and a next iteration question; it must not open an unrelated design search",
+            text,
+        )
+        self.assertIn(
+            "The convergence question must be \"what still differs from `GoalArtifact`?\"",
+            text,
+        )
+        self.assertIn("Do not generalize the convergence pass beyond that goal gap", text)
+        self.assertIn(
+            "ask what still differs from `GoalArtifact`, apply the smallest change that addresses that blocking goal gap",
+            text,
+        )
+        self.assertIn("next_iteration_question:", text)
 
     def test_sshx_worker_modes(self) -> None:
         text = read(SKILL)


### PR DESCRIPTION
## 摘要

实现 #393(maintainer 指令:sshx 把用户输入作为目标迭代):`skills/sshx/SKILL.md` 新增 `## Goal Contract`——**用户输入是 sshx goal 的唯一来源**,intake 先写 prompt-level `GoalArtifact`(raw_user_input/normalized_goal/constraints/success_criteria/iteration_question);后续 thinking/review/meta-judge/fix 轮次都围绕 goal 迭代,converge 表达为「距 GoalArtifact 还差什么」禁泛化发散;**禁止**从 crl milestone/release/`.refactor-loop/host.env`/GitHub 自动发现 goal。

design-consensus r1 **consensus(structural)**:GoalArtifact 为 prompt-level record 非 runtime API;保 sshx 轻量自包含、无 daemon/无 GitHub-git authority 定位。

## 范围(2 文件 +75/-5)

- `skills/sshx/SKILL.md`:新增 `## Goal Contract` 段 + 更新 stage order(intake 含 goal normalization)/Thinking Triplet/Design Truth Table/Fix Or Done(converge 表达为 goal gap)+ transcript template(goal 字段 + meta_judge 的 goal_gap/next_iteration_question)
- `skills/sshx/tests/test_sshx_contract.py`:+`test_sshx_goal_contract_source_regression`(锁 ## Goal Contract/GoalArtifact 字段/唯一来源/禁 milestone-release-host.env-GitHub discovery)+`test_sshx_goal_iteration_behavior_contract`(锁 intake-first + goal gap/next iteration question + converge 不泛化)

sshx tests **11 OK**。与 #392(crl 默认 goal 倒计时)同属 maintainer「目标概念」指令;sshx goal 永远来自用户输入(不搬 crl milestone/release 自动发现)。

Closes #393

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
