### PR TITLE
发布 rollup: integration ahead 1 commits (b482a794d9b4)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -42,6 +42,7 @@ from codex_refactor_loop.pr_checks import PrChecksProjection
 from codex_refactor_loop.release.required_checks import ReleaseRequiredChecksProjection, required_release_checks
 from codex_refactor_loop.release.gate import decide_release_artifact
 from codex_refactor_loop.restart import restart_managed_daemon_names
+from codex_refactor_loop.state import read_json
 from codex_refactor_loop.transition_assessment import TransitionAssessmentReader, transition_rank_key
 from codex_refactor_loop.worker_markers import (
     log_has_clean_exit,
@@ -115,6 +116,7 @@ RUNNER_NAMED_HELPER_ACTIONS = {
     "close_managed_item_from_drop_marker",
     "review_gate",
     "auto_merge_release_rollup_pr_from_action",
+    "dispatch_release_candidate",
     "publish_release_candidate",
     "apply_issue_decomposition_plan",
 }
@@ -151,6 +153,8 @@ EXECUTABLE_ACTION_KINDS = {
     "release-rollup-needed",
     "ci-red",
     "release-rollup-auto-merge",
+    "release-gate-dispatch",
+    "release-publish",
     "review-evidence-redispatch",
 }
 NON_ACTION_PHASE_LABELS = {
@@ -3412,6 +3416,89 @@ def release_countdown_actions(repo_root: Path, items: list[GhItem], scorer: Any 
     ]
 
 
+def release_gate_dispatch_actions(repo_root: Path, scorer: Any | None = None) -> list[dict[str, Any]]:
+    if os.environ.get("RELEASE_AUTO_ENABLE") != "true":
+        return []
+    candidate_path = repo_root / ".refactor-loop" / "state" / "release-candidate.json"
+    if candidate_path.exists():
+        return []
+    score = _release_countdown_score(repo_root, scorer=scorer)
+    if not score.get("ready"):
+        return []
+    from_version = str(score.get("from_version") or "")
+    to_version = str(score.get("to_version") or "")
+    if not from_version or not to_version or from_version == to_version:
+        return []
+    return [
+        {
+            "priority": 2,
+            "kind": "release-gate-dispatch",
+            "action_id": f"release-gate-dispatch:{from_version}->{to_version}",
+            "item": "release",
+            "phase": "publish",
+            "actor": "controller",
+            "route": "release-gate-dispatch",
+            "controller_action": "dispatch_release_candidate",
+            "source": "release-gate",
+            "source_artifact": ".refactor-loop/state/auto-release-signals.json",
+            "target_kind": None,
+            "target_number": None,
+            "target": None,
+            "preconditions": [
+                "active_controller_owner",
+                "release_auto_opt_in",
+                "release_gate_ready",
+                "decision_artifact_only",
+            ],
+            "runner_authority": RUNNER_AUTHORITY,
+            "no_generic_command": True,
+            "no_lifecycle_authority": True,
+            "from_version": from_version,
+            "to_version": to_version,
+        }
+    ]
+
+
+def release_publish_actions(repo_root: Path) -> list[dict[str, Any]]:
+    candidate_path = repo_root / ".refactor-loop" / "state" / "release-candidate.json"
+    candidate = read_json(candidate_path, {})
+    if not isinstance(candidate, dict) or candidate.get("ready") is not True:
+        return []
+    target_ref = str(candidate.get("target_ref") or "").strip()
+    to_version = str(candidate.get("to_version") or "").strip()
+    if not target_ref:
+        return []
+    return [
+        {
+            "priority": 2,
+            "kind": "release-publish",
+            "action_id": f"release-publish:{to_version or target_ref}",
+            "item": "release",
+            "phase": "publish",
+            "actor": "controller",
+            "route": "release-publish",
+            "controller_action": "publish_release_candidate",
+            "source": "release-candidate",
+            "source_artifact": ".refactor-loop/state/release-candidate.json",
+            "source_marker": to_version or target_ref,
+            "candidate_path": ".refactor-loop/state/release-candidate.json",
+            "target_ref": target_ref,
+            "target_kind": None,
+            "target_number": None,
+            "target": None,
+            "preconditions": [
+                "active_controller_owner",
+                "release_auto_opt_in",
+                "release_candidate_artifact",
+                "release_publish_preflight",
+            ],
+            "runner_authority": RUNNER_AUTHORITY,
+            "no_generic_command": True,
+            "no_lifecycle_authority": True,
+        }
+    ]
+
+
 def _default_goal_milestone(repo_root: Path) -> dict[str, Any] | None:
     slug = github_repo_slug()
     if not slug:
@@ -3906,6 +3993,8 @@ def build_plan(repo_root: Path) -> dict[str, Any]:
     actions.extend(rebase_resolve_completed_marker_actions(repo_root, gh_items if gh_items_loaded else []))
     actions.extend(release_rollup_actions(repo_root))
     actions.extend(rollup_auto_merge_actions)
+    actions.extend(release_publish_actions(repo_root))
+    actions.extend(release_gate_dispatch_actions(repo_root))
     actions.extend(ci_red_actions(repo_root, gh_items, ctx))
     actions.extend(no_gap_actions(repo_root))
     host_actions, host_spec_error = load_host_workflow_projection(repo_root)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -36,6 +36,7 @@ from .issue_decomposition import (
 )
 from .pr_checks import PrChecksProjection
 from .processes import ProcessSupervisor, launch_spawn_codex_supervisor
+from .release.gate import AutoReleaseGate
 from .release.publish_preflight import ReleasePublishPreflight
 from .state import read_json
 from .work_items import extract_closing_issue_numbers
@@ -87,6 +88,7 @@ SUPPORTED_CONTROLLER_ACTIONS = {
     "close_managed_item_from_drop_marker",
     "review_gate",
     "auto_merge_release_rollup_pr_from_action",
+    "dispatch_release_candidate",
     "publish_release_candidate",
     "apply_issue_decomposition_plan",
 }
@@ -406,6 +408,8 @@ class WakeupRunner:
             return self._validate_safe_push(action)
         if controller_action == "review_gate":
             return self._validate_review_gate(action)
+        if controller_action == "dispatch_release_candidate":
+            return self._validate_release_dispatch(action)
         if controller_action == "publish_release_candidate":
             return self._validate_release(action)
         if controller_action == "apply_issue_decomposition_plan":
@@ -571,6 +575,22 @@ class WakeupRunner:
         result = ReleasePublishPreflight(self.ctx.repo_root).validate(candidate_path=candidate_path, target_ref=target_ref)
         if not result.allowed:
             return "release_preflight_denied:" + ",".join(result.reasons)
+        return None
+
+    def _validate_release_dispatch(self, action: Mapping[str, Any]) -> str | None:
+        preconditions = action.get("preconditions")
+        if not isinstance(preconditions, list):
+            return "release_dispatch_missing_preconditions"
+        for required in ("release_auto_opt_in", "release_gate_ready", "decision_artifact_only"):
+            if required not in preconditions:
+                return f"release_dispatch_missing_precondition:{required}"
+        if self.ctx.host_env.get("RELEASE_AUTO_ENABLE") != "true":
+            return "release_auto_opt_in_missing"
+        candidate = self.ctx.paths.state / "release-candidate.json"
+        if candidate.exists():
+            return "release_candidate_already_exists"
+        if not str(action.get("from_version") or "").strip() or not str(action.get("to_version") or "").strip():
+            return "release_dispatch_version_missing"
         return None
 
     def _validate_issue_decomposition_apply(self, action: Mapping[str, Any]) -> str | None:
@@ -988,6 +1008,8 @@ class WakeupRunner:
                 f"WAKEUP_RUNNER_REVIEW_GATE_WAIT:{action.get('target_number')}:{decision['decision']}:{decision['reason']}"
             )
             return 3
+        if controller_action == "dispatch_release_candidate":
+            return self._dispatch_release_candidate(action)
         if controller_action == "publish_release_candidate":
             result = self.actions.publish_release_candidate(
                 candidate_path=str(action.get("candidate_path") or ".refactor-loop/state/release-candidate.json"),
@@ -999,6 +1021,33 @@ class WakeupRunner:
             return 0
         self._append_pending_event(f"WAKEUP_RUNNER_UNAPPLIED:{controller_action}:{action.get('action_id')}")
         return 0
+
+    def _dispatch_release_candidate(self, action: Mapping[str, Any]) -> int:
+        previous_env = os.environ.copy()
+        try:
+            os.environ.update(self.ctx.env_for_subprocess())
+            gate = AutoReleaseGate(self.ctx.repo_root)
+            stability = gate.compute_stability(
+                min_recent_merges=_release_int(self.ctx.host_env.get("RELEASE_AUTO_MIN_MERGES"), 1)
+            )
+            decision = gate.decide_release(
+                stability,
+                _release_int(self.ctx.host_env.get("RELEASE_AUTO_MIN_INTERVAL_HOURS"), 2),
+            )
+            if decision.get("ready") is not True:
+                self._append_pending_event("WAKEUP_RUNNER_RELEASE_DISPATCH_BLOCKED:not-ready")
+                return 3
+            if (
+                str(decision.get("from_version") or "") != str(action.get("from_version") or "")
+                or str(decision.get("to_version") or "") != str(action.get("to_version") or "")
+            ):
+                self._append_pending_event("WAKEUP_RUNNER_RELEASE_DISPATCH_BLOCKED:version-mismatch")
+                return 3
+            gate.dispatch_release(decision)
+            return 0
+        finally:
+            os.environ.clear()
+            os.environ.update(previous_env)
 
     def _spawn_codex(self, action: Mapping[str, Any]) -> int:
         if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):
@@ -1682,6 +1731,14 @@ def _positive_int(value: Any) -> int | None:
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         return None
     return value
+
+
+def _release_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(str(value))
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
 
 
 def _run_once_with_periodic_heartbeat(

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -48,6 +48,8 @@ from codex_refactor_loop.wakeup_plan import (  # noqa: E402
     release_countdown_actions,
     release_rollup_auto_merge_actions,
     release_rollup_actions,
+    release_gate_dispatch_actions,
+    release_publish_actions,
     review_evidence_redispatch_actions,
     restore_hard_gate_for_dispatchable_actions,
     resolve_repo_root,
@@ -5259,6 +5261,97 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertNotIn("command", actions[0])
         self.assertNotIn("controller_action", actions[0])
         self.assertFalse(has_dispatchable_action(actions))
+
+    def test_release_gate_dispatch_projects_ready_decision_into_artifact_only_action(self) -> None:
+        def scorer(_: Path) -> dict:
+            return {
+                "from_version": "1.2.3-beta.4",
+                "to_version": "1.2.3-beta.5",
+                "stability_score": 100,
+                "ready": True,
+                "signals": {"fresh_heartbeats": {"passed": True}},
+                "blocked_reasons": [],
+            }
+
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "true"}):
+            actions = release_gate_dispatch_actions(self.repo, scorer=scorer)
+
+        self.assertEqual(len(actions), 1)
+        action = actions[0]
+        self.assertEqual(action["kind"], "release-gate-dispatch")
+        self.assertEqual(action["controller_action"], "dispatch_release_candidate")
+        self.assertEqual(action["runner_authority"], "wakeup-runner-396")
+        self.assertTrue(action["no_generic_command"])
+        self.assertEqual(action["source_artifact"], ".refactor-loop/state/auto-release-signals.json")
+        self.assertNotIn("source_marker", action)
+        self.assertIn("release_gate_ready", action["preconditions"])
+        self.assertFalse(action.get("status_only", False))
+        self.assertTrue(has_dispatchable_action(actions))
+        self.assertFalse((self.repo / ".refactor-loop/state/release-candidate.json").exists())
+
+    def test_release_gate_dispatch_does_not_project_when_candidate_exists(self) -> None:
+        candidate = self.repo / ".refactor-loop/state/release-candidate.json"
+        candidate.write_text(json.dumps({"ready": True, "target_ref": "origin/review"}), encoding="utf-8")
+
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "true"}):
+            actions = release_gate_dispatch_actions(
+                self.repo,
+                scorer=lambda _: {
+                    "from_version": "1.2.3-beta.4",
+                    "to_version": "1.2.3-beta.5",
+                    "stability_score": 100,
+                    "ready": True,
+                    "signals": {},
+                    "blocked_reasons": [],
+                },
+            )
+
+        self.assertEqual(actions, [])
+
+    def test_release_gate_dispatch_requires_host_opt_in(self) -> None:
+        actions = release_gate_dispatch_actions(
+            self.repo,
+            scorer=lambda _: {
+                "from_version": "1.2.3-beta.4",
+                "to_version": "1.2.3-beta.5",
+                "stability_score": 100,
+                "ready": True,
+                "signals": {},
+                "blocked_reasons": [],
+            },
+        )
+
+        self.assertEqual(actions, [])
+
+    def test_release_publish_projects_existing_candidate_into_publisher_action(self) -> None:
+        candidate = self.repo / ".refactor-loop/state/release-candidate.json"
+        candidate.write_text(
+            json.dumps({"ready": True, "target_ref": "origin/review", "to_version": "1.2.3-beta.5"}),
+            encoding="utf-8",
+        )
+
+        actions = release_publish_actions(self.repo)
+
+        self.assertEqual(len(actions), 1)
+        action = actions[0]
+        self.assertEqual(action["kind"], "release-publish")
+        self.assertEqual(action["controller_action"], "publish_release_candidate")
+        self.assertEqual(action["candidate_path"], ".refactor-loop/state/release-candidate.json")
+        self.assertEqual(action["target_ref"], "origin/review")
+        self.assertEqual(action["source_marker"], "1.2.3-beta.5")
+        self.assertEqual(action["runner_authority"], "wakeup-runner-396")
+        self.assertTrue(action["no_generic_command"])
+        self.assertIn("release_publish_preflight", action["preconditions"])
+        self.assertFalse(action.get("status_only", False))
+        self.assertTrue(has_dispatchable_action(actions))
+
+    def test_release_publish_skips_candidate_without_target_ref(self) -> None:
+        (self.repo / ".refactor-loop/state/release-candidate.json").write_text(
+            json.dumps({"ready": True, "to_version": "1.2.3-beta.5"}),
+            encoding="utf-8",
+        )
+
+        self.assertEqual(release_publish_actions(self.repo), [])
 
     def test_release_countdown_default_goal_scorer_fallback_runs_once(self) -> None:
         calls: list[Path] = []

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -508,6 +508,60 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             "actions": [action],
         }
 
