### PR TITLE
#475: wakeup-runner 批量派 spawn-worker 到 floor deficit(修 1/tick 低并发)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -70,6 +70,7 @@ SUPPORTED_CONTROLLER_ACTIONS = {
     "review_gate",
     "publish_release_candidate",
 }
+SPAWN_BATCH_CONTROLLER_ACTION = "spawn_codex_harness_background"
 
 
 @dataclass(frozen=True)
@@ -77,6 +78,37 @@ class RunnerResult:
     action_id: str
     status: str
     reason: str = ""
+
+
+@dataclass(frozen=True)
+class WakeupApplyBudget:
+    spawn_budget: int
+    source: str
+
+    @classmethod
+    def from_plan(cls, plan: Mapping[str, Any]) -> "WakeupApplyBudget":
+        hard_gate = plan.get("hard_gate")
+        if not isinstance(hard_gate, Mapping):
+            concurrency_hard_gate = plan.get("concurrency")
+            if isinstance(concurrency_hard_gate, Mapping):
+                hard_gate = concurrency_hard_gate.get("hard_gate")
+        concurrency = plan.get("concurrency")
+        if not isinstance(hard_gate, Mapping) or not isinstance(concurrency, Mapping):
+            return cls.legacy()
+        if hard_gate.get("active") is not True:
+            return cls.legacy()
+        dispatch_required = _positive_int(hard_gate.get("dispatch_required"))
+        deficit = _positive_int(concurrency.get("deficit"))
+        if dispatch_required is None or deficit is None:
+            return cls.legacy()
+        return cls(min(dispatch_required, deficit), "hard_gate.dispatch_required/concurrency.deficit")
+
+    @classmethod
+    def legacy(cls) -> "WakeupApplyBudget":
+        return cls(1, "legacy-single-apply")
+
+    def is_spawn_action(self, action: Mapping[str, Any]) -> bool:
+        return action.get("controller_action") == SPAWN_BATCH_CONTROLLER_ACTION
 
 
 @dataclass(frozen=True)
@@ -172,14 +204,23 @@ class WakeupRunner:
             result = RunnerResult("", "blocked", plan_error)
             self._record(result, action=None)
             return [result]
+        budget = WakeupApplyBudget.from_plan(plan)
         results: list[RunnerResult] = []
+        applied_spawns = 0
         for action in plan.get("actions", []):
             if not isinstance(action, dict) or action.get("status_only") is True:
                 continue
+            if applied_spawns > 0 and not budget.is_spawn_action(action):
+                break
             result = self.apply_action(action)
             results.append(result)
-            if result.status == "applied":
+            if result.status != "applied":
                 break
+            if budget.is_spawn_action(action):
+                applied_spawns += 1
+                if applied_spawns < budget.spawn_budget:
+                    continue
+            break
         return results
 
     def apply_action(self, action: Mapping[str, Any]) -> RunnerResult:
@@ -960,6 +1001,12 @@ def _target_from_text(text: str) -> tuple[str, int] | None:
 
 def _terminal_blocked_reason(reason: str) -> bool:
     return reason in {"target_not_open:CLOSED", "target_not_open:MERGED"}
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
 
 
 def _run_once_with_periodic_heartbeat(

--- a/skills/codex-refactor-loop/scripts/test_runtime_exception_authorization_sources.py
+++ b/skills/codex-refactor-loop/scripts/test_runtime_exception_authorization_sources.py
@@ -924,6 +924,35 @@ class RuntimeExceptionAuthorizationSourceTests(unittest.TestCase):
                 self.assertIn(required, self.skill)
                 self.assertIn(required, observability_entry)
 
+    def test_wakeup_runner_batch_budget_is_spawn_only_and_per_action_validated(self) -> None:
+        runner = read(SKILL_ROOT / "scripts" / "codex_refactor_loop" / "wakeup_runner.py")
+        run_once = runner[runner.index("    def run_once(self)") : runner.index("    def apply_action(self,")]
+        budget = runner[runner.index("class WakeupApplyBudget") : runner.index("@dataclass(frozen=True)", runner.index("class WakeupApplyBudget"))]
+
+        for required in (
+            "SPAWN_BATCH_CONTROLLER_ACTION = \"spawn_codex_harness_background\"",
+            "class WakeupApplyBudget",
+            "hard_gate.dispatch_required/concurrency.deficit",
+            "return cls.legacy()",
+            "min(dispatch_required, deficit)",
+            "return action.get(\"controller_action\") == SPAWN_BATCH_CONTROLLER_ACTION",
+            "budget = WakeupApplyBudget.from_plan(plan)",
+            "result = self.apply_action(action)",
+            "if result.status != \"applied\":",
+            "if applied_spawns > 0 and not budget.is_spawn_action(action):",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, runner)
+        self.assertIn("applied_spawns += 1", run_once)
+        self.assertIn("if applied_spawns < budget.spawn_budget:", run_once)
+        for forbidden in (
+            "for action in plan.get(\"actions\", [])[:",
+            "dispatch_required = int(",
+            "controller_action in SUPPORTED_CONTROLLER_ACTIONS",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, budget + run_once)
+
     def test_observability_comment_writers_owner_local_contract_is_locked(self) -> None:
         heading = "## Named runtime exception — observability-comment-writers(per #53)"
         start = self.skill.index(heading)

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -254,6 +254,17 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             "actions": [action],
         }
 
