### PR TITLE
移除 review redispatch 的重复 head_sha payload

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -1501,7 +1501,6 @@ def review_evidence_redispatch_actions(repo_root: Path, gh_items: list[GhItem]) 
                 "target_kind": "PR",
                 "target_number": item.number,
                 "target": {"kind": "PR", "number": item.number},
-                "head_sha": item.head_sha,
                 "stale_review_roles": stale_roles,
                 "preconditions": ["active_controller_owner", "live_open_target_if_present", "missing_or_stale_reviewer_head_evidence"],
                 "runner_authority": RUNNER_AUTHORITY,

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -1934,7 +1934,7 @@ class ControllerActionsTests(unittest.TestCase):
                                 "target_kind": "PR",
                                 "target_number": 77,
                                 "stale_review_roles": ["architect", "tests"],
-                                "head_sha": "a" * 40,
+                                "head_sha": "b" * 40,
                             }
                         ),
                     )
@@ -1994,7 +1994,7 @@ class ControllerActionsTests(unittest.TestCase):
                                 "target_kind": "PR",
                                 "target_number": 77,
                                 "stale_review_roles": ["architect", "tests"],
-                                "head_sha": "a" * 40,
+                                "head_sha": "b" * 40,
                             }
                         ),
                     )
@@ -2035,8 +2035,10 @@ class ControllerActionsTests(unittest.TestCase):
 
     def test_dispatch_reviewers_source_requires_controller_head_oid_binding(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")
+        method = source[source.index("    def dispatch_reviewers") : source.index("    def _next_review_round")]
         self.assertIn('"title,baseRefName,headRefName,headRefOid"', source)
         self.assertIn('"HEAD_SHA": head_sha', source)
+        self.assertNotIn('action.get("head_sha"', method)
         self.assertIn("def _next_review_round(", source)
         self.assertIn("round_number = self._next_review_round(pr_target, role)", source)
         self.assertIn("intent_id=f\"dispatch-reviewers:{pr_target}:{role}:r{round_number}\"", source)

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -2438,7 +2438,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(action["controller_action"], "dispatch_reviewers")
         self.assertEqual(action["target_kind"], "PR")
         self.assertEqual(action["target_number"], 480)
-        self.assertEqual(action["head_sha"], "a" * 40)
+        self.assertNotIn("head_sha", action)
+        self.assertEqual(action["action_id"], "review-evidence-redispatch:480:" + "a" * 40)
         self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
         self.assertIn("missing_or_stale_reviewer_head_evidence", action["preconditions"])
         self.assertEqual(action["runner_authority"], "wakeup-runner-396")
@@ -2462,6 +2463,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
         self.assertEqual(action["target_number"], 480)
+        self.assertNotIn("head_sha", action)
         self.assertEqual(action["stale_review_roles"], ["architect"])
         self.assertNotIn("status_only", action)
 
@@ -3265,6 +3267,12 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertNotIn("pr list", caller_source)
         self.assertIn("review_evidence_redispatch_actions", projection.function_names)
         self.assertIn("review-evidence-redispatch", projection.set_members["EXECUTABLE_ACTION_KINDS"])
+        source = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "wakeup_plan.py").read_text(encoding="utf-8")
+        function_source = source[
+            source.index("def review_evidence_redispatch_actions") : source.index("\ndef phase_from_marker", source.index("def review_evidence_redispatch_actions"))
+        ]
+        self.assertIn('"action_id": f"review-evidence-redispatch:{item.number}:{item.head_sha}"', function_source)
+        self.assertNotIn('"head_sha"', function_source)
 
     def test_wakeup_plan_source_locks_stale_unexecutable_status_only_suppression(self) -> None:
         projection = wakeup_plan_projection()
@@ -3935,9 +3943,10 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
     def test_load_github_items_logs_unavailable_managed_work_snapshot(self) -> None:
         snapshot = ManagedWorkSnapshotResult((), False, "unavailable", "graphql-headroom-low", 901)
         output = StringIO()
-        with mock.patch("codex_refactor_loop.wakeup_plan.load_open_managed_work_snapshot", return_value=snapshot):
-            with redirect_stderr(output):
-                items, loaded_ok = load_github_items_with_status(self.repo)
+        with mock.patch.dict(os.environ, {"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}):
+            with mock.patch("codex_refactor_loop.wakeup_plan.load_open_managed_work_snapshot", return_value=snapshot):
+                with redirect_stderr(output):
+                    items, loaded_ok = load_github_items_with_status(self.repo)
 
         self.assertEqual(items, [])
         self.assertFalse(loaded_ok)

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -1966,7 +1966,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             action_id="review-evidence-redispatch:77:" + "a" * 40,
             source_artifact="wakeup-plan",
             source_marker="review-evidence-redispatch",
-            head_sha="a" * 40,
+            head_sha="b" * 40,
             stale_review_roles=["architect", "tests"],
             preconditions=[
                 "active_controller_owner",


### PR DESCRIPTION
## 修改文件

- `wakeup_plan.py` 不再在 `review-evidence-redispatch` action payload 暴露结构化 `head_sha`，仅在 `action_id` 中保留 snapshot head 用于去重和诊断。
- 更新 wakeup-plan/controller-actions/wakeup-runner 测试，覆盖 canonical redispatch payload 不含 `head_sha`、legacy action `head_sha` 被忽略、reviewer prompt `HEAD_SHA` 只来自 live `headRefOid`。

## 测试结果

- `python3 -m compileall skills/codex-refactor-loop/scripts skills/sshx -q`
- `test_controller_actions.py`: 108 tests OK
- `test_wakeup_plan.py`: 187 tests OK
- `test_wakeup_runner.py`: 82 tests OK
- optional `test_wakeup_runner_review_gate.py`: 19 tests OK
- host pytest command: `1496 passed, 1 skipped, 4710 subtests passed`; `skills/sshx/tests`: `13 passed`
- CI guards: `guards skipped: CI_GUARDS unset`

## deviation 记录

- SCOPE_EXTEND: none
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)
- No schema/protocol regeneration required.

Closes #542

⟦AI:AUTO-LOOP⟧
