### PR TITLE
#470: direct-post prompt 渲染时内联 _github-post-rules(host worktree 可达)

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -1042,7 +1042,7 @@ Refactor (iter6/issue-118):
 Posting rules:
 
 1. Controller posts lifecycle banners directly.
-2. A worker prompt is direct-post only when its own body contains `## GitHub post` and references `prompts/_github-post-rules.md`.
+2. A worker prompt is direct-post only when its own body contains `## GitHub post` and the fixed token `{{GITHUB_POST_RULES_CONTRACT}}`; `_github-post-rules.md` is the template-time source, and the rendered worker prompt inlines its shared rules body. The rules file is not a worker runtime path.
 3. Every GitHub body uses the sentinel final line.
 4. Avoid plain-text unverified human names or handles.
 5. `SKILL.md` must not maintain a posting-mode prompt filename roster; inventory tests derive posting mode from prompt bodies.
@@ -2218,7 +2218,7 @@ Refactor (iter6/issue-118):
   New principle: prompt-self-declaration posting mode is owned by the GitHub Posting Contract, prompts/_github-post-rules.md, prompt body self-declaration, test_marker_only_prompts_gh_ban.py, and test_marker_emission_contract.py; no SKILL-maintained prompt filename roster.
 -->
 
-- A prompt is direct-post only when its own body contains a `## GitHub post` section referencing `prompts/_github-post-rules.md`; prompts without that self-declaration are marker/artifact-only.
+- A prompt is direct-post only when its own body contains a `## GitHub post` section with fixed token `{{GITHUB_POST_RULES_CONTRACT}}`; prompts without that self-declaration are marker/artifact-only. `_github-post-rules.md` is the template-time source only, and rendered worker prompts inline the shared rules body instead of relying on a worker runtime path.
 - `SKILL.md` 不维护 posting-mode prompt filename roster,也不引入 JSON manifest 或 helper contract; inventory coverage 由 prompt body + tests 承担。
 - Direct-post prompts keep to GitHub comments, PR body edits, reactions, and temp files. Lifecycle/label/create/close/merge/push/release authority remains controller-owned.
 - body 必须 `## 🤖 <headline>` 开头(consensus-rnd-cli comment-monitor 据此识别 controller-post 跳 react)

--- a/skills/codex-refactor-loop/prompts/design-issue-reply.md
+++ b/skills/codex-refactor-loop/prompts/design-issue-reply.md
@@ -3,7 +3,7 @@
 <!--
 Refactor (iter1/issue-126):
   Old pattern: 跨平台 prompt 含 '该项目'/'该项目AI' 等硬编码 host 占位文本,违反 host-agnostic;应复用 host.env surface(GH_REPO_SLUG / MAINTAINER_WHITELIST)。
-  New principle: Host-agnostic prompt text is owned by the host.env surface matrix, GH_REPO_SLUG, MAINTAINER_WHITELIST, HOST_REFACTOR_COMMENT_POLICY, test_refactor_comment_policy_prompt_contract.py, this prompt's checklist, and prompts/_github-post-rules.md for direct-post behavior.
+  New principle: Host-agnostic prompt text is owned by the host.env surface matrix, GH_REPO_SLUG, MAINTAINER_WHITELIST, HOST_REFACTOR_COMMENT_POLICY, test_refactor_comment_policy_prompt_contract.py, this prompt's checklist, and render-time shared post rules for direct-post behavior.
 -->
 
 issue: ${ISSUE_URL}
@@ -76,7 +76,7 @@ NyxId API keys / secrets / 内部 URL 之类敏感信息绝对禁止出现在 re
 
 5. **输出**：
    - 把回复内容写到 `$REPO_ROOT/.refactor-loop/runs/design-issue-${ISSUE_NUMBER}-reply-$(date +%s).md`
-   - 写完 archive 后直接按 `prompts/_github-post-rules.md` post GitHub 回复
+   - 写完 archive 后直接按渲染期内联的共享规则 post GitHub 回复
    - 成功打印 `POSTED:design-reply:${ISSUE_NUMBER}:<URL>:<headline>`；失败打印 `POST_FAILED:design-reply:${ISSUE_NUMBER}:<reason>`
 
 ## 红线
@@ -90,12 +90,9 @@ NyxId API keys / secrets / 内部 URL 之类敏感信息绝对禁止出现在 re
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循渲染期内联的共享规则:
 
