### PR TITLE
wakeup-runner 派发前重新校验 target OPEN/live 状态 (#433)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -45,6 +45,13 @@ REVIEW_DONE_RE = re.compile(r"^REVIEW_DONE:([1-9][0-9]*):([A-Za-z][A-Za-z0-9_-]*
 REVIEW_ARTIFACT_RE = re.compile(r"^review-pr([1-9][0-9]*)-([A-Za-z][A-Za-z0-9_-]*)-r([1-9][0-9]*)\.md$")
 REVIEW_LOG_RE = re.compile(r"^review-pr([1-9][0-9]*)-([A-Za-z][A-Za-z0-9_-]*)-r([1-9][0-9]*)\.log$")
 REVIEW_HEAD_RE = re.compile(r"(?im)^(?:reviewed[-_ ]?head[-_ ]?sha|head[-_ ]?sha|headRefOid|REVIEW_HEAD_SHA)\s*[:=]\s*([0-9a-f]{7,64})\s*$")
+TARGET_TEXT_PATTERNS = (
+    (re.compile(r"(?i)\bPR\s*#([1-9][0-9]*)\b"), "PR"),
+    (re.compile(r"(?i)\bissue\s*#([1-9][0-9]*)\b"), "issue"),
+    (re.compile(r"\bphase9-" + r"issue([1-9][0-9]*)-r[1-9][0-9]*-[A-Za-z][A-Za-z0-9_-]*\b"), "issue"),
+    (re.compile(r"\breview-pr([1-9][0-9]*)-[A-Za-z][A-Za-z0-9_-]*-r[1-9][0-9]*\b"), "PR"),
+    (re.compile(r"\bfix-pr([1-9][0-9]*)(?:-r|-round-)"), "PR"),
+)
 SUPPORTED_CONTROLLER_ACTIONS = {
     "spawn_codex_harness_background",
     "safe_push",
@@ -194,15 +201,34 @@ class WakeupRunner:
         return None
 
     def _validate_target(self, action: Mapping[str, Any]) -> str | None:
-        kind = action.get("target_kind")
-        number = action.get("target_number")
-        if kind in {"PR", "issue"}:
-            if not isinstance(number, int):
+        target = self._github_target(action)
+        if target is not None:
+            kind, number = target
+            if number <= 0:
                 return "target_number_missing"
-            live = self._live_target_state(str(kind).lower(), number)
+            live = self._live_target_state(kind.lower(), number)
             if live not in {"OPEN", "open"}:
                 return f"target_not_open:{live or 'unknown'}"
         return None
+
+    def _github_target(self, action: Mapping[str, Any]) -> tuple[str, int] | None:
+        kind = action.get("target_kind")
+        number = action.get("target_number")
+        if kind in {"PR", "issue"} and isinstance(number, int):
+            return str(kind), number
+        target = action.get("target")
+        if isinstance(target, Mapping):
+            target_kind = target.get("kind")
+            target_number = target.get("number")
+            if target_kind in {"PR", "issue"} and isinstance(target_number, int):
+                return str(target_kind), target_number
+        text_parts = []
+        for field in ("item", "action_id", "source_marker", "source_artifact", "prompt", "log"):
+            value = action.get(field)
+            if isinstance(value, str) and value:
+                text_parts.append(value)
+        target_from_text = _target_from_text(" ".join(text_parts))
+        return target_from_text
 
     def _validate_controller_action(self, action: Mapping[str, Any]) -> str | None:
         controller_action = str(action.get("controller_action") or "")
@@ -657,6 +683,19 @@ class WakeupRunner:
         return (max(rounds) if rounds else 0) + 1
 
     def _live_target_state(self, kind: str, number: int) -> str:
+        if self.ctx.gh_repo_slug:
+            endpoint = "pulls" if kind == "pr" else "issues"
+            result = self.command_runner(["gh", "api", f"repos/{self.ctx.gh_repo_slug}/{endpoint}/{number}"])
+            if result.returncode == 0:
+                try:
+                    payload = json.loads(result.stdout or "{}")
+                except json.JSONDecodeError:
+                    return ""
+                if isinstance(payload, dict):
+                    if kind == "pr" and payload.get("merged") is True:
+                        return "MERGED"
+                    state = str(payload.get("state") or "").strip()
+                    return state.upper() if state else ""
         result = self.command_runner(["gh", kind, "view", str(number), "--json", "state", "--jq", ".state"])
         return result.stdout.strip() if result.returncode == 0 else ""
 
@@ -696,7 +735,10 @@ class WakeupRunner:
                 row = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if row.get("action_id") == action_id and row.get("status") in {"applied", "dry-run"}:
+            if row.get("action_id") == action_id and (
+                row.get("status") in {"applied", "dry-run"}
+                or (row.get("status") == "blocked" and _terminal_blocked_reason(str(row.get("reason") or "")))
+            ):
                 return True
         return False
 
@@ -752,6 +794,18 @@ def _safe_branch_name(value: str) -> bool:
 def _extract_review_head_sha(text: str) -> str:
     match = REVIEW_HEAD_RE.search(text)
     return match.group(1) if match else ""
+
+
+def _target_from_text(text: str) -> tuple[str, int] | None:
+    for pattern, kind in TARGET_TEXT_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return kind, int(match.group(1))
+    return None
+
+
+def _terminal_blocked_reason(reason: str) -> bool:
+    return reason in {"target_not_open:CLOSED", "target_not_open:MERGED"}
 
 
 def load_plan_file(path: Path) -> Mapping[str, Any]:

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -579,6 +579,51 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
 
                 self.assert_blocked_before_dispatch(results, action["action_id"], f"target_not_open:{gh_state}", actions)
 
+    def test_closed_pr_nested_target_mapping_blocks_before_dispatch(self) -> None:
+        actions = FakeActions()
+        action = self.reviewer_dispatch_action(
+            action_id="nested-target:review-pr423",
+            target_kind=None,
+            target_number=None,
+            target={"kind": "PR", "number": 423},
+        )
+
+        results = self.run_result(self.base_plan(action), gh_state="CLOSED", actions=actions)
+
+        self.assert_blocked_before_dispatch(results, action["action_id"], "target_not_open:CLOSED", actions)
+
+    def test_closed_pr_review_and_fix_text_targets_block_before_dispatch(self) -> None:
+        cases = (
+            (
+                "review-pr-text",
+                self.reviewer_dispatch_action(
+                    action_id="completed-marker:review-pr423-architect-r1.log:REVIEW_DONE",
+                    target_kind=None,
+                    target_number=None,
+                    target=None,
+                ),
+                "CLOSED",
+                "target_not_open:CLOSED",
+            ),
+            (
+                "fix-pr-text",
+                self.review_gate_action(
+                    action_id="completed-marker:fix-pr423-round-1.log:FIX_DONE",
+                    target_kind=None,
+                    target_number=None,
+                    target=None,
+                ),
+                "MERGED",
+                "target_not_open:MERGED",
+            ),
+        )
+        for name, action, gh_state, reason in cases:
+            with self.subTest(name=name):
+                actions = FakeActions()
+                results = self.run_result(self.base_plan(action), gh_state=gh_state, actions=actions)
+
+                self.assert_blocked_before_dispatch(results, action["action_id"], reason, actions)
+
     def test_closed_issue_design_consensus_spawn_skips_terminal_before_supervisor(self) -> None:
         actions = FakeActions()
         action = self.design_consensus_spawn_action()

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -107,6 +107,16 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         actions=None,
     ) -> list:
         def command_runner(command):
+            if command[:2] == ["gh", "api"]:
+                endpoint = str(command[2]) if len(command) > 2 else ""
+                if "/pulls/" in endpoint or "/issues/" in endpoint:
+                    if gh_state is None:
+                        return subprocess.CompletedProcess(command, 1, "", "not found")
+                    payload = {"state": str(gh_state).lower()}
+                    if gh_state == "MERGED":
+                        payload = {"state": "closed", "merged": True}
+                    return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+                return subprocess.CompletedProcess(command, 0, "{}", "")
             if command[:4] == ["gh", "pr", "list", "--state"]:
                 return subprocess.CompletedProcess(command, 0, json.dumps(duplicate_prs or []), "")
             if command[:3] == ["gh", "issue", "view"] or command[:3] == ["gh", "pr", "view"]:
@@ -366,6 +376,33 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         action.update(overrides)
         return action
 
+    def design_consensus_spawn_action(self, **overrides) -> dict:
+        prompt = self.repo / ".refactor-loop/prompts/phase9/phase9-issue104-r2-judge.md"
+        prompt.parent.mkdir(parents=True, exist_ok=True)
+        prompt.write_text("design consensus\n", encoding="utf-8")
+        pending = self.repo / ".refactor-loop/.controller-pending-events.log"
+        marker = "HARNESS_SPAWN_INTENT phase9-issue104-r2-judge"
+        pending.write_text(marker + "\n", encoding="utf-8")
+        action = {
+            "kind": "harness-spawn-intent",
+            "action_id": "harness-spawn-intent:phase9-router:104:2:judge",
+            "runner_authority": "wakeup-runner-396",
+            "preconditions": ["active_controller_owner", "source_artifact_contains_evidence", "target_log_absent"],
+            "source_artifact": ".refactor-loop/.controller-pending-events.log",
+            "source_marker": marker,
+            "target_kind": "codex",
+            "target_number": None,
+            "target": {"kind": "codex", "task_id": "phase9-issue104-r2-judge"},
+            "controller_action": "spawn_codex_harness_background",
+            "no_generic_command": True,
+            "cd": str(self.repo),
+            "prompt": str(prompt),
+            "log": str(self.repo / ".refactor-loop/logs/phase9-issue104-r2-judge.log"),
+            "stall": 30,
+        }
+        action.update(overrides)
+        return action
+
     def test_valid_harness_spawn_executes_through_checked_supervisor(self) -> None:
         results = self.run_result(self.base_plan(self.spawn_action()))
 
@@ -529,6 +566,48 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                 actions = FakeActions()
                 results = self.run_result(self.base_plan(action), gh_state=gh_state, actions=actions)
                 self.assert_blocked_before_dispatch(results, action["action_id"], reason, actions)
+
+    def test_closed_pr_review_and_fix_dispatch_skip_terminal_before_spawn(self) -> None:
+        cases = (
+            ("review-dispatch", self.reviewer_dispatch_action(action_id="stale-review:423"), "CLOSED"),
+            ("fix-dispatch", self.review_gate_action(action_id="stale-fix:423"), "MERGED"),
+        )
+        for name, action, gh_state in cases:
+            with self.subTest(name=name):
+                actions = FakeActions()
+                results = self.run_result(self.base_plan(action), gh_state=gh_state, actions=actions)
+
+                self.assert_blocked_before_dispatch(results, action["action_id"], f"target_not_open:{gh_state}", actions)
+
+    def test_closed_issue_design_consensus_spawn_skips_terminal_before_supervisor(self) -> None:
+        actions = FakeActions()
+        action = self.design_consensus_spawn_action()
+
+        results = self.run_result(self.base_plan(action), gh_state="CLOSED", actions=actions)
+
+        self.assert_blocked_before_dispatch(results, action["action_id"], "target_not_open:CLOSED", actions)
+
+    def test_open_issue_design_consensus_spawn_still_applies(self) -> None:
+        action = self.design_consensus_spawn_action(action_id="harness-spawn-intent:phase9-router:104:2:judge-open")
+
+        results = self.run_result(self.base_plan(action), gh_state="OPEN", actions=FakeActions())
+
+        self.assertEqual(results[0].status, "applied")
+        self.assertEqual(len(self.supervisor.calls), 1)
+
+    def test_terminal_closed_target_block_suppresses_next_tick_retry(self) -> None:
+        actions = FakeActions()
+        action = self.reviewer_dispatch_action(action_id="stale-review:423:dedupe")
+        plan = self.base_plan(action)
+
+        first = self.run_result(plan, gh_state="CLOSED", actions=actions)
+        second = self.run_result(plan, gh_state="CLOSED", actions=actions)
+
+        self.assertEqual(first[0].status, "blocked")
+        self.assertEqual(first[0].reason, "target_not_open:CLOSED")
+        self.assertEqual(second[0].status, "skipped")
+        self.assertEqual(second[0].reason, "duplicate")
+        self.assertEqual(actions.calls, [])
 
     def test_safe_push_missing_or_invalid_preconditions_block_at_runner_gate_before_helper(self) -> None:
         outside = self.repo / "outside-worktree"

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner_review_gate.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner_review_gate.py
@@ -94,7 +94,7 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
             if command[:3] == ["gh", "pr", "view"] and "mergeable,isDraft" in command:
                 return subprocess.CompletedProcess(command, 0, json.dumps({"mergeable": mergeable, "isDraft": False}), "")
             if command[:2] == ["gh", "api"] and command[2] == "repos/owner/repo/pulls/12":
-                return subprocess.CompletedProcess(command, 0, json.dumps({"head": {"sha": live_head}}), "")
+                return subprocess.CompletedProcess(command, 0, json.dumps({"state": "open", "head": {"sha": live_head}}), "")
             if command[:2] == ["gh", "api"] and command[2] == f"repos/owner/repo/commits/{live_head}/check-runs":
                 payload = {"check_runs": [{"name": "ci", "status": check_status, "conclusion": check_conclusion}]}
                 return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")


### PR DESCRIPTION
## 动机
#396 wakeup-runner 契约要求:每个 closed action 在 apply 前重新验证 target 的 OPEN/live GitHub 状态。但 reviewer / design-consensus / fix / publish 各派发路径漏做这步重校验,导致对已 CLOSED/MERGED 的 target 反复 re-dispatch(如对已合并 PR 重派 reviewer、对已关闭 issue 重开 design round),空转烧 graphql 配额。

## 改动范围
在 wakeup_runner.py 的 reviewer / design-consensus / fix / publish 派发路径补齐 #396 既有合同要求的 OPEN/live 状态重校验(REST-first 读 state):
- target 已 CLOSED/MERGED → skip + 标 blocked,**不重新 spawn、不每 tick 重试**。
- 仅 OPEN/live target 才机械调用既有 helper 派发。
不新增 controller 判断、不放宽 allowlist;只是把既有 #396 重校验要求落到这几条路径。

## 边界
纯收窄(少做无效派发),不新增 lifecycle authority,不改 SUPPORTED_CONTROLLER_ACTIONS 集合语义。

## 验证
`env -u GH_REPO_SLUG python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → `Ran 1130 tests OK (skipped=1)`(controller 独立复跑同样 OK)。配套 stub-gh behavior test:closed target → skip+blocked 不 re-spawn;open target → 正常派发。

Refs #433

⟦AI:AUTO-LOOP⟧
