### PR TITLE
统一 daemon tick 内 heartbeat 续租

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
@@ -300,7 +300,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         lease.beat()
         interval = max(1, int(args.interval_seconds))
         while True:
-            reconciler.run_once(beat=lease.beat)
+            lease.run_with_lease(lambda: reconciler.run_once(beat=lease.beat))
             lease.sleep_with_lease(interval)
     return reconciler.run_once()
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/heartbeat.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/heartbeat.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 import time
 from pathlib import Path
+from typing import Callable, TypeVar
 
 from .context import LoopContext
+
+T = TypeVar("T")
 
 
 class DaemonHeartbeatLease:
@@ -61,6 +65,26 @@ class DaemonHeartbeatLease:
             self.sleeper(chunk)
             self.beat()
             remaining -= chunk
+
+    def run_with_lease(self, callback: Callable[[], T]) -> T:
+        """Renew the heartbeat periodically while callback is still running."""
+        stop = threading.Event()
+
+        def renew_lease() -> None:
+            while not stop.wait(max(1.0, float(self.heartbeat_interval))):
+                self.beat()
+
+        renewer = threading.Thread(
+            target=renew_lease,
+            name=f"{self.name}-heartbeat-renewer",
+            daemon=True,
+        )
+        renewer.start()
+        try:
+            return callback()
+        finally:
+            stop.set()
+            renewer.join(timeout=1.0)
 
 
 def beat(name: str | None = None, repo_root: Path | str | None = None) -> None:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/heartbeat.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/heartbeat.py
@@ -53,7 +53,7 @@ class DaemonHeartbeatLease:
     def beat(self) -> None:
         """Atomically write the current integer epoch heartbeat."""
         self.heartbeat_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.heartbeat_file.with_name(f".{self.heartbeat_file.name}.tmp.{os.getpid()}")
+        tmp = self.heartbeat_file.with_name(f".{self.heartbeat_file.name}.tmp.{os.getpid()}.{threading.get_ident()}")
         tmp.write_text(f"{int(self.clock())}\n", encoding="utf-8")
         os.replace(tmp, self.heartbeat_file)
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/comment.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/comment.py
@@ -65,7 +65,7 @@ class CommentMonitor:
 
     def run_forever(self) -> int:
         while True:
-            self.tick()
+            self.heartbeat.run_with_lease(self.tick)
             self.heartbeat.beat()
             self.heartbeat.sleep_with_lease(self.interval)
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -662,7 +662,7 @@ class ConcurrencyMonitor:
         lease = DaemonHeartbeatLease("concurrency_monitor", self.repo_root)
         while True:
             try:
-                self.tick()
+                lease.run_with_lease(self.tick)
             except Exception as exc:
                 log(f"EXCEPTION in tick: {exc!r}")
             lease.beat()

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/progress.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/progress.py
@@ -69,7 +69,7 @@ class ProgressReporter:
     def run_forever(self) -> int:
         while True:
             self.log_msg("tick")