-- body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
-- 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`
-- 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
-- Post 后打印 `POSTED:design-reply:${ISSUE_NUMBER}:<URL>:<headline>` 或 `POST_FAILED:design-reply:${ISSUE_NUMBER}:<reason>`
+{{GITHUB_POST_RULES_CONTRACT}}
 
 
 ---

--- a/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -153,13 +153,13 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 <!--
 Refactor (iter6/issue-118):
   Old pattern: SKILL.md 维护 posting-mode prompt filename roster,会漂移
-  New principle: prompt-local GitHub post self-declaration plus prompts/_github-post-rules.md and marker/posting inventory tests own posting mode; SKILL.md does not keep a prompt filename roster.
+  New principle: prompt-local GitHub post self-declaration plus render-time shared post rules and marker/posting inventory tests own posting mode; SKILL.md does not keep a prompt filename roster.
 -->
 
 - You do NOT propose a solution; you ARBITRATE between proposals.
 - You do NOT dispatch other codexes; controller does.
 - You do NOT run GitHub lifecycle mutation. For decomposition, judge only the `IssueDecompositionPlan` artifact boundary; active-controller checked-in helpers own issue creation.
-- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below).
+- You DO post to GitHub directly per the rendered shared GitHub post rules (controller no longer relays — see "GitHub post" section below).
 - Be willing to converge on philosophy. Fundamental philosophy gaps are not human escalation by themselves; ask the solvers for exact clause/Tier/SPEC changes until consensus or router-derived true stall.
 - Treat deep consensus as sufficient authorization. Never require post-consensus human approval, physical GPG ratification, or Tier I reinstall ratification.
 - Do not invent a 4th hybrid framing not present in any solver — that means you're solving, not judging. If no solver covers the right framing → converge with "no solver covers correct framing; propose exact framing"; router owns stalled continuation.
@@ -168,12 +168,9 @@ Refactor (iter6/issue-118):
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循渲染期内联的共享规则:
 
-- body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
-- 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`
-- 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
-- Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
+{{GITHUB_POST_RULES_CONTRACT}}
 
 
 ---

--- a/skills/codex-refactor-loop/prompts/review-fix.md
+++ b/skills/codex-refactor-loop/prompts/review-fix.md
@@ -126,12 +126,9 @@ Begin.
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循渲染期内联的共享规则:
 
-- body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
-- 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`
-- 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
-- Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
+{{GITHUB_POST_RULES_CONTRACT}}
 
 
 ---

--- a/skills/codex-refactor-loop/prompts/reviewer-architect.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-architect.md
@@ -77,18 +77,15 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 - Read **the actual diff and the actual referenced files**. Don't trust the implement summary alone.
 - Cite a PROJECT_RULES/AGENTS clause **verbatim** for every reject. "Architectural smell" without a clause = comment, not reject.
-- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays).
+- You DO post to GitHub directly per the rendered shared GitHub post rules (controller no longer relays).
 - Don't edit any file outside `${REVIEW_OUTPUT_PATH}`.
 - No bilingual requirement here (this is an internal artifact consumed by controller).
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循渲染期内联的共享规则:
 
-- body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
-- 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`
-- 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
-- Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
+{{GITHUB_POST_RULES_CONTRACT}}
 
 
 ---

--- a/skills/codex-refactor-loop/prompts/reviewer-quality.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-quality.md
@@ -80,17 +80,14 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 - Open the actual files, not just hunks.
 - "I don't like this style" without an objective heuristic = approve (taste is the author's, not yours).
-- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below).
+- You DO post to GitHub directly per the rendered shared GitHub post rules (controller no longer relays — see "GitHub post" section below).
 - No bilingual requirement (internal artifact).
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循渲染期内联的共享规则:
 
-- body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
-- 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`
-- 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
-- Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
+{{GITHUB_POST_RULES_CONTRACT}}
 
 
 ---

--- a/skills/codex-refactor-loop/prompts/reviewer-tests.md
+++ b/skills/codex-refactor-loop/prompts/reviewer-tests.md
@@ -79,17 +79,14 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 - Open actual test files; don't infer from implement summary.
 - A single `verdict: reject` from this role on a real coverage gap is correct even if other reviewers approve.
-- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below).
+- You DO post to GitHub directly per the rendered shared GitHub post rules (controller no longer relays — see "GitHub post" section below).
 - No bilingual requirement (internal artifact).
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循渲染期内联的共享规则:
 
-- body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
-- 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`
-- 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
-- Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
+{{GITHUB_POST_RULES_CONTRACT}}
 
 
 ---

