### PR TITLE
发布 rollup: integration ahead 3 commits (94af01000863)

### DIFF
--- a/skills/codex-refactor-loop/prompts/implement.md
+++ b/skills/codex-refactor-loop/prompts/implement.md
@@ -53,9 +53,9 @@ ${SCOPE_PATHS}
 7. `git add -A && git status` 确认改动。
 8. **不要 commit**，把改动留在工作树。
 9. 摘要写入 `$REPO_ROOT/.refactor-loop/runs/implement-${CLUSTER_ID}.md`：
-   - 修改文件列表（带行数）
-   - 测试结果
-   - deviation 记录
+   - `## Changed files`（带行数）
+   - `## Test results`
+   - `## Deviations`
    - `SCOPE_EXTEND` 记录
 10. 若 status 为 `ok`，同时写入 worker-authored PR artifacts：`$REPO_ROOT/.refactor-loop/runs/implementation-pr-${CLUSTER_ID}-title.txt` 与 `$REPO_ROOT/.refactor-loop/runs/implementation-pr-${CLUSTER_ID}-body.md`。title 必须是一行非占位标题,语言遵循 `HOST_WORK_LANGUAGE`，不得是 placeholder；body 必须包含且只包含一个 `Closes #N`，必须使用这三个固定 section 标题作为语言无关机器 marker(不要翻译)：`## Changed files`、`## Test results`、`## Deviations`。每个标题下的 prose/content 遵循 `HOST_WORK_LANGUAGE`，并以 sentinel 作为最终独立行。
 11. 末尾打印 `IMPLEMENT_DONE:${CLUSTER_ID}:<status>` 其中 status ∈ {ok, partial, blocked}。

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py
@@ -16,10 +16,10 @@ IMPLEMENTATION_PR_REQUIRED_SECTION_HEADINGS = (
     "## Test results",
     "## Deviations",
 )
