### PR TITLE
发布 rollup: integration ahead 1 commits (0ccc9eb90a3a)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "consensus-rnd",
       "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
-      "version": "1.0.0-beta.9",
+      "version": "1.0.0-beta.10",
       "source": "./",
       "author": {
         "name": "auric",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎，可注入任意 host 仓库做自主研发循环",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
   "author": {
     "name": "auric",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "consensus-rnd",
   "displayName": "Consensus R&D",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
   "license": "MIT",
   "author": "auric <loning.ma@aelf.io>",

--- a/skills/codex-refactor-loop/VERSION.json
+++ b/skills/codex-refactor-loop/VERSION.json
@@ -1,6 +1,6 @@
 {
   "schema": "codex-refactor-loop-version",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "repository": "ChronoAIProject/consensus-rnd",
   "release_source": "github-release-then-tag",
   "install_hint": "host-owned"


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `713192bd9acf..0ccc9eb90a3a`

## commit 摘要

- Release v1.0.0-beta.10

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