-            self.tick()
+            self.heartbeat.run_with_lease(self.tick)
             self.heartbeat.beat()
             self.heartbeat.sleep_with_lease(self.interval)
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -2040,7 +2040,7 @@ def main(argv: list[str] | None = None, command_runner: Callable[[dict[str, obje
         lease = DaemonHeartbeatLease("phase9_router_daemon", repo_root)
         while True:
             try:
-                router.tick()
+                lease.run_with_lease(router.tick)
             except Exception as exc:
                 print(f"[{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}] EXCEPTION in tick: {exc!r}", flush=True)
             lease.beat()

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -8,7 +8,6 @@ import os
 import re
 import subprocess
 import sys
-import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1824,25 +1823,6 @@ def _release_int(value: Any, default: int) -> int:
     return parsed if parsed > 0 else default
 
 
-def _run_once_with_periodic_heartbeat(
-    run_once: Callable[[], list[RunnerResult]],
-    lease: DaemonHeartbeatLease,
-) -> list[RunnerResult]:
-    stop = threading.Event()
-
-    def renew_lease() -> None:
-        while not stop.wait(max(1.0, float(lease.heartbeat_interval))):
-            lease.beat()
-
-    renewer = threading.Thread(target=renew_lease, name="wakeup-runner-heartbeat-renewer", daemon=True)
-    renewer.start()
-    try:
-        return run_once()
-    finally:
-        stop.set()
-        renewer.join(timeout=1.0)
-
-
 def load_plan_file(path: Path) -> Mapping[str, Any]:
     data = read_json(path, {})
     return data if isinstance(data, dict) else {}
@@ -1873,7 +1853,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         lease.beat()
         interval = max(1, int(args.interval_seconds))
         while True:
-            results = _run_once_with_periodic_heartbeat(runner.run_once, lease)
+            results = lease.run_with_lease(runner.run_once)
             _log_tick_status("wakeup-runner", _wakeup_tick_action(results))
             lease.sleep_with_lease(interval)
     results = runner.run_once()

--- a/skills/codex-refactor-loop/scripts/test_daemon_heartbeat.py
+++ b/skills/codex-refactor-loop/scripts/test_daemon_heartbeat.py
@@ -8,14 +8,100 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading as real_threading
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.heartbeat import DaemonHeartbeatLease
+
+REAL_CONDITION = real_threading.Condition
+REAL_EVENT = real_threading.Event
+REAL_THREAD = real_threading.Thread
+
+
+class HeartbeatCoordinator:
+    def __init__(self) -> None:
+        self.condition = REAL_CONDITION()
+        self.callback_entered = False
+        self.beat_during_callback = False
+        self.stop_requested = False
+
+    def enter_callback(self) -> None:
+        with self.condition:
+            self.callback_entered = True
+            self.condition.notify_all()
+
+    def record_beat(self) -> None:
+        with self.condition:
+            if self.callback_entered and not self.stop_requested:
+                self.beat_during_callback = True
+            self.condition.notify_all()
+
+    def wait_for_heartbeat_while_callback_is_pending(self) -> bool:
+        with self.condition:
+            return self.condition.wait_for(lambda: self.beat_during_callback, timeout=1.0)
+
+    def request_stop(self) -> None:
+        with self.condition:
+            self.stop_requested = True
+            self.condition.notify_all()
+
+
+class ScriptedEvent:
+    instances: list["ScriptedEvent"] = []
+    coordinator: HeartbeatCoordinator | None = None
+
+    def __init__(self) -> None:
+        self.wait_timeouts: list[float] = []
+        self.set_called = False
+        ScriptedEvent.instances.append(self)
+
+    def wait(self, timeout: float | None = None) -> bool:
+        self.wait_timeouts.append(float(timeout or 0))
+        if ScriptedEvent.coordinator is None:
+            return True
+        coordinator = ScriptedEvent.coordinator
+        with coordinator.condition:
+            if not coordinator.callback_entered:
+                coordinator.condition.wait_for(lambda: coordinator.callback_entered or coordinator.stop_requested, timeout=1.0)
+            if coordinator.stop_requested:
+                return True
+            if not coordinator.beat_during_callback:
+                return False
+            coordinator.condition.wait_for(lambda: coordinator.stop_requested, timeout=1.0)
+            return True
+
+    def set(self) -> None:
+        self.set_called = True
+        if ScriptedEvent.coordinator is not None:
+            ScriptedEvent.coordinator.request_stop()
+
+
+class InlineThread:
+    instances: list["InlineThread"] = []
+
+    def __init__(self, *, target, name: str, daemon: bool) -> None:
+        self.target = target
+        self.name = name
+        self.daemon = daemon
+        self.started = False
+        with mock.patch("threading.Event", REAL_EVENT):
+            self.thread = REAL_THREAD(target=self.target, name=name, daemon=daemon)
+        self.join_timeouts: list[float] = []
+        InlineThread.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+        self.thread.start()
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeouts.append(float(timeout or 0))
+        self.thread.join(timeout=timeout)
 
 
 class DaemonHeartbeatLeaseTests(unittest.TestCase):
@@ -46,6 +132,85 @@ class DaemonHeartbeatLeaseTests(unittest.TestCase):
         self.assertEqual([2.0, 2.0, 1.0], slept)
         self.assertEqual("1003", (self.repo / ".refactor-loop" / "heartbeats" / "python-daemon.ts").read_text().strip())
         self.assertEqual([], list((self.repo / ".refactor-loop" / "heartbeats").glob("*.tmp.*")))
+
+    def test_run_with_lease_periodically_renews_heartbeat_during_callback(self) -> None:
+        ScriptedEvent.instances = []
+        ScriptedEvent.coordinator = HeartbeatCoordinator()
+        InlineThread.instances = []
+        times = iter([2000, 2001])
+        lease = DaemonHeartbeatLease(
+            "python-daemon",
+            self.repo,
+            heartbeat_interval=7,
+            clock=lambda: next(times),
+        )
+        expected = [object()]
+        original_beat = lease.beat
+
+        def beat() -> None:
+            original_beat()
+            if ScriptedEvent.coordinator is not None:
+                ScriptedEvent.coordinator.record_beat()
+
+        lease.beat = beat
+
+        with mock.patch("codex_refactor_loop.heartbeat.threading.Event", ScriptedEvent), mock.patch(
+            "codex_refactor_loop.heartbeat.threading.Thread",
+            InlineThread,
+        ):
+
+            def callback():
+                assert ScriptedEvent.coordinator is not None
+                ScriptedEvent.coordinator.enter_callback()
+                self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_callback_is_pending())
+                return expected
+
+            result = lease.run_with_lease(callback)
+
+        self.assertIs(result, expected)
+        self.assertTrue(ScriptedEvent.coordinator.beat_during_callback)
+        self.assertGreaterEqual(ScriptedEvent.instances[0].wait_timeouts.count(7.0), 1)
+        self.assertTrue(ScriptedEvent.instances[0].set_called)
+        self.assertTrue(InlineThread.instances[0].started)
+        self.assertTrue(InlineThread.instances[0].daemon)
+        self.assertEqual(InlineThread.instances[0].name, "python-daemon-heartbeat-renewer")
+        self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
+        self.assertEqual("2000", (self.repo / ".refactor-loop" / "heartbeats" / "python-daemon.ts").read_text().strip())
+        ScriptedEvent.coordinator = None
+
+    def test_run_with_lease_propagates_exception_and_stops_renewer(self) -> None:
+        ScriptedEvent.instances = []
+        ScriptedEvent.coordinator = HeartbeatCoordinator()
+        InlineThread.instances = []
+        lease = DaemonHeartbeatLease("python-daemon", self.repo, heartbeat_interval=7, clock=lambda: 2000)
+        original_beat = lease.beat
+
+        def beat() -> None:
+            original_beat()
+            if ScriptedEvent.coordinator is not None:
+                ScriptedEvent.coordinator.record_beat()
+
+        lease.beat = beat
+
+        with mock.patch("codex_refactor_loop.heartbeat.threading.Event", ScriptedEvent), mock.patch(
+            "codex_refactor_loop.heartbeat.threading.Thread",
+            InlineThread,
+        ):
+
+            def callback() -> None:
+                assert ScriptedEvent.coordinator is not None
+                ScriptedEvent.coordinator.enter_callback()
+                self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_callback_is_pending())
+                raise RuntimeError("boom")
+
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                lease.run_with_lease(callback)
+
+        self.assertTrue(ScriptedEvent.coordinator.beat_during_callback)
+        self.assertTrue(ScriptedEvent.instances[0].set_called)
+        self.assertTrue(InlineThread.instances[0].started)
+        self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
+        ScriptedEvent.coordinator = None
 
     def test_lease_requires_repo_root_context_or_explicit_heartbeat_file(self) -> None:
         old_env = os.environ.copy()

--- a/skills/codex-refactor-loop/scripts/test_daemon_heartbeat.py
+++ b/skills/codex-refactor-loop/scripts/test_daemon_heartbeat.py
@@ -146,6 +146,8 @@ class DaemonHeartbeatLeaseTests(unittest.TestCase):
         )
         expected = [object()]
         original_beat = lease.beat
+        original_replace = os.replace
+        replace_sources: list[Path] = []
 
         def beat() -> None:
             original_beat()
@@ -154,15 +156,20 @@ class DaemonHeartbeatLeaseTests(unittest.TestCase):
 
         lease.beat = beat
 
+        def record_replace(src: Path | str, dst: Path | str) -> None:
+            replace_sources.append(Path(src))
+            original_replace(src, dst)
+
         with mock.patch("codex_refactor_loop.heartbeat.threading.Event", ScriptedEvent), mock.patch(
             "codex_refactor_loop.heartbeat.threading.Thread",
             InlineThread,
-        ):
+        ), mock.patch("codex_refactor_loop.heartbeat.os.replace", side_effect=record_replace):
 
             def callback():
                 assert ScriptedEvent.coordinator is not None
                 ScriptedEvent.coordinator.enter_callback()
                 self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_callback_is_pending())