--- a/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -133,7 +133,7 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 - You do NOT delete code in this run; controller decides whether to act on your plan.
 - You do NOT commit / push / open PRs.
 - You do NOT run or propose GitHub lifecycle mutation. Decomposition plans may output `IssueDecompositionPlan` and child body artifact requirements, but active-controller checked-in helpers own issue creation.
-- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below).
+- You DO post to GitHub directly per the rendered shared GitHub post rules (controller no longer relays — see "GitHub post" section below).
 - Abstaining is honorable. Forcing a deletion that doesn't fit is worse than abstaining.
 - Philosophy is evolvable: touching CLAUDE.md/L0/L1/L2, Tier boundaries, SPEC, or architecture vocabulary is allowed when it is part of the best deletion/collapse plan.
 - Escalate only for physical ratification/reinstall or total inability to classify; never escalate just because deletion changes an existing philosophy boundary.
@@ -142,12 +142,9 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循渲染期内联的共享规则:
 
-- body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
-- 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`
-- 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
-- Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
+{{GITHUB_POST_RULES_CONTRACT}}
 
 
 ---

--- a/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -107,13 +107,13 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 <!--
 Refactor (iter6/issue-118):
   Old pattern: SKILL.md 维护 posting-mode prompt filename roster,会漂移
-  New principle: prompt-local GitHub post self-declaration plus prompts/_github-post-rules.md and marker/posting inventory tests own posting mode; SKILL.md does not keep a prompt filename roster.
+  New principle: prompt-local GitHub post self-declaration plus render-time shared post rules and marker/posting inventory tests own posting mode; SKILL.md does not keep a prompt filename roster.
 -->
 
 - You do NOT write code; you propose a plan.
 - You do NOT commit / push / open PRs.
 - You do NOT run or propose GitHub lifecycle mutation. Decomposition plans may output `IssueDecompositionPlan` and child body artifact requirements, but active-controller checked-in helpers own issue creation.
-- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below).
+- You DO post to GitHub directly per the rendered shared GitHub post rules (controller no longer relays — see "GitHub post" section below).
 - You do NOT dispatch other codexes.
 - "Minimal" means smallest code change; it does NOT mean "ignore architectural correctness". If the minimum is still wrong, abstain.
 - Philosophy is evolvable: touching CLAUDE.md/L0/L1/L2, Tier boundaries, SPEC, or architecture vocabulary is allowed when it is the minimum viable fix and is written as a concrete plan.
@@ -123,12 +123,9 @@ Refactor (iter6/issue-118):
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循渲染期内联的共享规则:
 
-- body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
-- 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`
-- 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
-- Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
+{{GITHUB_POST_RULES_CONTRACT}}
 
 
 ---

--- a/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -115,7 +115,7 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 - You do NOT write code; you propose a plan.
 - You do NOT commit / push / open PRs.
 - You do NOT run or propose GitHub lifecycle mutation. Decomposition plans may output `IssueDecompositionPlan` and child body artifact requirements, but active-controller checked-in helpers own issue creation.
-- You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see "GitHub post" section below).
+- You DO post to GitHub directly per the rendered shared GitHub post rules (controller no longer relays — see "GitHub post" section below).
 - You propose abstractions only when justified by ≥2 concrete callers OR by an explicit named extension point. "Future-proofing" alone is not justification.
 - Philosophy is evolvable: if the best structural answer changes CLAUDE.md/L0/L1/L2, Tier boundaries, SPEC, or architecture vocabulary, produce that as a concrete plan instead of escalating.
 - Escalate only for physical ratification/reinstall or total inability to produce a plan.
@@ -124,12 +124,9 @@ Only the markers listed above are valid role-routing markers for this prompt. Do
 
 ## GitHub post(强制)
 
-写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循 `prompts/_github-post-rules.md`(本 skill 的 `prompts/_github-post-rules.md`)所有规则:
+写完内部 artifact 后,**自己调 `gh` post 中文 GitHub 评论/PR body**。遵循渲染期内联的共享规则:
 