-IMPLEMENTATION_PR_REQUIRED_SECTION_RULES = (
-    ("changed files", ("changed", "file")),
-    ("test results", ("test", "result")),
-    ("deviations", ("deviation",)),
+IMPLEMENTATION_PR_REQUIRED_SECTION_ACCEPTED_HEADINGS = (
+    ("changed files", frozenset(("changed files", "changed file"))),
+    ("test results", frozenset(("test results", "test result"))),
+    ("deviations", frozenset(("deviations", "deviation record", "deviation", "deviation records"))),
 )
 PLACEHOLDER_IMPLEMENT_TITLE_RE_TEMPLATE = r"(?i)^(?:implement(?:ed|ation)?\s+issue\s+#%s\b|issue\s+#%s\s+implement(?:ed|ation)?\b|\u5b9e\u73b0\s+issue\s+#%s\s*$)"
 PLACEHOLDER_IMPLEMENT_HEADING_RE_TEMPLATE = r"(?im)^##\s+(?:implement(?:ed|ation)?\s+issue\s+#%s|issue\s+#%s\s+(?:implement(?:ed|ation)?|\u5b9e\u73b0)|\u5b9e\u73b0\s+issue\s+#%s)\s*$"
@@ -160,8 +160,8 @@ def _validate_body(path: Path, issue_target: int) -> ImplementationPrArtifactVal
         return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_body_github_body_invalid", detail=str(exc))
     if _closing_issue_numbers(text) != [issue_target]:
         return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_body_closes_mismatch")
-    for _concept, keywords in IMPLEMENTATION_PR_REQUIRED_SECTION_RULES:
-        if not _has_heading_with_keywords(text, keywords):
+    for _concept, accepted_headings in IMPLEMENTATION_PR_REQUIRED_SECTION_ACCEPTED_HEADINGS:
+        if not _has_accepted_heading(text, accepted_headings):
             return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_body_required_section_missing")
     issue_text = str(issue_target)
     if re.search(PLACEHOLDER_IMPLEMENT_HEADING_RE_TEMPLATE % (issue_text, issue_text, issue_text), text):
@@ -173,16 +173,15 @@ def _closing_issue_numbers(text: str) -> list[int]:
     return [int(match) for match in CLOSING_ISSUE_RE.findall(text)]
 
 
-def _has_heading_with_keywords(text: str, keywords: tuple[str, ...]) -> bool:
+def _has_accepted_heading(text: str, accepted_headings: frozenset[str]) -> bool:
     for line in text.splitlines():
-        if not re.match(r"^\s*##\s+", line):
+        match = re.match(r"^\s*##\s+(.+)$", line)
+        if not match:
             continue
-        tokens = set(re.findall(r"[A-Za-z0-9]+", line.casefold()))
-        if all(_heading_token_matches_keyword(tokens, keyword) for keyword in keywords):
+        if _normalize_section_heading(match.group(1)) in accepted_headings:
             return True
     return False
 
 
-def _heading_token_matches_keyword(tokens: set[str], keyword: str) -> bool:
-    normalized = keyword.casefold()
-    return normalized in tokens or f"{normalized}s" in tokens
+def _normalize_section_heading(heading: str) -> str:
+    return re.sub(r"\s+", " ", heading.casefold().strip())

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py
@@ -16,6 +16,11 @@ IMPLEMENTATION_PR_REQUIRED_SECTION_HEADINGS = (
     "## Test results",
     "## Deviations",
 )
+IMPLEMENTATION_PR_REQUIRED_SECTION_RULES = (
+    ("changed files", ("changed", "file")),
+    ("test results", ("test", "result")),
+    ("deviations", ("deviation",)),
+)
 PLACEHOLDER_IMPLEMENT_TITLE_RE_TEMPLATE = r"(?i)^(?:implement(?:ed|ation)?\s+issue\s+#%s\b|issue\s+#%s\s+implement(?:ed|ation)?\b|\u5b9e\u73b0\s+issue\s+#%s\s*$)"
 PLACEHOLDER_IMPLEMENT_HEADING_RE_TEMPLATE = r"(?im)^##\s+(?:implement(?:ed|ation)?\s+issue\s+#%s|issue\s+#%s\s+(?:implement(?:ed|ation)?|\u5b9e\u73b0)|\u5b9e\u73b0\s+issue\s+#%s)\s*$"
 FINAL_SENTINEL = "\u27e6AI:AUTO-LOOP\u27e7"
@@ -155,8 +160,8 @@ def _validate_body(path: Path, issue_target: int) -> ImplementationPrArtifactVal
         return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_body_github_body_invalid", detail=str(exc))
     if _closing_issue_numbers(text) != [issue_target]:
         return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_body_closes_mismatch")
-    for section in IMPLEMENTATION_PR_REQUIRED_SECTION_HEADINGS:
-        if not _has_exact_heading(text, section):
+    for _concept, keywords in IMPLEMENTATION_PR_REQUIRED_SECTION_RULES:
+        if not _has_heading_with_keywords(text, keywords):
             return ImplementationPrArtifactValidation(path, path, reason="implementation_pr_body_required_section_missing")
     issue_text = str(issue_target)
     if re.search(PLACEHOLDER_IMPLEMENT_HEADING_RE_TEMPLATE % (issue_text, issue_text, issue_text), text):
@@ -168,5 +173,11 @@ def _closing_issue_numbers(text: str) -> list[int]:
     return [int(match) for match in CLOSING_ISSUE_RE.findall(text)]
 
 
-def _has_exact_heading(text: str, heading: str) -> bool:
-    return any(line.strip() == heading for line in text.splitlines())
+def _has_heading_with_keywords(text: str, keywords: tuple[str, ...]) -> bool:
+    for line in text.splitlines():
+        if not re.match(r"^\s*##\s+", line):
+            continue
+        normalized = line.strip().casefold()
+        if all(keyword.casefold() in normalized for keyword in keywords):
+            return True
+    return False

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py
@@ -177,7 +177,12 @@ def _has_heading_with_keywords(text: str, keywords: tuple[str, ...]) -> bool:
     for line in text.splitlines():
         if not re.match(r"^\s*##\s+", line):
             continue
-        normalized = line.strip().casefold()
-        if all(keyword.casefold() in normalized for keyword in keywords):
+        tokens = set(re.findall(r"[A-Za-z0-9]+", line.casefold()))
+        if all(_heading_token_matches_keyword(tokens, keyword) for keyword in keywords):
             return True
     return False
+
+
+def _heading_token_matches_keyword(tokens: set[str], keyword: str) -> bool:
+    normalized = keyword.casefold()
+    return normalized in tokens or f"{normalized}s" in tokens

--- a/skills/codex-refactor-loop/scripts/test_controller_actions.py
+++ b/skills/codex-refactor-loop/scripts/test_controller_actions.py
@@ -2176,7 +2176,7 @@ class ControllerActionsTests(unittest.TestCase):
             ("wrong-closes", {}, lambda: body.write_text(valid_body.replace("Closes #77", "Closes #78"), encoding="utf-8"), "implementation PR body must contain exactly one matching Closes link"),
             ("multiple-closes", {}, lambda: body.write_text(valid_body.replace("Closes #77", "Closes #77\nCloses #78"), encoding="utf-8"), "implementation PR body must contain exactly one matching Closes link"),
             ("missing-closes", {}, lambda: body.write_text(valid_body.replace("Closes #77\n\n", ""), encoding="utf-8"), "implementation PR body must contain exactly one matching Closes link"),
-            ("missing-section", {}, lambda: body.write_text(valid_body.replace("## Test results", "## test result"), encoding="utf-8"), "implementation PR body missing required section"),
+            ("missing-section", {}, lambda: body.write_text(valid_body.replace("## Test results", "## Results"), encoding="utf-8"), "implementation PR body missing required section"),
             ("placeholder-body", {}, lambda: body.write_text("## issue #77 实现\n\n## Changed files\n\n- x\n\n## Test results\n\n- true\n\n## Deviations\n\n- none\n\nCloses #77\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8"), "implementation PR body is placeholder"),
             ("local-path-authority", {}, lambda: body.write_text(valid_body.replace("## Changed files", "授权: `.refactor-loop/runs/source.md`\n\n## Changed files"), encoding="utf-8"), "implementation PR body invalid: local .refactor-loop artifact path cannot be the only authority source"),
         )