+    def release_dispatch_action(self, **overrides) -> dict:
+        action = {
+            "kind": "release-gate-dispatch",
+            "action_id": "release-gate-dispatch:1.2.3-beta.4->1.2.3-beta.5",
+            "runner_authority": "wakeup-runner-396",
+            "preconditions": [
+                "active_controller_owner",
+                "release_auto_opt_in",
+                "release_gate_ready",
+                "decision_artifact_only",
+            ],
+            "source_artifact": ".refactor-loop/state/auto-release-signals.json",
+            "target_kind": None,
+            "target_number": None,
+            "target": None,
+            "controller_action": "dispatch_release_candidate",
+            "from_version": "1.2.3-beta.4",
+            "to_version": "1.2.3-beta.5",
+            "no_generic_command": True,
+            "no_lifecycle_authority": True,
+        }
+        action.update(overrides)
+        return action
+
+    def write_release_dispatch_fixtures(self, *, auto_enable: bool = True) -> None:
+        host_env = self.repo / ".config/consensus-rnd/host.env"
+        with host_env.open("a", encoding="utf-8") as handle:
+            handle.write(f'export RELEASE_AUTO_ENABLE="{"true" if auto_enable else "false"}"\n')
+            handle.write('export HOST_GITHUB_RELEASE_REQUIRED_CHECKS="ci"\n')
+            handle.write('export RELEASE_TARGET_REF="origin/dev"\n')
+        self.ctx = LoopContext.load(repo_root=self.repo, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"})
+        (self.repo / ".version-bump.json").write_text(
+            json.dumps({"files": [{"path": "package.json", "field": "version"}]}),
+            encoding="utf-8",
+        )
+        (self.repo / "package.json").write_text(json.dumps({"version": "1.2.3-beta.4"}), encoding="utf-8")
+        signals = {
+            "signals": {
+                "required_checks_recent_green": {"passed": True},
+                "no_open_blocked_pr": {"passed": True},
+                "no_human_decision_label": {"passed": True},
+                "no_phase8_reject_churn": {"passed": True},
+                "p0_alert_streak_ok": {"passed": True},
+                "recent_pr_merges_min": {"passed": True},
+                "fresh_heartbeats": {"passed": True},
+                "no_unresolved_human_escalation": {"passed": True},
+            }
+        }
+        (self.repo / ".refactor-loop/state/auto-release-signals.json").write_text(json.dumps(signals), encoding="utf-8")
+        (self.repo / ".refactor-loop/state/release-commits.json").write_text(
+            json.dumps({"commits": [{"sha": "abc123", "subject": "fix: release blocker", "body": ""}]}),
+            encoding="utf-8",
+        )
+
     def batch_plan(self, actions: list[dict], *, dispatch_required: object, deficit: object, active: bool = True) -> dict:
         return {
             "schema": "wakeup-plan",
@@ -1947,6 +2001,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             "close_managed_item_from_drop_marker",
             "review_gate",
             "auto_merge_release_rollup_pr_from_action",
+            "dispatch_release_candidate",
             "publish_release_candidate",
             "apply_issue_decomposition_plan",
         }
@@ -1960,6 +2015,30 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         ):
             with self.subTest(forbidden_runtime_abstraction=forbidden_runtime_abstraction):
                 self.assertNotIn(forbidden_runtime_abstraction, source)
