### PR TITLE
发布 rollup: integration ahead 1 commits (bb714ff5676c)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publish_preflight.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publish_preflight.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from ..state import read_json
 from .coordinates import validate_coordinate_policy
@@ -18,6 +19,7 @@ from .versions import compare_semver
 
 REQUIRED_CANDIDATE_SCHEMA = "decision-artifact-only/v2"
 PUBLISH_PREFLIGHT_NAME = "controller-release-publish-preflight"
+Runner = Callable[[Sequence[str], Path], subprocess.CompletedProcess[str]]
 
 
 @dataclass(frozen=True)
@@ -35,6 +37,7 @@ class PublishPreflightResult:
     target_ref: str
     version: str
     candidate_digest: str
+    already_bumped_reentry: bool = False
 
 
 class ReleasePublishPreflight:
@@ -48,10 +51,12 @@ class ReleasePublishPreflight:
         *,
         now: Callable[[], datetime] | None = None,
         max_age_minutes: int = 120,
+        runner: Runner | None = None,
     ) -> None:
         self.repo_root = repo_root
         self.now = now or (lambda: datetime.now(timezone.utc))
         self.max_age_minutes = max_age_minutes
+        self.runner = runner or run_command
 
     def validate(
         self,
@@ -82,7 +87,7 @@ class ReleasePublishPreflight:
         self._validate_time(candidate, reasons)
         self._validate_target_ref(candidate, target_ref, reasons)
         version = manifest_version if manifest_version is not None else self._current_manifest_version(reasons)
-        self._validate_version(candidate, decision, version, reasons)
+        already_bumped_reentry = self._validate_version(candidate, decision, version, reasons)
         self._validate_required_signals(candidate, decision, reasons)
         self._validate_decision_digest(candidate, decision, reasons)
         digest = canonical_digest(candidate) if candidate else ""
@@ -97,6 +102,7 @@ class ReleasePublishPreflight:
             target_ref=str(candidate.get("target_ref") or target_ref or ""),
             version=str(candidate.get("to_version") or version or ""),
             candidate_digest=digest,
+            already_bumped_reentry=already_bumped_reentry,
         )
 
     def _resolve_repo_path(self, path: str | Path) -> tuple[Path, str | None]:
@@ -194,20 +200,23 @@ class ReleasePublishPreflight:
             return ""
         return next(iter(versions))
 
-    def _validate_version(self, candidate: dict[str, Any], decision: dict[str, Any], version: str, reasons: list[str]) -> None:
+    def _validate_version(self, candidate: dict[str, Any], decision: dict[str, Any], version: str, reasons: list[str]) -> bool:
         to_version = candidate.get("to_version")
         if not isinstance(to_version, str) or not to_version:
             reasons.append("candidate_version_missing")
-            return
+            return False
         from_version = candidate.get("from_version")
         if not isinstance(from_version, str) or not from_version:
             reasons.append("candidate_from_version_missing")
-            return
+            return False
         try:
             versions_match = compare_semver(version, from_version) == 0
         except ValueError:
             versions_match = False
+        already_bumped_reentry = False
         if not versions_match:
+            already_bumped_reentry = self._already_bumped_reentry_allowed(version, to_version)
+        if not versions_match and not already_bumped_reentry:
             reasons.append("manifest_version_mismatch")
         if decision and decision.get("to_version") != to_version:
             reasons.append("decision_version_mismatch")
@@ -220,6 +229,15 @@ class ReleasePublishPreflight:
         )
         if coordinate_reason is not None:
             reasons.append(coordinate_reason)
+        return already_bumped_reentry
+
+    def _already_bumped_reentry_allowed(self, manifest_version: str, to_version: str) -> bool:
+        if manifest_version != to_version:
+            return False
+        result = self.runner(["git", "show", "-s", "--format=%s", "HEAD"], self.repo_root)
+        if result.returncode != 0:
+            return False
+        return result.stdout.strip() == f"Release v{to_version}"
 
     def _validate_required_signals(self, candidate: dict[str, Any], decision: dict[str, Any], reasons: list[str]) -> None:
         signals = candidate.get("required_signals")
@@ -286,6 +304,10 @@ def load_manifest_targets(repo_root: Path) -> list[dict[str, Any]]:
 def canonical_digest(data: Any) -> str:
     payload = json.dumps(data, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
+
+
+def run_command(cmd: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(cmd), cwd=cwd, capture_output=True, text=True, check=False)
 
 
 def default_candidate_expiry(now: datetime) -> str:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publisher.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/release/publisher.py
@@ -62,8 +62,10 @@ class ReleasePublisher:
     ) -> None:
         self.repo_root = repo_root
         self.runner = runner or run_command
