### PR TITLE
wakeup_runner 长 tick 周期 heartbeat,消除误判 stale (#441)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import sys
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
@@ -903,6 +904,25 @@ def _terminal_blocked_reason(reason: str) -> bool:
     return reason in {"target_not_open:CLOSED", "target_not_open:MERGED"}
 
 
+def _run_once_with_periodic_heartbeat(
+    run_once: Callable[[], list[RunnerResult]],
+    lease: DaemonHeartbeatLease,
+) -> list[RunnerResult]:
+    stop = threading.Event()
+
+    def renew_lease() -> None:
+        while not stop.wait(max(1.0, float(lease.heartbeat_interval))):
+            lease.beat()
+
+    renewer = threading.Thread(target=renew_lease, name="wakeup-runner-heartbeat-renewer", daemon=True)
+    renewer.start()
+    try:
+        return run_once()
+    finally:
+        stop.set()
+        renewer.join(timeout=1.0)
+
+
 def load_plan_file(path: Path) -> Mapping[str, Any]:
     data = read_json(path, {})
     return data if isinstance(data, dict) else {}
@@ -933,7 +953,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         lease.beat()
         interval = max(1, int(args.interval_seconds))
         while True:
-            runner.run_once()
+            _run_once_with_periodic_heartbeat(runner.run_once, lease)
             lease.sleep_with_lease(interval)
     results = runner.run_once()
     blocked = [result for result in results if result.status == "blocked"]

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -7,12 +7,17 @@ import json
 import subprocess
 import sys
 import tempfile
+import threading as real_threading
 import unittest
 from pathlib import Path
 from unittest import mock
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
+
+REAL_CONDITION = real_threading.Condition
+REAL_EVENT = real_threading.Event
+REAL_THREAD = real_threading.Thread
 
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop import labels
@@ -81,26 +86,73 @@ class FakeHeartbeatLease:
 
     def __init__(self) -> None:
         self.beats = 0
+        self.coordinator: HeartbeatCoordinator | None = None
 
     def beat(self) -> None:
         self.beats += 1
+        if self.coordinator is not None:
+            self.coordinator.record_beat()
+
+
+class HeartbeatCoordinator:
+    def __init__(self) -> None:
+        self.condition = REAL_CONDITION()
+        self.run_once_entered = False
+        self.beat_during_run_once = False
+        self.stop_requested = False
+        self.waiting_for_stop = False
+
+    def enter_run_once(self) -> None:
+        with self.condition:
+            self.run_once_entered = True
+            self.condition.notify_all()
+
+    def record_beat(self) -> None:
+        with self.condition:
+            if self.run_once_entered and not self.stop_requested:
+                self.beat_during_run_once = True
+            self.condition.notify_all()
+
+    def wait_for_heartbeat_while_run_once_is_pending(self) -> bool:
+        with self.condition:
+            return self.condition.wait_for(lambda: self.beat_during_run_once, timeout=1.0)
+
+    def request_stop(self) -> None:
+        with self.condition:
+            self.stop_requested = True
+            self.condition.notify_all()
 
 
 class ScriptedEvent:
     instances: list["ScriptedEvent"] = []
+    coordinator: HeartbeatCoordinator | None = None
 
     def __init__(self) -> None:
-        self.wait_results: list[bool] = []
         self.wait_timeouts: list[float] = []
         self.set_called = False
         ScriptedEvent.instances.append(self)
 
     def wait(self, timeout: float | None = None) -> bool:
         self.wait_timeouts.append(float(timeout or 0))
-        return self.wait_results.pop(0) if self.wait_results else True
+        if ScriptedEvent.coordinator is None:
+            return True
+        coordinator = ScriptedEvent.coordinator
+        with coordinator.condition:
+            if not coordinator.run_once_entered:
+                coordinator.condition.wait_for(lambda: coordinator.run_once_entered or coordinator.stop_requested, timeout=1.0)
+            if coordinator.stop_requested:
+                return True
+            if not coordinator.beat_during_run_once:
+                return False
+            coordinator.waiting_for_stop = True
+            coordinator.condition.notify_all()
+            coordinator.condition.wait_for(lambda: coordinator.stop_requested, timeout=1.0)
+            return True
 
     def set(self) -> None:
         self.set_called = True
+        if ScriptedEvent.coordinator is not None:
+            ScriptedEvent.coordinator.request_stop()
 
 
 class InlineThread:
@@ -111,14 +163,18 @@ class InlineThread:
         self.name = name
         self.daemon = daemon
         self.started = False
+        with mock.patch("threading.Event", REAL_EVENT):
+            self.thread = REAL_THREAD(target=self.target, name=name, daemon=daemon)
         self.join_timeouts: list[float] = []
         InlineThread.instances.append(self)
 
     def start(self) -> None:
         self.started = True
+        self.thread.start()
 
     def join(self, timeout: float | None = None) -> None:
         self.join_timeouts.append(float(timeout or 0))
+        self.thread.join(timeout=timeout)
 
 
 class WakeupRunnerBehaviorTests(unittest.TestCase):
@@ -1043,8 +1099,10 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
 
     def test_daemon_run_once_periodically_renews_heartbeat_during_long_tick(self) -> None:
         ScriptedEvent.instances = []
+        ScriptedEvent.coordinator = HeartbeatCoordinator()
         InlineThread.instances = []
         lease = FakeHeartbeatLease()
+        lease.coordinator = ScriptedEvent.coordinator
         expected = [object()]
 
         with mock.patch("codex_refactor_loop.wakeup_runner.threading.Event", ScriptedEvent), mock.patch(
@@ -1053,24 +1111,29 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         ):
 
             def run_once():
-                ScriptedEvent.instances[0].wait_results = [False, False, True]
-                InlineThread.instances[0].target()
+                ScriptedEvent.coordinator.enter_run_once()
+                self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_run_once_is_pending())
                 return expected
 
             result = _run_once_with_periodic_heartbeat(run_once, lease)
 
         self.assertIs(result, expected)