--- a/skills/codex-refactor-loop/scripts/test_implementation_pr_artifacts.py
+++ b/skills/codex-refactor-loop/scripts/test_implementation_pr_artifacts.py
@@ -68,7 +68,7 @@ class ImplementationPrArtifactsTest(unittest.TestCase):
     def validate(self) -> str | None:
         return validate_implementation_pr_artifacts(self.repo, self.runs, self.action, 77).reason
 
-    def test_required_section_heading_keywords_allow_canonical_and_language_specific_content(self) -> None:
+    def test_required_section_accepted_headings_allow_canonical_and_language_specific_content(self) -> None:
         cases = (
             self.body_with_content(
                 changed="- skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py",
@@ -86,11 +86,14 @@ class ImplementationPrArtifactsTest(unittest.TestCase):
                 self.write_artifacts(body)
                 self.assertIsNone(self.validate())
 
-    def test_required_section_heading_keywords_allow_reasonable_english_variants(self) -> None:
+    def test_required_section_accepted_headings_allow_explicit_english_variants(self) -> None:
         cases = (
+            ("changed-file", {"changed_heading": "## Changed File"}),
+            ("test-result", {"test_heading": "## Test Result"}),
             ("deviation-record", {"deviations_heading": "## Deviation record"}),
             ("deviation-singular", {"deviations_heading": "## Deviation"}),
-            ("changed-files-case", {"changed_heading": "## Changed Files"}),
+            ("deviation-records", {"deviations_heading": "## Deviation records"}),
+            ("changed-files-case", {"changed_heading": "## CHANGED FILES"}),
             ("test-results-case", {"test_heading": "## TEST RESULTS"}),
         )
         for name, headings in cases:
@@ -98,25 +101,31 @@ class ImplementationPrArtifactsTest(unittest.TestCase):
                 self.write_artifacts(self.body_with_content(changed="- x", tests="- true", deviations="- none", **headings))
                 self.assertIsNone(self.validate())
 
-    def test_required_section_heading_keywords_reject_embedded_token_matches(self) -> None:
+    def test_required_section_accepted_headings_reject_non_allowlisted_headings(self) -> None:
         cases = (
             ("unchanged-files", {"changed_heading": "## Unchanged files"}),
             ("unchanged-profile", {"changed_heading": "## Unchanged profile"}),
+            ("changed-url", {"changed_heading": "## Changed://files"}),
             ("latest-results", {"test_heading": "## Latest results"}),
             ("latest-result", {"test_heading": "## Latest result"}),
+            ("test-url", {"test_heading": "## foo://test results"}),
             ("nodeviation", {"deviations_heading": "## Nodeviation"}),
+            ("deviation-url", {"deviations_heading": "## http://deviation"}),
         )
         for name, headings in cases:
             with self.subTest(name=name):
                 self.write_artifacts(self.body_with_content(changed="- x", tests="- true", deviations="- none", **headings))
                 self.assertEqual("implementation_pr_body_required_section_missing", self.validate())
 
-    def test_required_section_heading_keywords_reject_missing_concept_or_translated_heading(self) -> None:
+    def test_required_section_accepted_headings_reject_missing_concept_or_translated_heading(self) -> None:
         valid_body = self.body_with_content(changed="- x", tests="- true", deviations="- none")
         cases = (
             ("changed", valid_body.replace("## Changed files", "## Files")),
             ("test", valid_body.replace("## Test results", "## Result summary")),
             ("deviations", valid_body.replace("## Deviations", "## Notes")),
+            ("missing-changed", valid_body.replace("## Changed files\n\n- x\n\n", "")),
+            ("missing-test", valid_body.replace("## Test results\n\n- true\n\n", "")),
+            ("missing-deviations", valid_body.replace("## Deviations\n\n- none\n\n", "")),
         )
         for name, body in cases:
             with self.subTest(name=name):
@@ -130,10 +139,16 @@ class ImplementationPrArtifactsTest(unittest.TestCase):
         )
         self.assertEqual("implementation_pr_body_required_section_missing", self.validate())
 
-    def test_required_section_keywords_must_be_heading_lines(self) -> None:
+    def test_required_section_accepted_heading_keywords_must_be_heading_lines(self) -> None:
         body = self.body_with_content(changed="- x", tests="- true", deviations="- none").replace(
-            "## Deviations\n\n- none",
-            "## Notes\n\n- deviation record: none",
+            "## Changed files\n\n- x\n\n",
+            "## Files\n\n- changed files\n\n",
+        ).replace(
+            "## Test results\n\n- true\n\n",
+            "## Results\n\n- test results: true\n\n",
+        ).replace(
+            "## Deviations\n\n- none\n\n",
+            "## Notes\n\n- deviation record: none\n\n",
         )
         self.write_artifacts(body)
         self.assertEqual("implementation_pr_body_required_section_missing", self.validate())

--- a/skills/codex-refactor-loop/scripts/test_implementation_pr_artifacts.py
+++ b/skills/codex-refactor-loop/scripts/test_implementation_pr_artifacts.py
@@ -44,13 +44,22 @@ class ImplementationPrArtifactsTest(unittest.TestCase):
         self.title.write_text(title, encoding="utf-8")
         self.body.write_text(body, encoding="utf-8")
 
-    def body_with_content(self, *, changed: str, tests: str, deviations: str) -> str:
+    def body_with_content(
+        self,
+        *,
+        changed: str,
+        tests: str,
+        deviations: str,
+        changed_heading: str = "## Changed files",
+        test_heading: str = "## Test results",
+        deviations_heading: str = "## Deviations",
+    ) -> str:
         return (
-            "## Changed files\n\n"
+            f"{changed_heading}\n\n"
             f"{changed}\n\n"
-            "## Test results\n\n"
+            f"{test_heading}\n\n"
             f"{tests}\n\n"
-            "## Deviations\n\n"
+            f"{deviations_heading}\n\n"
             f"{deviations}\n\n"
             "Closes #77\n\n"
             f"{FINAL_SENTINEL}\n"
@@ -59,7 +68,7 @@ class ImplementationPrArtifactsTest(unittest.TestCase):
     def validate(self) -> str | None:
         return validate_implementation_pr_artifacts(self.repo, self.runs, self.action, 77).reason
 
-    def test_fixed_required_section_markers_allow_english_and_chinese_content(self) -> None:
+    def test_required_section_heading_keywords_allow_canonical_and_language_specific_content(self) -> None:
         cases = (
             self.body_with_content(
                 changed="- skills/codex-refactor-loop/scripts/codex_refactor_loop/implementation_pr_artifacts.py",
@@ -77,11 +86,28 @@ class ImplementationPrArtifactsTest(unittest.TestCase):
                 self.write_artifacts(body)
                 self.assertIsNone(self.validate())
 
-    def test_fixed_required_section_markers_reject_missing_or_translated_heading(self) -> None:
+    def test_required_section_heading_keywords_allow_reasonable_english_variants(self) -> None:
+        cases = (
+            ("deviation-record", {"deviations_heading": "## Deviation record"}),
+            ("deviation-singular", {"deviations_heading": "## Deviation"}),
+            ("changed-files-case", {"changed_heading": "## Changed Files"}),
+            ("test-results-case", {"test_heading": "## TEST RESULTS"}),
+        )
+        for name, headings in cases:
+            with self.subTest(name=name):
+                self.write_artifacts(self.body_with_content(changed="- x", tests="- true", deviations="- none", **headings))
+                self.assertIsNone(self.validate())
+
+    def test_required_section_heading_keywords_reject_missing_concept_or_translated_heading(self) -> None:
         valid_body = self.body_with_content(changed="- x", tests="- true", deviations="- none")
-        for heading in ("## Changed files", "## Test results", "## Deviations"):
-            with self.subTest(heading=heading):
-                self.write_artifacts(valid_body.replace(heading, f"{heading} details"))
+        cases = (
+            ("changed", valid_body.replace("## Changed files", "## Files")),
+            ("test", valid_body.replace("## Test results", "## Result summary")),
+            ("deviations", valid_body.replace("## Deviations", "## Notes")),
+        )
+        for name, body in cases:
+            with self.subTest(name=name):
+                self.write_artifacts(body)
                 self.assertEqual("implementation_pr_body_required_section_missing", self.validate())
 
         self.write_artifacts(
@@ -89,6 +115,14 @@ class ImplementationPrArtifactsTest(unittest.TestCase):
                 "## Deviations", ZH_DEVIATION_HEADING
             )
         )
+        self.assertEqual("implementation_pr_body_required_section_missing", self.validate())
+
+    def test_required_section_keywords_must_be_heading_lines(self) -> None:
+        body = self.body_with_content(changed="- x", tests="- true", deviations="- none").replace(
+            "## Deviations\n\n- none",
+            "## Notes\n\n- deviation record: none",
+        )
+        self.write_artifacts(body)
         self.assertEqual("implementation_pr_body_required_section_missing", self.validate())
 
     def test_language_independent_placeholder_title_and_body_headings_are_rejected(self) -> None:

--- a/skills/codex-refactor-loop/scripts/test_implementation_pr_artifacts.py
+++ b/skills/codex-refactor-loop/scripts/test_implementation_pr_artifacts.py
@@ -98,6 +98,19 @@ class ImplementationPrArtifactsTest(unittest.TestCase):
                 self.write_artifacts(self.body_with_content(changed="- x", tests="- true", deviations="- none", **headings))
                 self.assertIsNone(self.validate())
 
+    def test_required_section_heading_keywords_reject_embedded_token_matches(self) -> None:
+        cases = (
+            ("unchanged-files", {"changed_heading": "## Unchanged files"}),
+            ("unchanged-profile", {"changed_heading": "## Unchanged profile"}),
+            ("latest-results", {"test_heading": "## Latest results"}),
+            ("latest-result", {"test_heading": "## Latest result"}),
+            ("nodeviation", {"deviations_heading": "## Nodeviation"}),
+        )
+        for name, headings in cases:
+            with self.subTest(name=name):
+                self.write_artifacts(self.body_with_content(changed="- x", tests="- true", deviations="- none", **headings))
+                self.assertEqual("implementation_pr_body_required_section_missing", self.validate())
+
     def test_required_section_heading_keywords_reject_missing_concept_or_translated_heading(self) -> None:
         valid_body = self.body_with_content(changed="- x", tests="- true", deviations="- none")
         cases = (

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -3125,7 +3125,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             ("wrong-closes", lambda: body.write_text(valid_body.replace("Closes #20", "Closes #21"), encoding="utf-8"), "implementation_pr_body_closes_mismatch"),
             ("multiple-closes", lambda: body.write_text(valid_body.replace("Closes #20", "Closes #20\nCloses #21"), encoding="utf-8"), "implementation_pr_body_closes_mismatch"),
             ("missing-closes", lambda: body.write_text(valid_body.replace("Closes #20\n\n", ""), encoding="utf-8"), "implementation_pr_body_closes_mismatch"),
-            ("missing-section", lambda: body.write_text(valid_body.replace("## Deviations", "## deviation"), encoding="utf-8"), "implementation_pr_body_required_section_missing"),
+            ("missing-section", lambda: body.write_text(valid_body.replace("## Deviations", "## Notes"), encoding="utf-8"), "implementation_pr_body_required_section_missing"),
             ("placeholder-body", lambda: body.write_text("## issue #20 实现\n\n## Changed files\n\n- x\n\n## Test results\n\n- true\n\n## Deviations\n\n- none\n\nCloses #20\n\n⟦AI:AUTO-LOOP⟧\n", encoding="utf-8"), "implementation_pr_body_placeholder"),
         )
         for name, mutate, reason in cases:


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `3` commits
- 范围: `050f63e80bec..94af01000863`
- 涉及 issue: #705

## commit 摘要

- Fix #705: explicit accepted-heading allowlist (eliminate fuzzy false-match surface)
- Fix #705 review: word-boundary keyword match (reject embedded-token headings)
- Fix #705: tolerant required-section heading match + align implement.md canonical markers

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
