### PR TITLE
G1 intake spawn intent 用绝对 cd 修 headless floor 盲区 (#430)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -938,7 +938,7 @@ class Phase9Router:
             "priority": "p1",
             "command": "spawn-codex",
             "controller_action": "spawn_codex_harness_background",
-            "cd": ".",
+            "cd": str(self.ctx.repo_root.resolve()),
             "prompt": self._artifact_path(prompt),
             "log": self._artifact_path(log_path),
             "stall": 3600,

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -81,6 +81,18 @@ RUNNER_NAMED_HELPER_ACTIONS = {
     "review_gate",
     "publish_release_candidate",
 }
+
+
+def _contained_execution_cd(ctx: LoopContext, text: str) -> Path:
+    cd = Path(text).expanduser()
+    if not cd.is_absolute():
+        cd = ctx.repo_root / cd
+    resolved = cd.resolve()
+    try:
+        resolved.relative_to(ctx.repo_root.resolve())
+    except ValueError as exc:
+        raise ValueError(f"cd escapes REPO_ROOT: {text!r}") from exc
+    return resolved
 EXECUTABLE_ACTION_KINDS = {
     "harness-spawn-intent",
     "unpushed-worker-output",
@@ -199,7 +211,7 @@ def harness_spawn_intent_actions(repo_root: Path, ctx: LoopContext, monitor: Any
             actions.append(_invalid_harness_spawn_intent(invalid_reason, line, intent_id=intent_id))
             continue
         try:
-            cd = ctx.artifact_execution_path(str(intent["cd"]))
+            cd = _contained_execution_cd(ctx, str(intent["cd"]))
             prompt = ctx.artifact_execution_path(str(intent["prompt"]))
             log_path = ctx.artifact_execution_path(str(intent["log"]))
         except Exception as exc:

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -286,7 +286,9 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         intent = self.commands[0]
         self.assertEqual(intent["command"], "spawn-codex")
         self.assertEqual(intent["controller_action"], "spawn_codex_harness_background")
-        self.assertEqual(intent["cd"], ".")
+        self.assertEqual(intent["cd"], str(self.repo.resolve()))
+        self.assertNotEqual(intent["cd"], ".")
+        self.assertTrue(Path(str(intent["cd"])).is_absolute())
         self.assertEqual(intent["log"], ".refactor-loop/logs/phase9-issue37-r4-judge.log")
         self.assertNotIn("argv", intent)
         self.assertNotIn("shell", intent)
@@ -311,7 +313,9 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         intent = json.loads(intent_lines[0].split(" HARNESS_SPAWN_INTENT ", 1)[1])
         self.assertEqual(intent["command"], "spawn-codex")
         self.assertEqual(intent["controller_action"], "spawn_codex_harness_background")
-        self.assertEqual(intent["cd"], ".")
+        self.assertEqual(intent["cd"], str(self.repo.resolve()))
+        self.assertNotEqual(intent["cd"], ".")
+        self.assertTrue(Path(str(intent["cd"])).is_absolute())
         self.assertEqual(intent["prompt"], ".refactor-loop/prompts/phase9/phase9-issue330-r4-judge.md")
         self.assertEqual(intent["log"], ".refactor-loop/logs/phase9-issue330-r4-judge.log")
         self.assertTrue(intent["run_in_background_required"])
@@ -356,7 +360,9 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             self.assertEqual(command["command"], "spawn-codex")
             self.assertEqual(command["controller_action"], "spawn_codex_harness_background")
             self.assertEqual(command["route"], "design_consensus_issue_intake")
-            self.assertEqual(command["cd"], ".")
+            self.assertEqual(command["cd"], str(self.repo.resolve()))
+            self.assertNotEqual(command["cd"], ".")
+            self.assertTrue(Path(str(command["cd"])).is_absolute())
             self.assertTrue(command["run_in_background_required"])
             self.assertTrue(command["no_lifecycle_authority"])
             self.assertNotIn("argv", command)
@@ -876,9 +882,11 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertNotIn(str(self.repo), json.dumps(ledger, ensure_ascii=False))
         intent = self.commands[0]
         self.assertEqual(intent["command"], "spawn-codex")
+        self.assertEqual(intent["cd"], str(self.repo.resolve()))
         self.assertEqual(intent["prompt"], ".refactor-loop/prompts/phase9/phase9-issue202-r1-judge.md")
         self.assertEqual(intent["log"], ".refactor-loop/logs/phase9-issue202-r1-judge.log")
-        self.assertNotIn(str(self.repo), json.dumps(intent, ensure_ascii=False))
+        self.assertNotIn(str(self.repo), str(intent["prompt"]))
+        self.assertNotIn(str(self.repo), str(intent["log"]))
         self.assertNotIn("argv", intent)
         self.assertNotIn("shell", intent)
 
@@ -1649,6 +1657,8 @@ class Phase9RouterDaemonTests(unittest.TestCase):
 
     def test_phase9_router_source_regression_uses_loop_context_artifact_path_boundary(self) -> None:
         src = PHASE9_ROUTER.read_text(encoding="utf-8")
+        self.assertIn('"cd": str(self.ctx.repo_root.resolve())', src)
+        self.assertNotIn('"cd": "."', src)
         self.assertIn("self.ctx.durable_artifact_path(path)", src)
         self.assertIn("self.ctx.artifact_execution_path(text)", src)
         for forbidden in (
@@ -1673,7 +1683,9 @@ class Phase9RouterDaemonTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0]["cd"], ".")
+        self.assertEqual(commands[0]["cd"], str(self.repo.resolve()))
+        self.assertNotEqual(commands[0]["cd"], ".")
+        self.assertTrue(Path(str(commands[0]["cd"])).is_absolute())
         self.assertEqual(commands[0]["command"], "spawn-codex")
         self.assertEqual([entry["key"] for entry in self.ledger_entries()], ["37-4-judge"])
 

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
@@ -14,6 +14,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from codex_refactor_loop.context import LoopContext
+from codex_refactor_loop.monitors.concurrency import ConcurrencyMonitor
 from codex_refactor_loop.phase9.router import (
     Phase9Router,
     Phase9SourceIssueDecision,
@@ -145,6 +146,10 @@ class Phase9RouterPackageTests(unittest.TestCase):
             self.router.tick()
 
         self.assertEqual(len(self.commands), 3)
+        for command in self.commands:
+            self.assertEqual(command["cd"], str(self.repo.resolve()))
+            self.assertNotEqual(command["cd"], ".")
+            self.assertTrue(Path(str(command["cd"])).is_absolute())
         self.assertEqual(
             sorted(command["log"] for command in self.commands),
             [
@@ -157,6 +162,44 @@ class Phase9RouterPackageTests(unittest.TestCase):
             sorted(entry["key"] for entry in self.ledger_entries()),
             ["410-1-delete", "410-1-minimal", "410-1-structural"],
         )
+
+    def test_design_issue_intake_absolute_cd_matches_concurrency_floor_scope(self) -> None:
+        rows = [
+            {
+                "number": 430,
+                "title": "intake floor scope",
+                "labels": [
+                    {"name": "crnd:lifecycle:managed"},
+                    {"name": "crnd:phase:design-solving"},
+                    {"name": "crnd:human:auto"},
+                ],
+            }
+        ]
+        self.router = Phase9Router(
+            ctx=LoopContext.load(repo_root=self.repo, env={"GH_REPO_SLUG": "owner/repo"}),
+            command_runner=self.commands.append,
+        )
+        self.router._read_source_issue_decision = self.open_source_issue_decision  # type: ignore[method-assign]
+        self.router._open_design_consensus_issues = self.router.__class__._open_design_consensus_issues.__get__(self.router)  # type: ignore[method-assign]
+
+        with mock.patch(
+            "codex_refactor_loop.phase9.router.subprocess.run",
+            return_value=mock.Mock(returncode=0, stdout=json.dumps(rows), stderr=""),
+        ):
+            self.router.tick()
+
+        self.assertEqual(len(self.commands), 3)
+        command = self.commands[0]
+        self.assertEqual(command["cd"], str(self.repo.resolve()))
+        self.assertNotEqual(command["cd"], ".")
+        fake_ps = (
+            f"python3 consensus-rnd-cli spawn-codex --cd {command['cd']} "
+            f"--prompt {self.repo.resolve()}/{command['prompt']} "
+            f"--log {self.repo.resolve()}/{command['log']}\n"
+        )
+        monitor = ConcurrencyMonitor(LoopContext.load(repo_root=self.repo))
+        with mock.patch.object(monitor, "run", return_value=mock.Mock(stdout=fake_ps, returncode=0)):
+            self.assertEqual(monitor.count_in_flight_codex(), 1)
 
     # Refactor (impl/issue191-single-active-controller): Old pattern: every
     # device-local phase9 router could write prompts, ledgers, and fallback

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -561,6 +561,24 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertNotIn("argv", action)
         self.assertNotIn("shell", action)
 
+    def test_harness_spawn_intent_accepts_absolute_repo_contained_cd(self) -> None:
+        self.append_harness_spawn_intent(cd=str(self.repo.resolve()))
+
+        plan = self.run_plan()
+
+        action = plan["actions"][0]
+        self.assertEqual(action["kind"], "harness-spawn-intent")
+        self.assertEqual(action["cd"], str(self.repo.resolve()))
+
+    def test_harness_spawn_intent_rejects_absolute_cd_outside_repo(self) -> None:
+        self.append_harness_spawn_intent(cd="/tmp/outside-consensus-rnd")
+
+        plan = self.run_plan()
+
+        action = plan["actions"][0]
+        self.assertEqual(action["kind"], "harness-spawn-intent-invalid")
+        self.assertIn("invalid-path:cd escapes REPO_ROOT", action["reason"])
+
     def test_harness_spawn_intent_rejects_argv_command_array(self) -> None:
         self.append_harness_spawn_intent(command=["consensus-rnd-cli", "spawn-codex"])
 
@@ -606,7 +624,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                 self.assert_harness_spawn_intent_invalid(f"missing-{field}", **{field: ""})
 
         self.assert_harness_spawn_intent_invalid(
-            "invalid-path:artifact path must be repo-relative POSIX text: '../outside'",
+            "invalid-path:cd escapes REPO_ROOT: '../outside'",
             cd="../outside",
         )
 


### PR DESCRIPTION
## 动机
headless 下 floor 计数对 wakeup-runner/router 派生的 worker 全盲(#430)。G1 design-consensus intake 的 spawn intent 用 `"cd":"."`(相对路径)派 worker,worker cmdline 里没有绝对 `$REPO_ROOT`;而 `concurrency --count-only` 只数 cmdline 含绝对 `$REPO_ROOT` 的本 loop codex → 实际有 N 个在跑却数到 0 → headless 下 floor 恒读 0 = 伪 P0 + 过度派发。

## 改动范围
phase9/router.py 的 G1 DesignConsensusIssueIntake spawn intent 把 `cd` 改为绝对 `$REPO_ROOT`(对齐既有 reviewer/fix 派发路径的绝对 cd 约定),使 headless-spawn 的 worker 对 floor counter 可见。配套 behavior test 断言 intent 的 cd 为绝对 repo_root。

## 边界
纯修计数可见性,不改派发语义、不放宽 allowlist。

## 验证
`env -u GH_REPO_SLUG python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` 全绿;新增 behavior test 锁住 absolute cd。

Refs #430

⟦AI:AUTO-LOOP⟧
