### PR TITLE
#420: closed_label_reconciler skip+warn 缺 human label 的 closed item

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
@@ -71,15 +71,32 @@ class ClosedLabelReconciler:
         seen: set[tuple[str, int]] = set()
         for kind, state in (("issue", "closed"), ("pr", "closed"), ("pr", "merged")):
             for item in self._list_managed(kind, state):
-                plan = plan_from_gh_item(kind, item, linked_merged=self._issue_has_merged_pr(item) if kind == "issue" else False)
+                plan = plan_from_gh_item(kind, item)
                 if plan is None:
                     continue
                 key = (plan.kind, plan.number)
                 if key in seen:
                     continue
                 seen.add(key)
+                if self._has_human_label_drift(item, plan):
+                    continue
+                if kind == "issue":
+                    plan = plan_from_gh_item(kind, item, linked_merged=self._issue_has_merged_pr(item))
+                    if plan is None:
+                        continue
                 plans.append(plan)
         return tuple(plans)
+
+    def _has_human_label_drift(self, item: Mapping[str, object], plan: ClosedPhaseLabelPlan) -> bool:
+        projection = label_catalog.normalize_label_set(_label_names(item))
+        humans = projection.labels_for_group("human")
+        if len(humans) == 1:
+            return False
+        print(
+            f"closed-label-reconciler warn: {plan.kind} #{plan.number} "
+            f"expected exactly one canonical human label, got {len(humans)}; skipping phase reconciliation"
+        )
+        return True
 
     def apply_plan(self, plan: ClosedPhaseLabelPlan) -> ClosedPhaseLabelPlan | None:
         live_plan = self._live_plan(plan)

--- a/skills/codex-refactor-loop/scripts/test_closed_label_reconciler.py
+++ b/skills/codex-refactor-loop/scripts/test_closed_label_reconciler.py
@@ -361,6 +361,89 @@ class ClosedLabelReconcilerBehaviorTests(unittest.TestCase):
         status = json.loads((self.repo / ".refactor-loop" / "state" / "active-controller-status.json").read_text(encoding="utf-8"))
         self.assertEqual("owner", status["active_controller"])
 
+    def test_closed_managed_item_without_human_label_warns_skips_and_continues(self) -> None:
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="closed-label-reconciler", lease_id="lease", expires_at="")
+        missing_human_row = {
+            "number": 31,
+            "state": "CLOSED",
+            "labels": [
+                {"name": labels.MANAGED},
+                {"name": labels.PHASE_REVIEWING},
+                {"name": labels.STUCK},
+            ],
+            "title": "old closed issue without human label",
+        }
+        normal_row = {
+            "number": 32,
+            "state": "CLOSED",
+            "labels": [
+                {"name": labels.MANAGED},
+                {"name": labels.PHASE_REVIEWING},
+                {"name": labels.HUMAN_AUTO},
+            ],
+            "title": "normal closed issue",
+        }
+        gh_json_responses = {
+            ("issue", "list", "--label", labels.MANAGED, "--state", "closed", "--limit", "100", "--json", "number,state,labels,title"): [missing_human_row, normal_row],
+            ("issue", "list", "--label", "auto-loop", "--state", "closed", "--limit", "100", "--json", "number,state,labels,title"): [missing_human_row, normal_row],
+            ("pr", "list", "--label", labels.MANAGED, "--state", "closed", "--limit", "100", "--json", "number,state,labels,title,mergedAt"): [],
+            ("pr", "list", "--label", "auto-loop", "--state", "closed", "--limit", "100", "--json", "number,state,labels,title,mergedAt"): [],
+            ("pr", "list", "--label", labels.MANAGED, "--state", "merged", "--limit", "100", "--json", "number,state,labels,title,mergedAt"): [],
+            ("pr", "list", "--label", "auto-loop", "--state", "merged", "--limit", "100", "--json", "number,state,labels,title,mergedAt"): [],
+            ("pr", "list", "--state", "merged", "--search", "in:body Closes #32", "--limit", "1", "--json", "number,mergedAt"): [],
+            ("issue", "view", "32", "--json", "number,state,labels"): {
+                "number": 32,
+                "state": "CLOSED",
+                "labels": [
+                    {"name": labels.MANAGED},
+                    {"name": labels.PHASE_CLOSED},
+                    {"name": labels.HUMAN_AUTO},
+                ],
+            },
+        }
+        edit_commands: list[tuple[str, ...]] = []
+        view_counts: dict[tuple[str, ...], int] = {}
+
+        def fake_gh(args: tuple[str, ...] | list[str], *, check: bool = True) -> CompletedProcess[str]:
+            command = tuple(args)
+            if command == ("issue", "view", "32", "--json", "number,state,labels"):
+                count = view_counts.get(command, 0)
+                view_counts[command] = count + 1
+                item = normal_row if count == 0 else gh_json_responses[command]
+                return CompletedProcess(["gh", *command], 0, json.dumps(item), "")
+            if command in gh_json_responses:
+                return CompletedProcess(["gh", *command], 0, json.dumps(gh_json_responses[command]), "")
+            if len(command) >= 2 and command[1] == "list":
+                return CompletedProcess(["gh", *command], 0, "[]", "")
+            edit_commands.append(command)
+            return CompletedProcess(["gh", *command], 0, "", "")
+
+        reconciler = ClosedLabelReconciler(self.ctx)
+        with mock.patch("codex_refactor_loop.closed_label_reconciler.require_active_controller", return_value=decision):
+            with mock.patch.object(reconciler, "_gh", side_effect=fake_gh):
+                with mock.patch("builtins.print") as print_mock:
+                    self.assertEqual(0, reconciler.run_once())
+
+        print_mock.assert_any_call(
+            "closed-label-reconciler warn: issue #31 "
+            "expected exactly one canonical human label, got 0; skipping phase reconciliation"
+        )
+        self.assertEqual(
+            [
+                (
+                    "issue",
+                    "edit",
+                    "32",
+                    "--add-label",
+                    labels.PHASE_CLOSED,
+                    "--remove-label",
+                    labels.PHASE_REVIEWING,
+                )
+            ],
+            edit_commands,
+        )
+        self.assertNotIn(("issue", "view", "31", "--json", "number,state,labels"), view_counts)
+
     def test_apply_rechecks_live_closed_state_and_skips_stale_open_item(self) -> None:
         plan = ClosedPhaseLabelPlan(
             kind="issue",


### PR DESCRIPTION
## Summary
closed_label_reconciler 在 closed managed item 缺 canonical human label(0 个,合法历史态)时崩溃 → crash/restart churn。改为 skip+warn 该 item 并继续,守 #238 边界。
## 验证
CI-style 全量套件 1124 tests OK(+regression: 0-human-label closed item 不崩 + skip+warn)。
Closes #420 · Base auto-refact-dev
🤖 Auto-loop
⟦AI:AUTO-LOOP⟧