### PR TITLE
收窄控制器 tick 脚手架边界

### DIFF
--- a/skills/codex-refactor-loop/SKILL.md
+++ b/skills/codex-refactor-loop/SKILL.md
@@ -2137,18 +2137,19 @@ Verification: `test_phase9_router_open_state_gate.py`, `test_phase9_router_daemo
 One-shot:`python3 <skill-root>/scripts/consensus-rnd-cli phase9-router --once --repo-root "$REPO_ROOT"`; dry-run:`python3 <skill-root>/scripts/consensus-rnd-cli phase9-router --once --dry-run --repo-root "$REPO_ROOT"`; monitor:`tail -50 .refactor-loop/logs/phase9-router-daemon.log`。
 
 <a id="tier0-scaffold-inventory"></a>
-### Tier 0 scaffold inventory(prose-only)
+### Tier 0 scaffold inventory
 
-This inventory is prose-only and non-authoritative. It is a reader index for existing owner-local surfaces, not a machine-readable catalog, registry, runtime scaffold, or package API. It is not imported by runtime code and has no dispatch, write, state-transition, or authorization authority.
+This inventory is prose plus the single test-owned/data-only `controller_runtime_inventory.py`, and remains non-authoritative. It is a reader index for existing owner-local surfaces, not a runtime scaffold, package API, or executable registry. Runtime execution paths must not import/read `controller_runtime_inventory.py`; it has no dispatch, write, state-transition, pending-events, label mutation, GitHub/git, or authorization authority.
 
 Owner-local fact sources stay where their behavior is owned:
 
 - Restart-helper-managed daemon commands are defined by `restart.py::DAEMON_COMMANDS` and projected by `restart_managed_daemon_names()`.
+- `controller_runtime_inventory.py` may list only daemon name, owner module/CLI command, tick import path, authority note, and test owner for tests; it must not contain callable, argv/shell/cmd/env, git/gh, executor, dispatch, authorization, pending-events, state-transition, or lifecycle owner fields.
 - Public CLI command authority tokens are defined by `cli.py::COMMANDS[*].authority`.
 - Work-unit behavior is owned by `SKILL.md#work-unit-contract` plus the worker prompt contracts and marker tests.
 - Pending controller events are owned by `ctx.paths.pending_events` / `.refactor-loop/.controller-pending-events.log`; this inventory has no pending-events authority.
 - Labels, workflow stage names, phase9 route names, progress target names, concurrency dispatch prefixes, and rollup heads stay with their existing owner-local files listed in [operational names](#operational-names).
-- Per-daemon tick action formatting, when extracted, stays inside the daemon owner module and is verified by behavior tests for observable log lines, pending-event deltas, dispatch suppression, and return status; it must not move into a shared `TickOutcome`, `tick_helpers.py`, or controller-runtime catalog.
+- Per-daemon tick action formatting, when extracted, stays inside the daemon owner module and is verified by behavior tests for observable log lines, pending-event deltas, dispatch suppression, and return status; it must not move into a shared `TickOutcome`, `DaemonReconcileTick`, `ReconcileTickResult`, `tick_helpers.py`, `reconcile_ticks.py`, `reconcile_registry.py`, or controller-runtime catalog.
 
 Allowlist(唯一 direct spawn-intent authority):
 There are five built-in phase9 direct routes.

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/closed_label_reconciler.py
@@ -281,6 +281,14 @@ def _log_tick_status(daemon: str, action: str) -> None:
     print(f"[{ts}] {daemon}: tick {action}", flush=True)
 
 
+def run_closed_label_reconciler_reconcile_tick(
+    reconciler: ClosedLabelReconciler,
+    *,
+    beat: Callable[[], None] | None = None,
+) -> int:
+    return reconciler.run_once(beat=beat)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="consensus-rnd-cli closed-label-reconciler")
     mode = parser.add_mutually_exclusive_group()
@@ -300,9 +308,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         lease.beat()
         interval = max(1, int(args.interval_seconds))
         while True:
-            lease.run_with_lease(lambda: reconciler.run_once(beat=lease.beat))
+            lease.run_with_lease(lambda: run_closed_label_reconciler_reconcile_tick(reconciler, beat=lease.beat))
             lease.sleep_with_lease(interval)
