### PR TITLE
发布 rollup: integration ahead 1 commits (d77a852c038e)

### DIFF
--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -57,7 +57,7 @@ ${SCOPE_PATHS}
    - 测试结果
    - deviation 记录
    - `SCOPE_EXTEND` 记录
-10. 若 status 为 `ok`，同时写入 worker-authored PR artifacts：`$REPO_ROOT/.refactor-loop/runs/implementation-pr-${CLUSTER_ID}-title.txt` 与 `$REPO_ROOT/.refactor-loop/runs/implementation-pr-${CLUSTER_ID}-body.md`。title 必须是一行非占位标题,语言遵循 `HOST_WORK_LANGUAGE`，不得是 placeholder；body 必须包含且只包含一个 `Closes #N`，包含 changed files、test results、deviation record 三个 section concepts(按 `HOST_WORK_LANGUAGE` 渲染)，并以 sentinel 作为最终独立行。
+10. 若 status 为 `ok`，同时写入 worker-authored PR artifacts：`$REPO_ROOT/.refactor-loop/runs/implementation-pr-${CLUSTER_ID}-title.txt` 与 `$REPO_ROOT/.refactor-loop/runs/implementation-pr-${CLUSTER_ID}-body.md`。title 必须是一行非占位标题,语言遵循 `HOST_WORK_LANGUAGE`，不得是 placeholder；body 必须包含且只包含一个 `Closes #N`，必须使用这三个固定 section 标题作为语言无关机器 marker(不要翻译)：`## Changed files`、`## Test results`、`## Deviations`。每个标题下的 prose/content 遵循 `HOST_WORK_LANGUAGE`，并以 sentinel 作为最终独立行。
 11. 末尾打印 `IMPLEMENT_DONE:${CLUSTER_ID}:<status>` 其中 status ∈ {ok, partial, blocked}。
 
 ## Marker emission allowlist(强制)