-        self.preflight = preflight or ReleasePublishPreflight(repo_root)
         self.now = now or (lambda: datetime.now(timezone.utc))
+        if preflight is None:
+            preflight = ReleasePublishPreflight(repo_root, runner=self.runner, now=self.now)
+        self.preflight = preflight
 
     @property
     def result_path(self) -> Path:
@@ -122,6 +124,15 @@ class ReleasePublisher:
     def _inspect_publication_state(self, result: PublishPreflightResult) -> ReleasePublicationState:
         version = result.version
         tag = f"v{version}" if version else ""
+        if result.allowed and result.already_bumped_reentry:
+            return ReleasePublicationState(
+                phase="already_bumped",
+                version=version,
+                tag=tag,
+                release_target_ref=None,
+                skip_bump_commit=True,
+                reason="preflight_already_bumped_reentry",
+            )
         if result.allowed:
             return ReleasePublicationState(
                 phase="first_run",

--- a/skills/codex-refactor-loop/scripts/test_release_publish_preflight.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publish_preflight.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Sequence
 from unittest import mock
 
 SCRIPT_PATH = Path(__file__).resolve()
@@ -138,6 +140,19 @@ def green_required_signals() -> dict[str, object]:
         "fresh_heartbeats": {"passed": True},
         "no_unresolved_human_escalation": {"passed": True},
     }
