### PR TITLE
收窄 patrol 异常日志证据抽取

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/patrol.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/patrol.py
@@ -188,8 +188,8 @@ def _find_log_exceptions(log_dir: Path) -> tuple[PatrolFinding, ...]:
     findings = []
     for path in sorted(log_dir.glob("*.log"))[-200:]:
         lines = _read_tail_or_fail(path, 80)
-        matched = [line for line in lines if _line_has_exception_signal(line)]
-        if not matched:
+        evidence = _extract_log_diagnostic_evidence(lines)
+        if not evidence:
             continue
         findings.append(
             PatrolFinding(
@@ -197,7 +197,7 @@ def _find_log_exceptions(log_dir: Path) -> tuple[PatrolFinding, ...]:
                 source=_repo_local_source(path),
                 summary=f"runtime log reports exception signals in {path.name}",
                 severity="high",
-                evidence=tuple(matched[-10:]),
+                evidence=evidence[-10:],
             )
         )
     return tuple(findings)
@@ -274,9 +274,49 @@ def _item_ref(item: GhItem | Mapping[str, object]) -> str:
     return f"{kind or 'item'} #{number or '?'}"
 
 
-def _line_has_exception_signal(line: str) -> bool:
+def _extract_log_diagnostic_evidence(lines: Sequence[str]) -> tuple[str, ...]:
+    evidence: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line == "Traceback (most recent call last):":
+            block, next_index = _extract_traceback_block(lines, index)
+            if block:
+                evidence.extend(block)
+            index = next_index
+            continue
+        if _is_single_line_diagnostic(line) or _is_command_failure_summary(line):
+            evidence.append(line)
+        index += 1
+    return tuple(evidence)
+
+
+def _extract_traceback_block(lines: Sequence[str], start: int) -> tuple[tuple[str, ...], int]:
+    block = [lines[start]]
+    index = start + 1
+    while index < len(lines):
+        line = lines[index]
+        block.append(line)
+        index += 1
+        if _is_python_exception_line(line):
+            return tuple(block), index
+    return (), index
+
+
+def _is_single_line_diagnostic(line: str) -> bool:
+    return line.startswith(("FATAL:", "POST_FAILED:", "RuntimeError:"))
+
+
+def _is_command_failure_summary(line: str) -> bool:
     lowered = line.lower()
-    return any(token in lowered for token in ("traceback", "exception", "runtimeerror", "fatal:", "failed"))
+    return lowered.startswith(("command failed:", "command failure:", "cmd failed:"))
+
+
+def _is_python_exception_line(line: str) -> bool:
+    if line.startswith((" ", "\t")):
+        return False
+    exception_type = line.split(":", 1)[0].strip()
+    return exception_type.endswith(("Error", "Exception")) or exception_type in {"KeyboardInterrupt", "SystemExit"}
 
 
 def _read_tail_or_fail(path: Path, max_lines: int) -> tuple[str, ...]:

--- a/skills/codex-refactor-loop/scripts/test_patrol_inspector.py
+++ b/skills/codex-refactor-loop/scripts/test_patrol_inspector.py
@@ -60,6 +60,67 @@ class PatrolInspectorTests(unittest.TestCase):
             {finding.kind for finding in findings},
         )
 
+    def test_log_exception_words_without_bounded_diagnostic_do_not_create_findings(self) -> None:
+        (self.tmp / ".refactor-loop" / "logs" / "router.log").write_text(
+            "\n".join(
+                (
+                    "docs/runtime-exceptions.md",
+                    "authorization prose mentions exception handling boundaries",
+                    "diff --git a/runtime-exceptions.md b/runtime-exceptions.md",
+                    "+ failed markdown checklist item",
+                    "path-only failed-state.md",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        findings = PatrolInspector(self.ctx, github_items=()).collect_findings()
+
+        self.assertNotIn("exception-log", {finding.kind for finding in findings})
+
+    def test_log_traceback_block_is_reported_as_bounded_evidence(self) -> None:
+        (self.tmp / ".refactor-loop" / "logs" / "router.log").write_text(
+            "\n".join(
+                (
+                    "before",
+                    "Traceback (most recent call last):",
+                    '  File "worker.py", line 4, in <module>',
+                    "    main()",
+                    "ValueError: broken",
+                    "after",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        findings = PatrolInspector(self.ctx, github_items=()).collect_findings()
+
+        exception_findings = [finding for finding in findings if finding.kind == "exception-log"]
+        self.assertEqual(1, len(exception_findings))
+        self.assertEqual(
+            (
+                "Traceback (most recent call last):",
+                '  File "worker.py", line 4, in <module>',
+                "    main()",
+                "ValueError: broken",
+            ),
+            exception_findings[0].evidence,
+        )
+
+    def test_log_command_failure_summary_is_reported(self) -> None:
+        (self.tmp / ".refactor-loop" / "logs" / "router.log").write_text(
+            "command failed: exit=2 cmd=python3 -m pytest\n",
+            encoding="utf-8",
+        )
+
+        findings = PatrolInspector(self.ctx, github_items=()).collect_findings()
+
+        exception_findings = [finding for finding in findings if finding.kind == "exception-log"]
+        self.assertEqual(1, len(exception_findings))
+        self.assertEqual(("command failed: exit=2 cmd=python3 -m pytest",), exception_findings[0].evidence)
+
     def test_run_once_publishes_findings_and_writes_dashboard_state(self) -> None:
         (self.tmp / ".refactor-loop" / "logs" / "router.log").write_text("FATAL: failed\n", encoding="utf-8")
         publisher = FakePublisher()


### PR DESCRIPTION
## 修改文件
- `skills/codex-refactor-loop/scripts/codex_refactor_loop/patrol.py`：将 patrol `exception-log` 从宽泛 keyword match 改为 bounded diagnostic evidence 抽取。
- `skills/codex-refactor-loop/scripts/test_patrol_inspector.py`：新增行为测试覆盖 false positive、traceback block、command failure summary。

## 测试结果
- `python3 -m unittest skills/codex-refactor-loop/scripts/test_patrol_inspector.py skills/codex-refactor-loop/scripts/test_patrol_fingerprint.py`
- `python3 -m compileall skills/codex-refactor-loop/scripts skills/sshx -q`
- `python3 -m pytest skills/codex-refactor-loop/scripts ... && python3 -m pytest skills/sshx/tests ...`
- 架构守卫：`guards skipped: CI_GUARDS unset`

## deviation 记录
- 无 scope extend。
- `HOST_REFACTOR_COMMENT_POLICY=none`，未添加 Refactor self-documentation 源码注释。

Closes #622

⟦AI:AUTO-LOOP⟧
