### PR TITLE
为耗尽 graphql 配额的 daemon 增加只读 rate-budget 退避守卫 (#427 止血)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
@@ -13,6 +13,7 @@ from . import labels as label_catalog
 from .active_controller import require_active_controller, write_active_controller_status
 from .closed_phase_labels import ClosedPhaseLabelPlan, plan_from_gh_item
 from .context import LoopContext, LoopContextError
+from .github_budget import graphql_headroom_ok, log_graphql_backoff
 from .heartbeat import DaemonHeartbeatLease
 
 
@@ -31,6 +32,9 @@ class ClosedLabelReconciler:
     # Old pattern: one slow or failing item could stall the whole tick and let the daemon heartbeat expire.
     # New principle: renew during the tick and isolate each item so closed-only phase reconciliation continues.
     def run_once(self, beat: Callable[[], None] | None = None) -> int:
+        if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):
+            log_graphql_backoff("closed-label-reconciler")
+            return 0
         decision = require_active_controller(self.ctx, "closed-label-reconciler")
         write_active_controller_status(self.ctx, decision)
         if not decision.allowed:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/github_budget.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/github_budget.py
@@ -1,0 +1,122 @@
+"""Shared read-only GitHub graphql budget guard."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+DEFAULT_GRAPHQL_MIN_REMAINING = 500
+DEFAULT_GRAPHQL_BUDGET_CACHE_TTL_SECONDS = 25.0
+
+
+@dataclass
+class _BudgetCache:
+    checked_at: float = 0.0
+    remaining: int | None = None
+
+
+_CACHE = _BudgetCache()
+
+
+def reset_graphql_budget_cache() -> None:
+    """Clear the process-local graphql budget cache for tests."""
+    _CACHE.checked_at = 0.0
+    _CACHE.remaining = None
+
+
+def graphql_headroom_ok(
+    min_remaining: int | None = None,
+    *,
+    cache_ttl_seconds: float | None = None,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    runner: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] | None = None,
+    now: float | None = None,
+) -> bool:
+    """Return whether the shared GitHub API graphql pool has enough remaining calls.
+
+    The guard is read-only and uses `gh api rate_limit`, whose REST endpoint does
+    not consume graphql quota. Failures fail open so a transient GitHub CLI,
+    network, or JSON error does not halt controller progress.
+    """
+    threshold = _int_env("GRAPHQL_BUDGET_MIN_REMAINING", DEFAULT_GRAPHQL_MIN_REMAINING) if min_remaining is None else int(min_remaining)
+    ttl = (
+        _float_env("GRAPHQL_BUDGET_CACHE_TTL_SECONDS", DEFAULT_GRAPHQL_BUDGET_CACHE_TTL_SECONDS)
+        if cache_ttl_seconds is None
+        else float(cache_ttl_seconds)
+    )
+    current = time.time() if now is None else float(now)
+    if runner is None and cwd is not None and not _looks_like_git_checkout(cwd):
+        return True
+    if _CACHE.remaining is not None and current - _CACHE.checked_at < max(0.0, ttl):
+        return _CACHE.remaining >= threshold
+
+    remaining = _read_graphql_remaining(cwd=cwd, env=env, runner=runner)
+    if remaining is None:
+        return True
+    _CACHE.checked_at = current
+    _CACHE.remaining = remaining
+    return remaining >= threshold
+
+
+def log_graphql_backoff(daemon: str) -> None:
+    print(f"graphql-backoff: skipping {daemon} tick (remaining<threshold)", flush=True)
+
+
+def _read_graphql_remaining(
+    *,
+    cwd: Path | None,
+    env: dict[str, str] | None,
+    runner: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] | None,
+) -> int | None:
+    command = ["gh", "api", "rate_limit"]
+    try:
+        if runner is None:
+            result = subprocess.run(
+                command,
+                cwd=str(cwd) if cwd is not None else None,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        else:
+            result = runner(command)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    remaining = (((payload.get("resources") or {}).get("graphql") or {}).get("remaining") if isinstance(payload, dict) else None)
+    try:
+        return int(remaining)
+    except (TypeError, ValueError):
+        return None
+
+
+def _looks_like_git_checkout(cwd: Path) -> bool:
+    return (cwd / ".git").exists()
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except ValueError:
+        return default

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/comment.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/comment.py
@@ -14,6 +14,7 @@ from typing import Iterable, Mapping, Sequence
 
 from ..active_controller import require_active_controller, write_active_controller_status
 from ..context import LoopContext, LoopContextError
+from ..github_budget import graphql_headroom_ok, log_graphql_backoff
 from ..heartbeat import DaemonHeartbeatLease
 from .. import labels as label_catalog
 
@@ -67,6 +68,9 @@ class CommentMonitor:
             self.heartbeat.sleep_with_lease(self.interval)
 
     def tick(self) -> None:
+        if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):
+            log_graphql_backoff("comment-monitor")
+            return
         self._poll_once()
 
     def _poll_once(self) -> None:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -17,6 +17,7 @@ from typing import Any, Sequence
 
 from ..active_controller import require_active_controller, write_active_controller_status
 from ..context import LoopContext, LoopContextError
+from ..github_budget import graphql_headroom_ok, log_graphql_backoff
 from ..heartbeat import DaemonHeartbeatLease
 from .. import labels as label_catalog
 from ..state import read_json, write_json
@@ -498,6 +499,10 @@ class ConcurrencyMonitor:
 
     def top_up_from_dispatch_queue(self, actual: int, floor: int) -> int:
         if actual >= floor:
+            return actual
+        if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):
+            self.write_pending_event("DISPATCH_BACKOFF:graphql-headroom-low")
+            log_graphql_backoff("concurrency-monitor")
             return actual
         max_dispatches = floor - actual
         for _ in range(max_dispatches):

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/progress.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/progress.py
@@ -17,6 +17,7 @@ from typing import Mapping, Sequence
 
 from ..active_controller import require_active_controller, write_active_controller_status
 from ..context import LoopContext, LoopContextError
+from ..github_budget import graphql_headroom_ok, log_graphql_backoff
 from ..heartbeat import DaemonHeartbeatLease
 
 
@@ -71,6 +72,9 @@ class ProgressReporter:
             self.heartbeat.sleep_with_lease(self.interval)
 
     def tick(self) -> None:
+        if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):
+            log_graphql_backoff("progress-reporter")
+            return
         for log in sorted(self.log_dir.glob("*.log")):
             base = log.stem
             if base.startswith("audit-iter-") or base.startswith("remote-ci-"):

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -26,6 +26,7 @@ from typing import Callable, Iterable, Literal, cast
 
 from ..active_controller import require_active_controller, write_active_controller_status
 from ..context import LoopContext
+from ..github_budget import graphql_headroom_ok, log_graphql_backoff
 from ..heartbeat import DaemonHeartbeatLease
 from ..transition_assessment import TransitionAssessment, TransitionAssessmentReader, projection_lines
 from ..workflow_stages import format_stage
@@ -264,6 +265,9 @@ class Phase9Router:
         self._source_issue_decisions: dict[str, Phase9SourceIssueDecision] = {}
 
     def tick(self) -> None:
+        if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):
+            log_graphql_backoff("phase9-router")
+            return
         decision = require_active_controller(self.ctx, "phase9-router")
         write_active_controller_status(self.ctx, decision)
         if not decision.allowed:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -16,6 +16,7 @@ from .active_controller import require_active_controller, write_active_controlle
 from . import labels
 from .context import LoopContext, LoopContextError
 from .controller_actions import ControllerActions
+from .github_budget import graphql_headroom_ok, log_graphql_backoff
 from .heartbeat import DaemonHeartbeatLease
 from .pr_checks import PrChecksProjection
 from .processes import ProcessSupervisor
@@ -105,6 +106,9 @@ class WakeupRunner:
         self.pending_events_path = ctx.paths.pending_events
 
     def run_once(self) -> list[RunnerResult]:
+        if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):
+            log_graphql_backoff("wakeup-runner")
+            return [RunnerResult("", "skipped", "graphql-backoff")]
         owner = require_active_controller(self.ctx, "wakeup-runner")
         write_active_controller_status(self.ctx, owner)
         if not owner.allowed:
@@ -484,6 +488,10 @@ class WakeupRunner:
         return 0
 
     def _spawn_codex(self, action: Mapping[str, Any]) -> int:
+        if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):
+            self._append_pending_event(f"WAKEUP_RUNNER_SPAWN_BACKOFF:{action.get('action_id', '')}:graphql-headroom-low")
+            log_graphql_backoff("wakeup-runner")
+            return 3
         cd = Path(str(action.get("cd") or self.ctx.repo_root))
         prompt = Path(str(action.get("prompt") or ""))
         log = Path(str(action.get("log") or ""))

--- a/skills/codex-refactor-loop/scripts/test_github_budget_backoff.py
+++ b/skills/codex-refactor-loop/scripts/test_github_budget_backoff.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Behavior and source-regression tests for GraphQL budget backoff."""
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop import github_budget
+from codex_refactor_loop.context import LoopContext
+from codex_refactor_loop.monitors.comment import CommentMonitor
+from codex_refactor_loop.monitors.concurrency import ConcurrencyMonitor
+from codex_refactor_loop.wakeup_runner import WakeupRunner
+
+
+class GraphqlBudgetGuardTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        github_budget.reset_graphql_budget_cache()
+
+    def test_remaining_below_threshold_returns_false(self) -> None:
+        calls: list[list[str]] = []
+
+        def runner(command):
+            calls.append(list(command))
+            return subprocess.CompletedProcess(command, 0, json.dumps({"resources": {"graphql": {"remaining": 499}}}), "")
+
+        self.assertFalse(github_budget.graphql_headroom_ok(min_remaining=500, cache_ttl_seconds=25, runner=runner, now=100))
+        self.assertEqual(calls, [["gh", "api", "rate_limit"]])
+
+    def test_remaining_at_threshold_returns_true(self) -> None:
+        def runner(command):
+            return subprocess.CompletedProcess(command, 0, json.dumps({"resources": {"graphql": {"remaining": 500}}}), "")
+
+        self.assertTrue(github_budget.graphql_headroom_ok(min_remaining=500, cache_ttl_seconds=25, runner=runner, now=100))
+
+    def test_cache_hit_does_not_repeat_rate_limit_lookup(self) -> None:
+        calls: list[list[str]] = []
+
+        def runner(command):
+            calls.append(list(command))
+            return subprocess.CompletedProcess(command, 0, json.dumps({"resources": {"graphql": {"remaining": 700}}}), "")
+
+        self.assertTrue(github_budget.graphql_headroom_ok(min_remaining=500, cache_ttl_seconds=25, runner=runner, now=100))
+        self.assertTrue(github_budget.graphql_headroom_ok(min_remaining=500, cache_ttl_seconds=25, runner=runner, now=120))
+        self.assertEqual(len(calls), 1)
+
+    def test_rate_limit_read_failure_fails_open(self) -> None:
+        def runner(command):
+            return subprocess.CompletedProcess(command, 1, "", "temporary failure")
+
+        self.assertTrue(github_budget.graphql_headroom_ok(min_remaining=500, cache_ttl_seconds=25, runner=runner, now=100))
+
+
+class GraphqlBackoffBehaviorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        github_budget.reset_graphql_budget_cache()
+        self.tmp = Path(tempfile.mkdtemp(prefix="graphql-budget-backoff-"))
+        (self.tmp / ".refactor-loop").mkdir()
+        (self.tmp / ".refactor-loop" / "host.env").write_text(
+            f'export REPO_ROOT="{self.tmp}"\nexport GH_REPO_SLUG="owner/repo"\nexport MAINTAINER_WHITELIST="maintainer"\n',
+            encoding="utf-8",
+        )
+        self.ctx = LoopContext.load(repo_root=self.tmp)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        github_budget.reset_graphql_budget_cache()
+
+    def test_comment_monitor_low_headroom_skips_tick_and_logs_backoff(self) -> None:
+        monitor = CommentMonitor(self.ctx, interval=1)
+        out = io.StringIO()
+        with (
+            mock.patch("codex_refactor_loop.monitors.comment.graphql_headroom_ok", return_value=False),
+            mock.patch.object(monitor, "_poll_once", side_effect=AssertionError("GraphQL work should be skipped")),
+            redirect_stdout(out),
+        ):
+            monitor.tick()
+
+        self.assertIn("graphql-backoff: skipping comment-monitor tick (remaining<threshold)", out.getvalue())
+
+    def test_comment_monitor_high_headroom_runs_tick_normally(self) -> None:
+        monitor = CommentMonitor(self.ctx, interval=1)
+        with (
+            mock.patch("codex_refactor_loop.monitors.comment.graphql_headroom_ok", return_value=True),
+            mock.patch.object(monitor, "_poll_once") as poll_once,
+        ):
+            monitor.tick()
+
+        poll_once.assert_called_once()
+
+    def test_concurrency_top_up_low_headroom_defers_spawn_intent_without_consuming_queue(self) -> None:
+        monitor = ConcurrencyMonitor(self.ctx)
+        queue_dir = self.tmp / ".refactor-loop" / "dispatch-queue" / "p0"
+        queue_dir.mkdir(parents=True)
+        dispatch_file = queue_dir / "task.dispatch.json"
+        dispatch_file.write_text(
+            json.dumps(
+                {
+                    "task_id": "phase9-issue1-r1-minimal",
+                    "cd": str(self.tmp),
+                    "prompt": str(self.tmp / ".refactor-loop" / "prompts" / "task.md"),
+                    "log": str(self.tmp / ".refactor-loop" / "logs" / "task.log"),
+                    "reason": "test",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        out = io.StringIO()
+        with (
+            mock.patch("codex_refactor_loop.monitors.concurrency.graphql_headroom_ok", return_value=False),
+            mock.patch.object(monitor, "dispatch_one_from_queue", side_effect=AssertionError("spawn dispatch should be deferred")),
+            redirect_stdout(out),
+        ):
+            actual = monitor.top_up_from_dispatch_queue(0, 1)
+
+        self.assertEqual(actual, 0)
+        self.assertTrue(dispatch_file.exists())
+        self.assertIn("graphql-backoff: skipping concurrency-monitor tick (remaining<threshold)", out.getvalue())
+        pending = (self.tmp / ".refactor-loop" / ".controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertIn("DISPATCH_BACKOFF:graphql-headroom-low", pending)
+
+    def test_wakeup_runner_low_headroom_skips_plan_apply_without_consume(self) -> None:
+        runner = WakeupRunner(self.ctx, plan_loader=lambda _repo: {"schema": "wakeup-plan"}, supervisor=mock.Mock())
+        out = io.StringIO()
+        with (
+            mock.patch("codex_refactor_loop.wakeup_runner.graphql_headroom_ok", return_value=False),
+            redirect_stdout(out),
+        ):
+            results = runner.run_once()
+
+        self.assertEqual(results[0].status, "skipped")
+        self.assertEqual(results[0].reason, "graphql-backoff")
+        self.assertIn("graphql-backoff: skipping wakeup-runner tick (remaining<threshold)", out.getvalue())
+
+
+class GraphqlBudgetSourceRegressionTests(unittest.TestCase):
+    def test_daemon_tick_entries_check_graphql_headroom_before_work(self) -> None:
+        checks = {
+            "monitors/comment.py": 'if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):\n            log_graphql_backoff("comment-monitor")\n            return\n        self._poll_once()',
+            "monitors/progress.py": 'if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):\n            log_graphql_backoff("progress-reporter")\n            return\n        for log in sorted(self.log_dir.glob("*.log")):',
+            "closed_label_reconciler.py": 'if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):\n            log_graphql_backoff("closed-label-reconciler")\n            return 0\n        decision = require_active_controller',
+            "phase9/router.py": 'if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):\n            log_graphql_backoff("phase9-router")\n            return\n        decision = require_active_controller',
+            "wakeup_runner.py": 'if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):\n            log_graphql_backoff("wakeup-runner")\n            return [RunnerResult("", "skipped", "graphql-backoff")]\n        owner = require_active_controller',
+        }
+        for rel_path, needle in checks.items():
+            with self.subTest(rel_path=rel_path):
+                text = (SCRIPT_DIR / "codex_refactor_loop" / rel_path).read_text(encoding="utf-8")
+                self.assertIn(needle, text)
+
+    def test_backoff_log_and_rate_limit_endpoint_are_locked(self) -> None:
+        text = (SCRIPT_DIR / "codex_refactor_loop" / "github_budget.py").read_text(encoding="utf-8")
+        self.assertIn('["gh", "api", "rate_limit"]', text)
+        self.assertIn("remaining = (((payload.get(\"resources\") or {}).get(\"graphql\") or {}).get(\"remaining\")", text)
+        self.assertIn("return True", text)
+        self.assertIn('graphql-backoff: skipping {daemon} tick (remaining<threshold)', text)
+
+    def test_spawn_side_backoff_is_locked(self) -> None:
+        concurrency = (SCRIPT_DIR / "codex_refactor_loop" / "monitors" / "concurrency.py").read_text(encoding="utf-8")
+        runner = (SCRIPT_DIR / "codex_refactor_loop" / "wakeup_runner.py").read_text(encoding="utf-8")
+        self.assertIn("DISPATCH_BACKOFF:graphql-headroom-low", concurrency)
+        self.assertIn("WAKEUP_RUNNER_SPAWN_BACKOFF", runner)

--- a/skills/codex-refactor-loop/scripts/test_github_budget_backoff.py
+++ b/skills/codex-refactor-loop/scripts/test_github_budget_backoff.py
@@ -18,9 +18,12 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop import github_budget
+from codex_refactor_loop.closed_label_reconciler import ClosedLabelReconciler
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.monitors.comment import CommentMonitor
 from codex_refactor_loop.monitors.concurrency import ConcurrencyMonitor
+from codex_refactor_loop.monitors.progress import ProgressReporter
+from codex_refactor_loop.phase9.router import Phase9Router
 from codex_refactor_loop.wakeup_runner import WakeupRunner
 
 
@@ -132,7 +135,7 @@ class GraphqlBackoffBehaviorTests(unittest.TestCase):
         self.assertIn("DISPATCH_BACKOFF:graphql-headroom-low", pending)
 
     def test_wakeup_runner_low_headroom_skips_plan_apply_without_consume(self) -> None:
-        runner = WakeupRunner(self.ctx, plan_loader=lambda _repo: {"schema": "wakeup-plan"}, supervisor=mock.Mock())
+        runner = WakeupRunner(self.ctx, plan_loader=lambda _repo: {"schema": "wakeup-plan"}, supervisor=mock.Mock(), actions=mock.Mock())
         out = io.StringIO()
         with (
             mock.patch("codex_refactor_loop.wakeup_runner.graphql_headroom_ok", return_value=False),
@@ -143,6 +146,56 @@ class GraphqlBackoffBehaviorTests(unittest.TestCase):
         self.assertEqual(results[0].status, "skipped")
         self.assertEqual(results[0].reason, "graphql-backoff")
         self.assertIn("graphql-backoff: skipping wakeup-runner tick (remaining<threshold)", out.getvalue())
+
+    def test_progress_reporter_low_headroom_skips_post_or_update(self) -> None:
+        reporter = ProgressReporter(self.ctx, interval=1)
+        reporter.log_dir.mkdir(parents=True, exist_ok=True)
+        log = reporter.log_dir / "fix-pr434-round-1.log"
+        log.write_text("still running\n", encoding="utf-8")
+
+        out = io.StringIO()
+        with (
+            mock.patch("codex_refactor_loop.monitors.progress.graphql_headroom_ok", return_value=False),
+            mock.patch.object(reporter, "post_or_update", side_effect=AssertionError("progress post/update should be skipped")),
+            redirect_stdout(out),
+        ):
+            reporter.tick()
+
+        self.assertIn("graphql-backoff: skipping progress-reporter tick (remaining<threshold)", out.getvalue())
+
+    def test_closed_label_reconciler_low_headroom_skips_active_controller_and_plan_collection(self) -> None:
+        reconciler = ClosedLabelReconciler(self.ctx)
+        out = io.StringIO()
+        with (
+            mock.patch("codex_refactor_loop.closed_label_reconciler.graphql_headroom_ok", return_value=False),
+            mock.patch(
+                "codex_refactor_loop.closed_label_reconciler.require_active_controller",
+                side_effect=AssertionError("active-controller check should be skipped"),
+            ),
+            mock.patch.object(reconciler, "collect_plans", side_effect=AssertionError("plan collection should be skipped")),
+            redirect_stdout(out),
+        ):
+            result = reconciler.run_once()
+
+        self.assertEqual(result, 0)
+        self.assertIn("graphql-backoff: skipping closed-label-reconciler tick (remaining<threshold)", out.getvalue())
+
+    def test_phase9_router_low_headroom_skips_marker_collection_and_dispatch(self) -> None:
+        router = Phase9Router(ctx=self.ctx, command_runner=mock.Mock())
+        out = io.StringIO()
+        with (
+            mock.patch("codex_refactor_loop.phase9.router.graphql_headroom_ok", return_value=False),
+            mock.patch(
+                "codex_refactor_loop.phase9.router.require_active_controller",
+                side_effect=AssertionError("active-controller check should be skipped"),
+            ),
+            mock.patch.object(router, "_collect_markers", side_effect=AssertionError("marker collection should be skipped")),
+            mock.patch.object(router, "_dispatch_design_issue_intake", side_effect=AssertionError("dispatch should be skipped")),
+            redirect_stdout(out),
+        ):
+            router.tick()
+
+        self.assertIn("graphql-backoff: skipping phase9-router tick (remaining<threshold)", out.getvalue())
 
 
 class GraphqlBudgetSourceRegressionTests(unittest.TestCase):

--- a/skills/codex-refactor-loop/scripts/test_github_budget_backoff.py
+++ b/skills/codex-refactor-loop/scripts/test_github_budget_backoff.py
@@ -147,6 +147,40 @@ class GraphqlBackoffBehaviorTests(unittest.TestCase):
         self.assertEqual(results[0].reason, "graphql-backoff")
         self.assertIn("graphql-backoff: skipping wakeup-runner tick (remaining<threshold)", out.getvalue())
 
+    def test_wakeup_runner_spawn_low_headroom_records_backoff_and_does_not_spawn(self) -> None:
+        supervisor = mock.Mock()
+        runner = WakeupRunner(self.ctx, supervisor=supervisor, actions=mock.Mock())
+        prompt = self.tmp / ".refactor-loop" / "prompts" / "spawn.md"
+        log = self.tmp / ".refactor-loop" / "logs" / "spawn.log"
+        prompt.parent.mkdir(parents=True)
+        log.parent.mkdir(parents=True)
+        prompt.write_text("run\n", encoding="utf-8")
+        action = {
+            "action_id": "spawn-low-headroom",
+            "controller_action": "spawn_codex_harness_background",
+            "runner_authority": "wakeup-runner-396",
+            "no_generic_command": True,
+            "preconditions": ["target_log_absent"],
+            "source_marker": "IMPLEMENT_DONE:0:ok",
+            "cd": str(self.tmp),
+            "prompt": str(prompt),
+            "log": str(log),
+        }
+
+        out = io.StringIO()
+        with (
+            mock.patch("codex_refactor_loop.wakeup_runner.graphql_headroom_ok", return_value=False),
+            redirect_stdout(out),
+        ):
+            result = runner.apply_action(action)
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason, "helper_exit:3")
+        self.assertIn("graphql-backoff: skipping wakeup-runner tick (remaining<threshold)", out.getvalue())
+        pending = (self.tmp / ".refactor-loop" / ".controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertIn("WAKEUP_RUNNER_SPAWN_BACKOFF:spawn-low-headroom:graphql-headroom-low", pending)
+        supervisor.supervise.assert_not_called()
+
     def test_progress_reporter_low_headroom_skips_post_or_update(self) -> None:
         reporter = ProgressReporter(self.ctx, interval=1)
         reporter.log_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## 动机
本仓库 dogfood headless loop 时,多个 daemon(comment-monitor 30s `gh search`、phase9-router、progress-reporter、closed-label-reconciler、wakeup_runner)+ 并发 codex worker 全走 GitHub graphql 桶(5000/hr),无任何退避;并发一大即打爆配额(实测 used≈4986/5000),`gh issue/pr view/search/create/merge` 全部 rate-limited,整个 loop 卡 ~1 小时。这是 headless 规模化的可靠性阻断点(#427 的最高优先级止血)。

## 改动范围
新增只读 rate-budget 退避守卫,各 daemon tick 前消费:
- 新增 `github_budget.py`:`graphql_headroom_ok(min_remaining, cache_ttl)` 经 `gh api rate_limit`(REST 端点,**不计配额**)读 `.resources.graphql.remaining`,按 TTL 进程内缓存;低于阈值返回 False。读失败 fail-open。`log_graphql_backoff(daemon)` 统一 backoff 日志。阈值/TTL 可经 `GRAPHQL_BUDGET_MIN_REMAINING` 注入,有合理默认,**不新增必填 host fact**。
- comment-monitor / phase9-router / progress-reporter / closed-label-reconciler / wakeup_runner 在 tick 前查 headroom,低则跳过本 tick 的 gh-重活并 log `graphql-backoff`,pending state 不丢(下个 headroom-ok 的 tick 再做);git/REST/本地工作不受影响。
- 派发侧 headroom 低时降频/推迟。

## 边界
守卫**只读、无 lifecycle authority**(只读 rate_limit + 本地决定跳过 tick),不改各 daemon allowlist 动作语义,不引入 generic scheduler。这是 #427 的止血子集;完整 REST 化(comment.py `gh search`→REST 等)留给 #427 全量。

## 验证
`env -u GH_REPO_SLUG python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → `Ran 1137 tests OK (skipped=1)`。新增 `test_github_budget_backoff.py`(stub rate_limit:低于阈值→守卫 False + tick skip + backoff log;高于→正常;缓存命中不重复查)。source-regression `test_pr_checks` 大写 "GraphQL" 不变量保持(守卫仅用小写 `graphql` API 字段名)。

Refs #427

⟦AI:AUTO-LOOP⟧
