### PR TITLE
发布 rollup: integration ahead 2 commits (256e4b827b26)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "consensus-rnd",
       "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.9",
       "source": "./",
       "author": {
         "name": "auric",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎，可注入任意 host 仓库做自主研发循环",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
   "author": {
     "name": "auric",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "consensus-rnd",
   "displayName": "Consensus R&D",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
   "license": "MIT",
   "author": "auric <loning.ma@aelf.io>",

--- a/skills/codex-refactor-loop/VERSION.json
+++ b/skills/codex-refactor-loop/VERSION.json
@@ -1,6 +1,6 @@
 {
   "schema": "codex-refactor-loop-version",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "repository": "ChronoAIProject/consensus-rnd",
   "release_source": "github-release-then-tag",
   "install_hint": "host-owned"

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -41,7 +41,7 @@ from codex_refactor_loop.issue_decomposition import (
 from codex_refactor_loop.managed_work_snapshot import load_open_managed_work_snapshot
 from codex_refactor_loop.pr_checks import PrChecksProjection
 from codex_refactor_loop.release.required_checks import ReleaseRequiredChecksProjection, required_release_checks
-from codex_refactor_loop.release.gate import decide_release_artifact
+from codex_refactor_loop.release.gate import canonical_digest, decide_release_artifact, parse_time
 from codex_refactor_loop.restart import restart_managed_daemon_names
 from codex_refactor_loop.state import read_json
 from codex_refactor_loop.transition_assessment import TransitionAssessmentReader, transition_rank_key
@@ -3441,9 +3441,11 @@ def release_gate_dispatch_actions(repo_root: Path, scorer: Any | None = None) ->
     if os.environ.get("RELEASE_AUTO_ENABLE") != "true":
         return []
     candidate_path = repo_root / ".refactor-loop" / "state" / "release-candidate.json"
+    decision_path = repo_root / ".refactor-loop" / "state" / "release-decision.json"
+    decision = read_json(decision_path, {})
     if candidate_path.exists():
         candidate = read_json(candidate_path, {})
-        if not release_candidate_target_ref_invalid(candidate):
+        if not release_candidate_target_ref_invalid(candidate, decision):
             return []
     score = _release_countdown_score(repo_root, scorer=scorer)
     if not score.get("ready"):
@@ -3487,19 +3489,39 @@ def release_gate_dispatch_actions(repo_root: Path, scorer: Any | None = None) ->
     ]
 
 
-def release_candidate_target_ref_invalid(candidate: Any) -> bool:
+def release_candidate_target_ref_invalid(candidate: Any, decision: Any | None = None) -> bool:
     if not isinstance(candidate, dict):
         return False
     if "target_ref" not in candidate:
         return True
     target_ref = candidate.get("target_ref")
-    return not isinstance(target_ref, str) or not target_ref.strip()
+    if not isinstance(target_ref, str) or not target_ref.strip():
+        return True
+    generated_at = parse_time(candidate.get("generated_at"))
+    expires_at = parse_time(candidate.get("expires_at"))
+    now = datetime.now(timezone.utc)
+    if generated_at is not None and (now - generated_at).total_seconds() > 120 * 60:
+        return True
+    if expires_at is not None and expires_at <= now:
+        return True
+    if not isinstance(decision, dict) or not decision:
+        return False
+    if candidate.get("ready") is not True:
+        return True
+    for field in ("from_version", "to_version", "bump_type", "coordinate_policy"):
+        if candidate.get(field) != decision.get(field):
+            return True
+    expected_digest = candidate.get("decision_digest")
+    return not isinstance(expected_digest, str) or canonical_digest(decision) != expected_digest
 
 
 def release_publish_actions(repo_root: Path) -> list[dict[str, Any]]:
     candidate_path = repo_root / ".refactor-loop" / "state" / "release-candidate.json"
     candidate = read_json(candidate_path, {})
     if not isinstance(candidate, dict) or candidate.get("ready") is not True:
+        return []
+    decision = read_json(repo_root / ".refactor-loop" / "state" / "release-decision.json", {})
+    if release_candidate_target_ref_invalid(candidate, decision):
         return []
     target_ref = str(candidate.get("target_ref") or "").strip()
     to_version = str(candidate.get("to_version") or "").strip()

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -592,9 +592,10 @@ class WakeupRunner:
             return "release_auto_opt_in_missing"
         candidate = self.ctx.paths.state / "release-candidate.json"
         if candidate.exists():
+            decision = read_json(self.ctx.paths.state / "release-decision.json", {})
             if (
                 "release_candidate_target_ref_invalid" not in preconditions
-                or not release_candidate_target_ref_invalid(read_json(candidate, {}))
+                or not release_candidate_target_ref_invalid(read_json(candidate, {}), decision)
             ):
                 return "release_candidate_already_exists"
         if not str(action.get("from_version") or "").strip() or not str(action.get("to_version") or "").strip():
@@ -1576,7 +1577,8 @@ class WakeupRunner:
         if not isinstance(preconditions, list) or "release_candidate_target_ref_invalid" not in preconditions:
             return ""
         candidate = self.ctx.paths.state / "release-candidate.json"
-        if not release_candidate_target_ref_invalid(read_json(candidate, {})):
+        decision = read_json(self.ctx.paths.state / "release-decision.json", {})
+        if not release_candidate_target_ref_invalid(read_json(candidate, {}), decision):
             return ""
         return "target_ref_invalid"
 

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -12,6 +12,7 @@ import textwrap
 import time
 import unittest
 from contextlib import redirect_stderr
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
 from unittest import mock
@@ -26,6 +27,7 @@ from codex_refactor_loop import labels as label_catalog  # noqa: E402
 from codex_refactor_loop.context import LoopContext  # noqa: E402
 from codex_refactor_loop.issue_decomposition import issue_decomposition_plan_file_digest  # noqa: E402
 from codex_refactor_loop.managed_work_snapshot import ManagedWorkSnapshotResult  # noqa: E402
+from codex_refactor_loop.release.gate import canonical_digest, isoformat  # noqa: E402
 from codex_refactor_loop.restart import restart_managed_daemon_names  # noqa: E402
 from codex_refactor_loop.workflow_stages import assert_stage_slug  # noqa: E402
 from codex_refactor_loop.wakeup_plan import (  # noqa: E402
@@ -79,6 +81,39 @@ def issue_decomposition_apply_actions(plan: dict) -> list[dict]:
         for action in plan["actions"]
         if action.get("controller_action") == "apply_issue_decomposition_plan"
     ]
+
+
+def release_decision(from_version: str, to_version: str) -> dict:
+    return {
+        "from_version": from_version,
+        "to_version": to_version,
+        "bump_type": "patch",
+        "coordinate_policy": None,
+        "ready": True,
+        "signals": {"fresh_heartbeats": {"passed": True}},
+        "blocked_reasons": [],
+    }
+
+
+def release_candidate(decision: dict, *, expires_at: str | None = None, target_ref: str = "origin/review") -> dict:
+    now = datetime.now(timezone.utc)
+    return {
+        "schema": "decision-artifact-only/v2",
+        "generated_at": isoformat(now),
+        "expires_at": expires_at or isoformat(now + timedelta(minutes=120)),
+        "decision_artifact": ".refactor-loop/state/release-decision.json",
+        "from_version": decision.get("from_version"),
+        "to_version": decision.get("to_version"),
+        "bump_type": decision.get("bump_type"),
+        "coordinate_policy": decision.get("coordinate_policy"),
+        "ready": decision.get("ready"),
+        "target_ref": target_ref,
+        "required_signals": {"fresh_heartbeats": {"passed": True}},
+        "decision_digest": canonical_digest(decision),
+        "publish_preflight": "controller-release-publish-preflight",
+        "host_opt_in": "RELEASE_AUTO_ENABLE=true",
+        "lifecycle_owner": "controller",
+    }
 
 
 class WakeupPlanBehaviorTests(unittest.TestCase):
@@ -5355,6 +5390,60 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             )
 
         self.assertEqual(actions, [])
+
+    def test_release_gate_dispatch_refreshes_decision_mismatched_candidate(self) -> None:
+        current = release_decision("1.0.0-beta.8", "1.0.0-beta.9")
+        stale = release_decision("1.0.0-beta.7", "1.0.0-beta.8")
+        (self.repo / ".refactor-loop/state/release-decision.json").write_text(json.dumps(current), encoding="utf-8")
+        (self.repo / ".refactor-loop/state/release-candidate.json").write_text(
+            json.dumps(release_candidate(stale)),
+            encoding="utf-8",
+        )
+
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "true"}):
+            actions = release_gate_dispatch_actions(
+                self.repo,
+                scorer=lambda _: {
+                    "from_version": "1.0.0-beta.8",
+                    "to_version": "1.0.0-beta.9",
+                    "stability_score": 100,
+                    "ready": True,
+                    "signals": {},
+                    "blocked_reasons": [],
+                },
+            )
+
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0]["controller_action"], "dispatch_release_candidate")
+        self.assertEqual(actions[0]["action_id"], "release-gate-dispatch:1.0.0-beta.8->1.0.0-beta.9")
+        self.assertIn("release_candidate_target_ref_invalid", actions[0]["preconditions"])
+        self.assertEqual(release_publish_actions(self.repo), [])
+
+    def test_release_gate_dispatch_refreshes_expired_candidate(self) -> None:
+        current = release_decision("1.2.3-beta.4", "1.2.3-beta.5")
+        (self.repo / ".refactor-loop/state/release-decision.json").write_text(json.dumps(current), encoding="utf-8")
+        (self.repo / ".refactor-loop/state/release-candidate.json").write_text(
+            json.dumps(release_candidate(current, expires_at=isoformat(datetime.now(timezone.utc) - timedelta(minutes=1)))),
+            encoding="utf-8",
+        )
+
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "true"}):
+            actions = release_gate_dispatch_actions(
+                self.repo,
+                scorer=lambda _: {
+                    "from_version": "1.2.3-beta.4",
+                    "to_version": "1.2.3-beta.5",
+                    "stability_score": 100,
+                    "ready": True,
+                    "signals": {},
+                    "blocked_reasons": [],
+                },
+            )
+
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0]["controller_action"], "dispatch_release_candidate")
+        self.assertIn("release_candidate_target_ref_invalid", actions[0]["preconditions"])
+        self.assertEqual(release_publish_actions(self.repo), [])
 
     def test_release_gate_dispatch_recovers_ready_gate_when_candidate_target_ref_is_empty(self) -> None:
         candidate = self.repo / ".refactor-loop/state/release-candidate.json"

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -10,6 +10,7 @@ import tempfile
 import threading as real_threading
 import unittest
 from contextlib import redirect_stdout
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
 from string import Template
