### PR TITLE
发布 rollup: integration ahead 3 commits (44a92aed233f)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/issue_decomposition.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/issue_decomposition.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import json
 import re
 import hashlib
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Sequence
 
 from .context import LoopContext, LoopContextError
 from .github_body import GitHubBodyError, validate_self_contained_github_body
@@ -159,6 +160,102 @@ def issue_decomposition_plan_file_digest(ctx: LoopContext, plan_path: str | Path
     except json.JSONDecodeError as exc:
         raise IssueDecompositionError(f"invalid IssueDecompositionPlan JSON: {exc}") from exc
     return issue_decomposition_plan_digest(raw)
+
+
+def applied_issue_decomposition_parent_suppresses_expected_worker(
+    ctx: LoopContext,
+    parent_issue: int,
+    *,
+    command_runner: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] | None = None,
+) -> bool:
+    """Return true when a design-solving issue is an already-applied decomposition parent."""
+
+    for plan_path in _candidate_issue_decomposition_plan_paths(ctx, parent_issue):
+        try:
+            plan = load_issue_decomposition_plan(ctx, plan_path)
+            digest = issue_decomposition_plan_file_digest(ctx, plan_path)
+        except IssueDecompositionError:
+            continue
+        if plan.parent_issue != parent_issue:
+            continue
+        if not _parent_comment_has_plan_digest_sentinel(ctx, parent_issue, digest, command_runner=command_runner):
+            continue
+        if not _wakeup_runner_has_applied_issue_decomposition_action(ctx, plan):
+            continue
+        return True
+    return False
+
+
+def _candidate_issue_decomposition_plan_paths(ctx: LoopContext, parent_issue: int) -> tuple[str, ...]:
+    canonical = ctx.paths.runs / f"issue-{parent_issue}-decomposition" / "plan.json"
+    candidates: list[str] = []
+    if canonical.is_file():
+        candidates.append(ctx.durable_artifact_path(canonical))
+    for path in sorted(ctx.paths.runs.glob("issue-*-decomposition/plan.json")):
+        rel = ctx.durable_artifact_path(path)
+        if rel not in candidates:
+            candidates.append(rel)
+    return tuple(candidates)
+
+
+def _parent_comment_has_plan_digest_sentinel(
+    ctx: LoopContext,
+    parent_issue: int,
+    digest: str,
+    *,
+    command_runner: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] | None,
+) -> bool:
+    runner = command_runner or (
+        lambda command: subprocess.run(
+            list(command),
+            cwd=str(ctx.repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    )
+    result = runner(["gh", "issue", "view", str(parent_issue), "--json", "comments"])
+    if result.returncode != 0:
+        return False
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    comments = payload.get("comments") if isinstance(payload, dict) else None
+    if not isinstance(comments, list):
+        return False
+    sentinel = f"IssueDecompositionPlan digest: {digest}"
+    hits = [
+        comment
+        for comment in comments
+        if isinstance(comment, dict) and isinstance(comment.get("body"), str) and sentinel in comment["body"]
+    ]
+    return len(hits) == 1
+
+
+def _wakeup_runner_has_applied_issue_decomposition_action(ctx: LoopContext, plan: IssueDecompositionPlan) -> bool:
+    ledger = ctx.paths.state / "wakeup-runner-ledger.jsonl"
+    if not ledger.is_file():
+        return False
+    source_log = Path(plan.source_consensus_artifact).with_suffix(".log").name
+    action_prefix = f"completed-marker:{source_log}:"
+    try:
+        lines = ledger.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return False
+    for line in lines:
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        action_id = str(row.get("action_id") or "")
+        if row.get("status") != "applied":
+            continue
+        if row.get("kind") not in (None, "completed-marker"):
+            continue
+        if action_id.startswith(action_prefix) and ":META_JUDGE_DONE:consensus:decompose" in action_id:
+            return True
+    return False
 
 
 def _resolve_input_path(ctx: LoopContext, plan_path: str | Path) -> Path:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/issue_decomposition.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/issue_decomposition.py
@@ -239,6 +239,7 @@ def _wakeup_runner_has_applied_issue_decomposition_action(ctx: LoopContext, plan
         return False
     source_log = Path(plan.source_consensus_artifact).with_suffix(".log").name
     action_prefix = f"completed-marker:{source_log}:"
+    action_statuses: dict[str, tuple[bool, str, str]] = {}
     try:
         lines = ledger.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
@@ -249,13 +250,26 @@ def _wakeup_runner_has_applied_issue_decomposition_action(ctx: LoopContext, plan
         except json.JSONDecodeError:
             continue
         action_id = str(row.get("action_id") or "")
-        if row.get("status") != "applied":
-            continue
         if row.get("kind") not in (None, "completed-marker"):
             continue
-        if action_id.startswith(action_prefix) and ":META_JUDGE_DONE:consensus:decompose" in action_id:
-            return True
-    return False
+        if not action_id.startswith(action_prefix):
+            continue
+        if not _completed_marker_action_id_is_decomposition_consensus(action_id, action_prefix):
+            continue
+        if row.get("status") == "applied":
+            action_statuses[action_id] = (True, "applied", "")
+        elif row.get("status") == "skipped" and row.get("reason") == "duplicate":
+            was_applied = action_statuses.get(action_id, (False, "", ""))[0]
+            action_statuses[action_id] = (was_applied, "skipped", "duplicate")
+    return any(
+        was_applied and (status == "applied" or (status == "skipped" and reason == "duplicate"))
+        for was_applied, status, reason in action_statuses.values()
+    )
+
+
+def _completed_marker_action_id_is_decomposition_consensus(action_id: str, action_prefix: str) -> bool:
+    marker = action_id.removeprefix(action_prefix)
+    return marker.startswith("META_JUDGE_DONE:consensus:")
 
 
 def _resolve_input_path(ctx: LoopContext, plan_path: str | Path) -> Path:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -20,6 +20,7 @@ from ..context import LoopContext, LoopContextError
 from ..github_budget import graphql_headroom_ok
 from ..heartbeat import DaemonHeartbeatLease
 from ..implement_lifecycle import implement_attempt_suppresses_expected_worker
+from ..issue_decomposition import applied_issue_decomposition_parent_suppresses_expected_worker
 from .. import labels as label_catalog
 from ..managed_work_snapshot import load_open_managed_work_snapshot
 from ..state import read_json, write_json
@@ -384,6 +385,16 @@ class ConcurrencyMonitor:
                     item.number,
                     integration_branch=integration_branch,
                     command_runner=command_runner,
+                ):
+                    continue
+                if (
+                    item.kind == "issue"
+                    and phase == label_catalog.PHASE_DESIGN_SOLVING
+                    and applied_issue_decomposition_parent_suppresses_expected_worker(
+                        self.ctx,
+                        item.number,
+                        command_runner=command_runner,
+                    )
                 ):
                     continue
                 breakdown.append({"id": f"#{item.number}", "kind": item.kind, "phase": phase, "expected": expected})

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -379,7 +379,7 @@ class ConcurrencyMonitor:
             phase = label_catalog.normalize_label_set([str(item.phase)]).phase or ""
             expected = label_catalog.phase_expected_workers(phase)
             if expected > 0:
-                if item.kind == "issue" and implement_attempt_suppresses_expected_worker(
+                if item.kind == "issue" and phase == label_catalog.PHASE_IMPLEMENTING and implement_attempt_suppresses_expected_worker(
                     self.repo_root,
                     item.number,
                     integration_branch=integration_branch,

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -35,6 +35,7 @@ from codex_refactor_loop.implementation_pr_artifacts import (
 )
 from codex_refactor_loop.issue_decomposition import (
     IssueDecompositionError,
+    applied_issue_decomposition_parent_suppresses_expected_worker,
     issue_decomposition_plan_file_digest,
 )
 from codex_refactor_loop.managed_work_snapshot import load_open_managed_work_snapshot
@@ -993,9 +994,24 @@ def expected_from_open_items(
             and _issue_has_terminal_implement_projection(repo_root, item.number)
         ):
             continue
+        if (
+            repo_root is not None
+            and item.kind == "issue"
+            and phase_label == label_catalog.PHASE_DESIGN_SOLVING
+            and _issue_is_applied_decomposition_parent(repo_root, item.number)
+        ):
+            continue
         breakdown.append({"id": f"#{item.number}", "kind": item.kind, "phase": phase_label, "expected": expected})
         total += expected
     return total, breakdown
+
+
+def _issue_is_applied_decomposition_parent(repo_root: Path, issue: int) -> bool:
+    return applied_issue_decomposition_parent_suppresses_expected_worker(
+        LoopContext.load(repo_root=repo_root, env=_repo_local_context_env(repo_root, os.environ), cwd=repo_root, read_only=True),
+        issue,
+        command_runner=lambda command: git_text(list(command), cwd=repo_root),
+    )
 
 
 def _issue_has_terminal_implement_projection(repo_root: Path, issue: int) -> bool:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -986,7 +986,12 @@ def expected_from_open_items(
         expected = label_catalog.phase_expected_workers(phase_label)
         if expected <= 0:
             continue
-        if repo_root is not None and item.kind == "issue" and _issue_has_terminal_implement_projection(repo_root, item.number):
+        if (
+            repo_root is not None
+            and item.kind == "issue"
+            and phase_label == label_catalog.PHASE_IMPLEMENTING
+            and _issue_has_terminal_implement_projection(repo_root, item.number)
+        ):
             continue
         breakdown.append({"id": f"#{item.number}", "kind": item.kind, "phase": phase_label, "expected": expected})
         total += expected

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
@@ -94,6 +94,94 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
             intents.append(json.loads(line.split(" HARNESS_SPAWN_INTENT ", 1)[1]))
         return intents
 
+    def design_issue_item(self, issue: int) -> dict:
+        return {
+            "number": issue,
+            "kind": "issue",
+            "phase": self.labels.PHASE_DESIGN_SOLVING,
+            "human": self.labels.HUMAN_AUTO,
+            "labels": [self.labels.MANAGED, self.labels.PHASE_DESIGN_SOLVING, self.labels.HUMAN_AUTO],
+            "body": "",
+            "head_ref": "",
+            "is_draft": False,
+            "state": "open",
+        }
+
+    def write_applied_issue_decomposition_evidence(self, *, issue: int = 537, round_no: int = 6) -> tuple[str, str]:
+        from codex_refactor_loop.context import LoopContext
+        from codex_refactor_loop.issue_decomposition import issue_decomposition_plan_file_digest
+
+        runs = self.refactor_loop / "runs"
+        runs.mkdir(parents=True, exist_ok=True)
+        consensus = f".refactor-loop/runs/phase9-issue{issue}-r{round_no}-judge.md"
+        child_one = f".refactor-loop/runs/issue-{issue}-decomposition/child-one.md"
+        child_two = f".refactor-loop/runs/issue-{issue}-decomposition/child-two.md"
+        for path, scope, non_goals in (
+            (child_one, "First bounded scope", "No parent lifecycle mutation"),
+            (child_two, "Second bounded scope", "No public issue factory"),
+        ):
+            (self.repo / path).parent.mkdir(parents=True, exist_ok=True)
+            (self.repo / path).write_text(
+                "## child\n\n"
+                f"Parent issue: #{issue}\n"
+                f"Source consensus artifact: {Path(consensus).name}\n"
+                f"Scope: {scope}\n"
+                f"Non-goals: {non_goals}\n\n"
+                "<details>\n<summary>内联 artifact 1: decision.md</summary>\n\n"
+                "```markdown\nraw decision\n```\n\n</details>\n\n"
+                "⟦AI:AUTO-LOOP⟧\n",
+                encoding="utf-8",
+            )
+        parent_comment = f".refactor-loop/runs/issue-{issue}-decomposition/parent-comment.md"
+        (self.repo / parent_comment).write_text(f"Parent issue: #{issue}\n\nChildren opened.\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8")
+        plan_path = f".refactor-loop/runs/issue-{issue}-decomposition/plan.json"
+        (self.repo / plan_path).write_text(
+            json.dumps(
+                {
+                    "schema": "IssueDecompositionPlan",
+                    "parent_issue": issue,
+                    "source_consensus_artifact": consensus,
+                    "children": [
+                        {
+                            "slug": "first-child",
+                            "title": "First child",
+                            "scope": "First bounded scope",
+                            "non_goals": "No parent lifecycle mutation",
+                            "body_artifact_path": child_one,
+                        },
+                        {
+                            "slug": "second-child",
+                            "title": "Second child",
+                            "scope": "Second bounded scope",
+                            "non_goals": "No public issue factory",
+                            "body_artifact_path": child_two,
+                        },
+                    ],
+                    "parent_update": {"comment_artifact_path": parent_comment},
+                }
+            ),
+            encoding="utf-8",
+        )
+        ctx = LoopContext.load(repo_root=self.repo, env=os.environ)
+        digest = issue_decomposition_plan_file_digest(ctx, plan_path)
+        (self.repo / consensus).write_text("META_JUDGE_DONE:consensus:decompose\n", encoding="utf-8")
+        ledger = self.refactor_loop / "state" / "wakeup-runner-ledger.jsonl"
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        ledger.write_text(
+            json.dumps(
+                {
+                    "action_id": f"completed-marker:phase9-issue{issue}-r{round_no}-judge.log:META_JUDGE_DONE:consensus:decompose:real",
+                    "kind": "completed-marker",
+                    "reason": "",
+                    "status": "applied",
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return plan_path, digest
+
     def assert_dispatch_rejected(self, task_id: str, reason: str, calls: list[list[str]]) -> None:
         self.assertEqual(calls, [])
         self.assertFalse((self.refactor_loop / "dispatch-queue" / "p0" / f"{task_id}.dispatch.json").exists())
@@ -189,6 +277,52 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
 
         self.assertEqual(expected, 0)
         self.assertEqual(breakdown, [])
+
+    def test_compute_expected_suppresses_applied_decomposition_parent_tracking_issue(self) -> None:
+        _plan_path, digest = self.write_applied_issue_decomposition_evidence(issue=537, round_no=6)
+
+        def runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            if command == ["gh", "issue", "view", "537", "--json", "comments"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    json.dumps({"comments": [{"body": f"IssueDecompositionPlan digest: {digest}\n⟦AI:AUTO-LOOP⟧\n"}]}),
+                    "",
+                )
+            return subprocess.CompletedProcess(command, 1, "", "unexpected command")
+
+        expected, breakdown = self.monitor.compute_expected(
+            [self.design_issue_item(537)],
+            command_runner=runner,
+        )
+
+        self.assertEqual(expected, 0)
+        self.assertEqual(breakdown, [])
+
+    def test_compute_expected_keeps_unapplied_decomposition_parent_tracking_issue(self) -> None:
+        self.write_applied_issue_decomposition_evidence(issue=537, round_no=6)
+        (self.refactor_loop / "state" / "wakeup-runner-ledger.jsonl").unlink()
+
+        def runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            if command == ["gh", "issue", "view", "537", "--json", "comments"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    json.dumps({"comments": [{"body": "IssueDecompositionPlan digest: present-but-not-applied\n"}]}),
+                    "",
+                )
+            return subprocess.CompletedProcess(command, 1, "", "unexpected command")
+
+        expected, breakdown = self.monitor.compute_expected(
+            [self.design_issue_item(537)],
+            command_runner=runner,
+        )
+
+        self.assertEqual(expected, 1)
+        self.assertEqual(
+            breakdown,
+            [{"id": "#537", "kind": "issue", "phase": self.labels.PHASE_DESIGN_SOLVING, "expected": 1}],
+        )
 
     # Refactor (iter6/issue-133):
     #   Old pattern: concurrency_monitor passed queue payload[cd] straight to consensus-rnd-cli spawn-codex --cd, letting a mutable task run in the repo-root/main worktree

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
@@ -107,7 +107,14 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
             "state": "open",
         }
 
-    def write_applied_issue_decomposition_evidence(self, *, issue: int = 537, round_no: int = 6) -> tuple[str, str]:
+    def write_applied_issue_decomposition_evidence(
+        self,
+        *,
+        issue: int = 537,
+        round_no: int = 6,
+        marker: str = "META_JUDGE_DONE:consensus:decompose:real",
+        ledger_rows: tuple[tuple[str, str], ...] = (("applied", ""),),
+    ) -> tuple[str, str]:
         from codex_refactor_loop.context import LoopContext
         from codex_refactor_loop.issue_decomposition import issue_decomposition_plan_file_digest
 
@@ -167,17 +174,21 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
         (self.repo / consensus).write_text("META_JUDGE_DONE:consensus:decompose\n", encoding="utf-8")
         ledger = self.refactor_loop / "state" / "wakeup-runner-ledger.jsonl"
         ledger.parent.mkdir(parents=True, exist_ok=True)
+        action_id = f"completed-marker:phase9-issue{issue}-r{round_no}-judge.log:{marker}"
         ledger.write_text(
-            json.dumps(
-                {
-                    "action_id": f"completed-marker:phase9-issue{issue}-r{round_no}-judge.log:META_JUDGE_DONE:consensus:decompose:real",
-                    "kind": "completed-marker",
-                    "reason": "",
-                    "status": "applied",
-                },
-                sort_keys=True,
-            )
-            + "\n",
+            "".join(
+                json.dumps(
+                    {
+                        "action_id": action_id,
+                        "kind": "completed-marker",
+                        "reason": reason,
+                        "status": status,
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+                for status, reason in ledger_rows
+            ),
             encoding="utf-8",
         )
         return plan_path, digest
@@ -298,6 +309,60 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
 
         self.assertEqual(expected, 0)
         self.assertEqual(breakdown, [])
+
+    def test_compute_expected_suppresses_hybrid_applied_duplicate_decomposition_parent(self) -> None:
+        _plan_path, digest = self.write_applied_issue_decomposition_evidence(
+            issue=537,
+            round_no=1,
+            marker="META_JUDGE_DONE:consensus:hybrid-A+B:bounded decomposition only; stage0 first, later runtime/gate/headless cleanup as child design issues",
+            ledger_rows=(("applied", ""), ("skipped", "duplicate")),
+        )
+
+        def runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            if command == ["gh", "issue", "view", "537", "--json", "comments"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    json.dumps({"comments": [{"body": f"IssueDecompositionPlan digest: {digest}\n⟦AI:AUTO-LOOP⟧\n"}]}),
+                    "",
+                )
+            return subprocess.CompletedProcess(command, 1, "", "unexpected command")
+
+        expected, breakdown = self.monitor.compute_expected(
+            [self.design_issue_item(537)],
+            command_runner=runner,
+        )
+
+        self.assertEqual(expected, 0)
+        self.assertEqual(breakdown, [])
+
+    def test_compute_expected_keeps_only_duplicate_decomposition_parent_tracking_issue(self) -> None:
+        _plan_path, digest = self.write_applied_issue_decomposition_evidence(
+            issue=537,
+            round_no=6,
+            ledger_rows=(("skipped", "duplicate"),),
+        )
+
+        def runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            if command == ["gh", "issue", "view", "537", "--json", "comments"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    json.dumps({"comments": [{"body": f"IssueDecompositionPlan digest: {digest}\n⟦AI:AUTO-LOOP⟧\n"}]}),
+                    "",
+                )
+            return subprocess.CompletedProcess(command, 1, "", "unexpected command")
+
+        expected, breakdown = self.monitor.compute_expected(
+            [self.design_issue_item(537)],
+            command_runner=runner,
+        )
+
+        self.assertEqual(expected, 1)
+        self.assertEqual(
+            breakdown,
+            [{"id": "#537", "kind": "issue", "phase": self.labels.PHASE_DESIGN_SOLVING, "expected": 1}],
+        )
 
     def test_compute_expected_keeps_unapplied_decomposition_parent_tracking_issue(self) -> None:
         self.write_applied_issue_decomposition_evidence(issue=537, round_no=6)

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
@@ -485,6 +485,33 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
 
         self.assertFalse((self.refactor_loop / ".controller-pending-events.log").exists())
 
+    def test_tick_terminal_implement_result_does_not_suppress_design_expected_worker(self) -> None:
+        items = [
+            {
+                "number": 537,
+                "kind": "issue",
+                "phase": self.labels.PHASE_DESIGN_SOLVING,
+                "human": self.labels.HUMAN_AUTO,
+                "labels": [self.labels.MANAGED, self.labels.PHASE_DESIGN_SOLVING, self.labels.HUMAN_AUTO],
+                "state": "open",
+            }
+        ]
+        logs = self.refactor_loop / "logs"
+        logs.mkdir(parents=True, exist_ok=True)
+        (logs / "implement-issue-537.log").write_text(
+            "old implementation no-op\nIMPLEMENT_DONE:issue-537:partial\nEXIT=0\n",
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(self.monitor, "list_auto_loop_issues", return_value=items):
+            with mock.patch.object(self.monitor, "count_in_flight_codex", return_value=0):
+                self.monitor.tick()
+
+        alert = (self.refactor_loop / ".concurrency-alert.log").read_text(encoding="utf-8")
+        self.assertIn("P0 no-gap-violation", alert)
+        snapshot = json.loads((self.refactor_loop / "state" / "statusline-snapshot.json").read_text(encoding="utf-8"))
+        self.assertEqual(snapshot["expected"], 1)
+
     def test_tick_zero_expected_actionable_work_bypasses_single_active_audit_wait(self) -> None:
         active_audit = (
             f"python3 /skill/consensus-rnd-cli spawn-codex --cd {self.repo} "

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -416,6 +416,13 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                         printf '[]\n'
                       fi
                       ;;
+                    open_design_parent_537)
+                      if [[ "$label" == "crnd:lifecycle:managed" ]]; then
+                        printf '[{"number":537,"title":"decomposition parent","labels":[{"name":"crnd:lifecycle:managed"},{"name":"crnd:phase:design-solving"},{"name":"crnd:human:auto"}]}]\n'
+                      else
+                        printf '[]\n'
+                      fi
+                      ;;
                     open_issue_53)
                       if [[ "$label" == "crnd:lifecycle:managed" ]]; then
                         printf '[{"number":53,"title":"drop target","labels":[{"name":"crnd:lifecycle:managed"},{"name":"crnd:phase:design-solving"},{"name":"crnd:human:auto"}]}]\n'
@@ -772,6 +779,11 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                   exit 0
                 fi
                 if [[ "$cmd1 $cmd2" == "issue view" || "$cmd1 $cmd2" == "pr view" ]]; then
+                  comments_file="${WAKEUP_PLAN_REPO_ROOT:-.}/gh-${cmd1}-${cmd3}-comments.json"
+                  if [[ -f "$comments_file" ]]; then
+                    cat "$comments_file"
+                    exit 0
+                  fi
                   printf '{"comments":[]}\n'
                   exit 0
                 fi
@@ -855,6 +867,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             ],
             "open_issue_453": [issue(453, "solver target", [managed, label_catalog.PHASE_DESIGN_SOLVING, auto])],
             "open_issue_403": [issue(403, "decompose target", [managed, label_catalog.PHASE_DESIGN_SOLVING, auto])],
+            "open_design_parent_537": [issue(537, "decomposition parent", [managed, label_catalog.PHASE_DESIGN_SOLVING, auto])],
             "open_issue_537": [issue(537, "decompose handoff target", [managed, label_catalog.PHASE_IMPLEMENTING, auto])],
             "open_issue_53": [issue(53, "drop target", [managed, label_catalog.PHASE_DESIGN_SOLVING, auto])],
             "open_issue_54": [issue(54, "judge target", [managed, label_catalog.PHASE_DESIGN_SOLVING, auto])],
@@ -1460,6 +1473,30 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         (self.repo / plan_path).unlink()
         ctx = LoopContext.load(repo_root=self.repo, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"})
         return target, issue_decomposition_plan_file_digest(ctx, target)
+
+    def write_applied_issue_decomposition_evidence(self, *, issue: int = 537, round_no: int = 6) -> tuple[str, str]:
+        plan_path, digest = self.write_issue_decomposition_plan_artifacts(issue=issue, round_no=round_no)
+        comments_path = self.repo / f"gh-issue-{issue}-comments.json"
+        comments_path.write_text(
+            json.dumps({"comments": [{"body": f"tracked\nIssueDecompositionPlan digest: {digest}\n⟦AI:AUTO-LOOP⟧\n"}]}),
+            encoding="utf-8",
+        )
+        ledger = self.repo / ".refactor-loop" / "state" / "wakeup-runner-ledger.jsonl"
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        ledger.write_text(
+            json.dumps(
+                {
+                    "action_id": f"completed-marker:phase9-issue{issue}-r{round_no}-judge.log:META_JUDGE_DONE:consensus:decompose:real",
+                    "kind": "completed-marker",
+                    "reason": "",
+                    "status": "applied",
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return plan_path, digest
 
     def write_implement_result(self, *, issue: int = 537, status: str = "partial") -> None:
         self.append_harness_spawn_intent(
@@ -5676,6 +5713,31 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             plan["concurrency"]["expected_breakdown"],
             [{"expected": 1, "id": "#255", "kind": "pr", "phase": label_catalog.PHASE_REVIEWING}],
         )
+
+    def test_applied_issue_decomposition_parent_does_not_count_expected_worker(self) -> None:
+        self.write_applied_issue_decomposition_evidence(issue=537, round_no=6)
+
+        plan, stdout = self.run_plan_with_stdout(fixture="open_design_parent_537", ps_count=0)
+
+        self.assertEqual(plan["concurrency"]["expected_breakdown"], [])
+        self.assertEqual(plan["concurrency"]["expected_from_active_tasks"], 0)
+        self.assertFalse(plan["hard_gate"]["active"])
+        self.assertEqual(plan["hard_gate"]["dispatch_required"], 0)
+        self.assertNotIn("HARD_GATE:dispatch_required=", stdout)
+
+    def test_unapplied_issue_decomposition_parent_still_counts_expected_worker(self) -> None:
+        self.write_issue_decomposition_plan_artifacts(issue=537, round_no=6)
+
+        plan, stdout = self.run_plan_with_stdout(fixture="open_design_parent_537", ps_count=0)
+
+        self.assertEqual(
+            plan["concurrency"]["expected_breakdown"],
+            [{"expected": 1, "id": "#537", "kind": "issue", "phase": label_catalog.PHASE_DESIGN_SOLVING}],
+        )
+        self.assertEqual(plan["concurrency"]["expected_from_active_tasks"], 1)
+        self.assertTrue(plan["hard_gate"]["active"])
+        self.assertEqual(plan["hard_gate"]["dispatch_required"], 5)
+        self.assertIn("HARD_GATE:dispatch_required=5", stdout)
 
     def test_draft_release_rollup_is_not_expected_active_review_task(self) -> None:
         plan = self.run_plan(fixture="draft_rollup_and_review_prs", ps_count=5)

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -1474,7 +1474,14 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         ctx = LoopContext.load(repo_root=self.repo, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"})
         return target, issue_decomposition_plan_file_digest(ctx, target)
 
-    def write_applied_issue_decomposition_evidence(self, *, issue: int = 537, round_no: int = 6) -> tuple[str, str]:
+    def write_applied_issue_decomposition_evidence(
+        self,
+        *,
+        issue: int = 537,
+        round_no: int = 6,
+        marker: str = "META_JUDGE_DONE:consensus:decompose:real",
+        ledger_rows: tuple[tuple[str, str], ...] = (("applied", ""),),
+    ) -> tuple[str, str]:
         plan_path, digest = self.write_issue_decomposition_plan_artifacts(issue=issue, round_no=round_no)
         comments_path = self.repo / f"gh-issue-{issue}-comments.json"
         comments_path.write_text(
@@ -1483,17 +1490,21 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         )
         ledger = self.repo / ".refactor-loop" / "state" / "wakeup-runner-ledger.jsonl"
         ledger.parent.mkdir(parents=True, exist_ok=True)
+        action_id = f"completed-marker:phase9-issue{issue}-r{round_no}-judge.log:{marker}"
         ledger.write_text(
-            json.dumps(
-                {
-                    "action_id": f"completed-marker:phase9-issue{issue}-r{round_no}-judge.log:META_JUDGE_DONE:consensus:decompose:real",
-                    "kind": "completed-marker",
-                    "reason": "",
-                    "status": "applied",
-                },
-                sort_keys=True,
-            )
-            + "\n",
+            "".join(
+                json.dumps(
+                    {
+                        "action_id": action_id,
+                        "kind": "completed-marker",
+                        "reason": reason,
+                        "status": status,
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+                for status, reason in ledger_rows
+            ),
             encoding="utf-8",
         )
         return plan_path, digest
@@ -5724,6 +5735,40 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertFalse(plan["hard_gate"]["active"])
         self.assertEqual(plan["hard_gate"]["dispatch_required"], 0)
         self.assertNotIn("HARD_GATE:dispatch_required=", stdout)
+
+    def test_hybrid_applied_duplicate_issue_decomposition_parent_does_not_count_expected_worker(self) -> None:
+        self.write_applied_issue_decomposition_evidence(
+            issue=537,
+            round_no=1,
+            marker="META_JUDGE_DONE:consensus:hybrid-A+B:bounded decomposition only; stage0 first, later runtime/gate/headless cleanup as child design issues",
+            ledger_rows=(("applied", ""), ("skipped", "duplicate")),
+        )
+
+        plan, stdout = self.run_plan_with_stdout(fixture="open_design_parent_537", ps_count=0)
+
+        self.assertEqual(plan["concurrency"]["expected_breakdown"], [])
+        self.assertEqual(plan["concurrency"]["expected_from_active_tasks"], 0)
+        self.assertFalse(plan["hard_gate"]["active"])
+        self.assertEqual(plan["hard_gate"]["dispatch_required"], 0)
+        self.assertNotIn("HARD_GATE:dispatch_required=", stdout)
+
+    def test_only_duplicate_issue_decomposition_parent_still_counts_expected_worker(self) -> None:
+        self.write_applied_issue_decomposition_evidence(
+            issue=537,
+            round_no=6,
+            ledger_rows=(("skipped", "duplicate"),),
+        )
+
+        plan, stdout = self.run_plan_with_stdout(fixture="open_design_parent_537", ps_count=0)
+
+        self.assertEqual(
+            plan["concurrency"]["expected_breakdown"],
+            [{"expected": 1, "id": "#537", "kind": "issue", "phase": label_catalog.PHASE_DESIGN_SOLVING}],
+        )
+        self.assertEqual(plan["concurrency"]["expected_from_active_tasks"], 1)
+        self.assertTrue(plan["hard_gate"]["active"])
+        self.assertEqual(plan["hard_gate"]["dispatch_required"], 5)
+        self.assertIn("HARD_GATE:dispatch_required=5", stdout)
 
     def test_unapplied_issue_decomposition_parent_still_counts_expected_worker(self) -> None:
         self.write_issue_decomposition_plan_artifacts(issue=537, round_no=6)

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -5747,6 +5747,27 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(plan["concurrency"]["expected_from_active_tasks"], 0)
         self.assertEqual(plan["concurrency"]["expected_breakdown"], [])
 
+    def test_design_solving_issue_keeps_expected_worker_despite_old_implement_terminal(self) -> None:
+        (self.logs / "implement-issue-537.log").write_text(
+            "old implementation terminal\nIMPLEMENT_DONE:issue-537:partial\nEXIT=0\n",
+            encoding="utf-8",
+        )
+        item = GhItem(
+            "issue",
+            537,
+            "design target",
+            (label_catalog.MANAGED, label_catalog.PHASE_DESIGN_SOLVING, label_catalog.HUMAN_AUTO),
+        )
+
+        concurrency = concurrency_plan(self.repo, fixed_point=False, gh_items=[item], monitor=None)
+
+        self.assertEqual(concurrency["expected_from_active_tasks"], 1)
+        self.assertEqual(
+            concurrency["expected_breakdown"],
+            [{"expected": 1, "id": "#537", "kind": "issue", "phase": label_catalog.PHASE_DESIGN_SOLVING}],
+        )
+        self.assertTrue(concurrency["hard_gate"]["active"])
+
     def test_github_action_queries_only_open_auto_loop_items(self) -> None:
         source = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "wakeup_plan.py").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `3` commits
- 范围: `d07215589396..44a92aed233f`

## commit 摘要

- 修复分解 ledger 重复记录抑制
- 修复分解父 issue 的 expected 计数
- 修复 no-gap expected worker 误抑制

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