+                lease.beat()
                 return expected
 
             result = lease.run_with_lease(callback)
@@ -175,7 +182,11 @@ class DaemonHeartbeatLeaseTests(unittest.TestCase):
         self.assertTrue(InlineThread.instances[0].daemon)
         self.assertEqual(InlineThread.instances[0].name, "python-daemon-heartbeat-renewer")
         self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
-        self.assertEqual("2000", (self.repo / ".refactor-loop" / "heartbeats" / "python-daemon.ts").read_text().strip())
+        self.assertEqual(2, len(replace_sources))
+        self.assertEqual(2, len(set(replace_sources)))
+        self.assertTrue(all(path.name.startswith(".python-daemon.ts.tmp.") for path in replace_sources))
+        self.assertIn((self.repo / ".refactor-loop" / "heartbeats" / "python-daemon.ts").read_text().strip(), {"2000", "2001"})
+        self.assertEqual([], list((self.repo / ".refactor-loop" / "heartbeats").glob("*.tmp.*")))
         ScriptedEvent.coordinator = None
 
     def test_run_with_lease_propagates_exception_and_stops_renewer(self) -> None:

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -7,7 +7,6 @@ import json
 import subprocess
 import sys
 import tempfile
-import threading as real_threading
 import unittest
 from contextlib import redirect_stdout
 from datetime import datetime, timedelta, timezone
