### PR TITLE
收紧实现派发预留 PR 边界

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
@@ -300,7 +300,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         lease.beat()
         interval = max(1, int(args.interval_seconds))
         while True:
-            reconciler.run_once(beat=lease.beat)
+            lease.run_with_lease(lambda: reconciler.run_once(beat=lease.beat))
             lease.sleep_with_lease(interval)
     return reconciler.run_once()
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -98,6 +98,11 @@ ROLLUP_AUTO_MERGE_POLICY_LINE = _utf8_hex(
 ROLLUP_SINGLETON_POLICY_LINE = _utf8_hex(
     "2d20e8afa520505220e698af2072656c6561736520726f6c6c75702073696e676c65746f6e3be5b7b2e69c89206f70656e20726f6c6c757020e697b620636f6e74726f6c6c657220e58faae69bb4e696b0206865616420e5928c20626f64792ce4b88de5bc80e696b0205052e38082"
 )
+IMPLEMENTATION_RESERVATION_TITLE_PREFIX = _utf8_hex("e9a284e795992069737375652023")
+IMPLEMENTATION_RESERVATION_TITLE_SUFFIX = _utf8_hex("20e5ae9ee78eb0e58886e694af")
+IMPLEMENTATION_RESERVATION_FILES_HEADING = _utf8_hex("232320e4bfaee694b9e69687e4bbb60a0a")
+IMPLEMENTATION_RESERVATION_TESTS_HEADING = _utf8_hex("232320e6b58be8af95e7bb93e69e9c0a0a")
+IMPLEMENTATION_RESERVATION_DEVIATION_HEADING = _utf8_hex("232320646576696174696f6e20e8aeb0e5bd950a0a")
 
 
 class ControllerActions:
@@ -991,6 +996,9 @@ class ControllerActions:
         if pr_error:
             sys.stderr.write(f"publish_implementation_output: {pr_error}\n")
             return 2
+        if pr_target is None:
+            sys.stderr.write("publish_implementation_output: matching_pr_missing\n")
+            return 2
         committed = self._commit_publish_implementation_diff(action, issue_target, head_ref, worktree)
         if committed != 0:
             return committed
@@ -1004,13 +1012,6 @@ class ControllerActions:
         pushed = self.safe_push(branch=head_ref, worktree=worktree)
         if pushed != 0:
             return pushed
-        if pr_target is None:
-            pr_target, _url = self.open_pr_with_label(
-                self._implementation_pr_title(action, issue_target),
-                str(self._implementation_pr_body_file(action, issue_target)),
-                base=self.integration_branch,
-                head=head_ref,
-            )
         return self.dispatch_reviewers({"target_kind": "PR", "target_number": pr_target})
 
     def _validate_publish_implementation_identity(
@@ -1191,6 +1192,15 @@ class ControllerActions:
         cluster_id = str(action["cluster_id"])
         iteration = str(action["iteration"])
         worktree, branch = self.fresh_safe_worktree(iteration, cluster_id, self.integration_branch)
+        reservation = self._reserve_implementation_pr(
+            action=action,
+            issue_target=number,
+            cluster_id=cluster_id,
+            branch=branch,
+            worktree=worktree,
+        )
+        if reservation != 0:
+            return reservation
         log = self.ctx.paths.logs / f"implement-{cluster_id}.log"
         self._clear_stale_implement_log_for_fresh_dispatch(log, action)
         prompt = self.ctx.paths.prompts / f"implement-{cluster_id}.md"
@@ -1223,6 +1233,71 @@ class ControllerActions:
             reason=f"issue #{number} consensus implementation",
         )
         return 0
+
+    def _reserve_implementation_pr(
+        self,
+        *,
+        action: Mapping[str, object],
+        issue_target: str,
+        cluster_id: str,
+        branch: str,
+        worktree: Path,
+    ) -> int:
+        body = self._reservation_implementation_pr_body(action, issue_target, cluster_id)
+        commit = self._git_in(worktree, ["commit", "--allow-empty", "-m", f"Reserve implementation PR for issue #{issue_target}"], check=False)
+        if commit.returncode != 0:
+            sys.stderr.write(
+                "dispatch_consensus_implementation: reservation_commit_failed: "
+                f"{_single_line(commit.stderr or commit.stdout)}\n"
+            )
+            return 2
+        pushed = self.safe_push(branch=branch, worktree=worktree)
+        if pushed != 0:
+            sys.stderr.write("dispatch_consensus_implementation: reservation_push_failed\n")
+            return pushed
+        try:
+            self.open_pr_with_label(
+                f"{IMPLEMENTATION_RESERVATION_TITLE_PREFIX}{issue_target}{IMPLEMENTATION_RESERVATION_TITLE_SUFFIX}",
+                self.ctx.durable_artifact_path(body),
+                base=self.integration_branch,
+                head=branch,
+            )
+        except Exception as exc:
+            sys.stderr.write(f"dispatch_consensus_implementation: reservation_pr_open_failed: {_single_line(str(exc))}\n")
+            return 2
+        pr_error, pr_target = self._matching_implementation_pr(branch, issue_target)
+        if pr_error or pr_target is None:
+            sys.stderr.write(f"dispatch_consensus_implementation: reservation_pr_unverified: {pr_error or 'matching_pr_missing'}\n")
+            return 2
+        return 0
+
+    def _reservation_implementation_pr_body(
+        self,
+        action: Mapping[str, object],
+        issue_target: str,
+        cluster_id: str,
+    ) -> Path:
+        path = self.ctx.paths.runs / f"implementation-reservation-{cluster_id}-body.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        body = (
+            IMPLEMENTATION_RESERVATION_FILES_HEADING
+            +
+            f"{str(action.get('scope_paths') or '').strip() or '- pending implementation'}\n\n"
+            +
+            IMPLEMENTATION_RESERVATION_TESTS_HEADING
+            +
+            "- pending implementation\n\n"
+            +
+            IMPLEMENTATION_RESERVATION_DEVIATION_HEADING
+            +
+            "- none\n\n"
+            +
+            f"Closes #{issue_target}\n\n"
+            +
+            f"{FINAL_SENTINEL}\n"
+        )
+        path.write_text(body, encoding="utf-8")
+        return path
 
     def _move_issue_to_implementing_phase(self, issue_target: str) -> int:
         add_labels = (labels.MANAGED, labels.PHASE_IMPLEMENTING, labels.HUMAN_AUTO)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -1012,7 +1012,30 @@ class ControllerActions:
         pushed = self.safe_push(branch=head_ref, worktree=worktree)
         if pushed != 0:
             return pushed
+        updated = self._update_existing_implementation_pr(pr_target, action, issue_target)
+        if updated != 0:
+            return updated
         return self.dispatch_reviewers({"target_kind": "PR", "target_number": pr_target})