-- body 第一行 `## 🤖 <headline>`(comment-monitor 据此识别)
-- 中文 TL;DR ≤ 6 行 + 详细说明 + raw artifact 折叠 `<details>`
-- 若 situation context 给了 `original_authors:` 列表,加 `📢 cc 原作者:@h1 @h2`
-- Post 后打印 `POSTED:<role>:<issue-or-pr>:<URL>:<headline>` 或 `POST_FAILED:...`
+{{GITHUB_POST_RULES_CONTRACT}}
 
 
 ---

--- a/skills/codex-refactor-loop/prompts/triage-external-issue.md
+++ b/skills/codex-refactor-loop/prompts/triage-external-issue.md
@@ -96,7 +96,9 @@ Artifact profile: marker-only-work-unit
 
 ## GitHub post
 
-遵循 `prompts/_github-post-rules.md`。
+遵循渲染期内联的共享规则。
+
+{{GITHUB_POST_RULES_CONTRACT}}
 
 按 accept / reject 分别:
 - accept 评论头行 `## 🤖 Triage codex — accept: issue-${ISSUE_NUMBER}`

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -19,6 +19,7 @@ from .banners import BannerRequest, build_status_banner, gh_comment_command
 from .context import LoopContext
 from .github_body import GitHubBodyError, validate_self_contained_github_body
 from .issue_decomposition import load_issue_decomposition_plan
+from .prompt_contracts import inline_prompt_contracts
 from .release.publisher import ReleasePublishResult, ReleasePublisher
 from .review_fix_dispatch import ReviewFixDispatchSpec
 from .triage import apply_decision, load_triage_apply_config
@@ -907,7 +908,7 @@ class ControllerActions:
         template = template_path.read_text(encoding="utf-8")
         for key, value in aliases.items():
             template = template.replace("{{" + key + "}}", value)
