### PR TITLE
#458: sshx 统一 SshxResultEnvelope 输出面

### DIFF
--- a/skills/sshx/SKILL.md
+++ b/skills/sshx/SKILL.md
@@ -62,8 +62,10 @@ Each thinking or review record must include these fields:
 - `worker_mode`
 - `worker_carrier`
 - `verdict`
+- `conclusion`
+- `log_ref`
 
-Thinking, implementation, and review are worker dispatches. The caller context may intake the task, choose worker mode, dispatch workers, run the meta-judge over returned summaries/verdicts, summarize outcomes, and produce the final report.
+Thinking, implementation, and review are worker dispatches. The caller context may intake the task, choose worker mode, dispatch workers, run the meta-judge over returned `SshxResultEnvelope.conclusion` values, aggregate conclusions, and produce the final report from conclusions only while preserving `log_ref` references.
 
 Each `visible_inputs` value must include the same `GoalArtifact.normalized_goal` and must not include same-round peer outputs.
 
@@ -83,15 +85,24 @@ Each `visible_inputs` value must include the same `GoalArtifact.normalized_goal`
 
 `abstain` is required when neither `codex-cli` nor `isolated-token-subagent` is available. Do not self-apply the triplet inside the caller context and present it as worker consensus.
 
+## Result Envelope
+
+`SshxResultEnvelope` is a prompt-level record, not a runtime API. Every caller-carried result from `thinking_triplet_workers`, `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done` must use exactly these top-level fields:
+
+- `conclusion`: compact structured result consumed by the caller. It may include verdicts, decisions, blocking goal gaps, final decision points, changed-file evidence, and test evidence when applicable. It must not include process logs, step-by-step reasoning, raw transcripts, debug output, or same-round peer output.
+- `log_ref`: artifact reference for the non-inline worker, meta-judge, implementation, review, or fix log. The caller may open the referenced artifact on demand, but caller-carried transcripts and final reports must keep only the reference and must not inline the log body.
+
+Logs are not inline in caller context. Final reports aggregate `conclusion` values only and retain `log_ref` references for optional inspection.
+
 ## No Context Pollution
 
 The caller context must not carry worker full reasoning or same-round peer outputs. It may carry only:
 
 - intake inputs and constraints;
 - dispatch briefs sent to each worker;
-- worker summaries, verdicts, and explicitly surfaced blockers;
-- meta-judge synthesis;
-- final summary and report.
+- `SshxResultEnvelope.conclusion` values, including verdicts and explicitly surfaced blockers;
+- `SshxResultEnvelope.log_ref` artifact references;
+- final reports that aggregate conclusions only.
 
 Same-round thinking workers must not see one another's outputs before their own verdicts are returned. Same-round review workers follow the same rule. If worker isolation is unavailable, exit through `abstain` instead of degrading the protocol into single-context roleplay.
 
@@ -133,7 +144,7 @@ Implement only the concrete plan approved by the thinking gate. Keep the impleme
 
 `sshx` does not grant permission to commit, push, merge, close issues, edit labels, publish releases, or mutate external lifecycle state.
 
-Implementation must be delegated to a worker using the selected `WorkerMode`. The caller context may pass the approved concrete plan and constraints, then receive a bounded implementation summary and changed-file/test evidence.
+Implementation must be delegated to a worker using the selected `WorkerMode`. The caller context may pass the approved concrete plan and constraints, then receive `conclusion` and `log_ref`; changed-file and test evidence belong in `conclusion`, and process logs stay behind `log_ref`.
 
 ## Review Triplet
 
@@ -165,7 +176,7 @@ Advisory comments do not count as approval. A reject blocks done until the issue
 
 If review exits `fix`, ask what still differs from `GoalArtifact`, apply the smallest change that addresses that blocking goal gap, and rerun the review triplet. Stop after a bounded number of fix passes and report remaining blockers honestly.
 
-If review exits `done with advisory surfaced`, summarize the final outcome and include any non-blocking advisory feedback.
+If review exits `done with advisory surfaced`, report the final outcome by aggregating `conclusion` values and include any non-blocking advisory feedback without inlining logs.
 
 If review exits `explicit user decision or another bounded review pass`, either run one more bounded pass with a concrete next iteration question tied to `GoalArtifact`, or ask the user to decide. Do not loop indefinitely.
 
@@ -222,38 +233,55 @@ thinking_triplet_workers:
     worker_mode:
     worker_carrier:
     verdict:
+    conclusion:
+    log_ref:
   - role: structural
     bias:
     visible_inputs:
     worker_mode:
     worker_carrier:
     verdict:
+    conclusion:
+    log_ref:
   - role: delete
     bias:
     visible_inputs:
     worker_mode:
     worker_carrier:
     verdict:
+    conclusion:
+    log_ref:
 meta_judge:
   exit:
   concrete_plan:
   goal_gap:
   next_iteration_question:
+  conclusion:
+  log_ref:
 implementation_worker:
   worker_mode:
-  summary:
+  conclusion:
+  log_ref:
 review_triplet_workers:
   - role: architecture
     worker_mode:
     verdict:
+    conclusion:
+    log_ref:
   - role: quality
     worker_mode:
     verdict:
+    conclusion:
+    log_ref:
   - role: tests
     worker_mode:
     verdict:
+    conclusion:
+    log_ref:
 fix_or_done:
   exit:
+  conclusion:
+  log_ref:
 ```
 
 ## Verification

--- a/skills/sshx/tests/test_sshx_contract.py
+++ b/skills/sshx/tests/test_sshx_contract.py
@@ -45,6 +45,7 @@ class SshxContractTests(unittest.TestCase):
             "## Goal Contract",
             "## InlineConsensusProtocol",
             "## Worker Delegation",
+            "## Result Envelope",
             "## No Context Pollution",
             "## Design Truth Table",
             "## Implementation Worker",
@@ -123,11 +124,17 @@ class SshxContractTests(unittest.TestCase):
         for allowed_context in [
             "intake inputs and constraints",
             "dispatch briefs sent to each worker",
+            "`SshxResultEnvelope.conclusion` values, including verdicts and explicitly surfaced blockers",
+            "`SshxResultEnvelope.log_ref` artifact references",
+            "final reports that aggregate conclusions only",
+        ]:
+            self.assertIn(allowed_context, text)
+        for removed_escape_hatch in [
             "worker summaries, verdicts, and explicitly surfaced blockers",
             "meta-judge synthesis",
             "final summary and report",
         ]:
-            self.assertIn(allowed_context, text)
+            self.assertNotIn(removed_escape_hatch, text)
         self.assertIn(
             "Same-round thinking workers must not see one another's outputs before their own verdicts are returned",
             text,
@@ -136,6 +143,96 @@ class SshxContractTests(unittest.TestCase):
             "If worker isolation is unavailable, exit through `abstain` instead of degrading the protocol into single-context roleplay",
             text,
         )
+
+    def test_sshx_result_envelope_contract(self) -> None:
+        text = read(SKILL)
+        self.assertIn("## Result Envelope", text)
+        self.assertIn("`SshxResultEnvelope` is a prompt-level record, not a runtime API", text)
+        self.assertIn(
+            "Every caller-carried result from `thinking_triplet_workers`, `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done` must use exactly these top-level fields",
+            text,
+        )
+        self.assertIn("`conclusion`: compact structured result consumed by the caller", text)
+        self.assertIn("`log_ref`: artifact reference for the non-inline worker", text)
+        for forbidden_inline in [
+            "process logs",
+            "step-by-step reasoning",
+            "raw transcripts",
+            "debug output",
+            "same-round peer output",
+        ]:
+            self.assertIn(forbidden_inline, text)
+        self.assertIn("Logs are not inline in caller context", text)
+        self.assertIn("Final reports aggregate `conclusion` values only", text)
+        self.assertIn("produce the final report from conclusions only while preserving `log_ref` references", text)
+        self.assertIn("process logs stay behind `log_ref`", text)
+        self.assertIn("without inlining logs", text)
+
+    def test_sshx_result_envelope_caller_context_excludes_inline_logs(self) -> None:
+        caller_carried_transcript = {
+            "thinking_triplet_workers": [
+                {
+                    "role": "minimal",
+                    "verdict": "propose",
+                    "conclusion": {
+                        "decision": "use the smallest contract edit",
+                        "goal_gap": "none",
+                    },
+                    "log_ref": "artifacts/sshx/minimal.log",
+                }
+            ],
+            "meta_judge": {
+                "conclusion": {
+                    "exit": "implement",
+                    "decision": "all worker conclusions agree",
+                },
+                "log_ref": "artifacts/sshx/meta-judge.log",
+            },
+            "implementation_worker": {
+                "conclusion": {
+                    "changed_files": ["skills/sshx/SKILL.md"],
+                    "tests": ["python3 -m unittest discover -s skills/sshx/tests -p 'test_*.py'"],
+                },
+                "log_ref": "artifacts/sshx/implementation.log",
+            },
+            "review_triplet_workers": [
+                {
+                    "role": "tests",
+                    "verdict": "approve",
+                    "conclusion": {"coverage": "contract locks envelope-only output"},
+                    "log_ref": "artifacts/sshx/review-tests.log",
+                }
+            ],
+            "fix_or_done": {
+                "conclusion": {"exit": "done with advisory surfaced"},
+                "log_ref": "artifacts/sshx/fix-or-done.log",
+            },
+        }
+
+        def assert_envelope(node: dict[str, object]) -> None:
+            self.assertIn("conclusion", node)
+            self.assertIn("log_ref", node)
+            self.assertNotIn("summary", node)
+            self.assertNotIn("report", node)
+            self.assertNotIn("synthesis", node)
+
+        for worker in caller_carried_transcript["thinking_triplet_workers"]:
+            assert_envelope(worker)
+        assert_envelope(caller_carried_transcript["meta_judge"])
+        assert_envelope(caller_carried_transcript["implementation_worker"])
+        for reviewer in caller_carried_transcript["review_triplet_workers"]:
+            assert_envelope(reviewer)
+        assert_envelope(caller_carried_transcript["fix_or_done"])
+
+        rendered = repr(caller_carried_transcript)
+        for inline_log_phrase in [
+            "worker reasoning:",
+            "raw transcript:",
+            "debug log body:",
+            "step-by-step reasoning:",
+            "same-round peer output:",
+        ]:
+            self.assertNotIn(inline_log_phrase, rendered)
 
     def test_sshx_design_truth_table(self) -> None:
         text = read(SKILL)


### PR DESCRIPTION
## 动机
#458:sshx caller 携带自由文本 summary/report 逃逸口,日志 inline 污染上下文。

## 改动
统一 `SshxResultEnvelope`(`conclusion` 结构化结论 + `log_ref` 非 inline 日志引用),thinking/meta_judge/implementation/review/fix 全 caller surface 只带 conclusion+log_ref;source-regression + behavior contract test 锁日志不 inline。仅改 skills/sshx/SKILL.md + tests。

## 验证
主套件 OK + `skills/sshx/tests` OK

⟦AI:AUTO-LOOP⟧