@@ -19,10 +18,6 @@ from unittest import mock
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-REAL_CONDITION = real_threading.Condition
-REAL_EVENT = real_threading.Event
-REAL_THREAD = real_threading.Thread
-
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.issue_decomposition import issue_decomposition_plan_file_digest
 from codex_refactor_loop import labels
@@ -32,7 +27,6 @@ from codex_refactor_loop.wakeup_runner import (
     RunnerResult,
     SUPPORTED_CONTROLLER_ACTIONS,
     _log_tick_status,
-    _run_once_with_periodic_heartbeat,
     _wakeup_tick_action,
     main as wakeup_runner_main,
     _source_log_has_clean_marker,
@@ -266,102 +260,6 @@ class FakeReviewFixActions(FakeActions):
         (self.repo / prompt_path).parent.mkdir(parents=True, exist_ok=True)
         (self.repo / prompt_path).write_text("headless rendered prompt\n", encoding="utf-8")
         return type("Spec", (), {"prompt_path": prompt_path, "log_path": log_path})()
-
-
-class FakeHeartbeatLease:
-    heartbeat_interval = 7
-
-    def __init__(self) -> None:
-        self.beats = 0
-        self.coordinator: HeartbeatCoordinator | None = None
-
-    def beat(self) -> None:
-        self.beats += 1
-        if self.coordinator is not None:
-            self.coordinator.record_beat()
-
-
-class HeartbeatCoordinator:
-    def __init__(self) -> None:
-        self.condition = REAL_CONDITION()
-        self.run_once_entered = False
-        self.beat_during_run_once = False
-        self.stop_requested = False
-        self.waiting_for_stop = False
-
-    def enter_run_once(self) -> None:
-        with self.condition:
-            self.run_once_entered = True
-            self.condition.notify_all()
-
-    def record_beat(self) -> None:
-        with self.condition:
-            if self.run_once_entered and not self.stop_requested:
-                self.beat_during_run_once = True
-            self.condition.notify_all()
-
-    def wait_for_heartbeat_while_run_once_is_pending(self) -> bool:
-        with self.condition:
-            return self.condition.wait_for(lambda: self.beat_during_run_once, timeout=1.0)
-
-    def request_stop(self) -> None:
-        with self.condition:
-            self.stop_requested = True
-            self.condition.notify_all()
-
-
-class ScriptedEvent:
-    instances: list["ScriptedEvent"] = []
-    coordinator: HeartbeatCoordinator | None = None
-
-    def __init__(self) -> None:
-        self.wait_timeouts: list[float] = []
-        self.set_called = False
-        ScriptedEvent.instances.append(self)
-
-    def wait(self, timeout: float | None = None) -> bool:
-        self.wait_timeouts.append(float(timeout or 0))
-        if ScriptedEvent.coordinator is None:
-            return True
-        coordinator = ScriptedEvent.coordinator
-        with coordinator.condition:
-            if not coordinator.run_once_entered:
-                coordinator.condition.wait_for(lambda: coordinator.run_once_entered or coordinator.stop_requested, timeout=1.0)
-            if coordinator.stop_requested:
-                return True
-            if not coordinator.beat_during_run_once:
-                return False
-            coordinator.waiting_for_stop = True
-            coordinator.condition.notify_all()
-            coordinator.condition.wait_for(lambda: coordinator.stop_requested, timeout=1.0)
-            return True
-
-    def set(self) -> None:
-        self.set_called = True
-        if ScriptedEvent.coordinator is not None:
-            ScriptedEvent.coordinator.request_stop()
-
-
-class InlineThread:
-    instances: list["InlineThread"] = []
-
-    def __init__(self, *, target, name: str, daemon: bool) -> None:
-        self.target = target
-        self.name = name
-        self.daemon = daemon
-        self.started = False
-        with mock.patch("threading.Event", REAL_EVENT):
-            self.thread = REAL_THREAD(target=self.target, name=name, daemon=daemon)
-        self.join_timeouts: list[float] = []
-        InlineThread.instances.append(self)
-
-    def start(self) -> None:
-        self.started = True
-        self.thread.start()
-
-    def join(self, timeout: float | None = None) -> None:
-        self.join_timeouts.append(float(timeout or 0))
-        self.thread.join(timeout=timeout)
 
 
 class WakeupRunnerBehaviorTests(unittest.TestCase):
@@ -3800,64 +3698,6 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                 results = self.run_result(self.base_plan(action), actions=actions)
 
                 self.assert_blocked_before_dispatch(results, action["action_id"], reason, actions)
-
-    def test_daemon_run_once_periodically_renews_heartbeat_during_long_tick(self) -> None:
-        ScriptedEvent.instances = []
-        ScriptedEvent.coordinator = HeartbeatCoordinator()
-        InlineThread.instances = []
-        lease = FakeHeartbeatLease()
-        lease.coordinator = ScriptedEvent.coordinator
-        expected = [object()]
-
-        with mock.patch("codex_refactor_loop.wakeup_runner.threading.Event", ScriptedEvent), mock.patch(
-            "codex_refactor_loop.wakeup_runner.threading.Thread",
-            InlineThread,
-        ):
-
-            def run_once():
-                ScriptedEvent.coordinator.enter_run_once()
-                self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_run_once_is_pending())
-                return expected
-
-            result = _run_once_with_periodic_heartbeat(run_once, lease)
-
-        self.assertIs(result, expected)
-        self.assertGreaterEqual(lease.beats, 1)
-        self.assertTrue(ScriptedEvent.coordinator.beat_during_run_once)
-        self.assertGreaterEqual(ScriptedEvent.instances[0].wait_timeouts.count(7.0), 1)
-        self.assertTrue(ScriptedEvent.instances[0].set_called)
-        self.assertTrue(InlineThread.instances[0].started)
-        self.assertTrue(InlineThread.instances[0].daemon)
-        self.assertEqual(InlineThread.instances[0].name, "wakeup-runner-heartbeat-renewer")
-        self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
-        ScriptedEvent.coordinator = None
-
-    def test_daemon_run_once_periodic_heartbeat_propagates_exception_and_stops_thread(self) -> None:
-        ScriptedEvent.instances = []
-        ScriptedEvent.coordinator = HeartbeatCoordinator()
-        InlineThread.instances = []
-        lease = FakeHeartbeatLease()
-        lease.coordinator = ScriptedEvent.coordinator
-
-        with mock.patch("codex_refactor_loop.wakeup_runner.threading.Event", ScriptedEvent), mock.patch(
-            "codex_refactor_loop.wakeup_runner.threading.Thread",
-            InlineThread,
-        ):
-
-            def run_once():
-                ScriptedEvent.coordinator.enter_run_once()
-                self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_run_once_is_pending())
-                raise RuntimeError("boom")
-
-            with self.assertRaisesRegex(RuntimeError, "boom"):
-                _run_once_with_periodic_heartbeat(run_once, lease)
-
-        self.assertGreaterEqual(lease.beats, 1)
-        self.assertTrue(ScriptedEvent.coordinator.beat_during_run_once)
-        self.assertTrue(ScriptedEvent.instances[0].set_called)
-        self.assertTrue(InlineThread.instances[0].started)
-        self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
-        ScriptedEvent.coordinator = None
 
     def test_wakeup_runner_continues_after_blocked_non_spawn_lifecycle_action(self) -> None:
         blocked_lifecycle = self.implementation_output_action(


### PR DESCRIPTION
## 修改文件
- `heartbeat.py`: 新增共享 `DaemonHeartbeatLease.run_with_lease()`，在 callable 未返回期间周期续写 actor-owned heartbeat。
- `wakeup_runner.py`: 删除私有周期续租 helper，改用共享 heartbeat helper。
- `phase9/router.py`、`monitors/comment.py`、`monitors/progress.py`、`monitors/concurrency.py`、`closed_label_reconciler.py`: persistent daemon tick body 改为通过共享 helper 执行，tick 间仍用 `sleep_with_lease()`。
- `test_daemon_heartbeat.py`、`test_wakeup_runner.py`: 将周期续租行为测试迁移到 heartbeat owner，移除 wakeup runner 私有 helper 覆盖。

## 测试结果
- Scoped verification hints: 277 passed, 250 subtests passed.
- Compile: `python3 -m compileall skills/codex-refactor-loop/scripts skills/sshx -q` passed.
- Required host test command: 1801 passed, 1 skipped, 5485 subtests passed; `skills/sshx/tests` 13 passed.
- Architecture guard: `guards skipped: CI_GUARDS unset`.

## deviation 记录
- No scope extension.
- No schema/protocol files changed.
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

Closes #634

⟦AI:AUTO-LOOP⟧
