### PR TITLE
Release rollup (#449)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -332,12 +332,27 @@ class Phase9Router:
         return markers
 
     def _final_marker_from_path(self, path: Path) -> str | None:
-        tail = self._read_tail_lines(path, 5)
-        for line in reversed(tail):
+        tail = self._read_tail_lines(path, self.MARKER_TAIL_LINES)
+        try:
+            exit_index = max(index for index, line in enumerate(tail) if line.strip() == "EXIT=0")
+        except ValueError:
+            return None
+        before_exit = tail[:exit_index]
+        for line in reversed(before_exit):
             stripped = line.strip()
-            if stripped == "EXIT=0" or not stripped:
+            if not stripped:
                 continue
-            return self._extract_marker(stripped)
+            marker = self._extract_marker(stripped)
+            if marker is not None:
+                return marker
+            break
+        for index, line in enumerate(before_exit):
+            if "⟦AI:AUTO-LOOP⟧" not in line:
+                continue
+            for candidate in before_exit[index + 1 : index + 4]:
+                marker = self._extract_marker(candidate.strip())
+                if marker is not None:
+                    return marker
         return None
 
     def _extract_marker(self, line: str) -> str | None:
@@ -356,6 +371,8 @@ class Phase9Router:
                 candidate = match.group(0)
         if candidate is None:
             return None
+        if any(candidate.startswith(prefix) for prefix in LIFECYCLE_PREFIXES):
+            return candidate
         return Phase9MarkerGrammar.parse_marker_candidate(candidate)
 
     def _is_placeholder_or_echo(self, text: str) -> bool:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -30,6 +30,7 @@ from codex_refactor_loop.workflow_stages import assert_stage_slug
 
 
 STALE_SECONDS = 90
+MARKER_TAIL_LINES = 30
 DONE_PREFIXES = (
     "AUDIT_DONE",
     "SOLVER_DONE",
@@ -543,15 +544,43 @@ def tail_lines(path: Path, count: int) -> list[str]:
 def marker_from_completed_log(log_path: Path) -> str | None:
     if not is_clean_exit(log_path):
         return None
-    for line in reversed(tail_lines(log_path, 5)):
-        stripped = line.strip()
-        if stripped == "EXIT=0" or not stripped:
-            continue
-        if "<" in stripped and ">" in stripped:
-            continue
-        if DONE_PREFIX_RE.fullmatch(stripped):
-            return stripped
+    tail = tail_lines(log_path, MARKER_TAIL_LINES)
+    try:
+        exit_index = max(index for index, line in enumerate(tail) if line.strip() == "EXIT=0")
+    except ValueError:
         return None
+    before_exit = tail[:exit_index]
+    for line in reversed(before_exit):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        marker = _extract_completed_marker_line(stripped)
+        if marker:
+            return marker
+        break
+    for index, line in enumerate(before_exit):
+        if "⟦AI:AUTO-LOOP⟧" not in line:
+            continue
+        for candidate in before_exit[index + 1 : index + 4]:
+            marker = _extract_completed_marker_line(candidate.strip())
+            if marker:
+                return marker
+    return None
+
+
+def _extract_completed_marker_line(text: str) -> str | None:
+    stripped = text.strip()
+    if stripped.startswith("+") and not stripped.startswith("+++"):
+        stripped = stripped[1:].strip()
+    stripped = stripped.strip("`")
+    if not stripped:
+        return None
+    if "<" in stripped and ">" in stripped:
+        return None
+    if any(stripped.startswith(f"{prefix}:") for prefix in DONE_PREFIXES):
+        return stripped
+    if DONE_PREFIX_RE.fullmatch(stripped):
+        return stripped
     return None
 
 

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -161,6 +161,45 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertEqual(self.commands, [])
         self.assertEqual(self.ledger_entries(), [])
 
+    def test_phase9_router_skips_harness_bookkeeping_after_exit_zero(self) -> None:
+        for role in ("minimal", "structural", "delete"):
+            path = self.write_log(f"phase9-issue449-r2-{role}.log", f"SOLVER_DONE:{role}:same:summary")
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write("DONE_AT=2026-06-02T12:00:00Z\n")
+        judge = self.write_log("phase9-issue450-r3-judge.log", "META_JUDGE_DONE:converge:round-3:continue")
+        with judge.open("a", encoding="utf-8") as handle:
+            handle.write("DONE_AT=2026-06-02T12:00:00Z\n")
+
+        self.router.tick()
+
+        logs = " ".join(self.intent_text(command) for command in self.commands)
+        self.assertIn("phase9-issue449-r2-judge.log", logs)
+        self.assertIn("phase9-issue450-r4-minimal.log", logs)
+        self.assertIn("phase9-issue450-r4-structural.log", logs)
+        self.assertIn("phase9-issue450-r4-delete.log", logs)
+        self.assertIn("449-2-judge", [entry["key"] for entry in self.ledger_entries()])
+        self.assertIn("450-4-minimal", [entry["key"] for entry in self.ledger_entries()])
+
+    def test_phase9_router_accepts_sentinel_marker_before_completion_summary(self) -> None:
+        judge = self.repo / ".refactor-loop" / "logs" / "phase9-issue451-r3-judge.log"
+        judge.write_text(
+            "diff context\n"
+            "⟦AI:AUTO-LOOP⟧\n"
+            "META_JUDGE_DONE:converge:round-3:continue\n"
+            "tokens used\n"
+            "1,234\n"
+            "completion summary\n"
+            "EXIT=0\n"
+            "DONE_AT=2026-06-02T12:00:00Z\n",
+            encoding="utf-8",
+        )
+
+        self.router.tick()
+
+        logs = " ".join(self.intent_text(command) for command in self.commands)
+        self.assertIn("phase9-issue451-r4-minimal.log", logs)
+        self.assertIn("451-4-minimal", [entry["key"] for entry in self.ledger_entries()])
+
     def test_phase9_router_unknown_marker_fallback_appends_event_only(self) -> None:
         self.write_log("phase9-issue37-r4-judge.log", "SOMETHING_DONE:surprise:payload")
 

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -851,6 +851,25 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         actions = self.run_plan()["actions"]
         self.assertFalse([action for action in actions if action["kind"] == "completed-marker"])
 
+    def test_completed_marker_accepts_sentinel_marker_before_completion_summary(self) -> None:
+        log = self.logs / "phase9-issue449-r2-judge.log"
+        log.write_text(
+            "diff context\n"
+            "⟦AI:AUTO-LOOP⟧\n"
+            "`META_JUDGE_DONE:consensus:minimal:delete .refactor-loop host.env runtime fallback`\n"
+            "tokens used\n"
+            "1,234\n"
+            "completion summary\n"
+            "EXIT=0\n"
+            "DONE_AT=2026-06-02T12:00:00Z\n",
+            encoding="utf-8",
+        )
+
+        self.assertEqual(
+            "META_JUDGE_DONE:consensus:minimal:delete .refactor-loop host.env runtime fallback",
+            marker_from_completed_log(log),
+        )
+
     def test_completed_marker_payload_does_not_include_raw_log_tail(self) -> None:
         (self.logs / "implement-worker.log").write_text(
             "target issue #999 in raw prose only\n"
@@ -1128,6 +1147,23 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertIn("wakeup_plan.py", consensus_action["scope_paths"])
         self.assertIn("wakeup_runner.py", consensus_action["scope_paths"])
         self.assertIn("durable_consensus_artifact", consensus_action["preconditions"])
+
+    def test_consensus_marker_after_exit_zero_with_harness_done_at_projects_implementation(self) -> None:
+        artifact = self.write_consensus_artifact(issue=449, round_no=2)
+        self.write_completed_log("phase9-issue449-r2-judge.log", "META_JUDGE_DONE:consensus:minimal")
+        with (self.logs / "phase9-issue449-r2-judge.log").open("a", encoding="utf-8") as handle:
+            handle.write("DONE_AT=2026-06-02T12:00:00Z\n")
+
+        plan = self.run_plan()
+
+        action = next(
+            item for item in plan["actions"]
+            if item.get("controller_action") == "dispatch_consensus_implementation"
+        )
+        self.assertEqual(action["consensus_artifact"], artifact.relative_to(self.repo).as_posix())
+        self.assertEqual(action["consensus_issue"], 449)
+        self.assertEqual(action["consensus_round"], 2)
+        self.assertIn("durable_consensus_artifact", action["preconditions"])
 
     def test_consensus_completed_marker_without_durable_artifact_is_not_executable(self) -> None:
         self.write_completed_log("phase9-issue20-r5-judge.log", "META_JUDGE_DONE:consensus:structural")


### PR DESCRIPTION
## Release rollup: auto-refact-dev → dev (#449)

- **#449** (#450):修 phase9-router/wakeup-plan marker 检测,接通 design-consensus 自动推进(solver-done→judge、converge→下一轮、consensus→dispatch_consensus_implementation 投影)。实测合后 wakeup-plan 投影完整 advancement(dispatch_design_consensus/implement/review_gate),router 自动路由全部 marker、正确抑制 closed-source,wakeup_runner bounded 执行 = headless 自驱接通。

经 3-reviewer 共识闸(reject=0)+ contract-tests 绿后 squash 入 auto-refact-dev。

⟦AI:AUTO-LOOP⟧
