### PR TITLE
发布 rollup: integration ahead 1 commits (9035066e7daf)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -1553,6 +1553,11 @@ class WakeupRunner:
             if status == "applied":
                 if _is_remote_ci_red_dispatch(action):
                     continue
+                if self._release_dispatch_stale_ledger_reason(action):
+                    self._append_pending_event(
+                        f"WAKEUP_RUNNER_STALE_RELEASE_DISPATCH_LEDGER:{action_id}:target_ref_invalid"
+                    )
+                    continue
                 stale_spawn_reason = self._applied_spawn_stale_reason(action)
                 if stale_spawn_reason:
                     self._append_pending_event(f"WAKEUP_RUNNER_STALE_SPAWN_LEDGER:{action_id}:{stale_spawn_reason}")
@@ -1561,6 +1566,19 @@ class WakeupRunner:
             if status == "blocked" and _terminal_blocked_reason(str(row.get("reason") or "")):
                 return True
         return False
+
+    def _release_dispatch_stale_ledger_reason(self, action: Mapping[str, Any]) -> str:
+        if action.get("kind") != "release-gate-dispatch":
+            return ""
+        if action.get("controller_action") != "dispatch_release_candidate":
+            return ""
+        preconditions = action.get("preconditions")
+        if not isinstance(preconditions, list) or "release_candidate_target_ref_invalid" not in preconditions:
+            return ""
+        candidate = self.ctx.paths.state / "release-candidate.json"
+        if not release_candidate_target_ref_invalid(read_json(candidate, {})):
+            return ""
+        return "target_ref_invalid"
 
     @property
     def remote_ci_fix_attempts_path(self) -> Path:

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -2062,6 +2062,88 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual(candidate["target_ref"], "origin/dev")
         self.assertEqual(candidate["to_version"], "1.2.3-beta.5")
 
+    def test_release_dispatch_recovers_stale_applied_ledger_with_empty_target_ref(self) -> None:
+        self.write_release_dispatch_fixtures()
+        bad_candidate = self.repo / ".refactor-loop/state/release-candidate.json"
+        bad_candidate.write_text(
+            json.dumps({"ready": True, "target_ref": "", "to_version": "1.2.3-beta.5"}),
+            encoding="utf-8",
+        )
+        action = self.release_dispatch_action(
+            preconditions=[
+                "active_controller_owner",
+                "release_auto_opt_in",
+                "release_gate_ready",
+                "decision_artifact_only",
+                "release_candidate_target_ref_invalid",
+            ],
+        )
+        ledger = self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl"
+        ledger.write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": ""}) + "\n",
+            encoding="utf-8",
+        )
+
+        results = self.run_result(self.base_plan(action), actions=FakeActions())
+
+        self.assertEqual(results[0].status, "applied")
+        self.assertEqual(results[0].reason, "")
+        candidate = json.loads(bad_candidate.read_text(encoding="utf-8"))
+        self.assertEqual(candidate["target_ref"], "origin/dev")
+        pending = (self.repo / ".refactor-loop/.controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertIn(
+            f"WAKEUP_RUNNER_STALE_RELEASE_DISPATCH_LEDGER:{action['action_id']}:target_ref_invalid",
+            pending,
+        )
+
+    def test_release_dispatch_valid_candidate_keeps_applied_ledger_duplicate(self) -> None:
+        self.write_release_dispatch_fixtures()
+        existing = self.repo / ".refactor-loop/state/release-candidate.json"
+        existing.write_text(
+            json.dumps({"ready": True, "target_ref": "origin/dev", "to_version": "1.2.3-beta.5"}),
+            encoding="utf-8",
+        )
+        action = self.release_dispatch_action(
+            preconditions=[
+                "active_controller_owner",
+                "release_auto_opt_in",
+                "release_gate_ready",
+                "decision_artifact_only",
+                "release_candidate_target_ref_invalid",
+            ],
+        )
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": ""}) + "\n",
+            encoding="utf-8",
+        )
+
+        results = self.run_result(self.base_plan(action), actions=FakeActions())
+
+        self.assertEqual(results[0].status, "skipped")
+        self.assertEqual(results[0].reason, "duplicate")
+        candidate = json.loads(existing.read_text(encoding="utf-8"))
+        self.assertEqual(candidate["target_ref"], "origin/dev")
+
+    def test_release_dispatch_without_recovery_precondition_keeps_applied_ledger_duplicate(self) -> None:
+        self.write_release_dispatch_fixtures()
+        bad_candidate = self.repo / ".refactor-loop/state/release-candidate.json"
+        bad_candidate.write_text(
+            json.dumps({"ready": True, "target_ref": "", "to_version": "1.2.3-beta.5"}),
+            encoding="utf-8",
+        )
+        action = self.release_dispatch_action()
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": ""}) + "\n",
+            encoding="utf-8",
+        )
+
+        results = self.run_result(self.base_plan(action), actions=FakeActions())
+
+        self.assertEqual(results[0].status, "skipped")
+        self.assertEqual(results[0].reason, "duplicate")
+        candidate = json.loads(bad_candidate.read_text(encoding="utf-8"))
+        self.assertEqual(candidate["target_ref"], "")
+
     def test_release_dispatch_rejects_existing_candidate_with_valid_target_ref(self) -> None:
         self.write_release_dispatch_fixtures()
         existing = self.repo / ".refactor-loop/state/release-candidate.json"


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `f6c491537694..9035066e7daf`

## commit 摘要

- 修复 release dispatch ledger 恢复

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