-        self.assertEqual(lease.beats, 2)
-        self.assertEqual(ScriptedEvent.instances[0].wait_timeouts, [7.0, 7.0, 7.0])
+        self.assertGreaterEqual(lease.beats, 1)
+        self.assertTrue(ScriptedEvent.coordinator.beat_during_run_once)
+        self.assertGreaterEqual(ScriptedEvent.instances[0].wait_timeouts.count(7.0), 1)
         self.assertTrue(ScriptedEvent.instances[0].set_called)
+        self.assertTrue(InlineThread.instances[0].started)
         self.assertTrue(InlineThread.instances[0].daemon)
         self.assertEqual(InlineThread.instances[0].name, "wakeup-runner-heartbeat-renewer")
         self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
+        ScriptedEvent.coordinator = None
 
     def test_daemon_run_once_periodic_heartbeat_propagates_exception_and_stops_thread(self) -> None:
         ScriptedEvent.instances = []
+        ScriptedEvent.coordinator = HeartbeatCoordinator()
         InlineThread.instances = []
         lease = FakeHeartbeatLease()
+        lease.coordinator = ScriptedEvent.coordinator
 
         with mock.patch("codex_refactor_loop.wakeup_runner.threading.Event", ScriptedEvent), mock.patch(
             "codex_refactor_loop.wakeup_runner.threading.Thread",
@@ -1078,16 +1141,19 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         ):
 
             def run_once():
-                ScriptedEvent.instances[0].wait_results = [False, True]
-                InlineThread.instances[0].target()
+                ScriptedEvent.coordinator.enter_run_once()
+                self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_run_once_is_pending())
                 raise RuntimeError("boom")
 
             with self.assertRaisesRegex(RuntimeError, "boom"):
                 _run_once_with_periodic_heartbeat(run_once, lease)
 
-        self.assertEqual(lease.beats, 1)
+        self.assertGreaterEqual(lease.beats, 1)
+        self.assertTrue(ScriptedEvent.coordinator.beat_during_run_once)
         self.assertTrue(ScriptedEvent.instances[0].set_called)
+        self.assertTrue(InlineThread.instances[0].started)
         self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
+        ScriptedEvent.coordinator = None
 
     def test_wakeup_runner_source_locks_named_g1_g3_helper_allowlist(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "wakeup_runner.py").read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop import labels
-from codex_refactor_loop.wakeup_runner import WakeupRunner, main as wakeup_runner_main
+from codex_refactor_loop.wakeup_runner import WakeupRunner, _run_once_with_periodic_heartbeat, main as wakeup_runner_main
 
 
 class FakeSupervisor:
@@ -74,6 +74,51 @@ class FakeActions:
 
     def publish_release_candidate(self, *, candidate_path: str, target_ref: str):
         raise AssertionError("release publish should not be dispatched")
+
+
+class FakeHeartbeatLease:
+    heartbeat_interval = 7
+
+    def __init__(self) -> None:
+        self.beats = 0
+
+    def beat(self) -> None:
+        self.beats += 1
+
+
+class ScriptedEvent:
+    instances: list["ScriptedEvent"] = []
+
+    def __init__(self) -> None:
+        self.wait_results: list[bool] = []
+        self.wait_timeouts: list[float] = []
+        self.set_called = False
+        ScriptedEvent.instances.append(self)
+
+    def wait(self, timeout: float | None = None) -> bool:
+        self.wait_timeouts.append(float(timeout or 0))
+        return self.wait_results.pop(0) if self.wait_results else True
+
+    def set(self) -> None:
+        self.set_called = True
+
+
+class InlineThread:
+    instances: list["InlineThread"] = []
+
+    def __init__(self, *, target, name: str, daemon: bool) -> None:
+        self.target = target
+        self.name = name
+        self.daemon = daemon
+        self.started = False
+        self.join_timeouts: list[float] = []
+        InlineThread.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeouts.append(float(timeout or 0))
 
 
 class WakeupRunnerBehaviorTests(unittest.TestCase):
