### PR TITLE
发布 rollup: integration ahead 1 commits (c1b95d57f7fb)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/gate.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/gate.py
@@ -469,7 +469,7 @@ class AutoReleaseGate:
             "bump_type": decision.get("bump_type"),
             "coordinate_policy": decision.get("coordinate_policy"),
             "ready": decision.get("ready"),
-            "target_ref": os.environ.get("RELEASE_TARGET_REF", ""),
+            "target_ref": release_target_ref_from_env(os.environ),
             "required_signals": required_signals,
             "decision_digest": canonical_digest(decision),
             "publish_preflight": "controller-release-publish-preflight",
@@ -482,6 +482,18 @@ class AutoReleaseGate:
                 "commit, push, tag, publish, merge, or close."
             ),
         }
+
+
+def release_target_ref_from_env(env: Mapping[str, str]) -> str:
+    explicit = str(env.get("RELEASE_TARGET_REF") or "").strip()
+    if explicit:
+        return explicit
+    review_base = str(env.get("REVIEW_BASE_BRANCH") or "").strip()
+    if not review_base:
+        return ""
+    if review_base.startswith("origin/"):
+        return review_base
+    return f"origin/{review_base}"
 
 
 def resolve_field(data: Any, field: str) -> Any:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -3421,7 +3421,9 @@ def release_gate_dispatch_actions(repo_root: Path, scorer: Any | None = None) ->
         return []
     candidate_path = repo_root / ".refactor-loop" / "state" / "release-candidate.json"
     if candidate_path.exists():
-        return []
+        candidate = read_json(candidate_path, {})
+        if not release_candidate_target_ref_invalid(candidate):
+            return []
     score = _release_countdown_score(repo_root, scorer=scorer)
     if not score.get("ready"):
         return []
@@ -3449,6 +3451,11 @@ def release_gate_dispatch_actions(repo_root: Path, scorer: Any | None = None) ->
                 "release_auto_opt_in",
                 "release_gate_ready",
                 "decision_artifact_only",
+                *(
+                    ["release_candidate_target_ref_invalid"]
+                    if candidate_path.exists()
+                    else []
+                ),
             ],
             "runner_authority": RUNNER_AUTHORITY,
             "no_generic_command": True,
@@ -3457,6 +3464,15 @@ def release_gate_dispatch_actions(repo_root: Path, scorer: Any | None = None) ->
             "to_version": to_version,
         }
     ]
+
+
+def release_candidate_target_ref_invalid(candidate: Any) -> bool:
+    if not isinstance(candidate, dict):
+        return False
+    if "target_ref" not in candidate:
+        return True
+    target_ref = candidate.get("target_ref")
+    return not isinstance(target_ref, str) or not target_ref.strip()
 
 
 def release_publish_actions(repo_root: Path) -> list[dict[str, Any]]:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -40,7 +40,11 @@ from .release.gate import AutoReleaseGate
 from .release.publish_preflight import ReleasePublishPreflight
 from .state import read_json
 from .work_items import extract_closing_issue_numbers
-from .wakeup_plan import build_plan, consensus_implementation_suppressed_reason
+from .wakeup_plan import (
+    build_plan,
+    consensus_implementation_suppressed_reason,
+    release_candidate_target_ref_invalid,
+)
 from .worker_markers import read_worker_terminal_marker
 
 
@@ -588,7 +592,11 @@ class WakeupRunner:
             return "release_auto_opt_in_missing"
         candidate = self.ctx.paths.state / "release-candidate.json"
         if candidate.exists():
-            return "release_candidate_already_exists"
+            if (
+                "release_candidate_target_ref_invalid" not in preconditions
+                or not release_candidate_target_ref_invalid(read_json(candidate, {}))
+            ):
+                return "release_candidate_already_exists"
         if not str(action.get("from_version") or "").strip() or not str(action.get("to_version") or "").strip():
             return "release_dispatch_version_missing"
         return None

--- a/skills/codex-refactor-loop/scripts/test_release_gate_module.py
+++ b/skills/codex-refactor-loop/scripts/test_release_gate_module.py
@@ -153,6 +153,30 @@ class ReleaseGateModuleTests(unittest.TestCase):
             self.assertFalse((repo / ".refactor-loop/.controller-pending-events.log").exists())
             self.assertFalse((repo / ".refactor-loop/dispatch-queue").exists())
 