-        rendered = Template(template).safe_substitute(values)
+        rendered = inline_prompt_contracts(Template(template).safe_substitute(values), skill_root=self.ctx.skill_root)
         Path(output_path).write_text(rendered, encoding="utf-8")
 
     def render_review_fix_prompt(

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -22,12 +22,14 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from string import Template
 from typing import Any, Callable, Iterable, Literal, cast
 
 from ..active_controller import require_active_controller, write_active_controller_status
 from ..context import LoopContext
 from ..github_budget import graphql_headroom_ok, log_graphql_backoff
 from ..heartbeat import DaemonHeartbeatLease
+from ..prompt_contracts import inline_prompt_contracts
 from ..transition_assessment import TransitionAssessment, TransitionAssessmentReader, projection_lines
 from ..workflow_stages import format_stage
 from .. import labels as label_catalog
@@ -213,7 +215,7 @@ class MetaJudgePromptRenderer:
         rendered = template
         for key in self.PLACEHOLDERS:
             rendered = rendered.replace("${" + key + "}", values[key])
-        return rendered
+        return inline_prompt_contracts(rendered, skill_root=self.template_path.parents[1])
 
 
 PHASE9_LOG_RE = re.compile(
@@ -1383,12 +1385,25 @@ class Phase9Router:
         )
 
     def _solver_prompt(self, issue: str, round_no: int, role: str, marker: str) -> str:
+        prompt = self._issue_snapshot_preferred_text(issue, self._render_solver_template(issue, round_no, role))
         return (
             f"# {format_stage('design-consensus')} {role} solver\n\n"
             f"{self._solver_work_unit_header(issue, round_no, role)}\n\n"
             f"{self._issue_source_snapshot_markdown(issue)}\n\n"
-            f"Convergence marker: {marker}\n\nUse prompts/solver-{role}.md contract and emit SOLVER_DONE:{role}:...\n"
+            f"Convergence marker: {marker}\n\n"
+            f"## Full solver template\n\n{prompt}\n"
         )
+
+    def _render_solver_template(self, issue: str, round_no: int, role: str) -> str:
+        template_path = self.skill_root / "prompts" / f"solver-{role}.md"
+        template = template_path.read_text(encoding="utf-8")
+        values = {
+            "ISSUE_NUMBER": issue,
+            "CLUSTER_ID": f"issue-{issue}",
+            "CONVERGENCE_ROUND": str(round_no),
+            "SOLVER_OUTPUT_PATH": f".refactor-loop/runs/phase9-issue{issue}-r{round_no}-{role}.md",
+        }
+        return inline_prompt_contracts(Template(template).safe_substitute(values), skill_root=self.skill_root)
 
     def _solver_work_unit_header(self, issue: str, round_no: int, role: str) -> str:
         output_path = f".refactor-loop/runs/phase9-issue{issue}-r{round_no}-{role}.md"

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/prompt_contracts.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/prompt_contracts.py
@@ -1,0 +1,29 @@
+"""Render-time prompt contract expansion for checked-in worker prompts."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+class PromptContractError(RuntimeError):
+    """Raised when a prompt contract token cannot be expanded safely."""
+
+
+GITHUB_POST_RULES_CONTRACT_TOKEN = "{{GITHUB_POST_RULES_CONTRACT}}"
+_CONTRACT_TOKEN_RE = re.compile(r"{{[A-Z0-9_]+_CONTRACT}}")
+
+
+def inline_prompt_contracts(text: str, *, skill_root: Path) -> str:
+    tokens = set(_CONTRACT_TOKEN_RE.findall(text))
+    unknown = sorted(tokens - {GITHUB_POST_RULES_CONTRACT_TOKEN})
+    if unknown:
+        raise PromptContractError(f"unknown prompt contract token(s): {', '.join(unknown)}")
+    if GITHUB_POST_RULES_CONTRACT_TOKEN not in tokens:
+        return text
+    rules_path = skill_root / "prompts" / "_github-post-rules.md"
+    try:
+        rules = rules_path.read_text(encoding="utf-8").rstrip()
+    except OSError as exc:
+        raise PromptContractError(f"missing GitHub post rules contract: {rules_path}") from exc
+    return text.replace(GITHUB_POST_RULES_CONTRACT_TOKEN, rules)

--- a/skills/codex-refactor-loop/scripts/test_comment_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_comment_monitor.py
@@ -56,6 +56,7 @@ class CommentMonitorTests(unittest.TestCase):
             {
                 "STATE_FILE": str(override_root / "state.json"),
                 "INTERVAL": "1",
+                "COMMENT_MONITOR_INTERVAL": "",
             },
         ):
             monitor = CommentMonitor(self.ctx)

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -26,6 +26,7 @@ from codex_refactor_loop.cli import COMMANDS
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.controller_actions import ControllerActions
 from codex_refactor_loop.git import Git
+from codex_refactor_loop.prompt_contracts import GITHUB_POST_RULES_CONTRACT_TOKEN
 from codex_refactor_loop.release.publisher import ReleasePublishResult
 from codex_refactor_loop.wakeup_plan import harness_spawn_intent_actions
 
@@ -1675,6 +1676,19 @@ class ControllerActionsTests(unittest.TestCase):
         )
 
         self.assertEqual(output.read_text(encoding="utf-8"), "Host example-host handles issue-219 from cluster-219.\n")
+
+    def test_render_template_inlines_github_post_rules_contract(self) -> None:
+        template = self.tmp / "template.md"
+        output = self.tmp / "rendered.md"
+        template.write_text(f"## GitHub post\n\n{GITHUB_POST_RULES_CONTRACT_TOKEN}\n", encoding="utf-8")
+
+        self.actions.render_template(str(template), str(output))
+
+        rendered = output.read_text(encoding="utf-8")
+        self.assertIn("# GitHub post rules", rendered)
+        self.assertIn("## Body 结构", rendered)
+        self.assertNotIn(GITHUB_POST_RULES_CONTRACT_TOKEN, rendered)
+        self.assertNotIn("prompts/_github-post-rules.md", rendered)
 
     def test_render_template_rejects_unknown_host_prompt_binding(self) -> None:
         actions = self.write_host_workflow_spec(self.valid_host_prompt_spec())

--- a/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
+++ b/skills/codex-refactor-loop/scripts/test_marker_only_prompts_gh_ban.py
@@ -14,6 +14,7 @@ PROMPTS_DIR = SCRIPT_PATH.parents[1] / "prompts"
 sys.path.insert(0, str(SCRIPT_PATH.parent))
 
 from codex_refactor_loop.cli import COMMANDS
+from codex_refactor_loop.prompt_contracts import GITHUB_POST_RULES_CONTRACT_TOKEN
 
 DENIAL_OR_CONTROLLER_OWNER_RE = re.compile(
     r"禁止|不可调|不得|不能|不要|Forbidden|forbidden|Do NOT|do not|must not|"
@@ -211,7 +212,8 @@ class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
             body = path.read_text(encoding="utf-8")
             section = github_post_section(body)
             with self.subTest(prompt=path.name):
-                self.assertIn("prompts/_github-post-rules.md", section)
+                self.assertIn(GITHUB_POST_RULES_CONTRACT_TOKEN, section)
+                self.assertNotIn("prompts/_github-post-rules.md", body)
                 for snippet in LOCAL_COMMAND_ROSTER_SNIPPETS:
                     self.assertNotIn(snippet, section)
 
@@ -259,7 +261,8 @@ class MarkerOnlyPromptsGhBanTests(unittest.TestCase):
         body = (PROMPTS_DIR / "design-issue-reply.md").read_text(encoding="utf-8")
         section = github_post_section(body)
         self.assertIn("## GitHub post", body)
-        self.assertIn("prompts/_github-post-rules.md", section)
+        self.assertIn(GITHUB_POST_RULES_CONTRACT_TOKEN, section)
+        self.assertNotIn("prompts/_github-post-rules.md", body)
         self.assertNotIn("controller 会读这个文件", body)
         self.assertNotIn("DESIGN_REPLY_READY", body)
         self.assertIn("POSTED:design-reply", body)

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -22,6 +22,7 @@ from codex_refactor_loop.phase9.router import (
     main,
     parse_phase9_log_identity,
 )
+from codex_refactor_loop.prompt_contracts import GITHUB_POST_RULES_CONTRACT_TOKEN
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -1376,6 +1377,9 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertNotIn("$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md", prompt)
         self.assertNotIn("cluster spec", prompt)
         self.assertNotIn("gh issue view 114", prompt)
+        self.assertIn("# GitHub post rules", prompt)
+        self.assertNotIn(GITHUB_POST_RULES_CONTRACT_TOKEN, prompt)
+        self.assertNotIn("prompts/_github-post-rules.md", prompt)
 
     def test_solver_prompt_for_missing_transition_assessment_uses_unknown_projection(self) -> None:
         self.write_log("phase9-issue115-r1-judge.log", "META_JUDGE_DONE:converge:round-2:need-more")

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_package.py
@@ -21,6 +21,7 @@ from codex_refactor_loop.phase9.router import (
     main,
     parse_phase9_log_identity,
 )
+from codex_refactor_loop.prompt_contracts import GITHUB_POST_RULES_CONTRACT_TOKEN
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -284,6 +285,9 @@ class Phase9RouterPackageTests(unittest.TestCase):
         for needle in required:
             with self.subTest(needle=needle):
                 self.assertIn(needle, prompt)
+        self.assertIn("# GitHub post rules", prompt)
+        self.assertNotIn(GITHUB_POST_RULES_CONTRACT_TOKEN, prompt)
+        self.assertNotIn("prompts/_github-post-rules.md", prompt)
         router_header = prompt.split("## Issue source snapshot", 1)[0]
         self.assertNotIn("$REPO_ROOT/.refactor-loop/runs/audit-iter-${ITERATION}.md", router_header)
         self.assertNotIn("cluster spec", router_header)

--- a/skills/codex-refactor-loop/scripts/test_prompt_contract_inliner.py
+++ b/skills/codex-refactor-loop/scripts/test_prompt_contract_inliner.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Behavior tests for render-time prompt contract inlining."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.prompt_contracts import (  # noqa: E402
+    GITHUB_POST_RULES_CONTRACT_TOKEN,
+    PromptContractError,
+    inline_prompt_contracts,
+)
+
+
+class PromptContractInlinerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="prompt-contract-test-"))
+        self.skill_root = self.tmp / "skill"
+        (self.skill_root / "prompts").mkdir(parents=True)
+        (self.skill_root / "prompts" / "_github-post-rules.md").write_text(
+            "# GitHub post rules\n\n## Body\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_inlines_fixed_github_post_rules_token(self) -> None:
+        rendered = inline_prompt_contracts(
+            f"before\n{GITHUB_POST_RULES_CONTRACT_TOKEN}\nafter\n",
+            skill_root=self.skill_root,
+        )
+
+        self.assertIn("# GitHub post rules", rendered)
+        self.assertIn("## Body", rendered)
+        self.assertNotIn(GITHUB_POST_RULES_CONTRACT_TOKEN, rendered)
+
+    def test_unknown_contract_token_fails_closed(self) -> None:
+        with self.assertRaisesRegex(PromptContractError, "unknown prompt contract token"):
+            inline_prompt_contracts("{{OTHER_CONTRACT}}\n", skill_root=self.skill_root)
+
+    def test_missing_github_post_rules_file_fails_closed(self) -> None:
+        (self.skill_root / "prompts" / "_github-post-rules.md").unlink()
+
+        with self.assertRaisesRegex(PromptContractError, "missing GitHub post rules contract"):
+            inline_prompt_contracts(GITHUB_POST_RULES_CONTRACT_TOKEN, skill_root=self.skill_root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_prompt_contracts.py
+++ b/skills/codex-refactor-loop/scripts/test_prompt_contracts.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Source-regression tests for checked-in prompt contract tokens."""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_ROOT = SCRIPT_DIR.parent
+PROMPTS_DIR = SKILL_ROOT / "prompts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.prompt_contracts import GITHUB_POST_RULES_CONTRACT_TOKEN  # noqa: E402
+
+
+DIRECT_POST_PROMPTS = (
+    "solver-minimal.md",
+    "solver-structural.md",
+    "solver-delete.md",
+    "meta-judge.md",
+    "reviewer-architect.md",
+    "reviewer-tests.md",
+    "reviewer-quality.md",
+    "review-fix.md",
+    "design-issue-reply.md",
+    "triage-external-issue.md",
+)
+
+
+class PromptContractsTests(unittest.TestCase):
+    def test_direct_post_prompts_declare_one_fixed_contract_token(self) -> None:
+        for name in DIRECT_POST_PROMPTS:
+            with self.subTest(prompt=name):
+                body = (PROMPTS_DIR / name).read_text(encoding="utf-8")
+                section = github_post_section(body)
+                self.assertIn("## GitHub post", section)
+                self.assertEqual(section.count(GITHUB_POST_RULES_CONTRACT_TOKEN), 1)
+                self.assertNotIn("prompts/_github-post-rules.md", body)
+
+    def test_only_known_contract_token_is_checked_in(self) -> None:
+        tokens: set[str] = set()
+        for path in PROMPTS_DIR.glob("*.md"):
+            tokens.update(re.findall(r"{{[A-Z0-9_]+_CONTRACT}}", path.read_text(encoding="utf-8")))
+
+        self.assertEqual(tokens, {GITHUB_POST_RULES_CONTRACT_TOKEN})
+
+
+def github_post_section(body: str) -> str:
+    match = re.search(r"(?ms)^## GitHub post.*?(?=^## |\Z)", body)
+    return match.group(0) if match else ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -140,6 +140,18 @@ class SkillReferenceAnchorTests(unittest.TestCase):
                 self.assertIn(stage.slug, index)
                 self.assertIn(stage.detail_anchor, available)
 
+    def test_github_posting_contract_documents_render_time_inline_rules(self) -> None:
+        contract = section_after_heading(self.skill, "GitHub Posting Contract")
+        for needle in (
+            "contains `## GitHub post` and the fixed token `{{GITHUB_POST_RULES_CONTRACT}}`",
+            "`_github-post-rules.md` is the template-time source",
+            "rendered worker prompt inlines",
+            "not a worker runtime path",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, contract)
+        self.assertNotIn("references `prompts/_github-post-rules.md`", contract)
+
     def test_skill_is_the_single_heavy_manual_after_merge(self) -> None:
         available = reference_anchors(self.skill)
         for anchor in (


### PR DESCRIPTION
## 摘要

解决设计 issue #470(r2 consensus:structural,fixed-token render-time inline)。

- **Old**:solver/meta-judge/reviewer 等 direct-post prompt 引用裸相对路径 `prompts/_github-post-rules.md`,在 host worktree cwd 不可达,worker 浪费精力定位。
- **New**:渲染时把 post-rules **fixed-token 内联**进 prompt(新增 prompt-contract inliner),host worktree 下自包含可达;覆盖所有 direct-post prompt。

## 范围

prompt_contracts.py + 新 inliner 模块 + router/controller_actions 渲染路径 + 各 direct-post prompt + behavior/source-regression test。基于含 #471 hotfix1+2 + skill-nogap 的最新 auto-refact-dev。

Closes #470

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
