### PR TITLE
降级无有效 PR 目标的远程 CI 完成标记

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -1183,11 +1183,13 @@ def completed_marker_actions(
             action["preconditions"] = ["active_controller_owner", "clean_exit_source_marker", "live_open_target", "live_managed_target"]
         if action["controller_action"] == "publish_implementation_output":
             _attach_implementation_pr_artifacts(repo_root, action)
+        _apply_remote_ci_fix_done_target_gate(action, open_targets)
         target = _action_target_key(action)
         if (
             open_targets is not None
             and target is not None
             and target not in open_targets
+            and not action.get("status_only")
             and not marker.startswith("META_JUDGE_DONE:consensus")
             and controller_action_from_marker(marker) != "close_managed_item_from_drop_marker"
         ):
@@ -1432,6 +1434,35 @@ def _action_target_key(action: dict[str, Any]) -> tuple[str, int] | None:
     number = action.get("target_number")
     if kind in {"PR", "issue"} and isinstance(number, int):
         return kind, number
+    return None
+
+
+def _apply_remote_ci_fix_done_target_gate(action: dict[str, Any], open_targets: set[tuple[str, int]] | None) -> None:
+    if action.get("controller_action") != "dispatch_remote_ci_fix":
+        return
+    reason = _remote_ci_fix_done_target_suppressed_reason(action, open_targets)
+    if not reason:
+        return
+    action["status_only"] = True
+    action["no_lifecycle_authority"] = True
+    action["suppressed_reason"] = reason
+    action.pop("runner_authority", None)
+    action.pop("no_generic_command", None)
+
+
+def _remote_ci_fix_done_target_suppressed_reason(
+    action: dict[str, Any],
+    open_targets: set[tuple[str, int]] | None,
+) -> str | None:
+    target = _action_target_key(action)
+    if target is None:
+        return "remote_ci_fix_target_missing"
+    if target[0] != "PR":
+        return "remote_ci_fix_target_not_pr"
+    if open_targets is None:
+        return "open_managed_read_model_unavailable"
+    if target not in open_targets:
+        return "target_not_open"
     return None
 
 

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -3728,6 +3728,22 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertNotIn("runner_authority", action)
         self.assertNotIn("no_generic_command", action)
 
+    def test_remote_ci_fix_done_when_read_model_unavailable_is_status_only(self) -> None:
+        marker = "REMOTE_CI_FIX_DONE:contract-tests:ok"
+        (self.logs / "remote-ci-fix-pr77-contract-tests.log").write_text(f"{marker}\nEXIT=0\n", encoding="utf-8")
+
+        plan = self.run_plan(fixture="gh_failure")
+
+        action = completed_marker_action(plan, "completed-marker:remote-ci-fix-pr77-contract-tests")
+        self.assertEqual(action["controller_action"], "dispatch_remote_ci_fix")
+        self.assertEqual(action["target_kind"], "PR")
+        self.assertEqual(action["target_number"], 77)
+        self.assertTrue(action["status_only"])
+        self.assertTrue(action["no_lifecycle_authority"])
+        self.assertEqual(action["suppressed_reason"], "open_managed_read_model_unavailable")
+        self.assertNotIn("runner_authority", action)
+        self.assertNotIn("no_generic_command", action)
+
     def test_remote_ci_fix_done_conflicting_duplicate_marker_fails_closed(self) -> None:
         (self.logs / "remote-ci-fix-pr77-contract-tests.log").write_text(
             "REMOTE_CI_FIX_DONE:contract-tests:blocked\n"

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -3683,6 +3683,51 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(action["source_marker"], marker)
         self.assertNotIn("status_only", action)
 
+    def test_remote_ci_fix_done_without_pr_target_is_status_only(self) -> None:
+        marker = "REMOTE_CI_FIX_DONE:contract-tests:ok"
+        (self.logs / "remote-ci-fix-contract-tests.log").write_text(f"{marker}\nEXIT=0\n", encoding="utf-8")
+
+        plan = self.run_plan(fixture="open_pr_77")
+
+        action = completed_marker_action(plan, "completed-marker:remote-ci-fix-contract-tests")
+        self.assertEqual(action["controller_action"], "dispatch_remote_ci_fix")
+        self.assertIsNone(action["target_kind"])
+        self.assertIsNone(action["target_number"])
+        self.assertTrue(action["status_only"])
+        self.assertEqual(action["suppressed_reason"], "remote_ci_fix_target_missing")
+        self.assertNotIn("runner_authority", action)
+        self.assertNotIn("no_generic_command", action)
+
+    def test_remote_ci_fix_done_issue_target_is_status_only(self) -> None:
+        marker = "REMOTE_CI_FIX_DONE:contract-tests:ok"
+        (self.logs / "remote-ci-fix-issue77-contract-tests.log").write_text(f"{marker}\nEXIT=0\n", encoding="utf-8")
+
+        plan = self.run_plan(fixture="open_pr_77")
+
+        action = completed_marker_action(plan, "completed-marker:remote-ci-fix-issue77-contract-tests")
+        self.assertEqual(action["controller_action"], "dispatch_remote_ci_fix")
+        self.assertEqual(action["target_kind"], "issue")
+        self.assertEqual(action["target_number"], 77)
+        self.assertTrue(action["status_only"])
+        self.assertEqual(action["suppressed_reason"], "remote_ci_fix_target_not_pr")
+        self.assertNotIn("runner_authority", action)
+        self.assertNotIn("no_generic_command", action)
+
+    def test_remote_ci_fix_done_non_open_pr_target_is_status_only(self) -> None:
+        marker = "REMOTE_CI_FIX_DONE:contract-tests:ok"
+        (self.logs / "remote-ci-fix-pr77-contract-tests.log").write_text(f"{marker}\nEXIT=0\n", encoding="utf-8")
+
+        plan = self.run_plan(fixture="open_issue_331")
+
+        action = completed_marker_action(plan, "completed-marker:remote-ci-fix-pr77-contract-tests")
+        self.assertEqual(action["controller_action"], "dispatch_remote_ci_fix")
+        self.assertEqual(action["target_kind"], "PR")
+        self.assertEqual(action["target_number"], 77)
+        self.assertTrue(action["status_only"])
+        self.assertEqual(action["suppressed_reason"], "target_not_open")
+        self.assertNotIn("runner_authority", action)
+        self.assertNotIn("no_generic_command", action)
+
     def test_remote_ci_fix_done_conflicting_duplicate_marker_fails_closed(self) -> None:
         (self.logs / "remote-ci-fix-pr77-contract-tests.log").write_text(
             "REMOTE_CI_FIX_DONE:contract-tests:blocked\n"


### PR DESCRIPTION
## 修改文件

- `skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py`
- `skills/codex-refactor-loop/scripts/test_wakeup_plan.py`

## 测试结果

- `python3 -m pytest skills/codex-refactor-loop/scripts/test_wakeup_plan.py -k remote_ci_fix_done -q -p no:cacheprovider -o addopts=`：通过，`6 passed, 256 deselected`。
- `python3 -m compileall skills/codex-refactor-loop/scripts skills/sshx -q`：通过。
- 指定完整测试命令：通过，`1806 passed, 1 skipped, 5485 subtests passed`；`13 passed`。
- `CI_GUARDS`：未配置，按 host 规则跳过。

## deviation 记录

- Focused hint 中的 `python` 在本机不存在，已记录失败并使用等价 `python3` 命令验证。
- `refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)`.

Closes #599

⟦AI:AUTO-LOOP⟧