-    return reconciler.run_once()
+    return run_closed_label_reconciler_reconcile_tick(reconciler)
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_runtime_inventory.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_runtime_inventory.py
@@ -1,0 +1,66 @@
+"""Test-owned data-only inventory for restart-managed controller daemons."""
+
+from __future__ import annotations
+
+
+CONTROLLER_RUNTIME_INVENTORY = (
+    {
+        "daemon_name": "concurrency_monitor",
+        "owner_module": "codex_refactor_loop.monitors.concurrency",
+        "cli_command": "concurrency --daemon",
+        "tick_import_path": "codex_refactor_loop.monitors.concurrency.run_concurrency_reconcile_tick",
+        "authority_note": "observability and dispatch-queue worker spawn-intent projection only",
+        "test_owner": "skills/codex-refactor-loop/scripts/test_concurrency_monitor.py",
+    },
+    {
+        "daemon_name": "comment-monitor",
+        "owner_module": "codex_refactor_loop.monitors.comment",
+        "cli_command": "comment-monitor --daemon",
+        "tick_import_path": "codex_refactor_loop.monitors.comment.run_comment_monitor_reconcile_tick",
+        "authority_note": "maintainer comment observation plus owner-gated acknowledgement banner",
+        "test_owner": "skills/codex-refactor-loop/scripts/test_comment_monitor.py",
+    },
+    {
+        "daemon_name": "codex-progress-reporter",
+        "owner_module": "codex_refactor_loop.monitors.progress",
+        "cli_command": "progress-reporter --daemon",
+        "tick_import_path": "codex_refactor_loop.monitors.progress.run_progress_reporter_reconcile_tick",
+        "authority_note": "worker log observation and configured global status comment patch",
+        "test_owner": "skills/codex-refactor-loop/scripts/test_progress_reporter.py",
+    },
+    {
+        "daemon_name": "dev_sync_daemon",
+        "owner_module": "codex_refactor_loop.sync.dev",
+        "cli_command": "dev-sync --daemon",
+        "tick_import_path": "codex_refactor_loop.sync.dev.run_dev_sync_reconcile_tick",
+        "authority_note": "narrow integration sync detector and #53 operation artifact executor",
+        "test_owner": "skills/codex-refactor-loop/scripts/test_sync_dev.py",
+    },
+    {
+        "daemon_name": "phase9_router_daemon",
+        "owner_module": "codex_refactor_loop.phase9.router",
+        "cli_command": "phase9-router --daemon",
+        "tick_import_path": "codex_refactor_loop.phase9.router.run_phase9_router_reconcile_tick",
+        "authority_note": "deterministic design-consensus route projection",
+        "test_owner": "skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py",
+    },
+    {
+        "daemon_name": "closed_label_reconciler",
+        "owner_module": "codex_refactor_loop.closed_label_reconciler",
+        "cli_command": "closed-label-reconciler --daemon",
+        "tick_import_path": "codex_refactor_loop.closed_label_reconciler.run_closed_label_reconciler_reconcile_tick",
+        "authority_note": "closed managed item terminal phase-label reconciliation only",
+        "test_owner": "skills/codex-refactor-loop/scripts/test_closed_label_reconciler.py",
+    },
+    {
+        "daemon_name": "wakeup_runner_daemon",
+        "owner_module": "codex_refactor_loop.wakeup_runner",
+        "cli_command": "wakeup-runner --daemon",
+        "tick_import_path": "codex_refactor_loop.wakeup_runner.run_wakeup_runner_reconcile_tick",
+        "authority_note": "mechanical apply of evidence-bound closed wakeup-plan actions",
+        "test_owner": "skills/codex-refactor-loop/scripts/test_wakeup_runner.py",
+    },
+)
+
+
+__all__ = ("CONTROLLER_RUNTIME_INVENTORY",)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/comment.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/comment.py
@@ -66,7 +66,7 @@ class CommentMonitor:
 
     def run_forever(self) -> int:
         while True:
-            self.heartbeat.run_with_lease(self.tick)
+            self.heartbeat.run_with_lease(lambda: run_comment_monitor_reconcile_tick(self))
             self.heartbeat.beat()
             self.heartbeat.sleep_with_lease(self.interval)
 
@@ -275,6 +275,10 @@ class CommentMonitor:
         print(f"[{ts}] comment-monitor: tick {action}", flush=True)
 
 
+def run_comment_monitor_reconcile_tick(monitor: CommentMonitor) -> None:
+    monitor.tick()
+
+
 def is_controller_post(first_line: str, body: str) -> bool:
     if AI_SENTINEL in body or "Generated with Claude Code" in body:
         return True
@@ -340,15 +344,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--daemon", action="store_true", help="run persistently")
     mode.add_argument("--once", action="store_true", help="run one tick and exit")
-    parser.parse_args(argv)
+    args = parser.parse_args(argv)
     try:
         ctx = LoopContext.load(cwd=os.getcwd())
         monitor = CommentMonitor(ctx)
     except (LoopContextError, RuntimeError) as exc:
         sys.stderr.write(f"{exc}\n")
         return 2
