### PR TITLE
#410: SKILL/prompt 引用改 durable anchor + source-regression(fresh base)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -23,7 +23,7 @@ Use intra-file anchors when a phase needs the detailed body, such as [host runti
 | Pure orchestration | Controller execution may be interactive or #396 `wakeup-runner`; all reasoning remains in codex workers / consensus gates. `phase9-router` handles only deterministic design-consensus routes; `wakeup-runner` consumes only `wakeup-plan` evidence-bound closed action projection and existing controller helpers. | Never implement product/refactor code in the controller conversation. Dispatch a codex for implementation, verification, fixing, review, and design solving; let `consensus-rnd-cli phase9-router` handle only its allowlisted deterministic routes and `consensus-rnd-cli wakeup-runner` mechanically apply only closed projection actions. | [controller contract details](#controller-contract-details) | `consensus-rnd-cli spawn-codex`, prompt files |
 | Sentinel | Every AI-authored GitHub body ends with a final independent `⟦AI:AUTO-LOOP⟧` line. | Filter AI comments by sentinel and AI banner prefixes; never react to own comments as maintainer input. | [sentinel and comment filters](#sentinel-and-comment-filters) | prompts, `consensus-rnd-cli comment-monitor` |
 <!-- Refactor (iter1/issue-139): Old pattern: Wake-source 契约措辞自相矛盾:SKILL.md/REFERENCE.md 多处写三选一(Monitor / task-notification / ScheduleWakeup 任一即可),与 checklist step15 / ownership 的必维持 Monitor 冲突,新会话据此漏挂 Monitor bridge。
-  New principle: 统一语义:每个 controller 会话必须 arm/confirm persistent daemon-event Monitor bridge;task-notification / ScheduleWakeup 仅作 turn 级 completion/fallback,非 Monitor 替代。删除所有三选一/or-ScheduleWakeup 弱化措辞,替换 test_skill_entrypoint_contract.py 与 test_skill_reference_anchors.py 两个 source-regression 入口,不引入 SessionWakeSourceContract 等新命名,不新增 helper/schema/daemon,不改 CLAUDE.md/Tier/lifecycle。严格按 .refactor-loop/runs/phase9-issue139-r2-judge.md 的 Implement plan 逐条改。
+  New principle: 统一语义:每个 controller 会话必须 arm/confirm persistent daemon-event Monitor bridge;task-notification / ScheduleWakeup 仅作 turn 级 completion/fallback,非 Monitor 替代。Durable anchors are the Wake source contract row, wake-source-rules anchor, test_skill_entrypoint_contract.py, and test_skill_reference_anchors.py; no SessionWakeSourceContract/helper/schema/daemon/Tier lifecycle expansion.
 -->
 | Wake source | Every controller session must maintain a persistent daemon-event Monitor bridge. | Arm or confirm the daemon-event Monitor bridge; before ending a turn, also confirm any in-flight codex task-notification or registered ScheduleWakeup fallback used as the next wake. | [wake source rules](#wake-source-rules) | Monitor bridge, harness Bash background tasks, ScheduleWakeup fallback |
 | First wakeup | Consensus-rnd Phase bootstrap is ordered and mandatory before any normal phase. | Run the Consensus-rnd Phase bootstrap checklist in this file, in order. | [daemon command bodies](#daemon-command-bodies) | scripts, `host.env` |
@@ -1036,7 +1036,7 @@ Recovery rules:
 <!--
 Refactor (iter6/issue-118):
   Old pattern: skill docs maintained a posting-mode prompt filename roster,会漂移
-  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
+  New principle: prompt-self-declaration posting mode is owned by the GitHub Posting Contract, prompts/_github-post-rules.md, prompt body self-declaration, test_marker_only_prompts_gh_ban.py, and test_marker_emission_contract.py; no SKILL-maintained prompt filename roster.
 -->
 
 Posting rules:
@@ -2215,7 +2215,7 @@ EVERYTHING ELSE(reviewer verdict、fix-done body、consensus 公告、escalation
 <!--
 Refactor (iter6/issue-118):
   Old pattern: skill docs maintained a posting-mode prompt filename roster,会漂移
-  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
+  New principle: prompt-self-declaration posting mode is owned by the GitHub Posting Contract, prompts/_github-post-rules.md, prompt body self-declaration, test_marker_only_prompts_gh_ban.py, and test_marker_emission_contract.py; no SKILL-maintained prompt filename roster.
 -->
 
 - A prompt is direct-post only when its own body contains a `## GitHub post` section referencing `prompts/_github-post-rules.md`; prompts without that self-declaration are marker/artifact-only.

--- a/skills/codex-refactor-loop/prompts/design-issue-reply.md
+++ b/skills/codex-refactor-loop/prompts/design-issue-reply.md
@@ -3,7 +3,7 @@
 <!--
 Refactor (iter1/issue-126):
   Old pattern: 跨平台 prompt 含 '该项目'/'该项目AI' 等硬编码 host 占位文本,违反 host-agnostic;应复用 host.env surface(GH_REPO_SLUG / MAINTAINER_WHITELIST)。
-  New principle: 按 .refactor-loop/runs/phase9-issue126-r3-judge.md consensus 逐条:删除 prompt 硬编码 host 文本,复用现有 host.env surface;硬约束:(1) 不重建 REFERENCE.md(单文件 SKILL.md);(2) refactor self-doc 注释必须自含 Old/New,禁止 'see issue #X' placeholder;(3) 严格按 design decision Implement plan,不超范围。
+  New principle: Host-agnostic prompt text is owned by the host.env surface matrix, GH_REPO_SLUG, MAINTAINER_WHITELIST, HOST_REFACTOR_COMMENT_POLICY, test_refactor_comment_policy_prompt_contract.py, this prompt's checklist, and prompts/_github-post-rules.md for direct-post behavior.
 -->
 
 issue: ${ISSUE_URL}

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -153,7 +153,7 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 <!--
 Refactor (iter6/issue-118):
   Old pattern: SKILL.md 维护 posting-mode prompt filename roster,会漂移
-  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
+  New principle: prompt-local GitHub post self-declaration plus prompts/_github-post-rules.md and marker/posting inventory tests own posting mode; SKILL.md does not keep a prompt filename roster.
 -->
 
 - You do NOT propose a solution; you ARBITRATE between proposals.

--- a/skills/codex-refactor-loop/prompts/reviewer-quality.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-quality.md
@@ -5,7 +5,7 @@ Artifact profile: phase8-reviewer
 <!--
 Refactor (iter1/issue-126):
   Old pattern: 跨平台 prompt 含 '该项目'/'该项目AI' 等硬编码 host 占位文本,违反 host-agnostic;应复用 host.env surface(GH_REPO_SLUG / MAINTAINER_WHITELIST)。
-  New principle: 按 .refactor-loop/runs/phase9-issue126-r3-judge.md consensus 逐条:删除 prompt 硬编码 host 文本,复用现有 host.env surface;硬约束:(1) 不重建 REFERENCE.md(单文件 SKILL.md);(2) refactor self-doc 注释必须自含 Old/New,禁止 'see issue #X' placeholder;(3) 严格按 design decision Implement plan,不超范围。
+  New principle: Host-agnostic prompt text is owned by the host.env surface matrix, GH_REPO_SLUG, MAINTAINER_WHITELIST, HOST_REFACTOR_COMMENT_POLICY, test_refactor_comment_policy_prompt_contract.py, and this prompt's checklist; no hardcoded host placeholder text or separate REFERENCE.md dependency.
 -->
 
 You are reviewing PR **${PR_NUMBER}** (`${PR_TITLE}`) against `${BASE_BRANCH}` from a **code quality** perspective: readability, naming, simplicity, complexity, dead code.

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -107,7 +107,7 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 <!--
 Refactor (iter6/issue-118):
   Old pattern: SKILL.md 维护 posting-mode prompt filename roster,会漂移
-  New principle: prompt-self-declaration consensus: 删 roster,posting mode 由 prompt body 派生 + inventory tests 强制。详见 .refactor-loop/runs/phase9-issue118-r3-judge.md
+  New principle: prompt-local GitHub post self-declaration plus prompts/_github-post-rules.md and marker/posting inventory tests own posting mode; SKILL.md does not keep a prompt filename roster.
 -->
 
 - You do NOT write code; you propose a plan.

--- a/skills/codex-refactor-loop/scripts/test_generated_artifacts_not_authority.py
+++ b/skills/codex-refactor-loop/scripts/test_generated_artifacts_not_authority.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Source-regression test for generated run artifacts used as authority."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_ROOT = SCRIPT_DIR.parents[0]
+RUN_JUDGE_PATH_RE = re.compile(r"\.refactor-loop/runs/phase9-issue\d+-r\d+-judge\.md")
+AUTHORITY_CONTEXT_RE = re.compile(
+    r"详见|严格按|按 .*consensus|Implement plan|per\b|See\b|see\b|"
+    r"authority|authorization|decision|依据|来源"
+)
+
+
+class GeneratedArtifactsNotAuthorityTests(unittest.TestCase):
+    def scanned_paths(self) -> list[Path]:
+        paths = [SKILL_ROOT / "SKILL.md"]
+        paths.extend(sorted((SKILL_ROOT / "prompts").glob("*.md")))
+        return paths
+
+    def test_generated_judge_artifacts_are_not_authority_sources(self) -> None:
+        failures: list[str] = []
+        for path in self.scanned_paths():
+            text = path.read_text(encoding="utf-8")
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                if self._forbidden_generated_artifact_authority(line):
+                    failures.append(f"{path.relative_to(SKILL_ROOT)}:{line_no}:{line.strip()}")
+        self.assertEqual(failures, [])
+
+    def test_runtime_output_and_tracking_paths_remain_allowed(self) -> None:
+        allowed_lines = [
+            "SOLVER_OUTPUT_PATH=.refactor-loop/runs/phase9-issue410-r1-judge.md",
+            "Write `.refactor-loop/runs/phase9-issue410-r1-judge.md`:",
+            "tracking lives in GitHub plus `.refactor-loop/runs/phase9-issue<N>-r<M>-*.md`",
+        ]
+        for line in allowed_lines:
+            with self.subTest(line=line):
+                self.assertFalse(self._forbidden_generated_artifact_authority(line))
+
+    def test_debug_and_antipattern_examples_remain_allowed(self) -> None:
+        allowed_lines = [
+            "raw evidence awaiting mirror: .refactor-loop/runs/phase9-issue410-r1-judge.md",
+            "<details><summary>本机调试线索</summary> .refactor-loop/runs/phase9-issue410-r1-judge.md",
+            "❌ 用 `授权:.refactor-loop/runs/phase9-issueN-rM-judge.md` 这类本地路径当唯一来源",
+        ]
+        for line in allowed_lines:
+            with self.subTest(line=line):
+                self.assertFalse(self._forbidden_generated_artifact_authority(line))
+
+    def _forbidden_generated_artifact_authority(self, line: str) -> bool:
+        if not RUN_JUDGE_PATH_RE.search(line):
+            return False
+        if self._allowed_generated_artifact_context(line):
+            return False
+        return bool(AUTHORITY_CONTEXT_RE.search(line))
+
+    def _allowed_generated_artifact_context(self, line: str) -> bool:
+        if "SOLVER_OUTPUT_PATH=" in line or line.lstrip().startswith("Write "):
+            return True
+        if "tracking lives in GitHub" in line:
+            return True
+        if "raw evidence awaiting mirror" in line:
+            return True
+        if "<details><summary>本机调试线索</summary>" in line:
+            return True
+        if "❌" in line:
+            return True
+        return False
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

解决设计 issue #410(r3 consensus:structural:narrow-no-boundary)。

- **Old**:checked-in SKILL/prompt 注释引用一次性 design-consensus judge 生成物作权威源,使生成物冒充长期事实源。
- **New**:注释改引 durable contract anchor(GitHub Posting Contract / `_github-post-rules.md` / host.env surface matrix / 现有 inventory tests);新增窄 source-regression test 只扫 SKILL.md 与 prompts。不新增 SKILL clause / 命名 classifier / production module。

## 范围

net diff 6 文件:SKILL.md(3 处注释)+ 4 prompt(各 1 处)+ 新增 source-regression test(+77)。LOC ~+84/-7。基于 fresh `auto-refact-dev`(替代 stale-base 已关的 #469)。

Closes #410

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
