### PR TITLE
check-project-rules patch 可 git apply (#431)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/project_rules.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/project_rules.py
@@ -82,14 +82,17 @@ class ProjectRulesPatchArtifact:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         original_name = str(report.target_relative)
         updated_name = str(report.target_relative)
+        proposed_text = _ensure_trailing_newline(report.proposed_text)
         patch = "".join(
             difflib.unified_diff(
                 report.original_text.splitlines(keepends=True),
-                report.proposed_text.splitlines(keepends=True),
+                proposed_text.splitlines(keepends=True),
                 fromfile=f"a/{original_name}",
                 tofile=f"b/{updated_name}",
+                lineterm="\n",
             )
         )
+        patch = _ensure_trailing_newline(patch)
         self.path.write_text(patch, encoding="utf-8")
         return self.path
 
@@ -196,6 +199,12 @@ class ProjectRulesFixedPointProbe:
             f"{CANONICAL_BODY}"
             f"{END_MARKER}"
         )
+
+
+def _ensure_trailing_newline(text: str) -> str:
+    if text.endswith("\n"):
+        return text
+    return f"{text}\n"
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
+++ b/skills/codex-refactor-loop/scripts/test_ensure_project_rules_fixed_points.py
@@ -74,6 +74,26 @@ class ProjectRulesFixedPointTests(unittest.TestCase):
         self.assertIn("+- FI-007 删除优先；废弃路径直接移除，除非 host 规则明确要求迁移期兼容。", patch)
         self.assertEqual(before, self.rules.read_bytes())
 
+    def test_generated_patch_is_git_apply_compatible_and_preserves_sentinel_hash(self) -> None:
+        report = ProjectRulesFixedPointProbe(str(self.tmp)).inspect()
+        artifact = ProjectRulesPatchArtifact(self.tmp).write(report)
+        patch = artifact.read_text(encoding="utf-8")
+
+        self.assertTrue(patch.endswith("\n"))
+        subprocess.run(["git", "apply", "--check", str(artifact)], cwd=self.tmp, check=True)
+        subprocess.run(["git", "apply", str(artifact)], cwd=self.tmp, check=True)
+
+        applied = self.rules.read_text(encoding="utf-8")
+        start = START_RE.search(applied)
+        self.assertIsNotNone(start)
+        assert start is not None
+        end_index = applied.find(END_MARKER, start.end())
+        self.assertGreaterEqual(end_index, 0)
+        enclosed = applied[start.end() + 1:end_index]
+        self.assertEqual(CANONICAL_BODY, enclosed)
+        self.assertEqual(start.group(1), sha256_text(enclosed))
+        self.assertEqual(CANONICAL_HASH, start.group(1))
+
     def test_probe_known_old_block_writes_replacement_patch_without_overwrite(self) -> None:
         old_text = f"# Host rules\n\n{self._managed_block(OLD_CANONICAL_BODY)}"
         self.rules.write_text(old_text, encoding="utf-8")


### PR DESCRIPTION
## 动机
`check-project-rules` 生成的 fixed-point patch 无法 `git apply`(#431)。

## 改动
修 project_rules.py 的 patch 生成,使产出可被 `git apply` 干净应用;配套 source-regression test。

## 边界
窄修 patch 生成,不引入 PROJECT_RULES_WRITE_ENABLE,保持 read-only probe + patch artifact 边界。

## 验证
`env -u GH_REPO_SLUG python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` 全绿。
Refs #431

⟦AI:AUTO-LOOP⟧