-    if os.environ.get("TEST_NO_LOOP") == "1":
-        monitor.tick()
+    if args.once or os.environ.get("TEST_NO_LOOP") == "1":
+        run_comment_monitor_reconcile_tick(monitor)
         return 0
     return monitor.run_forever()
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -686,11 +686,15 @@ class ConcurrencyMonitor:
         lease = DaemonHeartbeatLease("concurrency_monitor", self.repo_root)
         while True:
             try:
-                lease.run_with_lease(self.tick)
+                lease.run_with_lease(lambda: run_concurrency_reconcile_tick(self))
             except Exception as exc:
                 log(f"EXCEPTION in tick: {exc!r}")
             lease.beat()
             lease.sleep_with_lease(self.interval)
+
+
+def run_concurrency_reconcile_tick(monitor: ConcurrencyMonitor) -> None:
+    monitor.tick()
 
 
 def load_monitor(*, read_only: bool = False, allow_git_root_fallback: bool | None = None, cwd: str | Path | None = None) -> ConcurrencyMonitor:
@@ -799,7 +803,7 @@ def top_up_from_dispatch_queue(actual: int, floor: int) -> int:
 
 
 def tick() -> None:
-    _default_monitor().tick()
+    run_concurrency_reconcile_tick(_default_monitor())
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -826,7 +830,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(line)
         return 0
     if args.once:
-        monitor.tick()
+        run_concurrency_reconcile_tick(monitor)
         return 0
     return monitor.run_forever()
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/progress.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/monitors/progress.py
@@ -61,7 +61,7 @@ class ProgressReporter:
     def run_forever(self) -> int:
         while True:
             self.log_msg("tick")
-            self.heartbeat.run_with_lease(self.tick)
+            self.heartbeat.run_with_lease(lambda: run_progress_reporter_reconcile_tick(self))
             self.heartbeat.beat()
             self.heartbeat.sleep_with_lease(self.interval)
 
@@ -203,6 +203,10 @@ class ProgressReporter:
         print(f"[{ts}] progress-reporter: tick {action}", flush=True)
 
 
+def run_progress_reporter_reconcile_tick(reporter: ProgressReporter) -> None:
+    reporter.tick()
+
+
 @contextmanager
 def temp_body_file(body: str):
     import tempfile
@@ -274,7 +278,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         sys.stderr.write(f"{exc}\n")
         return 2
     if args.once or os.environ.get("TEST_NO_LOOP") == "1":
