### PR TITLE
closed_label_reconciler legacy-label host 不崩溃 (#432)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
@@ -27,6 +27,9 @@ class ClosedLabelReconciler:
     def __init__(self, ctx: LoopContext, *, dry_run: bool = False) -> None:
         self.ctx = ctx
         self.dry_run = dry_run
+        self._host_label_names: frozenset[str] | None = None
+        self._warned_unresolved_host_labels: set[tuple[str, int, str]] = set()
+        self._apply_skip_reasons: dict[tuple[str, int], str] = {}
 
     # Refactor (iter370/issue-370): keep the #238 reconciler alive across mixed closed-item drift.
     # Old pattern: one slow or failing item could stall the whole tick and let the daemon heartbeat expire.
@@ -57,7 +60,9 @@ class ClosedLabelReconciler:
                     continue
                 live_plan = self.apply_plan(plan)
                 if live_plan is None:
-                    print(f"closed-label-reconciler skip: {plan.kind} #{plan.number} no longer closed managed")
+                    reason = self._apply_skip_reasons.pop((plan.kind, plan.number), None)
+                    if reason is None:
+                        print(f"closed-label-reconciler skip: {plan.kind} #{plan.number} no longer closed managed")
                     continue
                 self.verify_plan(live_plan)
                 print(_format_plan(live_plan, dry_run=False))
@@ -108,13 +113,67 @@ class ClosedLabelReconciler:
             return None
         if not live_plan.needs_edit:
             return live_plan
+        edit_plan = self._plan_for_host_labels(live_plan)
+        if edit_plan is None:
+            self._warn_unresolved_host_label_once(live_plan)
+            self._apply_skip_reasons[(live_plan.kind, live_plan.number)] = "unresolved-host-label"
+            return None
         command = [live_plan.kind, "edit", str(live_plan.number)]
-        for label in live_plan.add_labels:
+        for label in edit_plan.add_labels:
             command.extend(["--add-label", label])
-        for label in live_plan.remove_labels:
+        for label in edit_plan.remove_labels:
             command.extend(["--remove-label", label])
         self._gh(command)
         return live_plan
+
+    def _warn_unresolved_host_label_once(self, plan: ClosedPhaseLabelPlan) -> None:
+        key = (plan.kind, plan.number, plan.terminal_phase)
+        if key in self._warned_unresolved_host_labels:
+            return
+        self._warned_unresolved_host_labels.add(key)
+        print(
+            f"closed-label-reconciler warn: {plan.kind} #{plan.number} "
+            f"cannot resolve host label for terminal phase {plan.terminal_phase}; skipping phase reconciliation"
+        )
+
+    def _plan_for_host_labels(self, plan: ClosedPhaseLabelPlan) -> ClosedPhaseLabelPlan | None:
+        add_labels = []
+        for label in plan.add_labels:
+            resolved = self._resolve_writable_label(label)
+            if resolved is None:
+                return None
+            add_labels.append(resolved)
+        return ClosedPhaseLabelPlan(
+            kind=plan.kind,
+            number=plan.number,
+            terminal_phase=plan.terminal_phase,
+            add_labels=tuple(add_labels),
+            remove_labels=plan.remove_labels,
+            reason=plan.reason,
+        )
+
+    def _resolve_writable_label(self, canonical_label: str) -> str | None:
+        host_labels = self._host_labels()
+        if canonical_label in host_labels:
+            return canonical_label
+        for alias in label_catalog.aliases_for(canonical_label):
+            if alias in host_labels:
+                return alias
+        return None
+
+    def _host_labels(self) -> frozenset[str]:
+        if self._host_label_names is not None:
+            return self._host_label_names
+        data = self._gh_json(["label", "list", "--json", "name", "--limit", "1000"], [])
+        if not isinstance(data, list):
+            self._host_label_names = frozenset()
+            return self._host_label_names
+        self._host_label_names = frozenset(
+            str(item.get("name", ""))
+            for item in data
+            if isinstance(item, Mapping)
+        )
+        return self._host_label_names
 
     # Refactor (iter370/issue-370): verify only the terminal phase label this daemon is authorized to own.
     # Old pattern: post-edit verification required a human label and coupled #238 cleanup to human authority.

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_phase_labels.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_phase_labels.py
@@ -8,9 +8,6 @@ from typing import Mapping, Sequence
 from . import labels as label_catalog
 
 
-TERMINAL_PHASES = frozenset({label_catalog.PHASE_MERGED, label_catalog.PHASE_CLOSED})
-
-
 @dataclass(frozen=True)
 class ClosedPhaseLabelPlan:
     """Read-only terminal phase-label plan for closed managed items."""
@@ -44,13 +41,18 @@ def plan_closed_phase_labels(
         return None
 
     terminal = _terminal_phase(kind=kind, merged=merged, linked_merged=linked_merged, projection=projection)
-    current_phases = set(projection.labels_for_group("phase"))
-    remove = set(current_phases - {terminal})
-    remove.update(projection.cleanup_only)
-    if label_catalog.STUCK in projection.canonical:
-        remove.add(label_catalog.STUCK)
-    remove.update(_legacy_phase_and_cleanup_labels(labels))
-    add = () if terminal in current_phases else (terminal,)
+    terminal_present = False
+    remove = set()
+    for label in labels:
+        label_projection = label_catalog.normalize_label_set([label])
+        phase_labels = set(label_projection.labels_for_group("phase"))
+        if terminal in phase_labels:
+            terminal_present = True
+        if label_projection.cleanup_only or label_catalog.STUCK in label_projection.canonical:
+            remove.add(label)
+        elif phase_labels and terminal not in phase_labels:
+            remove.add(label)
+    add = () if terminal_present else (terminal,)
     return ClosedPhaseLabelPlan(
         kind=kind,
         number=number,
@@ -100,18 +102,6 @@ def _reason(*, kind: str, merged: bool, linked_merged: bool, terminal: str) -> s
     if terminal == label_catalog.PHASE_MERGED:
         return "existing-merged-evidence"
     return "closed-no-merged-evidence"
-
-
-def _legacy_phase_and_cleanup_labels(labels: Sequence[str]) -> set[str]:
-    remove: set[str] = set()
-    for label in labels:
-        projection = label_catalog.normalize_label_set([label])
-        if projection.cleanup_only:
-            remove.add(label)
-        phase_labels = projection.labels_for_group("phase")
-        if phase_labels and label not in TERMINAL_PHASES:
-            remove.add(label)
-    return remove
 
 
 def plan_from_gh_item(kind: str, item: Mapping[str, object], *, linked_merged: bool = False) -> ClosedPhaseLabelPlan | None:

--- a/skills/codex-refactor-loop/scripts/test_closed_label_reconciler.py
+++ b/skills/codex-refactor-loop/scripts/test_closed_label_reconciler.py
@@ -88,6 +88,22 @@ class ClosedPhaseProjectionTests(unittest.TestCase):
         self.assertEqual((labels.PHASE_MERGED,), plan.add_labels)
         self.assertEqual((labels.PHASE_CLOSED,), plan.remove_labels)
 
+    def test_legacy_phase_alias_removal_uses_live_alias_not_missing_canonical(self) -> None:
+        plan = plan_closed_phase_labels(
+            kind="issue",
+            number=20,
+            state="CLOSED",
+            labels=["auto-loop", "🛠️ phase:implementing", "🤖 human:auto-推进"],
+            linked_merged=True,
+        )
+
+        self.assertIsNotNone(plan)
+        assert plan is not None
+        self.assertEqual(labels.PHASE_MERGED, plan.terminal_phase)
+        self.assertEqual((labels.PHASE_MERGED,), plan.add_labels)
+        self.assertEqual(("🛠️ phase:implementing",), plan.remove_labels)
+        self.assertNotIn(labels.PHASE_IMPLEMENTING, plan.remove_labels)
+
     def test_idempotent_terminal_phase_has_no_edit_plan(self) -> None:
         plan = plan_closed_phase_labels(
             kind="issue",
@@ -277,6 +293,7 @@ class ClosedLabelReconcilerBehaviorTests(unittest.TestCase):
             "title": "closed pr",
         }
         gh_json_responses = {
+            ("label", "list", "--json", "name", "--limit", "1000"): [{"name": name} for name in labels.canonical_labels()],
             ("issue", "list", "--label", labels.MANAGED, "--state", "closed", "--limit", "100", "--json", "number,state,labels,title"): [issue_row],
             ("issue", "list", "--label", "auto-loop", "--state", "closed", "--limit", "100", "--json", "number,state,labels,title"): [issue_row],
             ("pr", "list", "--label", labels.MANAGED, "--state", "closed", "--limit", "100", "--json", "number,state,labels,title,mergedAt"): [pr_row],
@@ -384,6 +401,7 @@ class ClosedLabelReconcilerBehaviorTests(unittest.TestCase):
             "title": "normal closed issue",
         }
         gh_json_responses = {
+            ("label", "list", "--json", "name", "--limit", "1000"): [{"name": name} for name in labels.canonical_labels()],
             ("issue", "list", "--label", labels.MANAGED, "--state", "closed", "--limit", "100", "--json", "number,state,labels,title"): [missing_human_row, normal_row],
             ("issue", "list", "--label", "auto-loop", "--state", "closed", "--limit", "100", "--json", "number,state,labels,title"): [missing_human_row, normal_row],
             ("pr", "list", "--label", labels.MANAGED, "--state", "closed", "--limit", "100", "--json", "number,state,labels,title,mergedAt"): [],
@@ -443,6 +461,132 @@ class ClosedLabelReconcilerBehaviorTests(unittest.TestCase):
             edit_commands,
         )
         self.assertNotIn(("issue", "view", "31", "--json", "number,state,labels"), view_counts)
+
+    def test_legacy_emoji_label_host_writes_existing_alias_without_canonical_retry_noise(self) -> None:
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="closed-label-reconciler", lease_id="lease", expires_at="")
+        issue_row = {
+            "number": 33,
+            "state": "CLOSED",
+            "labels": [
+                {"name": "auto-loop"},
+                {"name": "🛠️ phase:implementing"},
+                {"name": "🤖 human:auto-推进"},
+            ],
+            "title": "legacy closed issue",
+        }
+        after_row = {
+            "number": 33,
+            "state": "CLOSED",
+            "labels": [
+                {"name": "auto-loop"},
+                {"name": "🎉 phase:merged"},
+                {"name": "🤖 human:auto-推进"},
+            ],
+        }
+        gh_json_responses = {
+            ("label", "list", "--json", "name", "--limit", "1000"): [
+                {"name": "auto-loop"},
+                {"name": "🛠️ phase:implementing"},
+                {"name": "🎉 phase:merged"},
+                {"name": "🤖 human:auto-推进"},
+            ],
+            ("issue", "list", "--label", labels.MANAGED, "--state", "closed", "--limit", "100", "--json", "number,state,labels,title"): [],
+            ("issue", "list", "--label", "auto-loop", "--state", "closed", "--limit", "100", "--json", "number,state,labels,title"): [issue_row],
+            ("pr", "list", "--label", labels.MANAGED, "--state", "closed", "--limit", "100", "--json", "number,state,labels,title,mergedAt"): [],
+            ("pr", "list", "--label", "auto-loop", "--state", "closed", "--limit", "100", "--json", "number,state,labels,title,mergedAt"): [],
+            ("pr", "list", "--label", labels.MANAGED, "--state", "merged", "--limit", "100", "--json", "number,state,labels,title,mergedAt"): [],
+            ("pr", "list", "--label", "auto-loop", "--state", "merged", "--limit", "100", "--json", "number,state,labels,title,mergedAt"): [],
+            ("pr", "list", "--state", "merged", "--search", "in:body Closes #33", "--limit", "1", "--json", "number,mergedAt"): [{"number": 70, "mergedAt": "2026-05-31T00:00:00Z"}],
+            ("issue", "view", "33", "--json", "number,state,labels"): after_row,
+        }
+        edit_commands: list[tuple[str, ...]] = []
+        view_counts: dict[tuple[str, ...], int] = {}
+
+        def fake_gh(args: tuple[str, ...] | list[str], *, check: bool = True) -> CompletedProcess[str]:
+            command = tuple(args)
+            if command == ("issue", "view", "33", "--json", "number,state,labels"):
+                count = view_counts.get(command, 0)
+                view_counts[command] = count + 1
+                item = issue_row if count == 0 else after_row
+                return CompletedProcess(["gh", *command], 0, json.dumps(item), "")
+            if command in gh_json_responses:
+                return CompletedProcess(["gh", *command], 0, json.dumps(gh_json_responses[command]), "")
+            if len(command) >= 2 and command[1] == "list":
+                return CompletedProcess(["gh", *command], 0, "[]", "")
+            edit_commands.append(command)
+            if any(label.startswith("crnd:") for label in command):
+                return CompletedProcess(["gh", *command], 1, "", "'crnd:phase:implementing' not found")
+            return CompletedProcess(["gh", *command], 0, "", "")
+
+        reconciler = ClosedLabelReconciler(self.ctx)
+        with mock.patch("codex_refactor_loop.closed_label_reconciler.require_active_controller", return_value=decision):
+            with mock.patch.object(reconciler, "_gh", side_effect=fake_gh):
+                self.assertEqual(0, reconciler.run_once())
+                self.assertEqual(0, reconciler.run_once())
+
+        self.assertEqual(
+            [
+                (
+                    "issue",
+                    "edit",
+                    "33",
+                    "--add-label",
+                    "🎉 phase:merged",
+                    "--remove-label",
+                    "🛠️ phase:implementing",
+                )
+            ],
+            edit_commands,
+        )
+
+    def test_unresolvable_terminal_label_warns_skips_and_does_not_retry_failed_edit(self) -> None:
+        plan = ClosedPhaseLabelPlan(
+            kind="issue",
+            number=34,
+            terminal_phase=labels.PHASE_CLOSED,
+            add_labels=(labels.PHASE_CLOSED,),
+            remove_labels=("🛠️ phase:implementing",),
+            reason="closed-no-merged-evidence",
+        )
+        gh_json_responses = {
+            ("label", "list", "--json", "name", "--limit", "1000"): [
+                {"name": "auto-loop"},
+                {"name": "🛠️ phase:implementing"},
+                {"name": "🤖 human:auto-推进"},
+            ],
+            ("issue", "view", "34", "--json", "number,state,labels"): {
+                "number": 34,
+                "state": "CLOSED",
+                "labels": [
+                    {"name": "auto-loop"},
+                    {"name": "🛠️ phase:implementing"},
+                    {"name": "🤖 human:auto-推进"},
+                ],
+            },
+            ("pr", "list", "--state", "merged", "--search", "in:body Closes #34", "--limit", "1", "--json", "number,mergedAt"): [],
+        }
+        edit_commands: list[tuple[str, ...]] = []
+
+        def fake_gh(args: tuple[str, ...] | list[str], *, check: bool = True) -> CompletedProcess[str]:
+            command = tuple(args)
+            if command in gh_json_responses:
+                return CompletedProcess(["gh", *command], 0, json.dumps(gh_json_responses[command]), "")
+            edit_commands.append(command)
+            return CompletedProcess(["gh", *command], 1, "", "'crnd:phase:closed' not found")
+
+        reconciler = ClosedLabelReconciler(self.ctx)
+        with mock.patch.object(reconciler, "_gh", side_effect=fake_gh):
+            with mock.patch("builtins.print") as print_mock:
+                self.assertIsNone(reconciler.apply_plan(plan))
+                self.assertIsNone(reconciler.apply_plan(plan))
+
+        warning = (
+            "closed-label-reconciler warn: issue #34 "
+            f"cannot resolve host label for terminal phase {labels.PHASE_CLOSED}; skipping phase reconciliation"
+        )
+        print_mock.assert_any_call(warning)
+        self.assertEqual(1, [call.args[0] for call in print_mock.call_args_list].count(warning))
+        self.assertEqual([], edit_commands)
 
     def test_apply_rechecks_live_closed_state_and_skips_stale_open_item(self) -> None:
         plan = ClosedPhaseLabelPlan(


### PR DESCRIPTION
## 动机
`closed_label_reconciler` 在 legacy-label host 上尝试应用不存在的 canonical 标签 → 异常(#432)。

## 改动
reconciler 对缺 canonical phase label 的 closed item skip+warn(不崩溃);closed_phase_labels 对齐;配套 behavior test。

## 边界
仅 #238 closed managed item phase-label reconciliation 范畴;不开 open item mutation、不放宽 allowlist。

## 验证
`env -u GH_REPO_SLUG python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` 全绿。
Refs #432

⟦AI:AUTO-LOOP⟧
