### PR TITLE
发布 rollup: integration ahead 1 commits (2c144660a675)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -1773,7 +1773,8 @@ class ControllerActions:
             return 2
         if not self._require_github_actor_or_return("close-managed-drop", code=3):
             return 3
-        comment = "Closed from drop marker.\n\n⟦AI:AUTO-LOOP⟧"
+        drop_reason = marker.removeprefix("META_RESOLVED:drop:").strip() or "drop"
+        comment = f"Closed from drop marker.\n\nDrop reason: {drop_reason}\n\n⟦AI:AUTO-LOOP⟧"
         if kind == "pr":
             pr_target = issue_target
             result = self.gh(["pr", "close", pr_target, "--comment", comment], check=False)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -159,7 +159,7 @@ MANAGED_PR_HEAD_PATTERN = re.compile("^" + "refactor/" + r"iter[1-9][0-9]*-[A-Za
 REQUIRED_REVIEW_ROLES = ("architect", "tests", "quality")
 CONSENSUS_JUDGE_ARTIFACT_RE = re.compile(r"^phase9-issue([1-9][0-9]*)-r([1-9][0-9]*)-judge\.md$")
 CONSENSUS_JUDGE_LOG_RE = re.compile(r"^phase9-issue([1-9][0-9]*)-r([1-9][0-9]*)-judge\.log$")
-DESIGN_CONSENSUS_LOG_RE = re.compile(r"^phase9-issue([1-9][0-9]*)-r([1-9][0-9]*)-(minimal|structural|delete|judge)\.log$")
+DESIGN_CONSENSUS_LOG_RE = re.compile(r"^phase9-issue([1-9][0-9]*)-r([1-9][0-9]*)-(minimal|structural|delete|judge|reflector)\.log$")
 IMPLEMENT_PENDING_INTENT_PREFIX = "dispatch-consensus-implementation:"
 IMPLEMENT_TASK_PREFIX = "implement-"
 
@@ -917,6 +917,8 @@ def completed_marker_actions(
             "runner_authority": RUNNER_AUTHORITY,
             "no_generic_command": True,
         }
+        if action["controller_action"] == "close_managed_item_from_drop_marker":
+            action["preconditions"] = ["active_controller_owner", "clean_exit_source_marker", "live_open_target", "live_managed_target"]
         if action["controller_action"] == "publish_implementation_output":
             _attach_implementation_pr_artifacts(repo_root, action)
         target = _action_target_key(action)
@@ -3213,8 +3215,8 @@ def _stale_unexecutable_reason(
         return _stale_publish_implementation_reason(action, repo_root, open_targets, worktrees, gh_items)
     if controller_action == "close_managed_item_from_drop_marker":
         target = _action_target_key(action)
-        if target is not None and target in open_targets:
-            return "live_open_target"
+        if target is not None and target not in open_targets:
+            return "target_not_open"
     return None
 
 

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -2652,9 +2652,11 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertEqual(calls[0], ["issue", "view", "53", "--json", "labels,body"])
         self.assertEqual(calls[1][:3], ["issue", "close", "53"])
         self.assertIn("--reason", calls[1])
+        self.assertIn("Drop reason: no-action", calls[1][calls[1].index("--comment") + 1])
         self.assertEqual(calls[2], ["pr", "view", "77", "--json", "labels,body"])
         self.assertEqual(calls[3][:3], ["pr", "close", "77"])
         self.assertIn("--comment", calls[3])
+        self.assertIn("Drop reason: no-action", calls[3][calls[3].index("--comment") + 1])
 
     def test_close_managed_item_from_drop_marker_blocks_non_managed_live_target_before_close(self) -> None:
         decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="close-managed-drop", lease_id="lease", expires_at="soon")

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -816,6 +816,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             "open_issue_403": [issue(403, "decompose target", [managed, label_catalog.PHASE_DESIGN_SOLVING, auto])],
             "open_issue_53": [issue(53, "drop target", [managed, label_catalog.PHASE_DESIGN_SOLVING, auto])],
             "open_issue_54": [issue(54, "judge target", [managed, label_catalog.PHASE_DESIGN_SOLVING, auto])],
+            "open_issue_554": [issue(554, "reflector drop target", [managed, label_catalog.PHASE_DESIGN_SOLVING, auto])],
             "open_issue_449": [issue(449, "consensus target", [managed, label_catalog.PHASE_CONSENSUS_REACHED, auto])],
             "ci_red_issue20": [issue(20, "open target", [managed, label_catalog.PHASE_IMPLEMENTING, auto])],
             "consensus_issue_330": [issue(330, "consensus target", [managed, label_catalog.PHASE_CONSENSUS_REACHED, auto])],
@@ -2612,7 +2613,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertNotIn("review-gate-readiness", action)
         self.assertNotIn("review_gate_actions", action)
 
-    def test_meta_resolved_drop_completed_marker_for_open_target_is_status_only(self) -> None:
+    def test_meta_resolved_drop_completed_marker_for_open_target_projects_close_helper(self) -> None:
         (self.logs / "issue53-judge-drop.log").write_text(
             "raw prose is diagnostic only\n"
             "META_RESOLVED:drop:no-action\n"
@@ -2625,19 +2626,55 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         action = plan["actions"][0]
         self.assertEqual(action["kind"], "completed-marker")
         self.assertEqual(action["controller_action"], "close_managed_item_from_drop_marker")
-        self.assertTrue(action["status_only"])
-        self.assertTrue(action["no_lifecycle_authority"])
-        self.assertEqual(action["suppressed_reason"], "live_open_target")
-        self.assertNotIn("runner_authority", action)
-        self.assertNotIn("no_generic_command", action)
-        self.assertIn("clean_exit_source_marker", action["preconditions"])
+        self.assertEqual(action["runner_authority"], "wakeup-runner-396")
+        self.assertTrue(action["no_generic_command"])
+        self.assertEqual(
+            action["preconditions"],
+            ["active_controller_owner", "clean_exit_source_marker", "live_open_target", "live_managed_target"],
+        )
         self.assertEqual(action["source_artifact"], ".refactor-loop/logs/issue53-judge-drop.log")
         self.assertEqual(action["source_marker"], "META_RESOLVED:drop:no-action")
         self.assertEqual(action["target_kind"], "issue")
         self.assertEqual(action["target_number"], 53)
         self.assertEqual(action["target"], {"kind": "issue", "number": 53})
+        self.assertNotIn("status_only", action)
 
-    def test_meta_resolved_drop_completed_marker_for_closed_target_projects_close_helper(self) -> None:
+    def test_phase9_reflector_meta_resolved_drop_projects_close_helper_for_latest_issue_round(self) -> None:
+        (self.logs / "phase9-issue554-r3-judge.log").write_text(
+            "META_JUDGE_DONE:converge:round-3\n"
+            "EXIT=0\n",
+            encoding="utf-8",
+        )
+        (self.logs / "phase9-issue554-r4-reflector.log").write_text(
+            "raw prose is diagnostic only\n"
+            "META_RESOLVED:drop:no-actionable-framing-after-4-rounds\n"
+            "EXIT=0\n"
+            "DONE_AT=2026-06-06T02:33:09Z\n",
+            encoding="utf-8",
+        )
+        (self.logs / "phase9-issue554-r3-judge.log").touch()
+        (self.logs / "phase9-issue554-r4-reflector.log").touch()
+
+        plan = self.run_plan(fixture="open_issue_554")
+
+        actions = [item for item in plan["actions"] if str(item.get("action_id") or "").startswith("completed-marker:phase9-issue554")]
+        self.assertEqual(1, len(actions))
+        action = actions[0]
+        self.assertEqual(action["controller_action"], "close_managed_item_from_drop_marker")
+        self.assertEqual(action["runner_authority"], "wakeup-runner-396")
+        self.assertTrue(action["no_generic_command"])
+        self.assertEqual(
+            action["preconditions"],
+            ["active_controller_owner", "clean_exit_source_marker", "live_open_target", "live_managed_target"],
+        )
+        self.assertEqual(action["source_artifact"], ".refactor-loop/logs/phase9-issue554-r4-reflector.log")
+        self.assertEqual(action["source_marker"], "META_RESOLVED:drop:no-actionable-framing-after-4-rounds")
+        self.assertEqual(action["target_kind"], "issue")
+        self.assertEqual(action["target_number"], 554)
+        self.assertEqual(action["target"], {"kind": "issue", "number": 554})
+        self.assertNotIn("status_only", action)
+
+    def test_meta_resolved_drop_completed_marker_for_closed_target_is_status_only(self) -> None:
         (self.logs / "issue53-judge-drop.log").write_text(
             "raw prose is diagnostic only\n"
             "META_RESOLVED:drop:no-action\n"
@@ -2650,15 +2687,20 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         action = next(item for item in plan["actions"] if item["action_id"].startswith("completed-marker:issue53-judge-drop"))
         self.assertEqual(action["kind"], "completed-marker")
         self.assertEqual(action["controller_action"], "close_managed_item_from_drop_marker")
-        self.assertEqual(action["runner_authority"], "wakeup-runner-396")
-        self.assertTrue(action["no_generic_command"])
-        self.assertIn("clean_exit_source_marker", action["preconditions"])
+        self.assertTrue(action["status_only"])
+        self.assertTrue(action["no_lifecycle_authority"])
+        self.assertEqual(action["suppressed_reason"], "target_not_open")
+        self.assertNotIn("runner_authority", action)
+        self.assertNotIn("no_generic_command", action)
+        self.assertEqual(
+            action["preconditions"],
+            ["active_controller_owner", "clean_exit_source_marker", "live_open_target", "live_managed_target"],
+        )
         self.assertEqual(action["source_artifact"], ".refactor-loop/logs/issue53-judge-drop.log")
         self.assertEqual(action["source_marker"], "META_RESOLVED:drop:no-action")
         self.assertEqual(action["target_kind"], "issue")
         self.assertEqual(action["target_number"], 53)
         self.assertEqual(action["target"], {"kind": "issue", "number": 53})
-        self.assertNotIn("status_only", action)
 
     def test_non_drop_meta_resolved_is_status_only_for_phase9_router(self) -> None:
         self.write_completed_log("judge-issue54.log", "META_RESOLVED:continue")

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -3178,6 +3178,35 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual(results[0].status, "applied")
         self.assertEqual(actions.calls[0][0], "close_managed_item_from_drop_marker")
 
+    def test_phase9_reflector_drop_log_routes_to_close_helper_with_clean_marker_evidence(self) -> None:
+        actions = FakeActions()
+        marker = "META_RESOLVED:drop:no-actionable-framing-after-4-rounds"
+        log = self.repo / ".refactor-loop/logs/phase9-issue554-r4-reflector.log"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(
+            "raw prose is diagnostic only\n"
+            f"{marker}\n"
+            "EXIT=0\n"
+            "DONE_AT=2026-06-06T02:33:09Z\n",
+            encoding="utf-8",
+        )
+        action = self.close_action(
+            action_id="completed-marker:phase9-issue554-r4-reflector.log:" + marker,
+            source_artifact=".refactor-loop/logs/phase9-issue554-r4-reflector.log",
+            source_marker=marker,
+            target_number=554,
+            target={"kind": "issue", "number": 554},
+        )
+
+        results = self.run_result(self.base_plan(action), actions=actions)
+
+        self.assertEqual(results[0].status, "applied")
+        self.assertEqual([call[0] for call in actions.calls], ["close_managed_item_from_drop_marker"])
+        helper_action = actions.calls[0][1]
+        self.assertEqual(helper_action["source_artifact"], ".refactor-loop/logs/phase9-issue554-r4-reflector.log")
+        self.assertEqual(helper_action["source_marker"], marker)
+        self.assertEqual(helper_action["target_number"], 554)
+
     def test_close_managed_item_from_drop_marker_blocks_non_managed_open_target_before_helper(self) -> None:
         actions = FakeActions()
         action = self.close_action(action_id="close-managed-item:non-managed")


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `e9b7d06d9dc1..2c144660a675`
- 涉及 issue: #554

## commit 摘要

- 修 reflector META_RESOLVED:drop 不被消费关闭 issue(#554 卡 8h)

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