-        reporter.tick()
+        run_progress_reporter_reconcile_tick(reporter)
         return 0
     return reporter.run_forever()
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -2029,6 +2029,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def run_phase9_router_reconcile_tick(router: Phase9Router) -> None:
+    router.tick()
+
+
 def main(argv: list[str] | None = None, command_runner: Callable[[dict[str, object]], None] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     repo_root = Path(args.repo_root) if args.repo_root else LoopContext.load(cwd=os.getcwd()).repo_root
@@ -2037,12 +2041,12 @@ def main(argv: list[str] | None = None, command_runner: Callable[[dict[str, obje
     router = Phase9Router(repo_root, dry_run=args.dry_run, command_runner=command_runner)
     with router.singleton():
         if args.once:
-            router.tick()
+            run_phase9_router_reconcile_tick(router)
             return 0
         lease = DaemonHeartbeatLease("phase9_router_daemon", repo_root)
         while True:
             try:
-                lease.run_with_lease(router.tick)
+                lease.run_with_lease(lambda: run_phase9_router_reconcile_tick(router))
             except Exception as exc:
                 print(f"[{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}] EXCEPTION in tick: {exc!r}", flush=True)
             lease.beat()

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase_label_contract.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase_label_contract.py
@@ -1,0 +1,14 @@
+"""Declaration-only phase-label contract for source-regression tests."""
+
+from __future__ import annotations
+
+
+PHASE_LABEL_CONTRACT = {
+    "contract_owner": "codex_refactor_loop.labels and codex_refactor_loop.closed_phase_labels",
+    "open_managed_reader": "codex_refactor_loop.managed_work_snapshot.ManagedWorkSnapshot",
+    "closed_reconciler_planner": "codex_refactor_loop.closed_phase_labels.plan_closed_reconcile_candidate",
+    "execution_import_policy": "label mutation execution modules must not import codex_refactor_loop.phase_label_contract",
+}
+
+
+__all__ = ("PHASE_LABEL_CONTRACT",)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/sync/dev.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/sync/dev.py
@@ -802,9 +802,13 @@ def local_ahead_count(cwd: Path, config: DevSyncConfig | None = None) -> int:
     return IntegrationSyncDaemon.from_config(cfg).local_ahead_count(cwd)
 
 
+def run_dev_sync_reconcile_tick(daemon: IntegrationSyncDaemon) -> None:
+    daemon.tick()
+
+
 def tick(config: DevSyncConfig | None = None) -> None:
     cfg = config or load_dev_sync_config()
-    IntegrationSyncDaemon.from_config(cfg).tick()
+    run_dev_sync_reconcile_tick(IntegrationSyncDaemon.from_config(cfg))
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -819,7 +823,7 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(f"{exc}\n")
         return 2
     if args.once:
-        IntegrationSyncDaemon.from_config(config).tick()
+        run_dev_sync_reconcile_tick(IntegrationSyncDaemon.from_config(config))
         return 0
     with singleton_lock(config.lock_file):
         log(
@@ -840,7 +844,7 @@ def main(argv: list[str] | None = None) -> int:
         daemon = IntegrationSyncDaemon.from_config(config)
         while True:
             try:
-                daemon.tick()
+                run_dev_sync_reconcile_tick(daemon)
             except Exception as exc:
                 log(f"EXCEPTION in tick: {exc!r}")
             lease.beat()
@@ -859,6 +863,7 @@ __all__ = [
     "local_ahead_count",
     "main",
     "merge_in_progress",
+    "run_dev_sync_reconcile_tick",
     "singleton_lock",
     "tick",
     "working_tree_dirty",

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Mapping, Sequence
 
 from .active_controller import require_active_controller, write_active_controller_status
 from . import labels
-from .context import LoopContext
+from .context import LoopContext, LoopContextError
 from .controller_actions import ControllerActions
 from .gh_invoke import build_gh_argv
 from .github_budget import graphql_headroom_ok
@@ -1854,6 +1854,10 @@ def load_plan_file(path: Path) -> Mapping[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
+def run_wakeup_runner_reconcile_tick(runner: WakeupRunner) -> list[RunnerResult]:
+    return runner.run_once()
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="consensus-rnd-cli wakeup-runner")
     mode = parser.add_mutually_exclusive_group()
@@ -1879,10 +1883,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         lease.beat()
         interval = max(1, int(args.interval_seconds))
         while True:
-            results = lease.run_with_lease(runner.run_once)
+            results = lease.run_with_lease(lambda: run_wakeup_runner_reconcile_tick(runner))
             _log_tick_status("wakeup-runner", _wakeup_tick_action(results))
             lease.sleep_with_lease(interval)
-    results = runner.run_once()
+    results = run_wakeup_runner_reconcile_tick(runner)
     _log_tick_status("wakeup-runner", _wakeup_tick_action(results))
     blocked = [result for result in results if result.status == "blocked"]
     return 3 if blocked else 0

--- a/skills/codex-refactor-loop/scripts/test_closed_label_reconciler.py
+++ b/skills/codex-refactor-loop/scripts/test_closed_label_reconciler.py
@@ -17,7 +17,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop import labels
-from codex_refactor_loop.closed_label_reconciler import ClosedLabelReconciler
+from codex_refactor_loop.closed_label_reconciler import ClosedLabelReconciler, run_closed_label_reconciler_reconcile_tick
 from codex_refactor_loop.closed_phase_labels import (
     ClosedPhaseLabelPlan,
     RECENT_CLOSED_MANAGED_WINDOW_LIMIT,
@@ -978,7 +978,10 @@ class ClosedLabelReconcilerBehaviorTests(unittest.TestCase):
 
         with mock.patch("codex_refactor_loop.closed_label_reconciler.require_active_controller", return_value=decision):
             with mock.patch.object(reconciler, "collect_plans", return_value=plans):
-                self.assertEqual(0, reconciler.run_once(beat=lambda: beats.append("beat")))
+                self.assertEqual(
+                    0,
+                    run_closed_label_reconciler_reconcile_tick(reconciler, beat=lambda: beats.append("beat")),
+                )
 
         self.assertEqual(["beat", "beat", "beat"], beats)
 

--- a/skills/codex-refactor-loop/scripts/test_comment_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_comment_monitor.py
@@ -21,7 +21,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.managed_work_snapshot import ManagedWorkSnapshotItem, ManagedWorkSnapshotResult
-from codex_refactor_loop.monitors.comment import CommentMonitor, is_controller_post
+from codex_refactor_loop.monitors.comment import CommentMonitor, is_controller_post, run_comment_monitor_reconcile_tick
 from test_support.authorization_projection import project_python
 
 
@@ -324,7 +324,7 @@ class CommentMonitorTests(unittest.TestCase):
             mock.patch.object(monitor, "_poll_once", return_value={"targets": 2, "fetched": 1, "comments": 3}),
             redirect_stdout(output),
         ):
-            monitor.tick()
+            run_comment_monitor_reconcile_tick(monitor)
 
         line = output.getvalue().strip()
         self.assertRegex(

--- a/skills/codex-refactor-loop/scripts/test_comment_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_comment_monitor.py
@@ -21,7 +21,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.managed_work_snapshot import ManagedWorkSnapshotItem, ManagedWorkSnapshotResult
-from codex_refactor_loop.monitors.comment import CommentMonitor, is_controller_post, run_comment_monitor_reconcile_tick
+from codex_refactor_loop.monitors.comment import CommentMonitor, is_controller_post, main as comment_monitor_main, run_comment_monitor_reconcile_tick
 from test_support.authorization_projection import project_python
 
 
@@ -334,6 +334,20 @@ class CommentMonitorTests(unittest.TestCase):
         )
         self.assertNotIn("TickOutcome", line)
         self.assertNotIn("registry", line)
+
+    def test_once_cli_invokes_reconcile_tick_wrapper_and_exits_zero(self) -> None:
+        monitor = mock.Mock(spec=CommentMonitor)
+
+        with (
+            mock.patch("codex_refactor_loop.monitors.comment.LoopContext.load", return_value=self.ctx) as load_context,
+            mock.patch("codex_refactor_loop.monitors.comment.CommentMonitor", return_value=monitor) as monitor_class,
+            mock.patch("codex_refactor_loop.monitors.comment.run_comment_monitor_reconcile_tick") as wrapper,
+        ):
+            self.assertEqual(0, comment_monitor_main(["--once"]))
+
+        load_context.assert_called_once()
+        monitor_class.assert_called_once_with(self.ctx)
+        wrapper.assert_called_once_with(monitor)
 
     def test_last_updated_at_persists_and_reload_skips_unchanged_item(self) -> None:
         calls: list[str] = []

--- a/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
+++ b/skills/codex-refactor-loop/scripts/test_concurrency_monitor.py
@@ -635,7 +635,7 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
     def test_tick_empty_queue_zero_expected_writes_owner_local_status_snapshot_only(self) -> None:
         with mock.patch.object(self.monitor, "list_auto_loop_issues", return_value=[]):
             with mock.patch.object(self.monitor, "count_in_flight_codex", return_value=0):
-                self.monitor.tick()
+                self.module.run_concurrency_reconcile_tick(self.monitor)
 
         snapshot_path = self.refactor_loop / "state" / "statusline-snapshot.json"
         self.assertTrue(snapshot_path.exists())

--- a/skills/codex-refactor-loop/scripts/test_controller_runtime_inventory.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_runtime_inventory.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Source-regression tests for the test-owned controller runtime inventory."""
+
+from __future__ import annotations
+
+import ast
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.controller_runtime_inventory import CONTROLLER_RUNTIME_INVENTORY
+from codex_refactor_loop.restart import restart_managed_daemon_names
+
+
+ALLOWED_FIELDS = {
+    "daemon_name",
+    "owner_module",
+    "cli_command",
+    "tick_import_path",
+    "authority_note",
+    "test_owner",
+}
+
+FORBIDDEN_FIELDS = {
+    "callable",
+    "argv",
+    "shell",
+    "cmd",
+    "command",
+    "env",
+    "git",
+    "gh",
+    "executor",
+    "dispatch",
+    "authorization",
+    "pending_events",
+    "state_transition",
+    "lifecycle_owner",
+}
+
+
+class ControllerRuntimeInventoryTests(unittest.TestCase):
+    def test_inventory_is_data_only_and_matches_restart_managed_daemons(self) -> None:
+        rows = list(CONTROLLER_RUNTIME_INVENTORY)
+
+        self.assertEqual(list(restart_managed_daemon_names()), [row["daemon_name"] for row in rows])
+        for row in rows:
+            with self.subTest(row=row["daemon_name"]):
+                self.assertEqual(ALLOWED_FIELDS, set(row))
+                self.assertTrue(all(isinstance(value, str) and value for value in row.values()))
+                self.assertTrue(row["tick_import_path"].startswith(row["owner_module"] + ".run_"))
+                self.assertTrue(row["tick_import_path"].endswith("_reconcile_tick"))
+                self.assertNotIn(row["daemon_name"], row["authority_note"])
+                self.assertTrue(row["test_owner"].startswith("skills/codex-refactor-loop/scripts/test_"))
+
+    def test_inventory_source_has_no_executable_or_authorization_fields(self) -> None:
+        source = SCRIPT_DIR / "codex_refactor_loop" / "controller_runtime_inventory.py"
+        module = ast.parse(source.read_text(encoding="utf-8"))
+        literal_keys: set[str] = set()
+        for node in ast.walk(module):
+            if isinstance(node, ast.Dict):
+                for key in node.keys:
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                        literal_keys.add(key.value)
+            self.assertNotIsInstance(node, (ast.Lambda, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+
+        self.assertTrue(literal_keys)
+        self.assertTrue(literal_keys <= ALLOWED_FIELDS)
+        self.assertTrue(FORBIDDEN_FIELDS.isdisjoint(literal_keys))
+
+    def test_runtime_execution_modules_do_not_import_inventory(self) -> None:
+        runtime_paths = [
+            SCRIPT_DIR / "codex_refactor_loop" / "restart.py",
+            SCRIPT_DIR / "codex_refactor_loop" / "monitors" / "comment.py",
+            SCRIPT_DIR / "codex_refactor_loop" / "monitors" / "progress.py",
+            SCRIPT_DIR / "codex_refactor_loop" / "monitors" / "concurrency.py",
+            SCRIPT_DIR / "codex_refactor_loop" / "sync" / "dev.py",
+            SCRIPT_DIR / "codex_refactor_loop" / "phase9" / "router.py",
+            SCRIPT_DIR / "codex_refactor_loop" / "closed_label_reconciler.py",
+            SCRIPT_DIR / "codex_refactor_loop" / "wakeup_runner.py",
+        ]
+        for path in runtime_paths:
+            with self.subTest(path=path.relative_to(SCRIPT_DIR)):
+                self.assertNotIn("controller_runtime_inventory", path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -26,6 +26,7 @@ from codex_refactor_loop.phase9.router import (
     Phase9TerminalDecision,
     main,
     parse_phase9_log_identity,
+    run_phase9_router_reconcile_tick,
 )
 from codex_refactor_loop.prompt_contracts import GITHUB_POST_RULES_CONTRACT_TOKEN
 
@@ -2341,6 +2342,13 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(commands, [])
         self.assertEqual(self.ledger_entries(), [])
+
+    def test_reconcile_tick_wrapper_preserves_phase9_tick_behavior(self) -> None:
+        router = mock.Mock(spec=Phase9Router)
+
+        run_phase9_router_reconcile_tick(router)
+
+        router.tick.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/skills/codex-refactor-loop/scripts/test_phase_label_contract.py
+++ b/skills/codex-refactor-loop/scripts/test_phase_label_contract.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Source-regression tests for declaration-only phase-label contract."""
+
+from __future__ import annotations
+
+import ast
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.phase_label_contract import PHASE_LABEL_CONTRACT
+
+
+class PhaseLabelContractTests(unittest.TestCase):
+    def test_contract_is_declaration_only(self) -> None:
+        self.assertEqual(
+            {
+                "contract_owner",
+                "open_managed_reader",
+                "closed_reconciler_planner",
+                "execution_import_policy",
+            },
+            set(PHASE_LABEL_CONTRACT),
+        )
+        self.assertEqual(
+            "codex_refactor_loop.managed_work_snapshot.ManagedWorkSnapshot",
+            PHASE_LABEL_CONTRACT["open_managed_reader"],
+        )
+        self.assertIn("must not import", PHASE_LABEL_CONTRACT["execution_import_policy"])
+
+        source = SCRIPT_DIR / "codex_refactor_loop" / "phase_label_contract.py"
+        module = ast.parse(source.read_text(encoding="utf-8"))
+        for node in ast.walk(module):
+            self.assertNotIsInstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda))
+
+    def test_label_mutation_execution_modules_do_not_import_contract(self) -> None:
+        execution_modules = [
+            SCRIPT_DIR / "codex_refactor_loop" / "closed_label_reconciler.py",
+            SCRIPT_DIR / "codex_refactor_loop" / "closed_phase_labels.py",
+            SCRIPT_DIR / "codex_refactor_loop" / "wakeup_runner.py",
+            SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py",
+        ]
+        for path in execution_modules:
+            with self.subTest(path=path.relative_to(SCRIPT_DIR)):
+                self.assertNotIn("phase_label_contract", path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_progress_reporter.py
+++ b/skills/codex-refactor-loop/scripts/test_progress_reporter.py
@@ -17,7 +17,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.context import LoopContext
-from codex_refactor_loop.monitors.progress import ProgressReporter, exit_status
+from codex_refactor_loop.monitors.progress import ProgressReporter, exit_status, run_progress_reporter_reconcile_tick
 
 
 class ProgressReporterTests(unittest.TestCase):
@@ -90,7 +90,7 @@ class ProgressReporterTests(unittest.TestCase):
             with mock.patch.object(reporter, "sync_global_status_card") as sync_global_status_card:
                 self.assertFalse(hasattr(reporter, "gh"))
                 with mock.patch.object(reporter, "gh_api", side_effect=AssertionError("per-worker gh api comments are deleted")):
-                    reporter.tick()
+                    run_progress_reporter_reconcile_tick(reporter)
 
         sync_global_status_card.assert_called_once()
         self.assertEqual({}, reporter._state())

--- a/skills/codex-refactor-loop/scripts/test_reconcile_tick_scaffold.py
+++ b/skills/codex-refactor-loop/scripts/test_reconcile_tick_scaffold.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Behavior tests for owner-local reconcile tick wrappers."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop import closed_label_reconciler
+from codex_refactor_loop import wakeup_runner
+from codex_refactor_loop.monitors import comment, concurrency, progress
+from codex_refactor_loop.phase9 import router
+from codex_refactor_loop.sync import dev
+
+
+class FakeTickOwner:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def tick(self) -> None:
+        self.calls.append("tick")
+
+
+class FakeRunOnceOwner:
+    def __init__(self) -> None:
+        self.beat = None
+        self.calls = 0
+
+    def run_once(self, beat=None):
+        self.calls += 1
+        self.beat = beat
+        return "result"
+
+
+class ReconcileTickScaffoldTests(unittest.TestCase):
+    def test_owner_local_reconcile_tick_wrappers_delegate_to_owner_tick(self) -> None:
+        wrappers = (
+            comment.run_comment_monitor_reconcile_tick,
+            progress.run_progress_reporter_reconcile_tick,
+            concurrency.run_concurrency_reconcile_tick,
+            dev.run_dev_sync_reconcile_tick,
+            router.run_phase9_router_reconcile_tick,
+        )
+        for wrapper in wrappers:
+            with self.subTest(wrapper=wrapper.__name__):
+                owner = FakeTickOwner()
+                wrapper(owner)
+                self.assertEqual(["tick"], owner.calls)
+
+    def test_closed_label_reconciler_wrapper_preserves_run_once_result_and_beat(self) -> None:
+        owner = FakeRunOnceOwner()
+        beat = object()
+
+        result = closed_label_reconciler.run_closed_label_reconciler_reconcile_tick(owner, beat=beat)
+
+        self.assertEqual("result", result)
+        self.assertEqual(1, owner.calls)
+        self.assertIs(beat, owner.beat)
+
+    def test_wakeup_runner_wrapper_preserves_run_once_result(self) -> None:
+        owner = FakeRunOnceOwner()
+
+        result = wakeup_runner.run_wakeup_runner_reconcile_tick(owner)
+
+        self.assertEqual("result", result)
+        self.assertEqual(1, owner.calls)
+
+    def test_concurrency_module_tick_reuses_owner_local_wrapper(self) -> None:
+        owner = FakeTickOwner()
+
+        with mock.patch.object(concurrency, "_default_monitor", return_value=owner):
+            with mock.patch.object(concurrency, "run_concurrency_reconcile_tick") as wrapper:
+                concurrency.tick()
+
+        wrapper.assert_called_once_with(owner)
+
+    def test_dev_module_tick_reuses_owner_local_wrapper(self) -> None:
+        owner = FakeTickOwner()
+        config = mock.Mock()
+
+        with mock.patch.object(dev.IntegrationSyncDaemon, "from_config", return_value=owner):
+            with mock.patch.object(dev, "run_dev_sync_reconcile_tick") as wrapper:
+                dev.tick(config)
+
+        wrapper.assert_called_once_with(owner)
+
+    def test_no_shared_tick_result_or_registry_modules_exist(self) -> None:
+        package_root = SCRIPT_DIR / "codex_refactor_loop"
+        forbidden = {
+            "reconcile_ticks.py",
+            "reconcile_registry.py",
+            "tick_helpers.py",
+            "tick_outcome.py",
+            "tick_outcomes.py",
+        }
+
+        self.assertEqual([], sorted(path.name for path in package_root.rglob("*.py") if path.name in forbidden))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/codex-refactor-loop/scripts/test_skill_reference_anchors.py
@@ -1953,19 +1953,22 @@ class WakeupRunnerContractTests(unittest.TestCase):
     def test_no_shared_controller_runtime_registry_or_tick_envelope_scaffold(self) -> None:
         inventory = section_after_anchor_until_heading(self.skill, "tier0-scaffold-inventory", level=3)
         for needle in (
-            "prose-only and non-authoritative",
-            "not a machine-readable catalog, registry, runtime scaffold, or package API",
-            "not imported by runtime code",
-            "no dispatch, write, state-transition, or authorization authority",
+            "prose plus the single test-owned/data-only `controller_runtime_inventory.py`",
+            "remains non-authoritative",
+            "not a runtime scaffold, package API, or executable registry",
+            "Runtime execution paths must not import/read `controller_runtime_inventory.py`",
+            "no dispatch, write, state-transition, pending-events, label mutation, GitHub/git, or authorization authority",
             "restart.py::DAEMON_COMMANDS",
             "restart_managed_daemon_names()",
+            "daemon name, owner module/CLI command, tick import path, authority note, and test owner",
+            "callable, argv/shell/cmd/env, git/gh, executor, dispatch, authorization, pending-events, state-transition, or lifecycle owner fields",
             "cli.py::COMMANDS[*].authority",
             "SKILL.md#work-unit-contract",
             "ctx.paths.pending_events",
             ".refactor-loop/.controller-pending-events.log",
             "no pending-events authority",
             "owner-local files",
-            "shared `TickOutcome`, `tick_helpers.py`, or controller-runtime catalog",
+            "shared `TickOutcome`, `DaemonReconcileTick`, `ReconcileTickResult`, `tick_helpers.py`, `reconcile_ticks.py`, `reconcile_registry.py`, or controller-runtime catalog",
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, inventory)
@@ -1978,6 +1981,8 @@ class WakeupRunnerContractTests(unittest.TestCase):
             "tick_helpers.py",
             "tick_outcome.py",
             "tick_outcomes.py",
+            "reconcile_ticks.py",
+            "reconcile_registry.py",
             "daemon_registry.json",
             "daemon_registry.yaml",
             "daemon_registry.yml",

--- a/skills/codex-refactor-loop/scripts/test_sync_dev.py
+++ b/skills/codex-refactor-loop/scripts/test_sync_dev.py
@@ -24,6 +24,7 @@ from codex_refactor_loop.sync.dev import (
     dispatch_codex_resolve,
     load_dev_sync_config,
     merge_in_progress,
+    run_dev_sync_reconcile_tick,
 )
 
 
@@ -756,6 +757,13 @@ class SyncDevSourceRegressionTests(unittest.TestCase):
     def test_no_whole_tick_halt_on_rollup_adoption_ambiguity(self) -> None:
         src = SYNC_DEV.read_text(encoding="utf-8")
         self.assertNotRegex(src, r'rollup\.status == "ambiguous"[\s\S]{0,120}\breturn\b')
+
+    def test_reconcile_tick_wrapper_preserves_integration_sync_tick_behavior(self) -> None:
+        daemon = mock.Mock(spec=IntegrationSyncDaemon)
+
+        run_dev_sync_reconcile_tick(daemon)
+
+        daemon.tick.assert_called_once_with()
 
     def test_skill_documents_rollup_ambiguity_fallthrough(self) -> None:
         skill = (SCRIPT_DIR.parent / "SKILL.md").read_text(encoding="utf-8")

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -30,6 +30,7 @@ from codex_refactor_loop.wakeup_runner import (
     _wakeup_tick_action,
     main as wakeup_runner_main,
     _source_log_has_clean_marker,
+    run_wakeup_runner_reconcile_tick,
 )
 
 
@@ -3934,6 +3935,13 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             out.getvalue().strip(),
             r"^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\] wakeup-runner: tick dispatched spawn:1$",
         )
+
+    def test_reconcile_tick_wrapper_preserves_wakeup_runner_results(self) -> None:
+        runner = mock.Mock(spec=WakeupRunner)
+        runner.run_once.return_value = [RunnerResult("action-1", "applied")]
+
+        self.assertEqual([RunnerResult("action-1", "applied")], run_wakeup_runner_reconcile_tick(runner))
+        runner.run_once.assert_called_once_with()
 
     def test_refactor_loop_host_env_is_not_production_topology_ssot(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "wakeup_runner.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## 修改文件
- 为七个 restart-managed daemon owner module 增加 owner-local `run_*_reconcile_tick(...)` wrapper，并让 loop / `--once` / module-level `tick()` 复用这些本地 helper。
- 新增 test-owned/data-only `controller_runtime_inventory.py` 与 declaration-only `phase_label_contract.py`，并用测试锁住二者没有 runtime authority。
- 更新 `SKILL.md#tier0-scaffold-inventory`，保留 owner-local tick 抽取边界，禁止共享 tick/result/registry 抽象。

## 测试结果
- `python3 -m compileall skills/codex-refactor-loop/scripts skills/sshx -q`
- verification_hints 全部 unittest 通过
- 指定 pytest：`1883 passed, 1 skipped, 5688 subtests passed`；`skills/sshx/tests` 为 `26 passed, 6 subtests passed`
- pycache guard 无输出；`reconcile_tick` grep 显示 owner-local helper

## deviation 记录
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)
- HOST_ARCHITECTURE_GREP_CHECKS unset，host architecture guard 未配置，记录为 skipped。
- No SCOPE_EXTEND was used.

Closes #679

⟦AI:AUTO-LOOP⟧