+
+    def test_release_dispatch_writes_candidate_artifact_only(self) -> None:
+        self.write_release_dispatch_fixtures()
+        actions = FakeActions()
+
+        results = self.run_result(self.base_plan(self.release_dispatch_action()), actions=actions)
+
+        self.assertEqual(results[0].status, "applied")
+        self.assertEqual(actions.calls, [])
+        decision = json.loads((self.repo / ".refactor-loop/state/release-decision.json").read_text(encoding="utf-8"))
+        candidate = json.loads((self.repo / ".refactor-loop/state/release-candidate.json").read_text(encoding="utf-8"))
+        self.assertTrue(decision["ready"])
+        self.assertEqual(candidate["schema"], "decision-artifact-only/v2")
+        self.assertEqual(candidate["target_ref"], "origin/dev")
+        self.assertEqual(candidate["to_version"], "1.2.3-beta.5")
+
+    def test_release_dispatch_fails_closed_without_host_opt_in(self) -> None:
+        self.write_release_dispatch_fixtures(auto_enable=False)
+
+        results = self.run_result(self.base_plan(self.release_dispatch_action()), actions=FakeActions())
+
+        self.assertEqual(results[0].status, "blocked")
+        self.assertEqual(results[0].reason, "release_auto_opt_in_missing")
+        self.assertFalse((self.repo / ".refactor-loop/state/release-candidate.json").exists())
 
     def test_nested_forbidden_fields_fail_closed(self) -> None:
         action = self.issue_decomposition_action(


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `142c3b2612f0..b482a794d9b4`

## commit 摘要

- fix(skill): dispatch ready release gate from wakeup runner

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