+    def batch_plan(self, actions: list[dict], *, dispatch_required: object, deficit: object, active: bool = True) -> dict:
+        return {
+            "schema": "wakeup-plan",
+            "mode": "closed-action-projection",
+            "apply_authority": "wakeup-runner-396-only",
+            "no_lifecycle_authority": True,
+            "concurrency": {"deficit": deficit},
+            "hard_gate": {"active": active, "dispatch_required": dispatch_required},
+            "actions": actions,
+        }
+
     def spawn_action(self, **overrides) -> dict:
         prompt = self.repo / ".refactor-loop/prompts/task.md"
         prompt.write_text("hello\n", encoding="utf-8")
@@ -556,6 +567,96 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertTrue(kwargs["start_new_session"])
         popen.return_value.wait.assert_not_called()
         popen.return_value.poll.assert_not_called()
+
+    def test_wakeup_runner_batches_spawn_actions_up_to_hard_gate_dispatch_required(self) -> None:
+        actions = [self.spawn_action(action_id=f"spawn:{index}", log=str(self.repo / f".refactor-loop/logs/task-{index}.log")) for index in range(3)]
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
+            results = self.run_result(self.batch_plan(actions, dispatch_required=3, deficit=5))
+
+        self.assertEqual([result.status for result in results], ["applied", "applied", "applied"])
+        self.assertEqual([result.action_id for result in results], ["spawn:0", "spawn:1", "spawn:2"])
+        self.assertEqual(launch.call_count, 3)
+
+    def test_wakeup_runner_spawn_batch_does_not_overshoot_dispatch_required(self) -> None:
+        actions = [self.spawn_action(action_id=f"spawn:{index}", log=str(self.repo / f".refactor-loop/logs/task-{index}.log")) for index in range(4)]
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
+            results = self.run_result(self.batch_plan(actions, dispatch_required=2, deficit=4))
+
+        self.assertEqual([result.action_id for result in results], ["spawn:0", "spawn:1"])
+        self.assertEqual([result.status for result in results], ["applied", "applied"])
+        self.assertEqual(launch.call_count, 2)
+
+    def test_wakeup_runner_spawn_batch_uses_deficit_as_upper_bound(self) -> None:
+        actions = [self.spawn_action(action_id=f"spawn:{index}", log=str(self.repo / f".refactor-loop/logs/task-{index}.log")) for index in range(3)]
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
+            results = self.run_result(self.batch_plan(actions, dispatch_required=5, deficit=2))
+
+        self.assertEqual([result.action_id for result in results], ["spawn:0", "spawn:1"])
+        self.assertEqual(launch.call_count, 2)
+
+    def test_wakeup_runner_missing_or_invalid_budget_keeps_single_apply_compatibility(self) -> None:
+        cases = (
+            ("missing", self.base_plan),
+            ("inactive", lambda actions: self.batch_plan(actions, dispatch_required=2, deficit=2, active=False)),
+            ("zero", lambda actions: self.batch_plan(actions, dispatch_required=0, deficit=2)),
+            ("non-int", lambda actions: self.batch_plan(actions, dispatch_required="2", deficit=2)),
+            ("missing-deficit", lambda actions: self.batch_plan(actions, dispatch_required=2, deficit=None)),
+        )
+        for name, plan_factory in cases:
+            with self.subTest(name=name):
+                actions = [
+                    self.spawn_action(action_id=f"{name}:spawn:0", log=str(self.repo / f".refactor-loop/logs/{name}-0.log")),
+                    self.spawn_action(action_id=f"{name}:spawn:1", log=str(self.repo / f".refactor-loop/logs/{name}-1.log")),
+                ]
+                plan = plan_factory(actions) if name != "missing" else self.base_plan(actions[0])
+                if name == "missing":
+                    plan["actions"] = actions
+                with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
+                    results = self.run_result(plan)
+
+                self.assertEqual([result.action_id for result in results], [actions[0]["action_id"]])
+                self.assertEqual(launch.call_count, 1)
+
+    def test_wakeup_runner_non_spawn_action_does_not_consume_batch_budget(self) -> None:
+        first = self.close_action(action_id="close-managed-item:53:first")
+        second = self.close_action(action_id="close-managed-item:53:second")
+        actions = FakeActions()
+
+        results = self.run_result(self.batch_plan([first, second], dispatch_required=3, deficit=3), actions=actions)
+
+        self.assertEqual([result.action_id for result in results], ["close-managed-item:53:first"])
+        self.assertEqual([result.status for result in results], ["applied"])
+        self.assertEqual([call[0] for call in actions.calls], ["close_managed_item_from_drop_marker"])
+
+    def test_wakeup_runner_does_not_apply_non_spawn_after_spawn_batch(self) -> None:
+        close = self.close_action(action_id="close-managed-item:53:after-spawn")
+        spawn = self.spawn_action(action_id="spawn:first")
+        actions = FakeActions()
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
+            results = self.run_result(self.batch_plan([spawn, close], dispatch_required=3, deficit=3), actions=actions)
+
+        self.assertEqual([result.action_id for result in results], ["spawn:first"])
+        self.assertEqual(launch.call_count, 1)
+        self.assertEqual(actions.calls, [])
+
+    def test_wakeup_runner_stops_on_blocked_spawn_without_scanning_later_actions(self) -> None:
+        first = self.spawn_action(action_id="spawn:first", log=str(self.repo / ".refactor-loop/logs/first.log"))
+        blocked = self.spawn_action(action_id="spawn:blocked", log=str(self.repo / ".refactor-loop/logs/blocked.log"))
+        later = self.spawn_action(action_id="spawn:later", log=str(self.repo / ".refactor-loop/logs/later.log"))
+        Path(blocked["log"]).write_text("already claimed\n", encoding="utf-8")
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
+            results = self.run_result(self.batch_plan([first, blocked, later], dispatch_required=3, deficit=3))
+
+        self.assertEqual([result.action_id for result in results], ["spawn:first", "spawn:blocked"])
+        self.assertEqual([result.status for result in results], ["applied", "blocked"])
+        self.assertEqual(results[1].reason, "target_log_exists")
+        self.assertEqual(launch.call_count, 1)
+        self.assert_blocked_event("spawn:blocked", "target_log_exists")
 
     def test_dispatch_design_consensus_solver_triplet_renders_and_spawns_judge(self) -> None:
         with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:


### PR DESCRIPTION
## 摘要

解决设计 issue #475(r2 consensus:hybrid-A+B:spawn-only)。修 daemon 1/tick 线性恢复 → 批量填 floor。

- **Old**:`run_once()` 第一个 applied 后无条件 break → headless floor deficit 只能 1/tick 线性恢复(并发数偏低)。
- **New**:runner-private `WakeupApplyBudget` 把 `hard_gate.dispatch_required`/`concurrency.deficit` 解释为本 tick spawn-worker 预算;**仅 `spawn_codex_harness_background` 消耗预算**(批量到 deficit),**lifecycle action(review/merge/close/release)仍每 tick 最多 1 个**;blocked/skipped fail-stop;全走既有 `apply_action()` per-action 校验。

## 范围

wakeup_runner.py + tests。53 tests OK。基于 #471/#481/#485 之上。

Closes #475

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