+
+
+class FakeRunner:
+    def __init__(self, *, head_subject: str = "Release v1.9.10") -> None:
+        self.head_subject = head_subject
+        self.commands: list[list[str]] = []
+
+    def __call__(self, cmd: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        command = list(cmd)
+        self.commands.append(command)
+        if command == ["git", "show", "-s", "--format=%s", "HEAD"]:
+            return subprocess.CompletedProcess(command, 0, stdout=f"{self.head_subject}\n", stderr="")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected command")
 
 
 def write_ready_artifacts(
@@ -537,17 +552,34 @@ class ReleasePublishPreflightTests(unittest.TestCase):
             self.assertFalse(result.allowed)
             self.assertIn("manifest_version_mismatch", result.reasons)
 
-    def test_preflight_still_rejects_target_version_manifests(self) -> None:
+    def test_preflight_allows_already_bumped_release_head_reentry(self) -> None:
         with copy_repo_fixture() as tmp:
             repo = Path(tmp) / "repo"
             write_host_opt_in(repo)
             write_ready_artifacts(repo, from_version="1.9.9", version="1.9.10")
             set_mapped_version(repo, "1.9.10")
+            runner = FakeRunner(head_subject="Release v1.9.10")
 
-            result = ReleasePublishPreflight(repo, now=lambda: NOW).validate(target_ref="abc123")
+            result = ReleasePublishPreflight(repo, now=lambda: NOW, runner=runner).validate(target_ref="abc123")
+
+            self.assertTrue(result.allowed, result.reasons)
+            self.assertTrue(result.already_bumped_reentry)
+            self.assertEqual(runner.commands, [["git", "show", "-s", "--format=%s", "HEAD"]])
+
+    def test_preflight_still_rejects_target_version_manifests_with_wrong_head_subject(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            write_host_opt_in(repo)
+            write_ready_artifacts(repo, from_version="1.9.9", version="1.9.10")
+            set_mapped_version(repo, "1.9.10")
+            runner = FakeRunner(head_subject="Release v1.9.9")
+
+            result = ReleasePublishPreflight(repo, now=lambda: NOW, runner=runner).validate(target_ref="abc123")
 
             self.assertFalse(result.allowed)
+            self.assertFalse(result.already_bumped_reentry)
             self.assertIn("manifest_version_mismatch", result.reasons)
+            self.assertEqual(runner.commands, [["git", "show", "-s", "--format=%s", "HEAD"]])
 
     def test_manifest_version_compare_ignores_build_metadata(self) -> None:
         with copy_repo_fixture() as tmp:

--- a/skills/codex-refactor-loop/scripts/test_release_publisher.py
+++ b/skills/codex-refactor-loop/scripts/test_release_publisher.py
@@ -20,7 +20,8 @@ REPO_ROOT = SCRIPT_PATH.parents[3]
 NOW = datetime(2026, 5, 30, 12, 0, tzinfo=timezone.utc)
 sys.path.insert(0, str(SCRIPT_PATH.parent))
 
-from codex_refactor_loop.release.publish_preflight import PublishPreflightResult
+from codex_refactor_loop.release.gate import isoformat
+from codex_refactor_loop.release.publish_preflight import PublishPreflightResult, canonical_digest
 from codex_refactor_loop.release.publisher import ReleasePublisher
 FIXTURE_RELEASE_CHECKS = ("contract-tests", "manifest-version-sync", "skill-degradation")
 
@@ -54,6 +55,7 @@ def copy_repo_fixture() -> tempfile.TemporaryDirectory[str]:
     (repo / ".refactor-loop").mkdir(parents=True, exist_ok=True)
     (repo / ".config" / "consensus-rnd").mkdir(parents=True, exist_ok=True)
     (repo / ".config/consensus-rnd/host.env").write_text(
+        'export RELEASE_AUTO_ENABLE=true\n'
         'export GH_REPO_SLUG="owner/repo"\n'
         'export HOST_GITHUB_RELEASE_REQUIRED_CHECKS="contract-tests,manifest-version-sync,skill-degradation"\n',
         encoding="utf-8",
@@ -203,6 +205,61 @@ def set_mapped_version(repo: Path, version: str) -> None:
         else:
             current[last] = version
         write_json(path, data)
+
+
+def green_required_signals() -> dict[str, object]:
+    return {
+        "required_checks_recent_green": {
+            "passed": True,
+            "branches": {
+                "dev": {
+                    "contract-tests": True,
+                    "manifest-version-sync": True,
+                    "skill-degradation": True,
+                },
+                "auto-refact-dev": {
+                    "contract-tests": True,
+                    "manifest-version-sync": True,
+                    "skill-degradation": True,
+                },
+            },
+        },
+        "no_open_blocked_pr": {"passed": True},
+    }
+
+
+def write_ready_artifacts(
+    repo: Path,
+    *,
+    from_version: str = "2.0.0-beta.3",
+    version: str = "2.0.0-beta.4",
+    target_ref: str = "abc123",
+) -> None:
+    set_mapped_version(repo, from_version)
+    decision = {
+        "from_version": from_version,
+        "to_version": version,
+        "bump_type": "patch",
+        "signals": green_required_signals(),
+        "ready": True,
+    }
+    candidate = {
+        "schema": "decision-artifact-only/v2",
+        "generated_at": isoformat(NOW),
+        "expires_at": isoformat(NOW.replace(hour=13)),
+        "decision_artifact": ".refactor-loop/state/release-decision.json",
+        "from_version": from_version,
+        "to_version": version,
+        "bump_type": "patch",
+        "ready": True,
+        "target_ref": target_ref,
+        "required_signals": decision["signals"],
+        "decision_digest": canonical_digest(decision),
+        "publish_preflight": "controller-release-publish-preflight",
+        "lifecycle_owner": "controller",
+    }
+    write_json(repo / ".refactor-loop/state/release-decision.json", decision)
+    write_json(repo / ".refactor-loop/state/release-candidate.json", candidate)
 
 
 def expected_success_commands(version: str = "2.0.0-beta.4", prerelease: bool = True) -> list[list[str]]:
@@ -396,6 +453,25 @@ class ReleasePublisherTests(unittest.TestCase):
             self.assertIsInstance(payload, dict)
             assert isinstance(payload, dict)
             self.assertEqual(payload["target_ref"], "bumpcommit456")
+
+    def test_real_preflight_reentry_after_initial_push_failure_skips_bump_add_commit(self) -> None:
+        with copy_repo_fixture() as tmp:
+            repo = Path(tmp) / "repo"
+            write_ready_artifacts(repo, from_version="2.0.0-beta.3", version="2.0.0-beta.4")
+            set_mapped_version(repo, "2.0.0-beta.4")
+            runner = FakeRunner()
+            runner.head_subject = "Release v2.0.0-beta.4"
+            publisher = ReleasePublisher(repo, runner=runner, now=lambda: NOW)
+
+            with release_env():
+                result = publisher.publish(target_ref="abc123")
+
+            self.assertTrue(result.published)
+            self.assertEqual(result.target_ref, "bumpcommit456")
+            self.assertEqual(runner.commands, expected_reentry_success_commands())
+            self.assertFalse(any(command[:2] == ["python3", ".github/scripts/bump_version.py"] for command in runner.commands))
+            self.assertFalse(any(command[:2] == ["git", "add"] for command in runner.commands))
+            self.assertFalse(any(command[:2] == ["git", "commit"] for command in runner.commands))
 
     def test_already_bumped_reentry_accepts_exact_sha_green_checks_completed_before_rerun_now(self) -> None:
         with copy_repo_fixture() as tmp:


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `935a20082bf7..bb714ff5676c`

## commit 摘要

- 修复 release publish reentry 恢复

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
