### PR TITLE
#407: controller 非异常路径只消费结构化数据,收紧 marker 解析

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -28,6 +28,7 @@ Use intra-file anchors when a phase needs the detailed body, such as [host runti
 | Wake source | Every controller session must maintain a persistent daemon-event Monitor bridge. | Arm or confirm the daemon-event Monitor bridge; before ending a turn, also confirm any in-flight codex task-notification or registered ScheduleWakeup fallback used as the next wake. | [wake source rules](#wake-source-rules) | Monitor bridge, harness Bash background tasks, ScheduleWakeup fallback |
 | First wakeup | Consensus-rnd Phase bootstrap is ordered and mandatory before any normal phase. | Run the Consensus-rnd Phase bootstrap checklist in this file, in order. | [daemon command bodies](#daemon-command-bodies) | scripts, `host.env` |
 | Work unit state | The work-unit contract is stable; do not rename, migrate, or wrap it. Root `.refactor-loop/state.json` is not a contract surface. | Use GitHub labels/comments, clean `EXIT=0` logs, prompt artifacts, git topology, and named specialized state artifacts; export `WORK_UNIT_ID=$CLUSTER_ID` for audit-backed units. | [work-unit contract](#work-unit-contract), [specialized state artifacts](#specialized-state-artifacts) | `.refactor-loop/state/*.json`, daemon-owned state files |
+| Structured consumption | Steady-state controller/daemon paths consume only clean-exit status plus final allowlisted standalone marker/verdict lines, artifact frontmatter, CLI JSON/action fields, and artifact paths. Raw log prose is diagnostic-only. | Do not read, understand, quote, relay, or transcribe worker log prose, review reject prose, judge reasoning, or progress raw tails during normal routing. Raw logs are allowed only for `EXIT!=0`, stream disconnect/503, stuck/crash, missing/invalid structured artifact, router fallback, or worker self-post failure diagnostics. | [structured-consumption boundary](#structured-consumption-boundary), [phase routing details](#phase-routing-details) | `wakeup_plan.py`, `phase9/router.py`, `monitors/progress.py` |
 | Phase routing | Markers route immediately to the next actor in the same wakeup. | Sweep `EXIT=0` logs, parse verdict markers only after clean exit, then spawn next work if actionable. | [phase routing details](#phase-routing-details) | logs, prompts |
 | Operational names | Parsed or cross-agent names are operational interfaces with owner-local fact sources. | Keep each parser/generator in its owner surface; do not add a production registry or whole-repo naming lint. | [operational names](#operational-names) | router/progress/concurrency/git/controller actions/labels/cli/stages |
 | Design consensus | Concrete plans require Consensus-rnd Phase design-consensus multi-solver consensus and meta-judge consensus. | Dispatch minimal, structural, delete solvers; meta-judge returns consensus/converge only; router-owned stalled predicate may route qualifying converge to reflector, with legacy stalled markers read-only compatible. | [design-consensus details](#design-consensus-details) | `solver-*.md`, `meta-judge.md` |
@@ -730,6 +731,7 @@ Consensus-rnd Phase review-gate keeps the consensus merge gate local enough for 
 4. Truth table: `reject=0`, `approve=R`, `comment=0` → `MERGE`; `reject=0`, `approve>=1`, `comment>=1`, `approve+comment=R` → `MERGE_WITH_COMMENTS`; `reject=0`, `approve=0`, `comment=R` → `WAIT_EXPLICIT_APPROVAL`; `reject>=1` → `FIX`; missing role, duplicate/unknown verdict, no `EXIT=0`, stale head SHA, CI pending/fail, or non-mergeable PR → `WAIT_OR_REDISPATCH`.
 5. `comment` is terminal advisory evidence: surface it, but do not count it as approval and do not dispatch fix for comments alone.
 6. `FIX` dispatches fix codex; fix completion dispatches reviewers again.
+   Fix prompt rendering binds `REVIEW_ARCHITECT_PATH`, `REVIEW_TESTS_PATH`, `REVIEW_QUALITY_PATH`, and `FIX_OUTPUT_PATH`; the controller passes artifact paths and structured counts/status, not hand-copied reject prose from logs.
 7. After repeated fix failure, dispatch meta-layer reflector before any human label.
 8. Every Consensus-rnd Phase review-gate action posts to the PR for traceability.
 9. Detailed reviewer prompts, retry rules, and anti-spiral safeguards are in [review-gate details](#review-gate-details).
@@ -745,7 +747,8 @@ Consensus-rnd Phase design-consensus is the sole authorization gate for concrete
 5. Qualifying r3+ no-progress `converge` routes to reflector via router-owned stalled predicate, not directly to human; legacy `escalate:stalled` markers are compatibility input only.
 6. Maintainer replies reset the round when they materially change framing.
 7. Any concrete plan bypassing Consensus-rnd Phase design-consensus is invalid.
-8. Full consensus card template and solver rules are in [design-consensus details](#design-consensus-details).
+8. Full consensus artifact posting is worker-owned; controller records completion and next-step structured fields only. Self-post failure is an exceptional diagnostic fallback.
+9. Full consensus card template and solver rules are in [design-consensus details](#design-consensus-details).
 
 ## Status Banners
 
@@ -1257,8 +1260,15 @@ Auto-dispatch semantics:
 codex 常把 prompt 里的 marker 模板原样回显到 log(如 prompt 写 `SOLVER_DONE:<role>:<verdict>` 或 `REVIEW_DONE:<PR>:<role>:<approve|comment|reject>`)。`grep "SOLVER_DONE:"` 会命中 prompt 回显,误把失败 / 未完成 / 部分写入的 codex 判成 done,过早派 judge 或 merge 读到不完整输入。**修正**:
 - readiness / done 判据:只看 `tail -5 <log> | grep -q '^EXIT=0'`。
 - verdict 判据:只有 `EXIT=0` 后才解析 marker。
-- marker grep 排除占位回显——`grep -E "<MARKER>:" | grep -vE "<reason>|<id>|<status>|<category>|<framing>|<role>|<verdict>|round-N"`,取**真实值**那条;真实终止 marker 在 codex 最后输出段(controller 追加的 `EXIT=` 行之前),非 prompt 引用段。
-- codex 输出有时被包进 diff 风格段,marker 行带 `+` 前缀 → **不要用 `^MARKER` 锚定 verdict**(会漏),用不带行首锚的 `grep "MARKER:"` + 排占位;但完成判据仍必须锚定 `^EXIT=0` 且只看 log tail。
+- marker verdict 判据:只接受 `line.strip()` 本身是 allowlisted standalone final marker/verdict token 的行;禁止从前缀文本、引用、代码块示例、prompt echo、embedded prose、grep output 或占位符中截取 marker。
+- diff 兼容仅限 marker 行带单个 `+` 前缀且去掉 `+` 后整行仍是 standalone marker;除此之外不得用宽松 `find(prefix)` 或 body regex 从任意行中搜索 marker。
+
+<a id="structured-consumption-boundary"></a>
+### Controller structured-consumption boundary
+
+Steady-state controller/daemon paths consume only these structured surfaces: clean `EXIT=0` completion state, final allowlisted standalone marker/verdict lines, artifact frontmatter, CLI JSON/action fields, and artifact paths. Artifact paths may be passed through directly to the next worker or comment surface; the controller must not summarize or transcribe the raw prose behind those paths as routing evidence.
+
+Raw log prose, review reject prose, judge reasoning bodies, progress raw tails, and prompt echoes are not normal controller inputs. They may be read or quoted only for exceptional diagnostics: `EXIT!=0`, stream disconnect/503, stuck/crash, missing/invalid structured artifact, router fallback, or worker self-post failure. Worker self-posts own full solver, judge, reviewer, or fix artifacts; the controller records completion, route, counts, verdict token, artifact path, and next step.
 
 **反面(❌ 严禁)**:
 - ❌ 三个 solver log 里都出现 `SOLVER_DONE:` 字面就派 meta-judge。
@@ -2607,14 +2617,14 @@ Every Consensus-rnd Phase design-consensus action posts a 中文 comment to the 
 |---|---|
 | Round N solvers dispatched | 中文: "Consensus-rnd Phase design-consensus round N — minimal/structural/delete codex in flight. all implementation-bearing proposals must agree; only built-in Path A greenfield delete-abstain can be compatible-neutral; otherwise iterate." |
 | Maintainer reply detected mid-Phase-9 | 中文: "Halted in-flight round; resetting with maintainer comment as new constraint. New round dispatched. Old round outputs preserved for solver context." |
-| **Each individual solver completes** | Post FULL solver output as its own comment. Header: `## 🤖 Consensus-rnd Phase design-consensus Solver — \`<role>\` (round N)`. Body = verbatim solver output. One comment per solver, three comments per round. |
-| **Meta-judge completes** | Post FULL meta-judge output as its own comment. Header: `## 🤖 Consensus-rnd Phase design-consensus Meta-judge — round N verdict: \`<consensus\|converge>\``. Body = verbatim judge output. |
+| **Each individual solver completes** | Worker self-posts its full artifact/comment for traceability. Controller records clean completion, marker verdict, artifact path, and next-step fields only; if self-post fails, raw output may be referenced as diagnostic fallback. |
+| **Meta-judge completes** | Worker self-posts its full artifact/comment for traceability. Controller records clean completion, marker verdict, artifact path, and next-step fields only; if self-post fails, raw output may be referenced as diagnostic fallback. |
 | Meta-judge → consensus | Same as above + then a follow-up controller comment: "`crnd:triage:resume-requested` label added; implement codex dispatched" |
 | Meta-judge → converge | Same as above + the round-(N+1) "solvers dispatched" comment that includes the convergence question for transparency |
 | Router-derived stalled converge | Same as above + `## 🤖 Controller next-step` comment saying reflector is being dispatched for a no-progress stall |
 | Legacy escalation category emitted | Post meta-judge output + summary "legacy escalation category normalized back into consensus loop"; re-dispatch judge or reflector; do not label human directly |
 
-**Forbidden**: posting a "summary" of solver outputs instead of the FULL outputs. The raw reasoning, evidence, and concrete plans are the audit record; a summary loses too much fidelity. The 3+ comments per round are intentional.
+**Forbidden**: controller relay/transcription of solver or judge raw prose as normal routing evidence. Full raw artifacts remain the audit record through worker self-posts or artifact paths; controller comments use structured completion fields, counts, verdicts, and paths.
 
 Required labels (additions to Consensus-rnd Phase review-gate set):
 - `phase9-solving`: 3 solver codexes in flight

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/progress.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/progress.py
@@ -105,18 +105,23 @@ class ProgressReporter:
             elapsed_min = int((time.time() - log.stat().st_ctime) / 60)
         except OSError:
             elapsed_min = 0
-        tail_block = extract_tail(log)
         if finished == "failed":
             status_line = f"❌ 失败; 已跑 {elapsed_min} min"
+            details = f"""异常诊断 tail (non-zero EXIT only):
+
+```
+{extract_tail(log)}
+```"""
             delete_note = "codex 已非零退出;保留此 comment 直到 controller 处理失败。"
         else:
             status_line = f"⏳ 进行中; 已跑 {elapsed_min} min"
+            details = f"""Task id: `{base}`
+Log: `{log.name}`
+Raw log tail is intentionally omitted while the worker is still running."""
             delete_note = "自动更新每 10 分钟;edit-in-place 不堆评论;codex EXIT=0 后此 comment 自动删除。"
         body = f"""## 📊 codex 进展 {base} ({status_line})
 
-```
-{tail_block}
-```
+{details}
 
 > {delete_note}
 🤖 controller progress reporter

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -47,7 +47,7 @@ KNOWN_PREFIXES = (
     "META_JUDGE_DONE:",
     *LIFECYCLE_PREFIXES,
 )
-MARKER_RE = re.compile(r"\b(?:[A-Z][A-Z0-9_]*_(?:DONE|RESOLVED|BLOCKED)|META_JUDGE_DONE):[^\s`]+")
+MARKER_RE = re.compile(r"^(?:[A-Z][A-Z0-9_]*_(?:DONE|RESOLVED|BLOCKED)|META_JUDGE_DONE):[^\s`]+$")
 
 
 class Phase9MarkerGrammar:
@@ -320,20 +320,19 @@ class Phase9Router:
         return markers
 
     def _extract_marker(self, line: str) -> str | None:
-        stripped = line.strip().strip("`")
+        stripped = line.strip()
+        if stripped.startswith("+") and not stripped.startswith("+++"):
+            stripped = stripped[1:].strip()
+        stripped = stripped.strip("`")
         if self._is_placeholder_or_echo(stripped):
             return None
         candidate: str | None = None
-        for prefix in KNOWN_PREFIXES:
-            index = stripped.find(prefix)
-            if index == -1:
-                continue
-            candidate = stripped[index:].split()[0].rstrip("`.,);:|\"\\")
-            break
+        if any(stripped.startswith(prefix) for prefix in KNOWN_PREFIXES):
+            candidate = stripped
         if candidate is None:
-            match = MARKER_RE.search(stripped)
+            match = MARKER_RE.fullmatch(stripped)
             if match:
-                candidate = match.group(0).rstrip("`.,);:|\"\\")
+                candidate = match.group(0)
         if candidate is None:
             return None
         return Phase9MarkerGrammar.parse_marker_candidate(candidate)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -306,18 +306,25 @@ class Phase9Router:
             identity = self._identity_from_path(log_path)
             if identity is None:
                 continue
-            tail = self._read_tail_lines(log_path, self.MARKER_TAIL_LINES)
-            for line in tail:
-                marker = self._extract_marker(line)
-                if marker is None:
+            marker = self._final_marker_from_path(log_path)
+            if marker is None:
+                continue
+            role: str | None = identity.actor
+            if marker.startswith("SOLVER_DONE:"):
+                role = self._role_from_solver_marker(marker)
+                if role not in self._solver_roles():
                     continue
-                role: str | None = identity.actor
-                if marker.startswith("SOLVER_DONE:"):
-                    role = self._role_from_solver_marker(marker)
-                    if role not in self._solver_roles():
-                        continue
-                markers.append(Marker(marker, log_path, identity.issue, identity.round, role))
+            markers.append(Marker(marker, log_path, identity.issue, identity.round, role))
         return markers
+
+    def _final_marker_from_path(self, path: Path) -> str | None:
+        tail = self._read_tail_lines(path, 5)
+        for line in reversed(tail):
+            stripped = line.strip()
+            if stripped == "EXIT=0" or not stripped:
+                continue
+            return self._extract_marker(stripped)
+        return None
 
     def _extract_marker(self, line: str) -> str | None:
         stripped = line.strip()
@@ -573,13 +580,8 @@ class Phase9Router:
     def _collect_markers_from_path(self, path: Path) -> list[str]:
         if not path.exists():
             return []
-        tail = self._read_tail_lines(path, self.MARKER_TAIL_LINES)
-        markers: list[str] = []
-        for line in tail:
-            marker = self._extract_marker(line)
-            if marker:
-                markers.append(marker)
-        return markers
+        marker = self._final_marker_from_path(path)
+        return [marker] if marker else []
 
     def _solver_verdict_text(self, marker: str) -> str:
         parts = marker.split(":", 3)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -458,7 +458,7 @@ def tail_lines(path: Path, count: int) -> list[str]:
 def marker_from_completed_log(log_path: Path) -> str | None:
     if not is_clean_exit(log_path):
         return None
-    for line in reversed(tail_lines(log_path, 40)):
+    for line in reversed(tail_lines(log_path, 5)):
         stripped = line.strip()
         if stripped == "EXIT=0" or not stripped:
             continue
@@ -466,6 +466,7 @@ def marker_from_completed_log(log_path: Path) -> str | None:
             continue
         if DONE_PREFIX_RE.fullmatch(stripped):
             return stripped
+        return None
     return None
 
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -42,6 +42,7 @@ DONE_PREFIXES = (
     "TEST_ADD_DONE",
     "TRIAGE_DECISION_DONE",
 )
+DONE_PREFIX_RE = re.compile(r"^(?:" + "|".join(re.escape(prefix) for prefix in DONE_PREFIXES) + r")(?::[^\s`]+)*$")
 PHASE_TO_STAGE = {
     label_catalog.PHASE_DESIGN_SOLVING: "design-consensus",
     label_catalog.PHASE_IMPLEMENTING: "implementation",
@@ -458,14 +459,13 @@ def marker_from_completed_log(log_path: Path) -> str | None:
     if not is_clean_exit(log_path):
         return None
     for line in reversed(tail_lines(log_path, 40)):
-        if line == "EXIT=0" or not line.strip():
+        stripped = line.strip()
+        if stripped == "EXIT=0" or not stripped:
             continue
-        for prefix in DONE_PREFIXES:
-            if prefix in line:
-                marker = line[line.find(prefix) :].strip()
-                if "<" in marker and ">" in marker:
-                    continue
-                return marker
+        if "<" in stripped and ">" in stripped:
+            continue
+        if DONE_PREFIX_RE.fullmatch(stripped):
+            return stripped
     return None
 
 
@@ -480,7 +480,7 @@ def completed_marker_actions(repo_root: Path) -> list[dict[str, Any]]:
             continue
         if marker.startswith("AUDIT_DONE:none:0"):
             continue
-        target_text = f"{log_path.name} {marker} {' '.join(tail_lines(log_path, 40))}"
+        target_text = f"{log_path.name} {marker}"
         item = infer_item_from_text(target_text)
         action = {
             "priority": 3,

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -254,6 +254,19 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertEqual(len(self.commands), 1)
         self.assertEqual(self.ledger_entries()[0]["key"], "38-4-judge")
 
+    def test_phase9_router_ignores_standalone_marker_followed_by_raw_prose(self) -> None:
+        for role in ("minimal", "structural", "delete"):
+            self.write_log(
+                f"phase9-issue39-r4-{role}.log",
+                f"SOLVER_DONE:{role}:ok:x",
+                "later raw worker prose",
+            )
+
+        self.router.tick()
+
+        self.assertEqual(self.commands, [])
+        self.assertEqual(self.ledger_entries(), [])
+
     def test_phase9_router_solver_triplet_dispatches_meta_judge_once(self) -> None:
         self.solver_triplet(issue=37, round_no=4)
 

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -230,6 +230,30 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertEqual(self.commands, [])
         self.assertEqual(self.ledger_entries(), [])
 
+    def test_phase9_router_ignores_embedded_or_quoted_markers(self) -> None:
+        for role in ("minimal", "structural", "delete"):
+            self.write_log(
+                f"phase9-issue37-r4-{role}.log",
+                f"> SOLVER_DONE:{role}:quoted:summary",
+                f"controller saw SOLVER_DONE:{role}:embedded:summary",
+                f"grep output: SOLVER_DONE:{role}:grep:summary",
+            )
+
+        self.router.tick()
+
+        self.assertEqual(self.commands, [])
+        self.assertEqual(self.ledger_entries(), [])
+
+    def test_phase9_router_accepts_standalone_marker_and_diff_added_marker_only(self) -> None:
+        self.write_log("phase9-issue38-r4-minimal.log", "+SOLVER_DONE:minimal:ok:x")
+        self.write_log("phase9-issue38-r4-structural.log", "SOLVER_DONE:structural:ok:x")
+        self.write_log("phase9-issue38-r4-delete.log", "+ SOLVER_DONE:delete:ok:x")
+
+        self.router.tick()
+
+        self.assertEqual(len(self.commands), 1)
+        self.assertEqual(self.ledger_entries()[0]["key"], "38-4-judge")
+
     def test_phase9_router_solver_triplet_dispatches_meta_judge_once(self) -> None:
         self.solver_triplet(issue=37, round_no=4)
 

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
@@ -234,6 +234,19 @@ class Phase9RouterPackageTests(unittest.TestCase):
         self.assertEqual(self.ledger_entries(), [])
         self.assertEqual(self.pending_events(), "")
 
+    def test_package_router_ignores_standalone_marker_followed_by_raw_prose(self) -> None:
+        self.write_log(
+            "phase9-issue160-r1-judge.log",
+            "META_JUDGE_DONE:converge:round-2",
+            "later raw judge prose",
+        )
+
+        self.router.tick()
+
+        self.assertEqual(self.commands, [])
+        self.assertEqual(self.ledger_entries(), [])
+        self.assertEqual(self.pending_events(), "")
+
     def test_package_router_converge_dispatches_stalled_reflector_when_predicate_holds(self) -> None:
         # Refactor (issue-304): Old: package smoke used a fresh stalled judge
         # marker. New: r3 converge plus unchanged solver history renders the

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
@@ -220,6 +220,20 @@ class Phase9RouterPackageTests(unittest.TestCase):
         self.assertEqual(event["marker"], "SOMETHING_DONE:surprise:payload")
         self.assertEqual(self.ledger_entries(), [])
 
+    def test_package_router_ignores_embedded_marker_without_fallback(self) -> None:
+        self.write_log(
+            "phase9-issue160-r1-judge.log",
+            "controller saw META_JUDGE_DONE:converge:round-2:embedded prose",
+            "> META_JUDGE_DONE:converge:round-2:quoted",
+            "grep output: META_JUDGE_DONE:converge:round-2:grep",
+        )
+
+        self.router.tick()
+
+        self.assertEqual(self.commands, [])
+        self.assertEqual(self.ledger_entries(), [])
+        self.assertEqual(self.pending_events(), "")
+
     def test_package_router_converge_dispatches_stalled_reflector_when_predicate_holds(self) -> None:
         # Refactor (issue-304): Old: package smoke used a fresh stalled judge
         # marker. New: r3 converge plus unchanged solver history renders the
@@ -406,6 +420,13 @@ class Phase9RouterPackageTests(unittest.TestCase):
             with self.subTest(required=required):
                 self.assertIn(required, combined)
         self.assertNotIn("Read the three completed solver logs and emit META_JUDGE_DONE", src)
+
+    def test_router_source_uses_standalone_marker_matching(self) -> None:
+        src = PACKAGE_ROUTER.read_text(encoding="utf-8")
+        self.assertIn("MARKER_RE.fullmatch", src)
+        self.assertIn("stripped.startswith(prefix)", src)
+        self.assertNotIn("stripped.find(prefix)", src)
+        self.assertNotIn("MARKER_RE.search", src)
 
     def test_package_main_once_dispatches_via_absolute_repo_root(self) -> None:
         for role in ("minimal", "structural", "delete"):

--- a/skills/codex-refactor-loop/scripts/test_progress_reporter.py
+++ b/skills/codex-refactor-loop/scripts/test_progress_reporter.py
@@ -93,6 +93,28 @@ class ProgressReporterTests(unittest.TestCase):
         self.assertEqual(state["fix-pr47-round2"]["finished"], "failed")
         self.assertEqual(state["fix-pr47-round2"]["comment_id"], 24680)
 
+    def test_in_flight_progress_body_omits_raw_log_tail(self) -> None:
+        log = self.tmp / ".refactor-loop" / "logs" / "phase9-issue81-r10-minimal.log"
+        log.write_text("secret raw worker prose\nSOLVER_DONE:minimal:echo\n", encoding="utf-8")
+        reporter = ProgressReporter(self.ctx)
+
+        body = reporter.build_body(log.stem, log, "false")
+
+        self.assertIn("Task id: `phase9-issue81-r10-minimal`", body)
+        self.assertIn("Raw log tail is intentionally omitted", body)
+        self.assertNotIn("secret raw worker prose", body)
+        self.assertNotIn("SOLVER_DONE:minimal:echo", body)
+
+    def test_failed_progress_body_keeps_bounded_tail_as_exception_diagnostic(self) -> None:
+        log = self.tmp / ".refactor-loop" / "logs" / "fix-pr47-round2.log"
+        log.write_text("important failure diagnostic\nEXIT=17\n", encoding="utf-8")
+        reporter = ProgressReporter(self.ctx)
+
+        body = reporter.build_body(log.stem, log, "failed")
+
+        self.assertIn("异常诊断 tail (non-zero EXIT only)", body)
+        self.assertIn("important failure diagnostic", body)
+
     def test_orphan_delete_retry_keeps_state_when_delete_fails_and_comment_exists(self) -> None:
         state_file = self.tmp / ".refactor-loop" / "codex-progress-state.json"
         state_file.write_text(json.dumps({"fix-pr47-r1": {"target": "47", "kind": "pr", "comment_id": 123, "last_md5": "x", "finished": "false"}}), encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -1205,6 +1205,40 @@ class SkillReferenceAnchorTests(unittest.TestCase):
         self.assertIn("prefix `phase9-triplet-suppression:`", self.skill)
         self.assertIn("reason exactly one of", self.skill)
 
+    def test_structured_consumption_boundary_contract_is_locked(self) -> None:
+        wakeup_plan = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "wakeup_plan.py").read_text(encoding="utf-8")
+        router = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "phase9" / "router.py").read_text(encoding="utf-8")
+        progress = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "monitors" / "progress.py").read_text(
+            encoding="utf-8"
+        )
+        for needle in (
+            '<a id="structured-consumption-boundary"></a>',
+            "final allowlisted standalone marker/verdict lines",
+            "artifact frontmatter",
+            "CLI JSON/action fields",
+            "artifact paths",
+            "EXIT!=0",
+            "stream disconnect/503",
+            "stuck/crash",
+            "missing/invalid structured artifact",
+            "router fallback",
+            "worker self-post failure",
+            "controller must not summarize or transcribe",
+            "Worker self-posts own full solver, judge, reviewer, or fix artifacts",
+            "REVIEW_ARCHITECT_PATH",
+            "REVIEW_TESTS_PATH",
+            "REVIEW_QUALITY_PATH",
+            "FIX_OUTPUT_PATH",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.skill)
+        self.assertIn("DONE_PREFIX_RE.fullmatch", wakeup_plan)
+        self.assertNotIn("' '.join(tail_lines(log_path, 40))", wakeup_plan)
+        self.assertIn("MARKER_RE.fullmatch", router)
+        self.assertNotIn("stripped.find(prefix)", router)
+        self.assertIn("Raw log tail is intentionally omitted", progress)
+        self.assertIn("异常诊断 tail (non-zero EXIT only)", progress)
+
 
 class AutoLoopStatuslineContractTests(unittest.TestCase):
     # Refactor (iter1/issue-140):

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -660,6 +660,20 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         )
         self.assertIsNone(marker_from_completed_log(invalid))
 
+        stale_marker = self.logs / "implement-issue22.log"
+        stale_marker.write_text(
+            "IMPLEMENT_DONE:ok\n"
+            "later raw worker prose\n"
+            "EXIT=0\n",
+            encoding="utf-8",
+        )
+        self.assertIsNone(marker_from_completed_log(stale_marker))
+
+        valid.unlink()
+        invalid.unlink()
+        actions = self.run_plan()["actions"]
+        self.assertFalse([action for action in actions if action["kind"] == "completed-marker"])
+
     def test_completed_marker_payload_does_not_include_raw_log_tail(self) -> None:
         (self.logs / "implement-worker.log").write_text(
             "target issue #999 in raw prose only\n"

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -26,6 +26,7 @@ from codex_refactor_loop.wakeup_plan import (  # noqa: E402
     GhItem,
     existing_issue_actions,
     has_dispatchable_action,
+    marker_from_completed_log,
     release_countdown_actions,
     resolve_repo_root,
 )
@@ -636,6 +637,48 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(plan["actions"][0]["actor"], "controller")
         self.assertIn("IMPLEMENT_DONE:real", plan["actions"][0]["marker"])
 
+    def test_completed_marker_requires_standalone_final_marker_line(self) -> None:
+        valid = self.logs / "implement-issue20.log"
+        valid.write_text(
+            "prompt echo IMPLEMENT_DONE:<status>\n"
+            "> IMPLEMENT_DONE:quoted\n"
+            "controller saw IMPLEMENT_DONE:embedded prose\n"
+            "IMPLEMENT_DONE:ok\n"
+            "EXIT=0\n",
+            encoding="utf-8",
+        )
+        self.assertEqual("IMPLEMENT_DONE:ok", marker_from_completed_log(valid))
+
+        invalid = self.logs / "implement-issue21.log"
+        invalid.write_text(
+            "prompt echo IMPLEMENT_DONE:<status>\n"
+            "> IMPLEMENT_DONE:quoted\n"
+            "controller saw IMPLEMENT_DONE:embedded prose\n"
+            "grep output: IMPLEMENT_DONE:grep\n"
+            "EXIT=0\n",
+            encoding="utf-8",
+        )
+        self.assertIsNone(marker_from_completed_log(invalid))
+
+    def test_completed_marker_payload_does_not_include_raw_log_tail(self) -> None:
+        (self.logs / "implement-worker.log").write_text(
+            "target issue #999 in raw prose only\n"
+            "raw reviewer prose that must not be relayed\n"
+            "IMPLEMENT_DONE:ok\n"
+            "EXIT=0\n",
+            encoding="utf-8",
+        )
+
+        plan = self.run_plan()
+
+        action = plan["actions"][0]
+        rendered = json.dumps(action, sort_keys=True)
+        self.assertEqual(action["kind"], "completed-marker")
+        self.assertIsNone(action["item"])
+        self.assertNotIn("999", rendered)
+        self.assertNotIn("raw reviewer prose", rendered)
+        self.assertNotIn("target issue", rendered)
+
     def test_decompose_consensus_visible_only_as_generic_completed_marker(self) -> None:
         self.write_completed_log("phase9-issue403-r6-judge.log", "META_JUDGE_DONE:consensus:decompose")
 
@@ -699,8 +742,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertNotIn("review_gate_actions", action)
 
     def test_meta_resolved_drop_completed_marker_projects_close_helper(self) -> None:
-        (self.logs / "judge-drop.log").write_text(
-            "target issue #53\n"
+        (self.logs / "issue53-judge-drop.log").write_text(
+            "raw prose is diagnostic only\n"
             "META_RESOLVED:drop:no-action\n"
             "EXIT=0\n",
             encoding="utf-8",
@@ -714,7 +757,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(action["runner_authority"], "wakeup-runner-396")
         self.assertTrue(action["no_generic_command"])
         self.assertIn("clean_exit_source_marker", action["preconditions"])
-        self.assertEqual(action["source_artifact"], ".refactor-loop/logs/judge-drop.log")
+        self.assertEqual(action["source_artifact"], ".refactor-loop/logs/issue53-judge-drop.log")
         self.assertEqual(action["source_marker"], "META_RESOLVED:drop:no-action")
         self.assertEqual(action["target_kind"], "issue")
         self.assertEqual(action["target_number"], 53)


### PR DESCRIPTION
## Summary / 摘要

实现 #407 design-consensus 共识(r2,minimal framing):**controller/daemon 稳态非异常路径只消费结构化数据**。

- **Old**:稳态 controller/daemon 在非异常路径读取/理解/转写 codex 原始 log prose(review reject 散文、judge 推理正文、progress raw tail),并用宽松 marker 解析从任意行截取 marker。
- **New**:稳态只消费 clean-exit + final allowlisted standalone marker/verdict、artifact frontmatter、CLI JSON/action fields、artifact paths;raw log 仅限异常诊断 carveout(EXIT!=0 / stream-disconnect / stuck-crash / missing-invalid-structured-artifact / router-fallback / worker self-post-failure)。

## Scope / 范围

9 files changed (+189/-31):
- `SKILL.md`:新增 controller structured-consumption boundary 契约 + 改写 design-consensus traceability / review-fix 文案。
- `wakeup_plan.py` / `phase9/router.py`:marker 解析收紧为独立行匹配,拒绝 prefix/引用/代码块/prompt echo/embedded prose/grep output/占位符。
- `monitors/progress.py`:in-flight body 去掉 raw log tail;异常诊断保留 bounded tail。
- tests:`test_wakeup_plan.py` / `test_phase9_router_daemon.py` / `test_phase9_router_package.py` / `test_progress_reporter.py` / `test_skill_reference_anchors.py`(behavior + source-regression)。

## 验证

- `python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → **Ran 1086 tests, OK (skipped=1)**。

## 共识 / 治理

Consensus-rnd Phase design-consensus #407 r2 达成 Step 3 truth-table consensus(minimal/structural/delete 三者一致 propose)。无 CLAUDE.md / Tier / release / lifecycle 修宪;仅 codex-refactor-loop 内部 controller contract。

Closes #407
Base = `auto-refact-dev`(rollup target = `dev`)。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