+
+    def _update_existing_implementation_pr(
+        self,
+        pr_target: int,
+        action: Mapping[str, object],
+        issue_target: str,
+    ) -> int:
+        pr_target = str(pr_target)
+        if not self._require_github_actor_or_return("publish-implementation-output", code=3):
+            return 3
+        title = self._implementation_pr_title(action, issue_target)
+        body_file = self.ctx.durable_artifact_path(self._implementation_pr_body_file(action, issue_target))
+        result = self.gh(
+            ["pr", "edit", pr_target, "--title", title, "--body-file", body_file],
+            check=False,
+        )
+        if result.returncode != 0:
+            sys.stderr.write(f"publish_implementation_output: pr_update_failed: {_single_line(result.stderr or result.stdout)}\n")
+            return result.returncode or 2
+        return 0
 
     def _validate_publish_implementation_identity(
         self,

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/heartbeat.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/heartbeat.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 import time
 from pathlib import Path
+from typing import Callable, TypeVar
 
 from .context import LoopContext
+
+T = TypeVar("T")
 
 
 class DaemonHeartbeatLease:
@@ -49,7 +53,7 @@ class DaemonHeartbeatLease:
     def beat(self) -> None:
         """Atomically write the current integer epoch heartbeat."""
         self.heartbeat_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.heartbeat_file.with_name(f".{self.heartbeat_file.name}.tmp.{os.getpid()}")
+        tmp = self.heartbeat_file.with_name(f".{self.heartbeat_file.name}.tmp.{os.getpid()}.{threading.get_ident()}")
         tmp.write_text(f"{int(self.clock())}\n", encoding="utf-8")
         os.replace(tmp, self.heartbeat_file)
 
@@ -61,6 +65,26 @@ class DaemonHeartbeatLease:
             self.sleeper(chunk)
             self.beat()
             remaining -= chunk
+
+    def run_with_lease(self, callback: Callable[[], T]) -> T:
+        """Renew the heartbeat periodically while callback is still running."""
+        stop = threading.Event()
+
+        def renew_lease() -> None:
+            while not stop.wait(max(1.0, float(self.heartbeat_interval))):
+                self.beat()
+
+        renewer = threading.Thread(
+            target=renew_lease,
+            name=f"{self.name}-heartbeat-renewer",
+            daemon=True,
+        )
+        renewer.start()
+        try:
+            return callback()
+        finally:
+            stop.set()
+            renewer.join(timeout=1.0)
 
 
 def beat(name: str | None = None, repo_root: Path | str | None = None) -> None:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/comment.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/comment.py
@@ -65,7 +65,7 @@ class CommentMonitor:
 
     def run_forever(self) -> int:
         while True:
-            self.tick()
+            self.heartbeat.run_with_lease(self.tick)
             self.heartbeat.beat()
             self.heartbeat.sleep_with_lease(self.interval)
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -662,7 +662,7 @@ class ConcurrencyMonitor:
         lease = DaemonHeartbeatLease("concurrency_monitor", self.repo_root)
         while True:
             try:
-                self.tick()
+                lease.run_with_lease(self.tick)
             except Exception as exc:
                 log(f"EXCEPTION in tick: {exc!r}")
             lease.beat()

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/progress.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/progress.py
@@ -69,7 +69,7 @@ class ProgressReporter:
     def run_forever(self) -> int:
         while True:
             self.log_msg("tick")
-            self.tick()
+            self.heartbeat.run_with_lease(self.tick)
             self.heartbeat.beat()
             self.heartbeat.sleep_with_lease(self.interval)
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -2040,7 +2040,7 @@ def main(argv: list[str] | None = None, command_runner: Callable[[dict[str, obje
         lease = DaemonHeartbeatLease("phase9_router_daemon", repo_root)
         while True:
             try:
-                router.tick()
+                lease.run_with_lease(router.tick)
             except Exception as exc:
                 print(f"[{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}] EXCEPTION in tick: {exc!r}", flush=True)
             lease.beat()

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -1183,11 +1183,13 @@ def completed_marker_actions(
             action["preconditions"] = ["active_controller_owner", "clean_exit_source_marker", "live_open_target", "live_managed_target"]
         if action["controller_action"] == "publish_implementation_output":
             _attach_implementation_pr_artifacts(repo_root, action)
+        _apply_remote_ci_fix_done_target_gate(action, open_targets)
         target = _action_target_key(action)
         if (
             open_targets is not None
             and target is not None
             and target not in open_targets
+            and not action.get("status_only")
             and not marker.startswith("META_JUDGE_DONE:consensus")
             and controller_action_from_marker(marker) != "close_managed_item_from_drop_marker"
         ):
@@ -1432,6 +1434,35 @@ def _action_target_key(action: dict[str, Any]) -> tuple[str, int] | None:
     number = action.get("target_number")
     if kind in {"PR", "issue"} and isinstance(number, int):
         return kind, number
+    return None
+
+
+def _apply_remote_ci_fix_done_target_gate(action: dict[str, Any], open_targets: set[tuple[str, int]] | None) -> None:
+    if action.get("controller_action") != "dispatch_remote_ci_fix":
+        return
+    reason = _remote_ci_fix_done_target_suppressed_reason(action, open_targets)
+    if not reason:
+        return
+    action["status_only"] = True
+    action["no_lifecycle_authority"] = True
+    action["suppressed_reason"] = reason
+    action.pop("runner_authority", None)
+    action.pop("no_generic_command", None)
+
+
+def _remote_ci_fix_done_target_suppressed_reason(
+    action: dict[str, Any],
+    open_targets: set[tuple[str, int]] | None,
+) -> str | None:
+    target = _action_target_key(action)
+    if target is None:
+        return "remote_ci_fix_target_missing"
+    if target[0] != "PR":
+        return "remote_ci_fix_target_not_pr"
+    if open_targets is None:
+        return "open_managed_read_model_unavailable"
+    if target not in open_targets:
+        return "target_not_open"
     return None
 
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -3967,7 +3967,7 @@ def _stale_publish_implementation_reason(
         "fresh_integration_base",
         "single_linked_managed_issue",
         "worker_authored_pr_artifacts",
-        "no_conflicting_open_implementation_pr",
+        "matching_open_managed_pr",
         "host_checks_green",
         "clean_scoped_diff",
     ):
@@ -3990,7 +3990,7 @@ def _matching_open_pr_error(
         return "single_linked_managed_issue_missing"
     matches = [item for item in gh_items if item.kind == "PR" and item.head_ref == head_ref]
     if not matches:
-        return None
+        return "matching_pr_missing"
     if len(matches) > 1:
         return "multiple_matching_open_pr"
     pr = matches[0]

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -8,7 +8,6 @@ import os
 import re
 import subprocess
 import sys
-import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1824,25 +1823,6 @@ def _release_int(value: Any, default: int) -> int:
     return parsed if parsed > 0 else default
 
 
-def _run_once_with_periodic_heartbeat(
-    run_once: Callable[[], list[RunnerResult]],
-    lease: DaemonHeartbeatLease,
-) -> list[RunnerResult]:
-    stop = threading.Event()
-
-    def renew_lease() -> None:
-        while not stop.wait(max(1.0, float(lease.heartbeat_interval))):
-            lease.beat()
-
-    renewer = threading.Thread(target=renew_lease, name="wakeup-runner-heartbeat-renewer", daemon=True)
-    renewer.start()
-    try:
-        return run_once()
-    finally:
-        stop.set()
-        renewer.join(timeout=1.0)
-
-
 def load_plan_file(path: Path) -> Mapping[str, Any]:
     data = read_json(path, {})
     return data if isinstance(data, dict) else {}
@@ -1873,7 +1853,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         lease.beat()
         interval = max(1, int(args.interval_seconds))
         while True:
-            results = _run_once_with_periodic_heartbeat(runner.run_once, lease)
+            results = lease.run_with_lease(runner.run_once)
             _log_tick_status("wakeup-runner", _wakeup_tick_action(results))
             lease.sleep_with_lease(interval)
     results = runner.run_once()

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -794,7 +794,7 @@ class WakeupRunner:
             "host_checks_green",
             "single_linked_managed_issue",
             "worker_authored_pr_artifacts",
-            "no_conflicting_open_implementation_pr",
+            "matching_open_managed_pr",
         ):
             if required not in preconditions:
                 return f"publish_implementation_missing_precondition:{required}"
@@ -808,7 +808,7 @@ class WakeupRunner:
         worktree_error = self._validate_implementation_worktree(action)
         if worktree_error:
             return worktree_error
-        return self._validate_no_conflicting_open_implementation_pr(action)
+        return self._validate_matching_open_implementation_pr(action)
 
     def _validate_implementation_pr_artifacts(self, action: Mapping[str, Any]) -> str | None:
         target = action.get("target_number")
@@ -941,7 +941,7 @@ class WakeupRunner:
             return "rollup_auto_merge_base_mismatch"
         return None
 
-    def _validate_no_conflicting_open_implementation_pr(self, action: Mapping[str, Any]) -> str | None:
+    def _validate_matching_open_implementation_pr(self, action: Mapping[str, Any]) -> str | None:
         head_ref = str(action.get("head_ref") or "").strip()
         if not _safe_branch_name(head_ref):
             return "publish_implementation_invalid_head_ref"
@@ -955,7 +955,7 @@ class WakeupRunner:
         if not isinstance(payload, list):
             return "publish_implementation_matching_pr_invalid_json"
         if len(payload) == 0:
-            return None
+            return "publish_implementation_matching_pr_missing"
         if len(payload) > 1:
             return "publish_implementation_multiple_matching_open_pr"
         pr = payload[0]

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -175,9 +175,10 @@ class ControllerActionsTests(unittest.TestCase):
             with self.subTest(helper=helper):
                 self.assertIn(helper, source)
 
-    def test_publish_implementation_source_locks_stale_base_and_real_pr_open_contract(self) -> None:
+    def test_publish_implementation_source_locks_stale_base_and_existing_pr_contract(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")
         publish_body = source[source.index("    def publish_implementation_output") : source.index("    def _validate_publish_implementation_identity")]
+        dispatch_body = source[source.index("    def dispatch_consensus_implementation") : source.index("    def _reserve_implementation_pr")]
         for token in (
             "def _recover_publish_implementation_base",
             '["fetch", "origin"]',
@@ -192,15 +193,18 @@ class ControllerActionsTests(unittest.TestCase):
             "publish_implementation_output: delegated fallback resolver",
             "def _matching_implementation_pr",
             "matching_pr_issue_mismatch",
+            "matching_pr_missing",
             "implementation_produced_no_diff",
-            "self.open_pr_with_label",
             "return self.dispatch_reviewers",
+            "def _reserve_implementation_pr",
+            "Reserve implementation PR for issue",
+            "self.open_pr_with_label",
         ):
             with self.subTest(token=token):
                 self.assertIn(token, source)
         self.assertNotIn("def _open_pr_for_head", source)
-        self.assertIn("open_pr_with_label", publish_body)
-        self.assertNotIn("_reserve_implementation_pr", source)
+        self.assertNotIn("open_pr_with_label", publish_body)
+        self.assertIn("_reserve_implementation_pr", dispatch_body)
         self.assertNotIn("_placeholder_implementation_pr_body", source)
 
     def test_pr_open_helpers_do_not_use_legacy_branch_alias_values(self) -> None:
@@ -408,6 +412,19 @@ class ControllerActionsTests(unittest.TestCase):
             encoding="utf-8",
         )
         return title, body
+
+    def matching_implementation_pr_payload(self, issue: int, head_ref: str, pr_number: int = 414) -> str:
+        return json.dumps(
+            [
+                {
+                    "number": pr_number,
+                    "baseRefName": "canonical-integration",
+                    "headRefName": head_ref,
+                    "labels": [{"name": labels.MANAGED}],
+                    "body": f"Closes #{issue}\n",
+                }
+            ]
+        )
 
     def run_git(self, repo: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         result = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, check=False)
@@ -1329,7 +1346,7 @@ class ControllerActionsTests(unittest.TestCase):
 
         self.assertIn("publish_implementation_output: implementation_produced_no_diff", stderr.getvalue())
 
-    def test_publish_implementation_output_commits_pushes_opens_real_pr_then_dispatches_reviewers(self) -> None:
+    def test_publish_implementation_output_fails_closed_when_matching_pr_missing(self) -> None:
         worktree = self.tmp / ".worktrees" / "iter77-issue-77"
         worktree.mkdir(parents=True)
         self.write_implementation_pr_artifacts()
@@ -1352,78 +1369,34 @@ class ControllerActionsTests(unittest.TestCase):
             raise AssertionError(f"unexpected gh call: {args}")
 
         def fake_run(args: list[str], **kwargs: object) -> mock.Mock:
-            if args[:2] == ["bash", "-lc"]:
-                sequence.append(f"host:{args[2]}")
-                return mock.Mock(returncode=0, stdout="", stderr="")
             if args == ["git", "-C", str(worktree), "diff", "HEAD", "--quiet"]:
                 sequence.append("git:diff-head")
                 return mock.Mock(returncode=1, stdout="", stderr="")
             if args == ["git", "-C", str(worktree), "rev-parse", "--abbrev-ref", "HEAD"]:
                 sequence.append("git:branch")
                 return mock.Mock(returncode=0, stdout="refactor/iter77-issue-77\n", stderr="")
-            if args == ["git", "-C", str(worktree), "fetch", "origin"]:
-                sequence.append("git:fetch-origin")
-                return mock.Mock(returncode=0, stdout="", stderr="")
-            if args == ["git", "-C", str(worktree), "merge-base", "HEAD", "origin/canonical-integration"]:
-                sequence.append("git:merge-base")
-                return mock.Mock(returncode=0, stdout="base-sha\n", stderr="")
-            if args == ["git", "-C", str(worktree), "rev-parse", "--verify", "origin/canonical-integration"]:
-                sequence.append("git:origin-base")
-                return mock.Mock(returncode=0, stdout="base-sha\n", stderr="")
-            if args == ["git", "-C", str(worktree), "status", "--porcelain"]:
-                sequence.append("git:status")
-                return mock.Mock(returncode=0, stdout=" M implementation.txt\n", stderr="")
-            if args == ["git", "-C", str(worktree), "add", "-A"]:
-                sequence.append("git:add")
-                return mock.Mock(returncode=0, stdout="", stderr="")
-            if args == ["git", "-C", str(worktree), "commit", "-m", "实现 issue #77"]:
-                sequence.append("git:commit")
-                return mock.Mock(returncode=0, stdout="", stderr="")
             raise AssertionError(f"unexpected subprocess call: {args!r}")
 
-        def fake_safe_push(*, branch: str, worktree: Path) -> int:
-            sequence.append("safe_push")
-            self.assertEqual("refactor/iter77-issue-77", branch)
-            return 0
-
-        def fake_dispatch(review_action: Mapping[str, object]) -> int:
-            sequence.append("dispatch_reviewers")
-            self.assertEqual({"target_kind": "PR", "target_number": 414}, dict(review_action))
-            return 0
-
+        err = io.StringIO()
         with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
             with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
                 with mock.patch("codex_refactor_loop.controller_actions.subprocess.run", side_effect=fake_run):
-                    with mock.patch.object(self.actions, "safe_push", side_effect=fake_safe_push):
-                        with mock.patch.object(self.actions, "open_pr_with_label", return_value=(414, "https://github.com/owner/repo/pull/414")) as open_pr:
-                            with mock.patch.object(self.actions, "dispatch_reviewers", side_effect=fake_dispatch):
-                                self.assertEqual(0, self.actions.publish_implementation_output(action))
-
-        open_pr.assert_called_once()
-        open_args, open_kwargs = open_pr.call_args
-        self.assertEqual("完成 issue #77 的发布契约", open_args[0])
-        self.assertEqual((self.tmp / ".refactor-loop/runs/implementation-pr-issue-77-body.md").resolve(), Path(open_args[1]).resolve())
-        self.assertEqual({"base": "canonical-integration", "head": "refactor/iter77-issue-77"}, open_kwargs)
+                    with mock.patch.object(self.actions, "safe_push", side_effect=AssertionError("must not push")):
+                        with mock.patch.object(self.actions, "open_pr_with_label", side_effect=AssertionError("publish must not open PR")):
+                            with mock.patch.object(self.actions, "dispatch_reviewers", side_effect=AssertionError("must not dispatch reviewers")):
+                                with mock.patch("sys.stderr", err):
+                                    self.assertEqual(2, self.actions.publish_implementation_output(action))
 
         self.assertEqual(
             sequence,
             [
                 "git:branch",
                 "git:diff-head",
-                "git:status",
-                "git:add",
-                "git:commit",
-                "git:fetch-origin",
-                "git:merge-base",
-                "git:origin-base",
-                "host:true",
-                "host:python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'",
-                "safe_push",
-                "dispatch_reviewers",
             ],
         )
+        self.assertIn("publish_implementation_output: matching_pr_missing", err.getvalue())
 
-    def test_publish_implementation_output_opens_pr_for_already_committed_diff(self) -> None:
+    def test_publish_implementation_output_fails_closed_for_already_committed_diff_without_matching_pr(self) -> None:
         worktree = self.tmp / ".worktrees" / "iter77-issue-77"
         worktree.mkdir(parents=True)
         self.write_implementation_pr_artifacts()
@@ -1446,9 +1419,6 @@ class ControllerActionsTests(unittest.TestCase):
             raise AssertionError(f"unexpected gh call: {args}")
 
         def fake_run(args: list[str], **kwargs: object) -> mock.Mock:
-            if args[:2] == ["bash", "-lc"]:
-                sequence.append(f"host:{args[2]}")
-                return mock.Mock(returncode=0, stdout="", stderr="")
             if args == ["git", "-C", str(worktree), "rev-parse", "--abbrev-ref", "HEAD"]:
                 sequence.append("git:branch")
                 return mock.Mock(returncode=0, stdout="refactor/iter77-issue-77\n", stderr="")
@@ -1467,30 +1437,18 @@ class ControllerActionsTests(unittest.TestCase):
             if args == ["git", "-C", str(worktree), "status", "--porcelain"]:
                 sequence.append("git:status-clean")
                 return mock.Mock(returncode=0, stdout="", stderr="")
-            if args == ["git", "-C", str(worktree), "fetch", "origin"]:
-                sequence.append("git:fetch-origin")
-                return mock.Mock(returncode=0, stdout="", stderr="")
             raise AssertionError(f"unexpected subprocess call: {args!r}")
 
-        def fake_safe_push(*, branch: str, worktree: Path) -> int:
-            sequence.append("safe_push")
-            self.assertEqual("refactor/iter77-issue-77", branch)
-            return 0
-
-        def fake_dispatch(review_action: Mapping[str, object]) -> int:
-            sequence.append("dispatch_reviewers")
-            self.assertEqual({"target_kind": "PR", "target_number": 414}, dict(review_action))
-            return 0
-
+        err = io.StringIO()
         with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
             with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
                 with mock.patch("codex_refactor_loop.controller_actions.subprocess.run", side_effect=fake_run):
-                    with mock.patch.object(self.actions, "safe_push", side_effect=fake_safe_push):
-                        with mock.patch.object(self.actions, "open_pr_with_label", return_value=(414, "https://github.com/owner/repo/pull/414")) as open_pr:
-                            with mock.patch.object(self.actions, "dispatch_reviewers", side_effect=fake_dispatch):
-                                self.assertEqual(0, self.actions.publish_implementation_output(action))
+                    with mock.patch.object(self.actions, "safe_push", side_effect=AssertionError("must not push")):
+                        with mock.patch.object(self.actions, "open_pr_with_label", side_effect=AssertionError("publish must not open PR")):
+                            with mock.patch.object(self.actions, "dispatch_reviewers", side_effect=AssertionError("must not dispatch reviewers")):
+                                with mock.patch("sys.stderr", err):
+                                    self.assertEqual(2, self.actions.publish_implementation_output(action))
 
-        open_pr.assert_called_once()
         self.assertEqual(
             [
                 "git:branch",
@@ -1498,17 +1456,10 @@ class ControllerActionsTests(unittest.TestCase):
                 "git:origin-base",
                 "git:merge-base",
                 "git:diff-base-head",
-                "git:status-clean",
-                "git:fetch-origin",
-                "git:merge-base",
-                "git:origin-base",
-                "host:true",
-                "host:python3 -m unittest discover -s skills/codex-refactor-loop/scripts -p 'test_*.py'",
-                "safe_push",
-                "dispatch_reviewers",
             ],
             sequence,
         )
+        self.assertIn("publish_implementation_output: matching_pr_missing", err.getvalue())
 
     def test_publish_implementation_output_pushes_existing_open_pr_without_reopening(self) -> None:
         worktree = self.tmp / ".worktrees" / "iter77-issue-77"
@@ -2079,10 +2030,11 @@ class ControllerActionsTests(unittest.TestCase):
             sequence,
         )
 
-    def test_dispatch_consensus_implementation_renders_prompt_from_durable_artifact_fields(self) -> None:
+    def test_dispatch_consensus_implementation_reserves_pr_before_spawn_intent(self) -> None:
         decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-consensus-implementation", lease_id="lease", expires_at="soon")
         worktree = self.tmp / ".worktrees" / "iter413-issue-413"
         render_calls: list[dict[str, str]] = []
+        sequence: list[str] = []
 
         action = {
             "target_kind": "issue",
@@ -2100,35 +2052,56 @@ class ControllerActionsTests(unittest.TestCase):
 
         def fake_render(_template: str, output_path: str, env: Mapping[str, str] | None = None) -> None:
             assert env is not None
+            sequence.append("render_prompt")
             render_calls.append(dict(env))
             Path(output_path).write_text("rendered prompt\n", encoding="utf-8")
 
         gh_calls: list[list[str]] = []
 
         def fake_gh(args: Sequence[str], *, check: bool = True) -> mock.Mock:
+            sequence.append(f"gh:{list(args)[:3]}")
             gh_calls.append(list(args))
+            if list(args)[:4] == ["pr", "list", "--state", "open"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=self.matching_implementation_pr_payload(413, "refactor/iter413-issue-413"),
+                    stderr="",
+                )
             return mock.Mock(returncode=0, stdout="", stderr="")
 
         git_calls: list[list[str]] = []
 
         def fake_git_in(cwd: Path, args: Sequence[str], *, check: bool = True) -> mock.Mock:
+            sequence.append(f"git:{list(args)}")
             git_calls.append([str(cwd), *list(args)])
-            if args[:4] == ["ls-remote", "--exit-code", "--heads", "origin"]:
-                return mock.Mock(returncode=2, stdout="", stderr="")
             return mock.Mock(returncode=0, stdout="", stderr="")
+
+        def fake_safe_push(*, branch: str, worktree: Path) -> int:
+            sequence.append("safe_push")
+            self.assertEqual("refactor/iter413-issue-413", branch)
+            return 0
+
+        def fake_open_pr(title: str, body_file: str, *, base: str | None = None, head: str = "") -> tuple[int, str]:
+            sequence.append("open_pr")
+            self.assertEqual("预留 issue #413 实现分支", title)
+            self.assertEqual(".refactor-loop/runs/implementation-reservation-issue-413-body.md", body_file)
+            self.assertEqual("canonical-integration", base)
+            self.assertEqual("refactor/iter413-issue-413", head)
+            body = self.tmp / body_file
+            self.assertIn("Closes #413", body.read_text(encoding="utf-8"))
+            return 414, "https://github.com/owner/repo/pull/414"
 
         with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
             with mock.patch.object(self.actions, "fresh_safe_worktree", return_value=(worktree, "refactor/iter413-issue-413")) as safe_worktree:
                 with mock.patch.object(self.actions, "render_template", side_effect=fake_render):
                     with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
                         with mock.patch.object(self.actions, "_git_in", side_effect=fake_git_in):
-                            with mock.patch.object(self.actions, "open_pr_with_label", side_effect=AssertionError("dispatch must not open PR")) as open_pr:
-                                self.assertEqual(0, self.actions.dispatch_consensus_implementation(action))
-
-        open_pr.assert_not_called()
+                            with mock.patch.object(self.actions, "safe_push", side_effect=fake_safe_push):
+                                with mock.patch.object(self.actions, "open_pr_with_label", side_effect=fake_open_pr):
+                                    self.assertEqual(0, self.actions.dispatch_consensus_implementation(action))
 
         safe_worktree.assert_called_once_with("413", "issue-413", "canonical-integration")
-        self.assertEqual([], git_calls)
+        self.assertEqual([[str(worktree), "commit", "--allow-empty", "-m", "Reserve implementation PR for issue #413"]], git_calls)
         issue_edit = gh_calls[0]
         self.assertEqual(["issue", "edit", "413"], issue_edit[:3])
         self.assertEqual(
@@ -2143,6 +2116,7 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertIn("HARNESS_SPAWN_INTENT", pending)
         self.assertIn('"intent_id": "dispatch-consensus-implementation:413"', pending)
         self.assertIn('"task_id": "implement-issue-413"', pending)
+        self.assertLess(sequence.index("open_pr"), sequence.index("render_prompt"))
 
     def test_dispatch_consensus_implementation_phase_transition_failure_blocks_before_worktree(self) -> None:
         decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-consensus-implementation", lease_id="lease", expires_at="soon")
@@ -2188,6 +2162,34 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertIn(f'remove_labels="{",".join(ISSUE_LABELS_REMOVE)}"', canonical_line)
         self.assertNotIn("HARNESS_SPAWN_INTENT", pending)
 
+    def test_dispatch_consensus_implementation_reservation_failure_blocks_before_spawn(self) -> None:
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-consensus-implementation", lease_id="lease", expires_at="soon")
+        worktree = self.tmp / ".worktrees" / "iter413-issue-413"
+        action = {
+            "target_kind": "issue",
+            "target_number": 413,
+            "consensus_artifact": ".refactor-loop/runs/phase9-issue413-r5-judge.md",
+            "design_decision_path": ".refactor-loop/runs/phase9-issue413-r5-judge.md",
+            "scope_paths": "- skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py",
+            "old_pattern": "old",
+            "new_principle": "new",
+            "verification_hints": "python3 -m unittest",
+            "cluster_id": "issue-413",
+            "iteration": "413",
+            "source_ref": "gh-issue-413",
+        }
+
+        with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
+            with mock.patch.object(self.actions, "fresh_safe_worktree", return_value=(worktree, "refactor/iter413-issue-413")):
+                with mock.patch.object(self.actions, "gh", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
+                    with mock.patch.object(self.actions, "_git_in", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
+                        with mock.patch.object(self.actions, "safe_push", return_value=7):
+                            with mock.patch.object(self.actions, "open_pr_with_label", side_effect=AssertionError("must not open PR after push failure")):
+                                with mock.patch.object(self.actions, "render_template", side_effect=AssertionError("must not render implement prompt")):
+                                    self.assertEqual(7, self.actions.dispatch_consensus_implementation(action))
+
+        self.assertNotIn("HARNESS_SPAWN_INTENT", self.pending_events())
+
     def test_dispatch_consensus_implementation_intent_round_trips_through_wakeup_plan(self) -> None:
         decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-consensus-implementation", lease_id="lease", expires_at="soon")
         worktree = self.tmp / ".worktrees" / "iter413-issue-413"
@@ -2208,12 +2210,23 @@ class ControllerActionsTests(unittest.TestCase):
         def fake_render(_template: str, output_path: str, env: Mapping[str, str] | None = None) -> None:
             Path(output_path).write_text("rendered prompt\n", encoding="utf-8")
 
+        def fake_gh(args: Sequence[str], *, check: bool = True) -> mock.Mock:
+            if list(args)[:4] == ["pr", "list", "--state", "open"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=self.matching_implementation_pr_payload(413, "refactor/iter413-issue-413"),
+                    stderr="",
+                )
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
         with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
             with mock.patch.object(self.actions, "fresh_safe_worktree", return_value=(worktree, "refactor/iter413-issue-413")):
                 with mock.patch.object(self.actions, "render_template", side_effect=fake_render):
-                    with mock.patch.object(self.actions, "gh", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
-                        with mock.patch.object(self.actions, "open_pr_with_label", side_effect=AssertionError("dispatch must not open PR")):
-                            self.assertEqual(0, self.actions.dispatch_consensus_implementation(action))
+                    with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+                        with mock.patch.object(self.actions, "_git_in", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
+                            with mock.patch.object(self.actions, "safe_push", return_value=0):
+                                with mock.patch.object(self.actions, "open_pr_with_label", return_value=(414, "https://github.com/owner/repo/pull/414")):
+                                    self.assertEqual(0, self.actions.dispatch_consensus_implementation(action))
 
         pending = self.pending_events()
         self.assertRegex(pending, r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z HARNESS_SPAWN_INTENT ")
@@ -2330,12 +2343,23 @@ class ControllerActionsTests(unittest.TestCase):
         def fake_render(_template: str, output_path: str, env: Mapping[str, str] | None = None) -> None:
             Path(output_path).write_text("rendered prompt\n", encoding="utf-8")
 
+        def fake_gh(args: Sequence[str], *, check: bool = True) -> mock.Mock:
+            if list(args)[:4] == ["pr", "list", "--state", "open"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=self.matching_implementation_pr_payload(413, "refactor/iter413-issue-413"),
+                    stderr="",
+                )
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
         with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
             with mock.patch.object(self.actions, "fresh_safe_worktree", return_value=(worktree, "refactor/iter413-issue-413")) as fresh_safe_worktree:
                 with mock.patch.object(self.actions, "render_template", side_effect=fake_render):
-                    with mock.patch.object(self.actions, "gh", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
-                        with mock.patch.object(self.actions, "open_pr_with_label", side_effect=AssertionError("dispatch must not open PR")):
-                            self.assertEqual(0, self.actions.dispatch_consensus_implementation(action))
+                    with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+                        with mock.patch.object(self.actions, "_git_in", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
+                            with mock.patch.object(self.actions, "safe_push", return_value=0):
+                                with mock.patch.object(self.actions, "open_pr_with_label", return_value=(414, "https://github.com/owner/repo/pull/414")):
+                                    self.assertEqual(0, self.actions.dispatch_consensus_implementation(action))
 
         fresh_safe_worktree.assert_called_once_with("413", "issue-413", "canonical-integration")
         self.assertIn("HARNESS_SPAWN_INTENT", self.pending_events())
@@ -2363,12 +2387,23 @@ class ControllerActionsTests(unittest.TestCase):
         def fake_render(_template: str, output_path: str, env: Mapping[str, str] | None = None) -> None:
             Path(output_path).write_text("rendered prompt\n", encoding="utf-8")
 
+        def fake_gh(args: Sequence[str], *, check: bool = True) -> mock.Mock:
+            if list(args)[:4] == ["pr", "list", "--state", "open"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=self.matching_implementation_pr_payload(493, "refactor/iter493-issue-493", pr_number=494),
+                    stderr="",
+                )
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
         with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
             with mock.patch.object(self.actions, "fresh_safe_worktree", return_value=(worktree, "refactor/iter493-issue-493")):
                 with mock.patch.object(self.actions, "render_template", side_effect=fake_render):
-                    with mock.patch.object(self.actions, "gh", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
-                        with mock.patch.object(self.actions, "open_pr_with_label", side_effect=AssertionError("dispatch must not open PR")):
-                            self.assertEqual(0, self.actions.dispatch_consensus_implementation(action))
+                    with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+                        with mock.patch.object(self.actions, "_git_in", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
+                            with mock.patch.object(self.actions, "safe_push", return_value=0):
+                                with mock.patch.object(self.actions, "open_pr_with_label", return_value=(494, "https://github.com/owner/repo/pull/494")):
+                                    self.assertEqual(0, self.actions.dispatch_consensus_implementation(action))
 
         self.assertFalse(log.exists())
         projected = harness_spawn_intent_actions(

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -195,6 +195,9 @@ class ControllerActionsTests(unittest.TestCase):
             "matching_pr_issue_mismatch",
             "matching_pr_missing",
             "implementation_produced_no_diff",
+            "def _update_existing_implementation_pr",
+            '"pr", "edit", pr_target, "--title"',
+            "pr_update_failed",
             "return self.dispatch_reviewers",
             "def _reserve_implementation_pr",
             "Reserve implementation PR for issue",
@@ -412,6 +415,28 @@ class ControllerActionsTests(unittest.TestCase):
             encoding="utf-8",
         )
         return title, body
+
+    def successful_publish_pr_edit_response(self, args: Sequence[str], *, pr_number: int = 414) -> mock.Mock | None:
+        if list(args)[:3] != ["pr", "edit", str(pr_number)]:
+            return None
+        self.assertIn("--title", args)
+        self.assertIn("--body-file", args)
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    def dispatch_consensus_implementation_action(self) -> dict[str, object]:
+        return {
+            "target_kind": "issue",
+            "target_number": 413,
+            "consensus_artifact": ".refactor-loop/runs/phase9-issue413-r5-judge.md",
+            "design_decision_path": ".refactor-loop/runs/phase9-issue413-r5-judge.md",
+            "scope_paths": "- skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py",
+            "old_pattern": "old",
+            "new_principle": "new",
+            "verification_hints": "python3 -m unittest",
+            "cluster_id": "issue-413",
+            "iteration": "413",
+            "source_ref": "gh-issue-413",
+        }
 
     def matching_implementation_pr_payload(self, issue: int, head_ref: str, pr_number: int = 414) -> str:
         return json.dumps(
@@ -1461,10 +1486,10 @@ class ControllerActionsTests(unittest.TestCase):
         )
         self.assertIn("publish_implementation_output: matching_pr_missing", err.getvalue())
 
-    def test_publish_implementation_output_pushes_existing_open_pr_without_reopening(self) -> None:
+    def test_publish_implementation_output_updates_existing_open_pr_before_reviewers(self) -> None:
         worktree = self.tmp / ".worktrees" / "iter77-issue-77"
         worktree.mkdir(parents=True)
-        self.write_implementation_pr_artifacts()
+        title_file, body_file = self.write_implementation_pr_artifacts()
         decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="publish-implementation-output", lease_id="lease", expires_at="soon")
         sequence: list[str] = []
 
@@ -1487,6 +1512,11 @@ class ControllerActionsTests(unittest.TestCase):
                     ),
                     stderr="",
                 )
+            if args[:3] == ["pr", "edit", "414"]:
+                sequence.append("gh:edit-pr")
+                self.assertEqual(title_file.read_text(encoding="utf-8").strip(), args[args.index("--title") + 1])
+                self.assertEqual(self.actions.ctx.durable_artifact_path(body_file), args[args.index("--body-file") + 1])
+                return mock.Mock(returncode=0, stdout="", stderr="")
             raise AssertionError(f"unexpected gh call: {args}")
 
         action = {
@@ -1544,7 +1574,71 @@ class ControllerActionsTests(unittest.TestCase):
                                 self.assertEqual(0, self.actions.publish_implementation_output(action))
 
         self.assertIn("safe_push", sequence)
+        self.assertLess(sequence.index("safe_push"), sequence.index("gh:edit-pr"))
+        self.assertLess(sequence.index("gh:edit-pr"), sequence.index("dispatch_reviewers"))
         self.assertIn("dispatch_reviewers", sequence)
+
+    def test_publish_implementation_output_fails_closed_when_existing_pr_update_fails(self) -> None:
+        worktree = self.tmp / ".worktrees" / "iter77-issue-77"
+        worktree.mkdir(parents=True)
+        self.write_implementation_pr_artifacts()
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="publish-implementation-output", lease_id="lease", expires_at="soon")
+        sequence: list[str] = []
+        action = {
+            "source_marker": "IMPLEMENT_DONE:issue-77:ok",
+            "target_kind": "issue",
+            "target_number": 77,
+            "head_ref": "refactor/iter77-issue-77",
+            "worktree": str(worktree),
+        }
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            if args == ["issue", "view", "77", "--json", "labels,body"]:
+                return mock.Mock(returncode=0, stdout=json.dumps({"labels": [{"name": labels.MANAGED}], "body": ""}), stderr="")
+            if args[:4] == ["pr", "list", "--state", "open"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=self.matching_implementation_pr_payload(77, "refactor/iter77-issue-77"),
+                    stderr="",
+                )
+            if args[:3] == ["pr", "edit", "414"]:
+                sequence.append("gh:edit-pr-failed")
+                return mock.Mock(returncode=9, stdout="", stderr="edit failed")
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        def fake_run(args: list[str], **kwargs: object) -> mock.Mock:
+            if args[:2] == ["bash", "-lc"]:
+                sequence.append(f"host:{args[2]}")
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            if args == ["git", "-C", str(worktree), "rev-parse", "--abbrev-ref", "HEAD"]:
+                return mock.Mock(returncode=0, stdout="refactor/iter77-issue-77\n", stderr="")
+            if args == ["git", "-C", str(worktree), "fetch", "origin"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            if args == ["git", "-C", str(worktree), "merge-base", "HEAD", "origin/canonical-integration"]:
+                return mock.Mock(returncode=0, stdout="base-sha\n", stderr="")
+            if args == ["git", "-C", str(worktree), "rev-parse", "--verify", "origin/canonical-integration"]:
+                return mock.Mock(returncode=0, stdout="base-sha\n", stderr="")
+            if args == ["git", "-C", str(worktree), "diff", "HEAD", "--quiet"]:
+                return mock.Mock(returncode=1, stdout="", stderr="")
+            if args == ["git", "-C", str(worktree), "status", "--porcelain"]:
+                return mock.Mock(returncode=0, stdout=" M implementation.txt\n", stderr="")
+            if args == ["git", "-C", str(worktree), "add", "-A"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            if args == ["git", "-C", str(worktree), "commit", "-m", "实现 issue #77"]:
+                return mock.Mock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected subprocess call: {args!r}")
+
+        err = io.StringIO()
+        with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
+            with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+                with mock.patch("codex_refactor_loop.controller_actions.subprocess.run", side_effect=fake_run):
+                    with mock.patch.object(self.actions, "safe_push", return_value=0):
+                        with mock.patch.object(self.actions, "dispatch_reviewers", side_effect=AssertionError("must not dispatch reviewers")):
+                            with mock.patch("sys.stderr", err):
+                                self.assertEqual(9, self.actions.publish_implementation_output(action))
+
+        self.assertIn("gh:edit-pr-failed", sequence)
+        self.assertIn("publish_implementation_output: pr_update_failed: edit failed", err.getvalue())
 
     def test_publish_implementation_output_with_empty_diff_opens_no_pr_or_review(self) -> None:
         worktree = self.tmp / ".worktrees" / "iter77-issue-77"
@@ -1631,6 +1725,9 @@ class ControllerActionsTests(unittest.TestCase):
                     ),
                     stderr="",
                 )
+            edit = self.successful_publish_pr_edit_response(args)
+            if edit is not None:
+                return edit
             raise AssertionError(f"unexpected gh call: {args}")
 
         def fake_run(args: list[str], **kwargs: object) -> mock.Mock:
@@ -1711,6 +1808,9 @@ class ControllerActionsTests(unittest.TestCase):
                     ),
                     stderr="",
                 )
+            edit = self.successful_publish_pr_edit_response(args)
+            if edit is not None:
+                return edit
             raise AssertionError(f"unexpected gh call: {args}")
 
         def fake_run(args: list[str], **kwargs: object) -> mock.Mock:
@@ -1890,6 +1990,9 @@ class ControllerActionsTests(unittest.TestCase):
                     ),
                     stderr="",
                 )
+            edit = self.successful_publish_pr_edit_response(args)
+            if edit is not None:
+                return edit
             raise AssertionError(f"unexpected gh call: {args}")
 
         def fake_run(args: list[str], **kwargs: object) -> mock.Mock:
@@ -1972,6 +2075,9 @@ class ControllerActionsTests(unittest.TestCase):
                     ),
                     stderr="",
                 )
+            edit = self.successful_publish_pr_edit_response(args)
+            if edit is not None:
+                return edit
             raise AssertionError(f"unexpected gh call: {args}")
 
         def fake_run(args: list[str], **kwargs: object) -> mock.Mock:
@@ -2188,6 +2294,82 @@ class ControllerActionsTests(unittest.TestCase):
                                 with mock.patch.object(self.actions, "render_template", side_effect=AssertionError("must not render implement prompt")):
                                     self.assertEqual(7, self.actions.dispatch_consensus_implementation(action))
 
+        self.assertNotIn("HARNESS_SPAWN_INTENT", self.pending_events())
+
+    def test_dispatch_consensus_implementation_reservation_commit_failure_blocks_before_spawn(self) -> None:
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-consensus-implementation", lease_id="lease", expires_at="soon")
+        worktree = self.tmp / ".worktrees" / "iter413-issue-413"
+        action = self.dispatch_consensus_implementation_action()
+
+        stderr = io.StringIO()
+        with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
+            with mock.patch.object(self.actions, "fresh_safe_worktree", return_value=(worktree, "refactor/iter413-issue-413")):
+                with mock.patch.object(self.actions, "gh", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
+                    with mock.patch.object(self.actions, "_git_in", return_value=mock.Mock(returncode=1, stdout="", stderr="commit failed")):
+                        with mock.patch.object(self.actions, "safe_push", side_effect=AssertionError("must not push after reservation commit failure")):
+                            with mock.patch.object(self.actions, "open_pr_with_label", side_effect=AssertionError("must not open PR after reservation commit failure")):
+                                with mock.patch.object(self.actions, "render_template", side_effect=AssertionError("must not render implement prompt")):
+                                    with mock.patch("sys.stderr", stderr):
+                                        self.assertEqual(2, self.actions.dispatch_consensus_implementation(action))
+
+        self.assertIn("dispatch_consensus_implementation: reservation_commit_failed: commit failed", stderr.getvalue())
+        self.assertNotIn("HARNESS_SPAWN_INTENT", self.pending_events())
+
+    def test_dispatch_consensus_implementation_reservation_pr_open_failure_blocks_before_spawn(self) -> None:
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-consensus-implementation", lease_id="lease", expires_at="soon")
+        worktree = self.tmp / ".worktrees" / "iter413-issue-413"
+        action = self.dispatch_consensus_implementation_action()
+
+        stderr = io.StringIO()
+        with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
+            with mock.patch.object(self.actions, "fresh_safe_worktree", return_value=(worktree, "refactor/iter413-issue-413")):
+                with mock.patch.object(self.actions, "gh", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
+                    with mock.patch.object(self.actions, "_git_in", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
+                        with mock.patch.object(self.actions, "safe_push", return_value=0):
+                            with mock.patch.object(self.actions, "open_pr_with_label", side_effect=RuntimeError("open failed")):
+                                with mock.patch.object(self.actions, "render_template", side_effect=AssertionError("must not render implement prompt")):
+                                    with mock.patch("sys.stderr", stderr):
+                                        self.assertEqual(2, self.actions.dispatch_consensus_implementation(action))
+
+        self.assertIn("dispatch_consensus_implementation: reservation_pr_open_failed: open failed", stderr.getvalue())
+        self.assertNotIn("HARNESS_SPAWN_INTENT", self.pending_events())
+
+    def test_dispatch_consensus_implementation_reservation_post_open_verification_failure_blocks_before_spawn(self) -> None:
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-consensus-implementation", lease_id="lease", expires_at="soon")
+        worktree = self.tmp / ".worktrees" / "iter413-issue-413"
+        action = self.dispatch_consensus_implementation_action()
+
+        def fake_gh(args: Sequence[str], *, check: bool = True) -> mock.Mock:
+            if list(args)[:4] == ["pr", "list", "--state", "open"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        [
+                            {
+                                "number": 414,
+                                "baseRefName": "canonical-integration",
+                                "headRefName": "refactor/iter413-issue-413",
+                                "labels": [{"name": "not-managed"}],
+                                "body": "Closes #413\n",
+                            }
+                        ]
+                    ),
+                    stderr="",
+                )
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        stderr = io.StringIO()
+        with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
+            with mock.patch.object(self.actions, "fresh_safe_worktree", return_value=(worktree, "refactor/iter413-issue-413")):
+                with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+                    with mock.patch.object(self.actions, "_git_in", return_value=mock.Mock(returncode=0, stdout="", stderr="")):
+                        with mock.patch.object(self.actions, "safe_push", return_value=0):
+                            with mock.patch.object(self.actions, "open_pr_with_label", return_value=(414, "https://github.com/owner/repo/pull/414")):
+                                with mock.patch.object(self.actions, "render_template", side_effect=AssertionError("must not render implement prompt")):
+                                    with mock.patch("sys.stderr", stderr):
+                                        self.assertEqual(2, self.actions.dispatch_consensus_implementation(action))
+
+        self.assertIn("dispatch_consensus_implementation: reservation_pr_unverified: matching_pr_not_managed", stderr.getvalue())
         self.assertNotIn("HARNESS_SPAWN_INTENT", self.pending_events())
 
     def test_dispatch_consensus_implementation_intent_round_trips_through_wakeup_plan(self) -> None:

--- a/skills/codex-refactor-loop/scripts/test_daemon_heartbeat.py
+++ b/skills/codex-refactor-loop/scripts/test_daemon_heartbeat.py
@@ -8,14 +8,100 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading as real_threading
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.heartbeat import DaemonHeartbeatLease
+
+REAL_CONDITION = real_threading.Condition
+REAL_EVENT = real_threading.Event
+REAL_THREAD = real_threading.Thread
+
+
+class HeartbeatCoordinator:
+    def __init__(self) -> None:
+        self.condition = REAL_CONDITION()
+        self.callback_entered = False
+        self.beat_during_callback = False
+        self.stop_requested = False
+
+    def enter_callback(self) -> None:
+        with self.condition:
+            self.callback_entered = True
+            self.condition.notify_all()
+
+    def record_beat(self) -> None:
+        with self.condition:
+            if self.callback_entered and not self.stop_requested:
+                self.beat_during_callback = True
+            self.condition.notify_all()
+
+    def wait_for_heartbeat_while_callback_is_pending(self) -> bool:
+        with self.condition:
+            return self.condition.wait_for(lambda: self.beat_during_callback, timeout=1.0)
+
+    def request_stop(self) -> None:
+        with self.condition:
+            self.stop_requested = True
+            self.condition.notify_all()
+
+
+class ScriptedEvent:
+    instances: list["ScriptedEvent"] = []
+    coordinator: HeartbeatCoordinator | None = None
+
+    def __init__(self) -> None:
+        self.wait_timeouts: list[float] = []
+        self.set_called = False
+        ScriptedEvent.instances.append(self)
+
+    def wait(self, timeout: float | None = None) -> bool:
+        self.wait_timeouts.append(float(timeout or 0))
+        if ScriptedEvent.coordinator is None:
+            return True
+        coordinator = ScriptedEvent.coordinator
+        with coordinator.condition:
+            if not coordinator.callback_entered:
+                coordinator.condition.wait_for(lambda: coordinator.callback_entered or coordinator.stop_requested, timeout=1.0)
+            if coordinator.stop_requested:
+                return True
+            if not coordinator.beat_during_callback:
+                return False
+            coordinator.condition.wait_for(lambda: coordinator.stop_requested, timeout=1.0)
+            return True
+
+    def set(self) -> None:
+        self.set_called = True
+        if ScriptedEvent.coordinator is not None:
+            ScriptedEvent.coordinator.request_stop()
+
+
+class InlineThread:
+    instances: list["InlineThread"] = []
+
+    def __init__(self, *, target, name: str, daemon: bool) -> None:
+        self.target = target
+        self.name = name
+        self.daemon = daemon
+        self.started = False
+        with mock.patch("threading.Event", REAL_EVENT):
+            self.thread = REAL_THREAD(target=self.target, name=name, daemon=daemon)
+        self.join_timeouts: list[float] = []
+        InlineThread.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+        self.thread.start()
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeouts.append(float(timeout or 0))
+        self.thread.join(timeout=timeout)
 
 
 class DaemonHeartbeatLeaseTests(unittest.TestCase):
@@ -46,6 +132,96 @@ class DaemonHeartbeatLeaseTests(unittest.TestCase):
         self.assertEqual([2.0, 2.0, 1.0], slept)
         self.assertEqual("1003", (self.repo / ".refactor-loop" / "heartbeats" / "python-daemon.ts").read_text().strip())
         self.assertEqual([], list((self.repo / ".refactor-loop" / "heartbeats").glob("*.tmp.*")))
+
+    def test_run_with_lease_periodically_renews_heartbeat_during_callback(self) -> None:
+        ScriptedEvent.instances = []
+        ScriptedEvent.coordinator = HeartbeatCoordinator()
+        InlineThread.instances = []
+        times = iter([2000, 2001])
+        lease = DaemonHeartbeatLease(
+            "python-daemon",
+            self.repo,
+            heartbeat_interval=7,
+            clock=lambda: next(times),
+        )
+        expected = [object()]
+        original_beat = lease.beat
+        original_replace = os.replace
+        replace_sources: list[Path] = []
+
+        def beat() -> None:
+            original_beat()
+            if ScriptedEvent.coordinator is not None:
+                ScriptedEvent.coordinator.record_beat()
+
+        lease.beat = beat
+
+        def record_replace(src: Path | str, dst: Path | str) -> None:
+            replace_sources.append(Path(src))
+            original_replace(src, dst)
+
+        with mock.patch("codex_refactor_loop.heartbeat.threading.Event", ScriptedEvent), mock.patch(
+            "codex_refactor_loop.heartbeat.threading.Thread",
+            InlineThread,
+        ), mock.patch("codex_refactor_loop.heartbeat.os.replace", side_effect=record_replace):
+
+            def callback():
+                assert ScriptedEvent.coordinator is not None
+                ScriptedEvent.coordinator.enter_callback()
+                self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_callback_is_pending())
+                lease.beat()
+                return expected
+
+            result = lease.run_with_lease(callback)
+
+        self.assertIs(result, expected)
+        self.assertTrue(ScriptedEvent.coordinator.beat_during_callback)
+        self.assertGreaterEqual(ScriptedEvent.instances[0].wait_timeouts.count(7.0), 1)
+        self.assertTrue(ScriptedEvent.instances[0].set_called)
+        self.assertTrue(InlineThread.instances[0].started)
+        self.assertTrue(InlineThread.instances[0].daemon)
+        self.assertEqual(InlineThread.instances[0].name, "python-daemon-heartbeat-renewer")
+        self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
+        self.assertEqual(2, len(replace_sources))
+        self.assertEqual(2, len(set(replace_sources)))
+        self.assertTrue(all(path.name.startswith(".python-daemon.ts.tmp.") for path in replace_sources))
+        self.assertIn((self.repo / ".refactor-loop" / "heartbeats" / "python-daemon.ts").read_text().strip(), {"2000", "2001"})
+        self.assertEqual([], list((self.repo / ".refactor-loop" / "heartbeats").glob("*.tmp.*")))
+        ScriptedEvent.coordinator = None
+
+    def test_run_with_lease_propagates_exception_and_stops_renewer(self) -> None:
+        ScriptedEvent.instances = []
+        ScriptedEvent.coordinator = HeartbeatCoordinator()
+        InlineThread.instances = []
+        lease = DaemonHeartbeatLease("python-daemon", self.repo, heartbeat_interval=7, clock=lambda: 2000)
+        original_beat = lease.beat
+
+        def beat() -> None:
+            original_beat()
+            if ScriptedEvent.coordinator is not None:
+                ScriptedEvent.coordinator.record_beat()
+
+        lease.beat = beat
+
+        with mock.patch("codex_refactor_loop.heartbeat.threading.Event", ScriptedEvent), mock.patch(
+            "codex_refactor_loop.heartbeat.threading.Thread",
+            InlineThread,
+        ):
+
+            def callback() -> None:
+                assert ScriptedEvent.coordinator is not None
+                ScriptedEvent.coordinator.enter_callback()
+                self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_callback_is_pending())
+                raise RuntimeError("boom")
+
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                lease.run_with_lease(callback)
+
+        self.assertTrue(ScriptedEvent.coordinator.beat_during_callback)
+        self.assertTrue(ScriptedEvent.instances[0].set_called)
+        self.assertTrue(InlineThread.instances[0].started)
+        self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
+        ScriptedEvent.coordinator = None
 
     def test_lease_requires_repo_root_context_or_explicit_heartbeat_file(self) -> None:
         old_env = os.environ.copy()

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -936,6 +936,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             "local_iter_branch_issue20_stale_base": [issue(20, "open target", [managed, label_catalog.PHASE_IMPLEMENTING, auto, label_catalog.MILESTONE_CURRENT])],
             "local_iter_branch_issue20": [issue(20, "open target", [managed, label_catalog.PHASE_IMPLEMENTING, auto])],
             "local_iter_branch_issue20_noop": [issue(20, "open target", [managed, label_catalog.PHASE_IMPLEMENTING, auto])],
+            "local_iter_branch_issue20_missing_pr": [issue(20, "open target", [managed, label_catalog.PHASE_IMPLEMENTING, auto])],
             "remote_iter_branch_issue20": [issue(20, "open target", [managed, label_catalog.PHASE_IMPLEMENTING, auto])],
             "open_issue_331": [issue(331, "different open target", [managed, label_catalog.PHASE_IMPLEMENTING, auto])],
             "open_issues_330_331_332": [
@@ -1144,7 +1145,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                     printf 'worktree %s/.worktrees/pr77\nbranch refs/heads/impl/pr77\n\n' "$WAKEUP_PLAN_REPO_ROOT"
                     exit 0
                   fi
-                  if [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_stale_base" || "$fixture" == "local_iter_branch_issue20_noop" ]]; then
+                  if [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_stale_base" || "$fixture" == "local_iter_branch_issue20_noop" || "$fixture" == "local_iter_branch_issue20_missing_pr" ]]; then
                     printf 'worktree %s/.worktrees/iter20-issue-20\nbranch refs/heads/refactor/iter20-issue-20\n\n' "$WAKEUP_PLAN_REPO_ROOT"
                     exit 0
                   fi
@@ -1169,7 +1170,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                   exit 0
                 fi
                 if [[ "$*" == *"rev-parse --verify refs/heads/refactor/iter20-issue-20"* ]]; then
-                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_stale_base" || "$fixture" == "local_iter_branch_issue20_noop" ]] && printf 'local-iter-sha\n' && exit 0
+                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_stale_base" || "$fixture" == "local_iter_branch_issue20_noop" || "$fixture" == "local_iter_branch_issue20_missing_pr" ]] && printf 'local-iter-sha\n' && exit 0
                   exit 1
                 fi
                 if [[ "$*" == *"rev-parse --verify refs/heads/refactor/iter581-issue-581"* ]]; then
@@ -1177,7 +1178,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                   exit 1
                 fi
                 if [[ "$*" == *"rev-parse --verify refs/remotes/origin/refactor/iter20-issue-20"* ]]; then
-                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_stale_base" || "$fixture" == "local_iter_branch_issue20_noop" || "$fixture" == "remote_iter_branch_issue20" ]] && printf 'remote-iter-sha\n' && exit 0
+                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_stale_base" || "$fixture" == "local_iter_branch_issue20_noop" || "$fixture" == "local_iter_branch_issue20_missing_pr" || "$fixture" == "remote_iter_branch_issue20" ]] && printf 'remote-iter-sha\n' && exit 0
                   exit 1
                 fi
                 if [[ "$*" == *"rev-parse --verify refs/remotes/origin/refactor/iter581-issue-581"* ]]; then
@@ -1225,6 +1226,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                   [[ "$fixture" == "local_iter_branch_issue20" ]] && printf 'refactor/iter20-issue-20\n' && exit 0
                   [[ "$fixture" == "local_iter_branch_issue20_stale_base" ]] && printf 'refactor/iter20-issue-20\n' && exit 0
                   [[ "$fixture" == "local_iter_branch_issue20_noop" ]] && printf 'refactor/iter20-issue-20\n' && exit 0
+                  [[ "$fixture" == "local_iter_branch_issue20_missing_pr" ]] && printf 'refactor/iter20-issue-20\n' && exit 0
                   exit 1
                 fi
                 if [[ "$*" == *".worktrees/iter581-issue-581"* && "$*" == *"rev-parse --abbrev-ref HEAD"* ]]; then
@@ -1236,7 +1238,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                     printf 'old-base\n'
                     exit 0
                   fi
-                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_noop" ]] && printf 'fresh-base\n' && exit 0
+                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_noop" || "$fixture" == "local_iter_branch_issue20_missing_pr" ]] && printf 'fresh-base\n' && exit 0
                   exit 1
                 fi
                 if [[ "$*" == *".worktrees/iter581-issue-581"* && "$*" == *"merge-base HEAD origin/auto-refact-dev"* ]]; then
@@ -1248,7 +1250,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                     printf 'new-base\n'
                     exit 0
                   fi
-                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_noop" ]] && printf 'fresh-base\n' && exit 0
+                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_noop" || "$fixture" == "local_iter_branch_issue20_missing_pr" ]] && printf 'fresh-base\n' && exit 0
                   exit 1
                 fi
                 if [[ "$*" == *".worktrees/iter581-issue-581"* && "$*" == *"rev-parse --verify origin/auto-refact-dev"* ]]; then
@@ -1264,7 +1266,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                   exit 0
                 fi
                 if [[ "$*" == *"rev-list --count refs/remotes/origin/refactor/iter20-issue-20..HEAD"* ]]; then
-                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_stale_base" || "$fixture" == "local_iter_branch_issue20_noop" ]] && printf '2\n' && exit 0
+                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_stale_base" || "$fixture" == "local_iter_branch_issue20_noop" || "$fixture" == "local_iter_branch_issue20_missing_pr" ]] && printf '2\n' && exit 0
                   exit 1
                 fi
                 if [[ "$*" == *"rev-list --count refs/remotes/origin/refactor/iter581-issue-581..HEAD"* ]]; then
@@ -1274,7 +1276,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                 if [[ "$*" == *"diff"* && "$*" == *"--quiet"* ]]; then
                   [[ "$fixture" == "fix_done_dirty_worktree" ]] && exit 1
                   [[ "$fixture" == "fix_done_clean_worktree" ]] && exit 0
-                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_stale_base" ]] && exit 1
+                  [[ "$fixture" == "local_iter_branch_issue20" || "$fixture" == "local_iter_branch_issue20_stale_base" || "$fixture" == "local_iter_branch_issue20_missing_pr" ]] && exit 1
                   exit 0
                 fi
                 if [[ "$*" == *"rev-parse --verify refs/remotes/origin/integration"* ]]; then
@@ -2654,9 +2656,26 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertIn("canonical_implementation_identity", action["preconditions"])
         self.assertIn("fresh_integration_base", action["preconditions"])
         self.assertIn("worker_authored_pr_artifacts", action["preconditions"])
-        self.assertIn("no_conflicting_open_implementation_pr", action["preconditions"])
+        self.assertIn("matching_open_managed_pr", action["preconditions"])
         self.assertEqual(action["target_pr_number"], 320)
         self.assertNotIn("verified_pr_head", action["preconditions"])
+
+    def test_publish_implementation_marker_without_matching_pr_is_status_only(self) -> None:
+        (self.repo / ".worktrees" / "iter20-issue-20").mkdir(parents=True)
+        self.write_implementation_pr_artifacts()
+        (self.logs / "implement-issue20.log").write_text(
+            "IMPLEMENT_DONE:issue-20:ok\nEXIT=0\n",
+            encoding="utf-8",
+        )
+
+        plan = self.run_plan(fixture="local_iter_branch_issue20_missing_pr")
+
+        action = next(item for item in plan["actions"] if item["action_id"].startswith("completed-marker:implement-issue20"))
+        self.assertEqual(action["controller_action"], "publish_implementation_output")
+        self.assertTrue(action["status_only"])
+        self.assertEqual(action["suppressed_reason"], "matching_pr_missing")
+        self.assertNotIn("runner_authority", action)
+        self.assertNotIn("no_generic_command", action)
 
     def test_noop_implementation_done_empty_scoped_diff_is_status_only_not_hard_gate(self) -> None:
         (self.repo / ".worktrees" / "iter20-issue-20").mkdir(parents=True)
@@ -3049,7 +3068,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(publish["head_ref"], "refactor/iter20-issue-20")
         self.assertEqual(Path(publish["worktree"]).resolve(), (self.repo / ".worktrees/iter20-issue-20").resolve())
         self.assertEqual(publish["runner_authority"], "wakeup-runner-396")
-        self.assertIn("no_conflicting_open_implementation_pr", publish["preconditions"])
+        self.assertIn("matching_open_managed_pr", publish["preconditions"])
         self.assertEqual(publish["target_pr_number"], 320)
         self.assertTrue(log.exists())
         self.assertFalse(
@@ -4972,7 +4991,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             "close_managed_item_from_drop_marker",
             "implementation_worktree_missing",
             "implementation_head_ref_missing",
-            "no_conflicting_open_implementation_pr",
+            "matching_open_managed_pr",
+            "matching_pr_missing",
             "status_only",
         ):
             with self.subTest(token=token):

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -3683,6 +3683,67 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(action["source_marker"], marker)
         self.assertNotIn("status_only", action)
 
+    def test_remote_ci_fix_done_without_pr_target_is_status_only(self) -> None:
+        marker = "REMOTE_CI_FIX_DONE:contract-tests:ok"
+        (self.logs / "remote-ci-fix-contract-tests.log").write_text(f"{marker}\nEXIT=0\n", encoding="utf-8")
+
+        plan = self.run_plan(fixture="open_pr_77")
+
+        action = completed_marker_action(plan, "completed-marker:remote-ci-fix-contract-tests")
+        self.assertEqual(action["controller_action"], "dispatch_remote_ci_fix")
+        self.assertIsNone(action["target_kind"])
+        self.assertIsNone(action["target_number"])
+        self.assertTrue(action["status_only"])
+        self.assertEqual(action["suppressed_reason"], "remote_ci_fix_target_missing")
+        self.assertNotIn("runner_authority", action)
+        self.assertNotIn("no_generic_command", action)
+
+    def test_remote_ci_fix_done_issue_target_is_status_only(self) -> None:
+        marker = "REMOTE_CI_FIX_DONE:contract-tests:ok"
+        (self.logs / "remote-ci-fix-issue77-contract-tests.log").write_text(f"{marker}\nEXIT=0\n", encoding="utf-8")
+
+        plan = self.run_plan(fixture="open_pr_77")
+
+        action = completed_marker_action(plan, "completed-marker:remote-ci-fix-issue77-contract-tests")
+        self.assertEqual(action["controller_action"], "dispatch_remote_ci_fix")
+        self.assertEqual(action["target_kind"], "issue")
+        self.assertEqual(action["target_number"], 77)
+        self.assertTrue(action["status_only"])
+        self.assertEqual(action["suppressed_reason"], "remote_ci_fix_target_not_pr")
+        self.assertNotIn("runner_authority", action)
+        self.assertNotIn("no_generic_command", action)
+
+    def test_remote_ci_fix_done_non_open_pr_target_is_status_only(self) -> None:
+        marker = "REMOTE_CI_FIX_DONE:contract-tests:ok"
+        (self.logs / "remote-ci-fix-pr77-contract-tests.log").write_text(f"{marker}\nEXIT=0\n", encoding="utf-8")
+
+        plan = self.run_plan(fixture="open_issue_331")
+
+        action = completed_marker_action(plan, "completed-marker:remote-ci-fix-pr77-contract-tests")
+        self.assertEqual(action["controller_action"], "dispatch_remote_ci_fix")
+        self.assertEqual(action["target_kind"], "PR")
+        self.assertEqual(action["target_number"], 77)
+        self.assertTrue(action["status_only"])
+        self.assertEqual(action["suppressed_reason"], "target_not_open")
+        self.assertNotIn("runner_authority", action)
+        self.assertNotIn("no_generic_command", action)
+
+    def test_remote_ci_fix_done_when_read_model_unavailable_is_status_only(self) -> None:
+        marker = "REMOTE_CI_FIX_DONE:contract-tests:ok"
+        (self.logs / "remote-ci-fix-pr77-contract-tests.log").write_text(f"{marker}\nEXIT=0\n", encoding="utf-8")
+
+        plan = self.run_plan(fixture="gh_failure")
+
+        action = completed_marker_action(plan, "completed-marker:remote-ci-fix-pr77-contract-tests")
+        self.assertEqual(action["controller_action"], "dispatch_remote_ci_fix")
+        self.assertEqual(action["target_kind"], "PR")
+        self.assertEqual(action["target_number"], 77)
+        self.assertTrue(action["status_only"])
+        self.assertTrue(action["no_lifecycle_authority"])
+        self.assertEqual(action["suppressed_reason"], "open_managed_read_model_unavailable")
+        self.assertNotIn("runner_authority", action)
+        self.assertNotIn("no_generic_command", action)
+
     def test_remote_ci_fix_done_conflicting_duplicate_marker_fails_closed(self) -> None:
         (self.logs / "remote-ci-fix-pr77-contract-tests.log").write_text(
             "REMOTE_CI_FIX_DONE:contract-tests:blocked\n"

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -7,7 +7,6 @@ import json
 import subprocess
 import sys
 import tempfile
-import threading as real_threading
 import unittest
 from contextlib import redirect_stdout
 from datetime import datetime, timedelta, timezone
@@ -19,10 +18,6 @@ from unittest import mock
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-REAL_CONDITION = real_threading.Condition
-REAL_EVENT = real_threading.Event
-REAL_THREAD = real_threading.Thread
-
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.issue_decomposition import issue_decomposition_plan_file_digest
 from codex_refactor_loop import labels
@@ -32,7 +27,6 @@ from codex_refactor_loop.wakeup_runner import (
     RunnerResult,
     SUPPORTED_CONTROLLER_ACTIONS,
     _log_tick_status,
-    _run_once_with_periodic_heartbeat,
     _wakeup_tick_action,
     main as wakeup_runner_main,
     _source_log_has_clean_marker,
@@ -266,102 +260,6 @@ class FakeReviewFixActions(FakeActions):
         (self.repo / prompt_path).parent.mkdir(parents=True, exist_ok=True)
         (self.repo / prompt_path).write_text("headless rendered prompt\n", encoding="utf-8")
         return type("Spec", (), {"prompt_path": prompt_path, "log_path": log_path})()
-
-
-class FakeHeartbeatLease:
-    heartbeat_interval = 7
-
-    def __init__(self) -> None:
-        self.beats = 0
-        self.coordinator: HeartbeatCoordinator | None = None
-
-    def beat(self) -> None:
-        self.beats += 1
-        if self.coordinator is not None:
-            self.coordinator.record_beat()
-
-
-class HeartbeatCoordinator:
-    def __init__(self) -> None:
-        self.condition = REAL_CONDITION()
-        self.run_once_entered = False
-        self.beat_during_run_once = False
-        self.stop_requested = False
-        self.waiting_for_stop = False
-
-    def enter_run_once(self) -> None:
-        with self.condition:
-            self.run_once_entered = True
-            self.condition.notify_all()
-
-    def record_beat(self) -> None:
-        with self.condition:
-            if self.run_once_entered and not self.stop_requested:
-                self.beat_during_run_once = True
-            self.condition.notify_all()
-
-    def wait_for_heartbeat_while_run_once_is_pending(self) -> bool:
-        with self.condition:
-            return self.condition.wait_for(lambda: self.beat_during_run_once, timeout=1.0)
-
-    def request_stop(self) -> None:
-        with self.condition:
-            self.stop_requested = True
-            self.condition.notify_all()
-
-
-class ScriptedEvent:
-    instances: list["ScriptedEvent"] = []
-    coordinator: HeartbeatCoordinator | None = None
-
-    def __init__(self) -> None:
-        self.wait_timeouts: list[float] = []
-        self.set_called = False
-        ScriptedEvent.instances.append(self)
-
-    def wait(self, timeout: float | None = None) -> bool:
-        self.wait_timeouts.append(float(timeout or 0))
-        if ScriptedEvent.coordinator is None:
-            return True
-        coordinator = ScriptedEvent.coordinator
-        with coordinator.condition:
-            if not coordinator.run_once_entered:
-                coordinator.condition.wait_for(lambda: coordinator.run_once_entered or coordinator.stop_requested, timeout=1.0)
-            if coordinator.stop_requested:
-                return True
-            if not coordinator.beat_during_run_once:
-                return False
-            coordinator.waiting_for_stop = True
-            coordinator.condition.notify_all()
-            coordinator.condition.wait_for(lambda: coordinator.stop_requested, timeout=1.0)
-            return True
-
-    def set(self) -> None:
-        self.set_called = True
-        if ScriptedEvent.coordinator is not None:
-            ScriptedEvent.coordinator.request_stop()
-
-
-class InlineThread:
-    instances: list["InlineThread"] = []
-
-    def __init__(self, *, target, name: str, daemon: bool) -> None:
-        self.target = target
-        self.name = name
-        self.daemon = daemon
-        self.started = False
-        with mock.patch("threading.Event", REAL_EVENT):
-            self.thread = REAL_THREAD(target=self.target, name=name, daemon=daemon)
-        self.join_timeouts: list[float] = []
-        InlineThread.instances.append(self)
-
-    def start(self) -> None:
-        self.started = True
-        self.thread.start()
-
-    def join(self, timeout: float | None = None) -> None:
-        self.join_timeouts.append(float(timeout or 0))
-        self.thread.join(timeout=timeout)
 
 
 class WakeupRunnerBehaviorTests(unittest.TestCase):
@@ -3800,64 +3698,6 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                 results = self.run_result(self.base_plan(action), actions=actions)
 
                 self.assert_blocked_before_dispatch(results, action["action_id"], reason, actions)
-
-    def test_daemon_run_once_periodically_renews_heartbeat_during_long_tick(self) -> None:
-        ScriptedEvent.instances = []
-        ScriptedEvent.coordinator = HeartbeatCoordinator()
-        InlineThread.instances = []
-        lease = FakeHeartbeatLease()
-        lease.coordinator = ScriptedEvent.coordinator
-        expected = [object()]
-
-        with mock.patch("codex_refactor_loop.wakeup_runner.threading.Event", ScriptedEvent), mock.patch(
-            "codex_refactor_loop.wakeup_runner.threading.Thread",
-            InlineThread,
-        ):
-
-            def run_once():
-                ScriptedEvent.coordinator.enter_run_once()
-                self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_run_once_is_pending())
-                return expected
-
-            result = _run_once_with_periodic_heartbeat(run_once, lease)
-
-        self.assertIs(result, expected)
-        self.assertGreaterEqual(lease.beats, 1)
-        self.assertTrue(ScriptedEvent.coordinator.beat_during_run_once)
-        self.assertGreaterEqual(ScriptedEvent.instances[0].wait_timeouts.count(7.0), 1)
-        self.assertTrue(ScriptedEvent.instances[0].set_called)
-        self.assertTrue(InlineThread.instances[0].started)
-        self.assertTrue(InlineThread.instances[0].daemon)
-        self.assertEqual(InlineThread.instances[0].name, "wakeup-runner-heartbeat-renewer")
-        self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
-        ScriptedEvent.coordinator = None
-
-    def test_daemon_run_once_periodic_heartbeat_propagates_exception_and_stops_thread(self) -> None:
-        ScriptedEvent.instances = []
-        ScriptedEvent.coordinator = HeartbeatCoordinator()
-        InlineThread.instances = []
-        lease = FakeHeartbeatLease()
-        lease.coordinator = ScriptedEvent.coordinator
-
-        with mock.patch("codex_refactor_loop.wakeup_runner.threading.Event", ScriptedEvent), mock.patch(
-            "codex_refactor_loop.wakeup_runner.threading.Thread",
-            InlineThread,
-        ):
-
-            def run_once():
-                ScriptedEvent.coordinator.enter_run_once()
-                self.assertTrue(ScriptedEvent.coordinator.wait_for_heartbeat_while_run_once_is_pending())
-                raise RuntimeError("boom")
-
-            with self.assertRaisesRegex(RuntimeError, "boom"):
-                _run_once_with_periodic_heartbeat(run_once, lease)
-
-        self.assertGreaterEqual(lease.beats, 1)
-        self.assertTrue(ScriptedEvent.coordinator.beat_during_run_once)
-        self.assertTrue(ScriptedEvent.instances[0].set_called)
-        self.assertTrue(InlineThread.instances[0].started)
-        self.assertEqual(InlineThread.instances[0].join_timeouts, [1.0])
-        ScriptedEvent.coordinator = None
 
     def test_wakeup_runner_continues_after_blocked_non_spawn_lifecycle_action(self) -> None:
         blocked_lifecycle = self.implementation_output_action(

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -899,7 +899,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                 "host_checks_green",
                 "single_linked_managed_issue",
                 "worker_authored_pr_artifacts",
-                "no_conflicting_open_implementation_pr",
+                "matching_open_managed_pr",
             ],
             "source_artifact": ".refactor-loop/logs/implement-issue77.log",
             "source_marker": marker,
@@ -1467,7 +1467,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                 "clean_scoped_diff",
                 "host_checks_green",
                 "single_linked_managed_issue",
-                "no_conflicting_open_implementation_pr",
+                "matching_open_managed_pr",
             ],
         )
         later = self.spawn_action(action_id="spawn:after-blocked-lifecycle")
@@ -1527,7 +1527,6 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             results = self.run_result(
                 self.batch_plan([*status_only_prefix, duplicate, applied_lifecycle, *spawn_batch], dispatch_required=3, deficit=3),
                 actions=actions,
-                duplicate_prs=[],
                 git_diff_code=1,
             )
 
@@ -1586,7 +1585,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                 "clean_scoped_diff",
                 "host_checks_green",
                 "single_linked_managed_issue",
-                "no_conflicting_open_implementation_pr",
+                "matching_open_managed_pr",
             ],
         )
         spawns = [
@@ -1670,7 +1669,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                 "clean_scoped_diff",
                 "host_checks_green",
                 "single_linked_managed_issue",
-                "no_conflicting_open_implementation_pr",
+                "matching_open_managed_pr",
             ],
         )
         close = self.close_action(action_id="close-managed-item:53:after-blocked-publish")
@@ -2935,7 +2934,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                         "clean_scoped_diff",
                         "single_linked_managed_issue",
                         "worker_authored_pr_artifacts",
-                        "no_conflicting_open_implementation_pr",
+                        "matching_open_managed_pr",
                     ],
                 ),
                 "publish_implementation_missing_precondition:host_checks_green",
@@ -3482,7 +3481,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual(results[0].status, "applied")
         self.assertEqual(actions.calls[0][0], "publish_implementation_output")
 
-    def test_publish_implementation_output_allows_missing_pr_so_publish_can_open_it(self) -> None:
+    def test_publish_implementation_output_blocks_missing_matching_pr_before_helper(self) -> None:
         actions = FakeActions()
 
         def command_runner(command):
@@ -3514,8 +3513,9 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
 
         results = runner.run_once()
 
-        self.assertEqual(results[0].status, "applied")
-        self.assertEqual(actions.calls[0][0], "publish_implementation_output")
+        self.assertEqual(results[0].status, "blocked")
+        self.assertEqual(results[0].reason, "publish_implementation_matching_pr_missing")
+        self.assertEqual(actions.calls, [])
 
     def test_dispatch_reviewers_routes_to_named_helper_after_pr_target_validation(self) -> None:
         actions = FakeActions()


### PR DESCRIPTION
## 修改文件
- skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py
- skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
- skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
- skills/codex-refactor-loop/scripts/test_controller_actions.py
- skills/codex-refactor-loop/scripts/test_wakeup_plan.py
- skills/codex-refactor-loop/scripts/test_wakeup_runner.py

## 测试结果
- python3 -m unittest skills/codex-refactor-loop/scripts/test_controller_actions.py -q
- python3 -m unittest skills/codex-refactor-loop/scripts/test_wakeup_plan.py -q
- python3 -m unittest skills/codex-refactor-loop/scripts/test_wakeup_runner.py -q
- python3 -m unittest skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py skills/codex-refactor-loop/scripts/test_runtime_exception_authorization_sources.py -q
- bash -lc "source "${CONSENSUS_RND_HOST_ENV:-.refactor-loop/host.env}" && python3 -m compileall skills/codex-refactor-loop/scripts skills/sshx -q"
- bash -lc "source "${CONSENSUS_RND_HOST_ENV:-.refactor-loop/host.env}" && python3 -m pytest skills/codex-refactor-loop/scripts -q -p no:cacheprovider -o addopts= --ignore=skills/codex-refactor-loop/scripts/test_restart_daemons.py --ignore=skills/codex-refactor-loop/scripts/test_restart_supervisor.py --ignore=skills/codex-refactor-loop/scripts/test_daemon_heartbeat.py --ignore=skills/codex-refactor-loop/scripts/test_cli_daemon_help_smoke.py --ignore=skills/codex-refactor-loop/scripts/test_peek_status_lens.py --ignore=skills/codex-refactor-loop/scripts/test_zz_daemon_leak_guard.py --ignore=skills/codex-refactor-loop/scripts/test_anti_stop_restart_helper_contract.py && python3 -m pytest skills/sshx/tests -q -p no:cacheprovider -o addopts="

## deviation 记录
- none
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

Closes #631

⟦AI:AUTO-LOOP⟧