--- a/skills/codex-refactor-loop/prompts/implementation-pr-artifact-repair.md
+++ b/skills/codex-refactor-loop/prompts/implementation-pr-artifact-repair.md
@@ -42,11 +42,13 @@ Use the implementation summary, implementation log, and current implementation w
 
 Internal marker-bearing runs/*.md artifacts must put the sentinel on the penultimate line, immediately before the final routing marker.
 
-Write a self-contained PR body that follows `${HOST_WORK_LANGUAGE}` to the body output path. It must include these section concepts, rendered in the selected work language:
+Write a self-contained PR body to the body output path. It must use these exact fixed section headings as language-independent machine markers. Do not translate the headings:
 
-- changed files
-- test results
-- deviation record
+- `## Changed files`
+- `## Test results`
+- `## Deviations`
+
+The prose/content under each heading follows `${HOST_WORK_LANGUAGE}`.
 
 The body must contain exactly one matching closing link:
 

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py
@@ -11,13 +11,13 @@ from .github_body import GitHubBodyError, validate_self_contained_github_body
 
 
 SAFE_IMPLEMENTATION_CLUSTER_RE = re.compile(r"^[A-Za-z0-9._-]+$")
-IMPLEMENTATION_PR_REQUIRED_SECTION_BYTES = (
-    b"## \xe4\xbf\xae\xe6\x94\xb9\xe6\x96\x87\xe4\xbb\xb6",
-    b"## \xe6\xb5\x8b\xe8\xaf\x95\xe7\xbb\x93\xe6\x9e\x9c",
-    b"## deviation \xe8\xae\xb0\xe5\xbd\x95",
+IMPLEMENTATION_PR_REQUIRED_SECTION_HEADINGS = (
+    "## Changed files",
+    "## Test results",
+    "## Deviations",
 )
-PLACEHOLDER_IMPLEMENT_TITLE_BYTES = b"\xe5\xae\x9e\xe7\x8e\xb0 issue #"
-PLACEHOLDER_IMPLEMENT_HEADING_RE = rb"(?im)^##\s+issue\s+#%s\s+\xe5\xae\x9e\xe7\x8e\xb0\s*$"
+PLACEHOLDER_IMPLEMENT_TITLE_RE_TEMPLATE = r"(?i)^(?:implement(?:ed|ation)?\s+issue\s+#%s\b|issue\s+#%s\s+implement(?:ed|ation)?\b|\u5b9e\u73b0\s+issue\s+#%s\s*$)"
+PLACEHOLDER_IMPLEMENT_HEADING_RE_TEMPLATE = r"(?im)^##\s+(?:implement(?:ed|ation)?\s+issue\s+#%s|issue\s+#%s\s+(?:implement(?:ed|ation)?|\u5b9e\u73b0)|\u5b9e\u73b0\s+issue\s+#%s)\s*$"
 FINAL_SENTINEL = "\u27e6AI:AUTO-LOOP\u27e7"
 CLOSING_ISSUE_RE = re.compile(r"(?im)\bCloses\s+#([1-9][0-9]*)\b")
 
@@ -134,10 +134,8 @@ def _validate_title(path: Path, issue_target: int) -> ImplementationPrArtifactVa
     if len(lines) != 1:
         return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_title_artifact_invalid")
     title = lines[0]
-    title_bytes = title.encode("utf-8")
-    if title_bytes == PLACEHOLDER_IMPLEMENT_TITLE_BYTES + str(issue_target).encode("ascii") or title.lower().startswith(
-        f"implement issue #{issue_target}"
-    ):
+    issue_text = str(issue_target)
+    if re.search(PLACEHOLDER_IMPLEMENT_TITLE_RE_TEMPLATE % (issue_text, issue_text, issue_text), title):
         return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_title_placeholder")
     if FINAL_SENTINEL in title or re.search(r"\bCloses\s+#", title, flags=re.IGNORECASE):
         return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_title_contains_body_content")
@@ -157,14 +155,18 @@ def _validate_body(path: Path, issue_target: int) -> ImplementationPrArtifactVal
         return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_body_github_body_invalid", detail=str(exc))
     if _closing_issue_numbers(text) != [issue_target]:
         return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_body_closes_mismatch")
-    body_bytes = text.encode("utf-8")
-    for section in IMPLEMENTATION_PR_REQUIRED_SECTION_BYTES:
-        if section not in body_bytes:
+    for section in IMPLEMENTATION_PR_REQUIRED_SECTION_HEADINGS:
+        if not _has_exact_heading(text, section):
             return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_body_required_section_missing")
-    if re.search(PLACEHOLDER_IMPLEMENT_HEADING_RE % str(issue_target).encode("ascii"), body_bytes):
+    issue_text = str(issue_target)
+    if re.search(PLACEHOLDER_IMPLEMENT_HEADING_RE_TEMPLATE % (issue_text, issue_text, issue_text), text):
         return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_body_placeholder")
     return ImplementationPrArtifactValidation(path, path)
 
 
 def _closing_issue_numbers(text: str) -> list[int]:
     return [int(match) for match in CLOSING_ISSUE_RE.findall(text)]
+
+
+def _has_exact_heading(text: str, heading: str) -> bool:
+    return any(line.strip() == heading for line in text.splitlines())

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -436,9 +436,9 @@ class ControllerActionsTests(unittest.TestCase):
         body = runs / f"implementation-pr-{cluster}-body.md"
         title.write_text(f"完成 issue #{issue} 的发布契约\n", encoding="utf-8")
         body.write_text(
-            "## 修改文件\n\n- skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py\n\n"
-            "## 测试结果\n\n- python3 skills/codex-refactor-loop/scripts/test_controller_actions.py\n\n"
-            "## deviation 记录\n\n- none\n\n"
+            "## Changed files\n\n- skills/codex-refactor-loop/scripts/codex_refactor_loop/controller_actions.py\n\n"
+            "## Test results\n\n- python3 skills/codex-refactor-loop/scripts/test_controller_actions.py\n\n"
+            "## Deviations\n\n- none\n\n"
             f"Closes #{issue}\n\n"
             "⟦AI:AUTO-LOOP⟧\n",
             encoding="utf-8",
@@ -2176,9 +2176,9 @@ class ControllerActionsTests(unittest.TestCase):
             ("wrong-closes", {}, lambda: body.write_text(valid_body.replace("Closes #77", "Closes #78"), encoding="utf-8"), "implementation PR body must contain exactly one matching Closes link"),
             ("multiple-closes", {}, lambda: body.write_text(valid_body.replace("Closes #77", "Closes #77\nCloses #78"), encoding="utf-8"), "implementation PR body must contain exactly one matching Closes link"),
             ("missing-closes", {}, lambda: body.write_text(valid_body.replace("Closes #77\n\n", ""), encoding="utf-8"), "implementation PR body must contain exactly one matching Closes link"),
-            ("missing-section", {}, lambda: body.write_text(valid_body.replace("## 测试结果", "## test result"), encoding="utf-8"), "implementation PR body missing required section"),
-            ("placeholder-body", {}, lambda: body.write_text("## issue #77 实现\n\n## 修改文件\n\n- x\n\n## 测试结果\n\n- true\n\n## deviation 记录\n\n- none\n\nCloses #77\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8"), "implementation PR body is placeholder"),
-            ("local-path-authority", {}, lambda: body.write_text(valid_body.replace("## 修改文件", "授权: `.refactor-loop/runs/source.md`\n\n## 修改文件"), encoding="utf-8"), "implementation PR body invalid: local .refactor-loop artifact path cannot be the only authority source"),
+            ("missing-section", {}, lambda: body.write_text(valid_body.replace("## Test results", "## test result"), encoding="utf-8"), "implementation PR body missing required section"),
+            ("placeholder-body", {}, lambda: body.write_text("## issue #77 实现\n\n## Changed files\n\n- x\n\n## Test results\n\n- true\n\n## Deviations\n\n- none\n\nCloses #77\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8"), "implementation PR body is placeholder"),
+            ("local-path-authority", {}, lambda: body.write_text(valid_body.replace("## Changed files", "授权: `.refactor-loop/runs/source.md`\n\n## Changed files"), encoding="utf-8"), "implementation PR body invalid: local .refactor-loop artifact path cannot be the only authority source"),
         )
 
         def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:

--- a/skills/codex-refactor-loop/scripts/test_implementation_pr_artifacts.py
+++ b/skills/codex-refactor-loop/scripts/test_implementation_pr_artifacts.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Behavior tests for implementation PR artifact validation."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.implementation_pr_artifacts import validate_implementation_pr_artifacts  # noqa: E402
+
+FINAL_SENTINEL = "\u27e6AI:AUTO-LOOP\u27e7"
+ZH_CHANGED_CONTENT = "- \u66f4\u65b0 implementation PR artifact validator"
+ZH_TEST_CONTENT = "- \u5355\u5143\u6d4b\u8bd5\u901a\u8fc7"
+ZH_DEVIATION_CONTENT = "- \u65e0"
+ZH_CHANGED_HEADING = "## \u4fee\u6539\u6587\u4ef6"
+ZH_TEST_HEADING = "## \u6d4b\u8bd5\u7ed3\u679c"
+ZH_DEVIATION_HEADING = "## deviation \u8bb0\u5f55"
+
+
+class ImplementationPrArtifactsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmpdir.name)
+        self.runs = self.repo / ".refactor-loop" / "runs"
+        self.runs.mkdir(parents=True)
+        self.title = self.runs / "implementation-pr-issue-77-title.txt"
+        self.body = self.runs / "implementation-pr-issue-77-body.md"
+        self.action = {
+            "source_marker": "IMPLEMENT_DONE:issue-77:ok",
+            "title_file": ".refactor-loop/runs/implementation-pr-issue-77-title.txt",
+            "body_file": ".refactor-loop/runs/implementation-pr-issue-77-body.md",
+        }
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def write_artifacts(self, body: str, title: str = "Fix publish artifact validation\n") -> None:
+        self.title.write_text(title, encoding="utf-8")
+        self.body.write_text(body, encoding="utf-8")
+
+    def body_with_content(self, *, changed: str, tests: str, deviations: str) -> str:
+        return (
+            "## Changed files\n\n"
+            f"{changed}\n\n"
+            "## Test results\n\n"
+            f"{tests}\n\n"
+            "## Deviations\n\n"
+            f"{deviations}\n\n"
+            "Closes #77\n\n"
+            f"{FINAL_SENTINEL}\n"
+        )
+
+    def validate(self) -> str | None:
+        return validate_implementation_pr_artifacts(self.repo, self.runs, self.action, 77).reason
+
+    def test_fixed_required_section_markers_allow_english_and_chinese_content(self) -> None:
+        cases = (
+            self.body_with_content(
+                changed="- skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py",
+                tests="- python3 -m unittest skills/codex-refactor-loop/scripts/test_implementation_pr_artifacts.py",
+                deviations="- none",
+            ),
+            self.body_with_content(
+                changed=ZH_CHANGED_CONTENT,
+                tests=ZH_TEST_CONTENT,
+                deviations=ZH_DEVIATION_CONTENT,
+            ),
+        )
+        for body in cases:
+            with self.subTest(body=body):
+                self.write_artifacts(body)
+                self.assertIsNone(self.validate())
+
+    def test_fixed_required_section_markers_reject_missing_or_translated_heading(self) -> None:
+        valid_body = self.body_with_content(changed="- x", tests="- true", deviations="- none")
+        for heading in ("## Changed files", "## Test results", "## Deviations"):
+            with self.subTest(heading=heading):
+                self.write_artifacts(valid_body.replace(heading, f"{heading} details"))
+                self.assertEqual("implementation_pr_body_required_section_missing", self.validate())
+
+        self.write_artifacts(
+            valid_body.replace("## Changed files", ZH_CHANGED_HEADING).replace("## Test results", ZH_TEST_HEADING).replace(
+                "## Deviations", ZH_DEVIATION_HEADING
+            )
+        )
+        self.assertEqual("implementation_pr_body_required_section_missing", self.validate())
+
+    def test_language_independent_placeholder_title_and_body_headings_are_rejected(self) -> None:
+        valid_body = self.body_with_content(changed="- x", tests="- true", deviations="- none")
+        self.write_artifacts(valid_body, title="Implement issue #77\n")
+        self.assertEqual("implementation_pr_title_placeholder", self.validate())
+
+        self.write_artifacts(f"## Implement issue #77\n\n{valid_body}")
+        self.assertEqual("implementation_pr_body_placeholder", self.validate())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -1682,9 +1682,9 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         body = runs / f"implementation-pr-{cluster}-body.md"
         title.write_text(f"完成 issue #{issue} 的发布契约\n", encoding="utf-8")
         body.write_text(
-            "## 修改文件\n\n- skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py\n\n"
-            "## 测试结果\n\n- python3 skills/codex-refactor-loop/scripts/test_wakeup_plan.py\n\n"
-            "## deviation 记录\n\n- none\n\n"
+            "## Changed files\n\n- skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py\n\n"
+            "## Test results\n\n- python3 skills/codex-refactor-loop/scripts/test_wakeup_plan.py\n\n"
+            "## Deviations\n\n- none\n\n"
             f"Closes #{issue}\n\n"
             "⟦AI:AUTO-LOOP⟧\n",
             encoding="utf-8",
@@ -2855,9 +2855,9 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         (self.repo / ".worktrees" / "iter581-issue-581").mkdir(parents=True)
         _title, body = self.write_implementation_pr_artifacts(issue=581, cluster="issue-581")
         body.write_text(
-            "## 修改文件\n\n- 0 LOC no source changes\n\n"
-            "## 测试结果\n\n- no-op verification only\n\n"
-            "## deviation 记录\n\n- none\n\n"
+            "## Changed files\n\n- 0 LOC no source changes\n\n"
+            "## Test results\n\n- no-op verification only\n\n"
+            "## Deviations\n\n- none\n\n"
             "Closes #581\n\n"
             "⟦AI:AUTO-LOOP⟧\n",
             encoding="utf-8",
@@ -3125,8 +3125,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             ("wrong-closes", lambda: body.write_text(valid_body.replace("Closes #20", "Closes #21"), encoding="utf-8"), "implementation_pr_body_closes_mismatch"),
             ("multiple-closes", lambda: body.write_text(valid_body.replace("Closes #20", "Closes #20\nCloses #21"), encoding="utf-8"), "implementation_pr_body_closes_mismatch"),
             ("missing-closes", lambda: body.write_text(valid_body.replace("Closes #20\n\n", ""), encoding="utf-8"), "implementation_pr_body_closes_mismatch"),
-            ("missing-section", lambda: body.write_text(valid_body.replace("## deviation 记录", "## deviation"), encoding="utf-8"), "implementation_pr_body_required_section_missing"),
-            ("placeholder-body", lambda: body.write_text("## issue #20 实现\n\n## 修改文件\n\n- x\n\n## 测试结果\n\n- true\n\n## deviation 记录\n\n- none\n\nCloses #20\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8"), "implementation_pr_body_placeholder"),
+            ("missing-section", lambda: body.write_text(valid_body.replace("## Deviations", "## deviation"), encoding="utf-8"), "implementation_pr_body_required_section_missing"),
+            ("placeholder-body", lambda: body.write_text("## issue #20 实现\n\n## Changed files\n\n- x\n\n## Test results\n\n- true\n\n## Deviations\n\n- none\n\nCloses #20\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8"), "implementation_pr_body_placeholder"),
         )
         for name, mutate, reason in cases:
             with self.subTest(name=name):

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -860,9 +860,9 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             encoding="utf-8",
         )
         (runs / f"implementation-pr-{cluster_id}-body.md").write_text(
-            "## 修改文件\n\n- 0 LOC no source changes\n\n"
-            "## 测试结果\n\n- no-op verification only\n\n"
-            "## deviation 记录\n\n- none\n\n"
+            "## Changed files\n\n- 0 LOC no source changes\n\n"
+            "## Test results\n\n- no-op verification only\n\n"
+            "## Deviations\n\n- none\n\n"
             f"Closes #{issue}\n\n"
             "⟦AI:AUTO-LOOP⟧\n",
             encoding="utf-8",
@@ -980,9 +980,9 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         body = runs / "implementation-pr-issue-77-body.md"
         title.write_text("完成 issue #77 的发布契约\n", encoding="utf-8")
         body.write_text(
-            "## 修改文件\n\n- skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py\n\n"
-            "## 测试结果\n\n- python3 skills/codex-refactor-loop/scripts/test_wakeup_runner.py\n\n"
-            "## deviation 记录\n\n- none\n\n"
+            "## Changed files\n\n- skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py\n\n"
+            "## Test results\n\n- python3 skills/codex-refactor-loop/scripts/test_wakeup_runner.py\n\n"
+            "## Deviations\n\n- none\n\n"
             "Closes #77\n\n"
             "⟦AI:AUTO-LOOP⟧\n",
             encoding="utf-8",
@@ -3357,9 +3357,9 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         title = self.repo / ".refactor-loop" / "runs" / "implementation-pr-issue-77-title.txt"
         body = self.repo / ".refactor-loop" / "runs" / "implementation-pr-issue-77-body.md"
         valid_body = (
-            "## 修改文件\n\n- skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py\n\n"
-            "## 测试结果\n\n- python3 skills/codex-refactor-loop/scripts/test_wakeup_runner.py\n\n"
-            "## deviation 记录\n\n- none\n\n"
+            "## Changed files\n\n- skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_runner.py\n\n"
+            "## Test results\n\n- python3 skills/codex-refactor-loop/scripts/test_wakeup_runner.py\n\n"
+            "## Deviations\n\n- none\n\n"
             "Closes #77\n\n"
             "⟦AI:AUTO-LOOP⟧\n"
         )
@@ -3379,8 +3379,8 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             ("wrong-closes", {}, lambda: body.write_text(valid_body.replace("Closes #77", "Closes #78"), encoding="utf-8"), "publish_implementation_body_closes_mismatch"),
             ("multiple-closes", {}, lambda: body.write_text(valid_body.replace("Closes #77", "Closes #77\nCloses #78"), encoding="utf-8"), "publish_implementation_body_closes_mismatch"),
             ("missing-closes", {}, lambda: body.write_text(valid_body.replace("Closes #77\n\n", ""), encoding="utf-8"), "publish_implementation_body_closes_mismatch"),
-            ("missing-section", {}, lambda: body.write_text(valid_body.replace("## 修改文件", "## files"), encoding="utf-8"), "publish_implementation_body_required_section_missing"),
-            ("placeholder-body", {}, lambda: body.write_text("## issue #77 实现\n\n## 修改文件\n\n- x\n\n## 测试结果\n\n- true\n\n## deviation 记录\n\n- none\n\nCloses #77\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8"), "publish_implementation_body_placeholder"),
+            ("missing-section", {}, lambda: body.write_text(valid_body.replace("## Changed files", "## files"), encoding="utf-8"), "publish_implementation_body_required_section_missing"),
+            ("placeholder-body", {}, lambda: body.write_text("## issue #77 实现\n\n## Changed files\n\n- x\n\n## Test results\n\n- true\n\n## Deviations\n\n- none\n\nCloses #77\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8"), "publish_implementation_body_placeholder"),
         )
         for name, overrides, mutate, reason in cases:
             with self.subTest(name=name):


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `f1bf325e05c8..d77a852c038e`
- 涉及 issue: #701

## commit 摘要

- Fix #701: language-independent PR body required-section markers (en host implement->publish)

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