+    def test_dispatch_candidate_uses_review_base_target_ref_when_release_target_ref_is_unset(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            write_green_fixture_signals(repo)
+            release_gate = gate.AutoReleaseGate(repo, now=lambda: NOW, runner=FakeRunner())
+            old_env = {key: gate.os.environ.get(key) for key in ("RELEASE_TARGET_REF", "REVIEW_BASE_BRANCH")}
+            try:
+                gate.os.environ.pop("RELEASE_TARGET_REF", None)
+                gate.os.environ["REVIEW_BASE_BRANCH"] = "dev/auto-refact-dev"
+                stability = release_gate.compute_stability(min_recent_merges=0)
+                decision = release_gate.decide_release(stability, min_interval_hours=2)
+                release_gate.dispatch_release(decision)
+            finally:
+                for key, value in old_env.items():
+                    if value is None:
+                        gate.os.environ.pop(key, None)
+                    else:
+                        gate.os.environ[key] = value
+
+            candidate = read_json(repo / ".refactor-loop/state/release-candidate.json")
+            self.assertIsInstance(candidate, dict)
+            assert isinstance(candidate, dict)
+            self.assertEqual(candidate["target_ref"], "origin/dev/auto-refact-dev")
+
     def test_live_signal_parity_for_required_checks_labels_and_heartbeats(self) -> None:
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -5308,6 +5308,36 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         self.assertEqual(actions, [])
 
+    def test_release_gate_dispatch_recovers_ready_gate_when_candidate_target_ref_is_empty(self) -> None:
+        candidate = self.repo / ".refactor-loop/state/release-candidate.json"
+        candidate.write_text(
+            json.dumps({"ready": True, "target_ref": "", "to_version": "1.2.3-beta.5"}),
+            encoding="utf-8",
+        )
+
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "true"}):
+            actions = release_gate_dispatch_actions(
+                self.repo,
+                scorer=lambda _: {
+                    "from_version": "1.2.3-beta.4",
+                    "to_version": "1.2.3-beta.5",
+                    "stability_score": 100,
+                    "ready": True,
+                    "signals": {},
+                    "blocked_reasons": [],
+                },
+            )
+
+        self.assertEqual(len(actions), 1)
+        action = actions[0]
+        self.assertEqual(action["controller_action"], "dispatch_release_candidate")
+        self.assertEqual(action["action_id"], "release-gate-dispatch:1.2.3-beta.4->1.2.3-beta.5")
+        self.assertIn("release_candidate_target_ref_invalid", action["preconditions"])
+        self.assertNotIn("target_ref", action)
+        self.assertFalse(action.get("status_only", False))
+        self.assertTrue(has_dispatchable_action(actions))
+        self.assertEqual(release_publish_actions(self.repo), [])
+
     def test_release_gate_dispatch_requires_host_opt_in(self) -> None:
         actions = release_gate_dispatch_actions(
             self.repo,
@@ -5344,6 +5374,21 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertIn("release_publish_preflight", action["preconditions"])
         self.assertFalse(action.get("status_only", False))
         self.assertTrue(has_dispatchable_action(actions))
+
+    def test_release_publish_remains_projected_for_valid_target_ref_candidate(self) -> None:
+        candidate = self.repo / ".refactor-loop/state/release-candidate.json"
+        candidate.write_text(
+            json.dumps({"ready": True, "target_ref": "origin/dev/auto-refact-dev", "to_version": "1.2.3-beta.5"}),
+            encoding="utf-8",
+        )
+
+        actions = release_publish_actions(self.repo)
+
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0]["controller_action"], "publish_release_candidate")
+        self.assertEqual(actions[0]["target_ref"], "origin/dev/auto-refact-dev")
+        self.assertEqual(actions[0]["source_marker"], "1.2.3-beta.5")
+        self.assertFalse(actions[0].get("status_only", False))
 
     def test_release_publish_skips_candidate_without_target_ref(self) -> None:
         (self.repo / ".refactor-loop/state/release-candidate.json").write_text(

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -2031,6 +2031,63 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual(candidate["target_ref"], "origin/dev")
         self.assertEqual(candidate["to_version"], "1.2.3-beta.5")
 
+    def test_release_dispatch_recovers_existing_candidate_with_empty_target_ref(self) -> None:
+        self.write_release_dispatch_fixtures()
+        bad_candidate = self.repo / ".refactor-loop/state/release-candidate.json"
+        bad_candidate.write_text(
+            json.dumps({"ready": True, "target_ref": "", "to_version": "1.2.3-beta.5"}),
+            encoding="utf-8",
+        )
+        actions = FakeActions()
+
+        results = self.run_result(
+            self.base_plan(
+                self.release_dispatch_action(
+                    preconditions=[
+                        "active_controller_owner",
+                        "release_auto_opt_in",
+                        "release_gate_ready",
+                        "decision_artifact_only",
+                        "release_candidate_target_ref_invalid",
+                    ],
+                )
+            ),
+            actions=actions,
+        )
+
+        self.assertEqual(results[0].status, "applied")
+        self.assertEqual(actions.calls, [])
+        candidate = json.loads(bad_candidate.read_text(encoding="utf-8"))
+        self.assertTrue(candidate["ready"])
+        self.assertEqual(candidate["target_ref"], "origin/dev")
+        self.assertEqual(candidate["to_version"], "1.2.3-beta.5")
+
+    def test_release_dispatch_rejects_existing_candidate_with_valid_target_ref(self) -> None:
+        self.write_release_dispatch_fixtures()
+        existing = self.repo / ".refactor-loop/state/release-candidate.json"
+        existing.write_text(
+            json.dumps({"ready": True, "target_ref": "origin/dev", "to_version": "1.2.3-beta.5"}),
+            encoding="utf-8",
+        )
+
+        results = self.run_result(
+            self.base_plan(
+                self.release_dispatch_action(
+                    preconditions=[
+                        "active_controller_owner",
+                        "release_auto_opt_in",
+                        "release_gate_ready",
+                        "decision_artifact_only",
+                        "release_candidate_target_ref_invalid",
+                    ],
+                )
+            ),
+            actions=FakeActions(),
+        )
+
+        self.assertEqual(results[0].status, "blocked")
+        self.assertEqual(results[0].reason, "release_candidate_already_exists")
+
     def test_release_dispatch_fails_closed_without_host_opt_in(self) -> None:
         self.write_release_dispatch_fixtures(auto_enable=False)
 


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `3619a28f718f..c1b95d57f7fb`

## commit 摘要

- Fix release candidate target ref recovery

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
