### PR TITLE
#419: wakeup-plan release-countdown fail-soft(P0 回归)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -1165,18 +1165,20 @@ def release_countdown_actions(repo_root: Path, items: list[GhItem], scorer: Any 
     red_signals = [name for name, signal in signals.items() if isinstance(signal, dict) and not signal.get("passed")]
     blocked = score.get("blocked_reasons")
     blocked_reasons = [str(reason) for reason in blocked] if isinstance(blocked, list) else red_signals
-    release_goal = {
-        "from_version": score.get("from_version"),
-        "to_version": score.get("to_version"),
-        "countdown_to_version": score.get("to_version"),
-        "stability_score": score.get("stability_score"),
-        "ready": bool(score.get("ready")),
-        "passed_signals": sum(1 for signal in signals.values() if isinstance(signal, dict) and signal.get("passed")),
-        "total_signals": len(signals),
-        "red_signals": red_signals,
-        "blocked_reasons": blocked_reasons,
-        "source": "release-gate",
-    }
+    release_goal = None
+    if score:
+        release_goal = {
+            "from_version": score.get("from_version"),
+            "to_version": score.get("to_version"),
+            "countdown_to_version": score.get("to_version"),
+            "stability_score": score.get("stability_score"),
+            "ready": bool(score.get("ready")),
+            "passed_signals": sum(1 for signal in signals.values() if isinstance(signal, dict) and signal.get("passed")),
+            "total_signals": len(signals),
+            "red_signals": red_signals,
+            "blocked_reasons": blocked_reasons,
+            "source": "release-gate",
+        }
     return [
         {
             "priority": 8,
@@ -1232,8 +1234,12 @@ def _default_goal_milestone(repo_root: Path) -> dict[str, Any] | None:
 
 
 def _release_countdown_score(repo_root: Path, scorer: Any | None = None) -> dict[str, Any]:
-    with contextlib.redirect_stdout(sys.stderr):
-        score = (scorer or decide_release_artifact)(repo_root)
+    try:
+        with contextlib.redirect_stdout(sys.stderr):
+            score = (scorer or decide_release_artifact)(repo_root)
+    except (KeyError, RuntimeError, ValueError) as exc:
+        print(f"release-countdown: release goal unavailable: {exc}", file=sys.stderr)
+        return {}
     return score if isinstance(score, dict) else {}
 
 

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -1290,6 +1290,45 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(action["goal"]["release"]["total_signals"], 8)
         self.assertIn("api milestones", (self.repo / "gh-query-labels.log").read_text(encoding="utf-8"))
 
+    def test_release_countdown_fail_soft_when_version_manifest_has_no_files_list(self) -> None:
+        (self.repo / ".version-bump.json").write_text(json.dumps({"version": "0.0.0"}), encoding="utf-8")
+
+        plan = self.run_plan(fixture="default_milestones")
+
+        actions = [action for action in plan["actions"] if action["kind"] == "release-countdown"]
+        self.assertEqual(len(actions), 1)
+        action = actions[0]
+        self.assertEqual(action["activation"], "default-goal")
+        self.assertEqual(action["goal"]["milestone"], {"number": 1, "title": "Soon", "due_on": "2026-06-15T00:00:00Z"})
+        self.assertIsNone(action["goal"]["release"])
+        self.assertIsNone(action["from_version"])
+        self.assertIsNone(action["to_version"])
+        self.assertFalse(action["ready"])
+        self.assertEqual(action["red_signals"], [])
+        self.assertEqual(action["blocked_reasons"], [])
+        self.assertIn("api milestones", (self.repo / "gh-query-labels.log").read_text(encoding="utf-8"))
+
+    def test_release_countdown_fail_soft_when_mapped_manifest_versions_are_not_synchronized(self) -> None:
+        (self.repo / ".version-bump.json").write_text(
+            json.dumps(
+                {
+                    "files": [
+                        {"path": "package.json", "field": "version"},
+                        {"path": "other-package.json", "field": "version"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        (self.repo / "other-package.json").write_text(json.dumps({"version": "9.9.9"}), encoding="utf-8")
+
+        plan = self.run_plan(fixture="existing")
+
+        by_kind = {action["kind"]: action for action in plan["actions"]}
+        self.assertEqual(by_kind["existing-issue"]["item"], "issue #10")
+        self.assertIsNone(by_kind["release-countdown"]["goal"]["release"])
+        self.assertFalse(has_dispatchable_action([by_kind["release-countdown"]]))
+
     def test_release_countdown_default_goal_falls_back_to_release_only_without_open_milestone(self) -> None:
         old_env = os.environ.copy()
         os.environ.pop("GH_REPO_SLUG", None)


### PR DESCRIPTION
## Summary
P0 回归(beta.7):`wakeup-plan`(强制 step 1)在「有 open milestone + 无 version manifest」的 host 上崩溃,整个 loop 不可用。fail-soft 修复:`release_countdown_actions` 对取版本失败优雅降级,绝不崩主路径。

## 验证
- CI-style 全量套件(GH_REPO_SLUG unset)1116 tests OK(+regression test 覆盖 missing-files-list 与 not-synchronized 两种崩溃)。
- 无-manifest stub host 跑 `wakeup-plan`:崩溃 → exit 0 正常输出。

Closes #419 · Base auto-refact-dev

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