@@ -996,6 +1041,54 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                 results = self.run_result(self.base_plan(action), actions=actions)
                 self.assert_blocked_before_dispatch(results, action["action_id"], reason, actions)
 
+    def test_daemon_run_once_periodically_renews_heartbeat_during_long_tick(self) -> None:
+        ScriptedEvent.instances = []
+        InlineThread.instances = []
+        lease = FakeHeartbeatLease()
+        expected = [object()]
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.threading.Event", ScriptedEvent), mock.patch(
+            "codex_refactor_loop.wakeup_runner.threading.Thread",
+            InlineThread,
+        ):
+
+            def run_once():
+                ScriptedEvent.instances[0].wait_results = [False, False, True]
+                InlineThread.instances[0].target()
+                return expected
+
+            result = _run_once_with_periodic_heartbeat(run_once, lease)
+
+        self.assertIs(result, expected)
+        self.assertEqual(lease.beats, 2)
+        self.assertEqual(ScriptedEvent.instances[0].wait_timeouts, [7.0, 7.0, 7.0])
+        self.assertTrue(ScriptedEvent.instances[0].set_called)
+        self.assertTrue(InlineThread.instances[0].daemon)
+        self.assertEqual(InlineThread.instances[0].name, "wakeup-runner-heartbeat-renewer")
+        self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
+
+    def test_daemon_run_once_periodic_heartbeat_propagates_exception_and_stops_thread(self) -> None:
+        ScriptedEvent.instances = []
+        InlineThread.instances = []
+        lease = FakeHeartbeatLease()
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.threading.Event", ScriptedEvent), mock.patch(
+            "codex_refactor_loop.wakeup_runner.threading.Thread",
+            InlineThread,
+        ):
+
+            def run_once():
+                ScriptedEvent.instances[0].wait_results = [False, True]
+                InlineThread.instances[0].target()
+                raise RuntimeError("boom")
+
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                _run_once_with_periodic_heartbeat(run_once, lease)
+
+        self.assertEqual(lease.beats, 1)
+        self.assertTrue(ScriptedEvent.instances[0].set_called)
+        self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
+
     def test_wakeup_runner_source_locks_named_g1_g3_helper_allowlist(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "wakeup_runner.py").read_text(encoding="utf-8")
         for helper in (
@@ -1012,6 +1105,31 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertNotIn("dispatch_next_step_worker", source)
         self.assertNotIn("HeadlessLifecycleAction", source)
         self.assertNotIn("headless_actions", source)
+
+    def test_wakeup_runner_daemon_long_tick_heartbeat_source_contract(self) -> None:
+        source = (SCRIPT_DIR / "codex_refactor_loop" / "wakeup_runner.py").read_text(encoding="utf-8")
+        helper_start = source.index("def _run_once_with_periodic_heartbeat(")
+        helper_end = source.index("\ndef load_plan_file", helper_start)
+        helper = source[helper_start:helper_end]
+        daemon_branch = source[source.index("    if args.daemon:") : source.index("    results = runner.run_once()")]
+
+        for needle in (
+            "def _run_once_with_periodic_heartbeat(",
+            "threading.Event()",
+            "threading.Thread(",
+            "daemon=True",
+            "lease.heartbeat_interval",
+            "lease.beat()",
+            "return run_once()",
+            "finally:",
+            "stop.set()",
+            "renewer.join(timeout=1.0)",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, helper)
+        self.assertIn("_run_once_with_periodic_heartbeat(runner.run_once, lease)", daemon_branch)
+        self.assertIn("lease.sleep_with_lease(interval)", daemon_branch)
+        self.assertNotIn("_run_once_with_periodic_heartbeat(runner.run_once, lease)", source[source.index("    results = runner.run_once()") :])
 
     def test_close_managed_item_from_drop_marker_routes_to_named_helper(self) -> None:
         actions = FakeActions()


### PR DESCRIPTION
## 动机
wakeup_runner daemon 的 run_once() 长 tick(gh-heavy wakeup-plan 生成,实测 >90s)期间不续租 heartbeat → daemon-status 误判 stale → 触发 restart 打断长 tick → 执行不稳/不收敛。这是 headless loop 自驱可靠性的关键(#441,r4 共识 minimal:A)。

## 改动
`wakeup_runner.py`:daemon 模式用私有 `_run_once_with_periodic_heartbeat` 包住 `run_once()`,长 tick 期间按同一 heartbeat lease 周期续租。不改 authorization mirror、不放宽 #396 allowlist、不新增 lifecycle authority。配套确定性 behavior test(无 sleep/poll)+ source-regression。

## 验证
`env -u GH_REPO_SLUG python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'` → `Ran 1173 tests OK (skipped=1)`(controller 独立全量复跑)。

## 影响
合并 + 重启后 wakeup_runner 长 tick 不再误判 stale → router+wakeup_runner 可长期稳定自驱 design-consensus,无需 controller 周期重启干预。配合 #427(REST 化降 tick 时长)= 平滑无人值守。

Refs #441 #453 #413

⟦AI:AUTO-LOOP⟧