@@ -25,6 +26,7 @@ REAL_THREAD = real_threading.Thread
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.issue_decomposition import issue_decomposition_plan_file_digest
 from codex_refactor_loop import labels
+from codex_refactor_loop.release.gate import canonical_digest, isoformat
 from codex_refactor_loop.wakeup_runner import (
     WakeupRunner,
     RunnerResult,
@@ -35,6 +37,18 @@ from codex_refactor_loop.wakeup_runner import (
     main as wakeup_runner_main,
     _source_log_has_clean_marker,
 )
+
+
+def release_decision(from_version: str, to_version: str) -> dict:
+    return {
+        "from_version": from_version,
+        "to_version": to_version,
+        "bump_type": "patch",
+        "coordinate_policy": None,
+        "ready": True,
+        "signals": {"fresh_heartbeats": {"passed": True}},
+        "blocked_reasons": [],
+    }
 
 
 class SourceMarkerRevalidationFallbackTests(unittest.TestCase):
@@ -2060,6 +2074,53 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         candidate = json.loads(bad_candidate.read_text(encoding="utf-8"))
         self.assertTrue(candidate["ready"])
         self.assertEqual(candidate["target_ref"], "origin/dev")
+        self.assertEqual(candidate["to_version"], "1.2.3-beta.5")
+
+    def test_release_dispatch_recovers_existing_candidate_for_previous_decision(self) -> None:
+        self.write_release_dispatch_fixtures()
+        current_decision = release_decision("1.2.3-beta.4", "1.2.3-beta.5")
+        old_decision = release_decision("1.2.3-beta.3", "1.2.3-beta.4")
+        (self.repo / ".refactor-loop/state/release-decision.json").write_text(
+            json.dumps(current_decision),
+            encoding="utf-8",
+        )
+        existing = self.repo / ".refactor-loop/state/release-candidate.json"
+        existing.write_text(
+            json.dumps(
+                {
+                    "ready": True,
+                    "target_ref": "origin/dev",
+                    "from_version": "1.2.3-beta.3",
+                    "to_version": "1.2.3-beta.4",
+                    "bump_type": "patch",
+                    "coordinate_policy": None,
+                    "generated_at": isoformat(datetime.now(timezone.utc)),
+                    "expires_at": isoformat(datetime.now(timezone.utc) + timedelta(minutes=120)),
+                    "decision_digest": canonical_digest(old_decision),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        results = self.run_result(
+            self.base_plan(
+                self.release_dispatch_action(
+                    preconditions=[
+                        "active_controller_owner",
+                        "release_auto_opt_in",
+                        "release_gate_ready",
+                        "decision_artifact_only",
+                        "release_candidate_target_ref_invalid",
+                    ],
+                )
+            ),
+            actions=FakeActions(),
+        )
+
+        self.assertEqual(results[0].status, "applied")
+        candidate = json.loads(existing.read_text(encoding="utf-8"))
+        self.assertEqual(candidate["target_ref"], "origin/dev")
+        self.assertEqual(candidate["from_version"], "1.2.3-beta.4")
         self.assertEqual(candidate["to_version"], "1.2.3-beta.5")
 
     def test_release_dispatch_recovers_stale_applied_ledger_with_empty_target_ref(self) -> None:


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `2` commits
- 范围: `d8d2ce174147..256e4b827b26`

## commit 摘要

- Release v1.0.0-beta.9
- 修复发布候选刷新阻塞

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
