### PR TITLE
发布 rollup: integration ahead 2 commits (1337d02f8c73)

### DIFF
--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/banners.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/banners.py
@@ -50,7 +50,7 @@ def build_status_banner(request: BannerRequest) -> str:
 |---|---|
 | 阶段 | **派出 codex(role=`{role}`)** |
 | codex log | `{log_name}` |
-| no-output stall window | {request.stall}s(~{request.stall // 60} min 无输出窗口) |
+| total wall-clock timeout | {request.stall}s(~{request.stall // 60} min) |
 | 上下文 | {request.detail or "(none)"} |
 | 下一步自动会做 | {next_step} |
 | **是否需要人介入** | **❌ 否**(自动推进) |

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/patrol.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/patrol.py
@@ -381,7 +381,7 @@ def _terminal_failure_evidence(lines: Sequence[str], exit_index: int) -> tuple[s
     structured_failure = [
         line
         for line in window
-        if line.strip().startswith(("SPAWN_FAILED=", "STALL_KILL_AFTER="))
+        if line.strip().startswith(("SPAWN_FAILED=", "TIMEOUT_KILL_AFTER=", "STALL_KILL_AFTER="))
     ]
     if structured_failure:
         return tuple(structured_failure + [lines[exit_index]])

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/patrol_analysis.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/patrol_analysis.py
@@ -13,7 +13,8 @@ from .processes import ProcessSupervisor
 
 
 PATROL_ANALYSIS_PROMPT = "patrol-analysis.md"
-PATROL_ANALYSIS_STALL_SECONDS = 900
+# Compatibility name: this is a total wall-clock timeout, not a log-idle window.
+PATROL_ANALYSIS_STALL_SECONDS = 5400
 PATROL_ANALYSIS_CODEX_HOME = "patrol-analysis-codex-home"
 PATROL_ANALYSIS_CWD = "patrol-analysis-cwd"
 PATROL_ANALYSIS_ENV_ALLOWLIST = frozenset(

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -1672,7 +1672,7 @@ class Phase9Router:
             "cd": str(self.ctx.repo_root.resolve()),
             "prompt": self._artifact_path(prompt),
             "log": self._artifact_path(log_path),
-            "stall": 3600,
+            "stall": 5400,
             "reason": reason,
             "queued_at": self._now(),
             "run_in_background_required": True,

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/processes.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/processes.py
@@ -15,11 +15,16 @@ from typing import Mapping, Sequence
 
 
 STALL_EXIT_CODE = 137
+TIMEOUT_EXIT_CODE = STALL_EXIT_CODE
 
 
 @dataclass(frozen=True)
 class ProcessSupervisor:
-    """Supervise a command by log liveness, not wall-clock duration."""
+    """Supervise a command by process exit or total wall-clock timeout.
+
+    The `stall` argument is a compatibility name for the total wall-clock
+    runtime limit in seconds. It is not a log-idle timeout.
+    """
 
     poll_interval: float = 1.0
     clock: callable = time.time
@@ -39,7 +44,7 @@ class ProcessSupervisor:
         if not stdin.is_file():
             raise ValueError(f"prompt file not found: {stdin}")
         if stall <= 0:
-            raise ValueError(f"stall must be positive: {stall}")
+            raise ValueError(f"total wall-clock timeout must be positive: {stall}")
         log.parent.mkdir(parents=True, exist_ok=True)
         if log.exists() and not _has_exit_marker(log):
             _rotate_unfinished_log(log)
@@ -59,29 +64,23 @@ class ProcessSupervisor:
             except OSError as exc:
                 _append(log, f"SPAWN_FAILED={exc}\nEXIT=127\nDONE_AT={_utc_now()}\n")
                 return 127
-            last_size = _log_size(log)
-            last_output_at = self.clock()
-            stalled = False
+            start = self.clock()
+            timed_out = False
             try:
                 while proc.poll() is None:
                     self.sleeper(self.poll_interval)
-                    size = _log_size(log)
-                    if size != last_size:
-                        last_size = size
-                        last_output_at = self.clock()
-                        continue
-                    if self.clock() - last_output_at >= stall:
-                        _append(log, f"STALL_KILL_AFTER={stall}s\nSTALL_KILL_AT={_utc_now()}\n")
+                    if self.clock() - start >= stall:
+                        _append(log, f"TIMEOUT_KILL_AFTER={stall}s\nTIMEOUT_KILL_AT={_utc_now()}\n")
                         kill_process_group(proc.pid)
-                        stalled = True
+                        timed_out = True
                         break
                 exit_code = proc.wait()
             finally:
                 if proc.poll() is None:
                     kill_process_group(proc.pid)
                     proc.wait()
-            if stalled:
-                exit_code = STALL_EXIT_CODE
+            if timed_out:
+                exit_code = TIMEOUT_EXIT_CODE
         _append(log, f"EXIT={exit_code}\nDONE_AT={_utc_now()}\n")
         return exit_code
 
@@ -102,7 +101,7 @@ def launch_spawn_codex_supervisor(
     if not prompt.is_file():
         return 2
     if stall <= 0:
-        raise ValueError(f"stall must be positive: {stall}")
+        raise ValueError(f"total wall-clock timeout must be positive: {stall}")
     repo_root = repo_root.resolve()
     skill_root = skill_root.resolve()
     cli = skill_root / "scripts" / "consensus-rnd-cli"
@@ -179,13 +178,6 @@ def _has_exit_marker(path: Path) -> bool:
     except OSError:
         return False
     return any(line.startswith("EXIT=") for line in tail)
-
-
-def _log_size(path: Path) -> int:
-    try:
-        return path.stat().st_size
-    except OSError:
-        return 0
 
 
 def _append(path: Path, text: str) -> None:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/processes.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/processes.py
@@ -69,6 +69,8 @@ class ProcessSupervisor:
             try:
                 while proc.poll() is None:
                     self.sleeper(self.poll_interval)
+                    if proc.poll() is not None:
+                        break
                     if self.clock() - start >= stall:
                         _append(log, f"TIMEOUT_KILL_AFTER={stall}s\nTIMEOUT_KILL_AT={_utc_now()}\n")
                         kill_process_group(proc.pid)

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/spawn.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/spawn.py
@@ -31,7 +31,7 @@ def build_codex_args(*, cd: str, model: str, add_dirs: Sequence[str]) -> list[st
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run codex with log-liveness supervision")
+    parser = argparse.ArgumentParser(description="Run codex with process-exit or total wall-clock timeout supervision")
     parser.add_argument("--cd", required=True)
     prompt = parser.add_mutually_exclusive_group(required=True)
     prompt.add_argument("--prompt")
@@ -51,7 +51,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         sys.stderr.write(f"prompt file not found: {prompt_path}\n")
         return 2
     if args.stall <= 0:
-        sys.stderr.write(f"codex stall window must be a positive integer number of seconds: {args.stall}\n")
+        sys.stderr.write(f"codex total wall-clock timeout must be a positive integer number of seconds: {args.stall}\n")
         return 2
     command = build_codex_args(cd=args.cd, model=args.model, add_dirs=args.add_dir)
     try:
@@ -70,7 +70,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         sys.stderr.write(f"SPAWN_CLAIM_HELD:task={claim.task_id} lock={claim.lock_path}\n")
         return 0
     child_env = accounting_env(os.environ, skill_root=Path(__file__).resolve().parents[2], repo_root=usage_repo, source=f"codex:{task_id}", force_source=True)
-    banner = f"SPAWN: prompt={prompt_path} log={log_path} cd={args.cd} stall={args.stall}s"
+    banner = f"SPAWN: prompt={prompt_path} log={log_path} cd={args.cd} timeout={args.stall}s"
     if args.model:
         banner += f" model={args.model}"
     try:

--- a/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -600,7 +600,7 @@ def _revive_stale_redispatchable_implement_log(
 
     Automatic callers leave force=False: the log must be idle longer than
     stale_revival_seconds() (a live supervised codex cannot be silent past the
-    no-output stall window, so a >threshold-stale in_flight log is a dead worker).
+    total wall-clock timeout, so a >threshold-stale in_flight log is a dead worker).
     The manual trigger passes force=True to revive now without waiting, but then
     an in_flight log is cleared only when a live-process check proves no codex is
     running it, so a genuinely running worker is never cleared."""
@@ -2851,7 +2851,7 @@ def release_rollup_actions(repo_root: Path) -> list[dict[str, Any]]:
                     "cd": str(repo_root.resolve()),
                     "prompt": str((repo_root / RELEASE_ROLLUP_BODY_PROMPT).resolve()),
                     "log": str((repo_root / RELEASE_ROLLUP_BODY_LOG).resolve()),
-                    "stall": 1800,
+                    "stall": 5400,
                     "runner_authority": RUNNER_AUTHORITY,
                     "no_generic_command": True,
                     "no_lifecycle_authority": True,
@@ -3246,7 +3246,7 @@ def implementation_pr_artifact_repair_actions(actions: list[dict[str, Any]], rep
                 "cd": str(repo_root.resolve()),
                 "prompt": str((repo_root / prompt).resolve()),
                 "log": str((repo_root / log).resolve()),
-                "stall": 1800,
+                "stall": 5400,
                 "issue_number": target[1],
                 "cluster_id": cluster_id,
                 "title_file": str(action.get("title_file") or ""),

--- a/skills/codex-refactor-loop/scripts/test_banner_package.py
+++ b/skills/codex-refactor-loop/scripts/test_banner_package.py
@@ -39,7 +39,7 @@ class BannerPackageTests(unittest.TestCase):
         for required in (
             "| 阶段 | **派出 codex(role=`implement`)** |",
             "| codex log | `implement-160.log` |",
-            "| no-output stall window | 180s(~3 min 无输出窗口) |",
+            "| total wall-clock timeout | 180s(~3 min) |",
             "| 上下文 | phase9 issue160 parity |",
             "IMPLEMENT_DONE:<cluster>:<status>",
             "| **是否需要人介入** | **❌ 否**(自动推进) |",

--- a/skills/codex-refactor-loop/scripts/test_patrol_inspector.py
+++ b/skills/codex-refactor-loop/scripts/test_patrol_inspector.py
@@ -247,7 +247,7 @@ class PatrolInspectorTests(unittest.TestCase):
         self.assertIsNotNone(supervisor.log)
         self.assertIsNotNone(supervisor.cwd)
         self.assertIsNotNone(supervisor.env)
-        self.assertEqual(900, supervisor.stall)
+        self.assertEqual(5400, supervisor.stall)
         self.assertEqual("patrol-analysis", supervisor.stdin.parent.name)
         self.assertEqual(".md", supervisor.stdin.suffix)
         self.assertEqual("logs", supervisor.log.parent.name)
@@ -490,7 +490,20 @@ class PatrolInspectorTests(unittest.TestCase):
         self.assertEqual(("SPAWN_FAILED=missing executable", "EXIT=127"), exception_signals[0].evidence)
         self.assertIn("EXIT=127", exception_signals[0].summary)
 
-    def test_stall_kill_terminal_envelope_creates_finding(self) -> None:
+    def test_timeout_kill_terminal_envelope_creates_finding(self) -> None:
+        (self.tmp / ".refactor-loop" / "logs" / "worker.log").write_text(
+            "progress update\nTIMEOUT_KILL_AFTER=600s\nEXIT=137\n",
+            encoding="utf-8",
+        )
+
+        signals = PatrolInspector(self.ctx, github_items=()).collect_candidate_signals()
+
+        exception_signals = [signal for signal in signals if signal.kind == "exception-log"]
+        self.assertEqual(1, len(exception_signals))
+        self.assertEqual(("TIMEOUT_KILL_AFTER=600s", "EXIT=137"), exception_signals[0].evidence)
+        self.assertIn("EXIT=137", exception_signals[0].summary)
+
+    def test_legacy_stall_kill_terminal_envelope_still_creates_finding(self) -> None:
         (self.tmp / ".refactor-loop" / "logs" / "worker.log").write_text(
             "progress update\nSTALL_KILL_AFTER=600\nEXIT=137\n",
             encoding="utf-8",

--- a/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/codex-refactor-loop/scripts/test_phase9_router_daemon.py
@@ -428,7 +428,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
             self.setUp()
             self.solver_triplet(issue=38, round_no=5)
             target_log = self.router._log_path("38", 5, "judge")
-            ps_output = f"/bin/sh /tmp/consensus-rnd-cli spawn-codex --cd {self.repo.resolve()} --log {target_log} --stall 3600\n"
+            ps_output = f"/bin/sh /tmp/consensus-rnd-cli spawn-codex --cd {self.repo.resolve()} --log {target_log} --stall 5400\n"
 
             with mock.patch("codex_refactor_loop.phase9.router.subprocess.run", return_value=mock.Mock(stdout=ps_output)):
                 self.router.tick()
@@ -646,7 +646,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.router._log_path("417", 1, "minimal").write_text("already seeded\n", encoding="utf-8")
         self.write_ledger_key("417-1-structural")
         delete_log = self.router._log_path("417", 1, "delete")
-        ps_output = f"/bin/sh /tmp/consensus-rnd-cli spawn-codex --cd {self.repo.resolve()} --log {delete_log} --stall 3600\n"
+        ps_output = f"/bin/sh /tmp/consensus-rnd-cli spawn-codex --cd {self.repo.resolve()} --log {delete_log} --stall 5400\n"
 
         def fake_run(command, **kwargs):
             return mock.Mock(returncode=0, stdout=ps_output, stderr="")
@@ -782,7 +782,7 @@ class Phase9RouterDaemonTests(unittest.TestCase):
     def test_phase9_router_triplet_in_flight_target_suppression_appends_single_fallback(self) -> None:
         self.solver_triplet(issue=284, round_no=1)
         target_log = self.router._log_path("284", 1, "judge")
-        ps_output = f"/bin/sh /tmp/consensus-rnd-cli spawn-codex --cd {self.repo.resolve()} --log {target_log} --stall 3600\n"
+        ps_output = f"/bin/sh /tmp/consensus-rnd-cli spawn-codex --cd {self.repo.resolve()} --log {target_log} --stall 5400\n"
 
         with mock.patch("codex_refactor_loop.phase9.router.subprocess.run", return_value=mock.Mock(stdout=ps_output)):
             self.router.tick()

--- a/skills/codex-refactor-loop/scripts/test_spawn_supervisor.py
+++ b/skills/codex-refactor-loop/scripts/test_spawn_supervisor.py
@@ -9,6 +9,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -16,7 +17,7 @@ from unittest import mock
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from codex_refactor_loop.processes import ProcessSupervisor, launch_spawn_codex_supervisor, prompt_file_from_text
+from codex_refactor_loop.processes import TIMEOUT_EXIT_CODE, ProcessSupervisor, launch_spawn_codex_supervisor, prompt_file_from_text
 
 
 class SpawnSupervisorTests(unittest.TestCase):
@@ -67,7 +68,46 @@ class SpawnSupervisorTests(unittest.TestCase):
         self.assertEqual(1, len(rotated))
         self.assertIn("SPAWN: still running", rotated[0].read_text(encoding="utf-8"))
 
-    def test_stall_writes_exit_137_and_kills_process_group(self) -> None:
+    def test_silent_process_runs_past_old_log_idle_window_until_natural_exit(self) -> None:
+        marker = self.tmp_root / "silent.done"
+        code = (
+            "import pathlib, sys, time\n"
+            "sys.stdout.write('started\\n'); sys.stdout.flush()\n"
+            "time.sleep(1.2)\n"
+            f"pathlib.Path({str(marker)!r}).write_text('done', encoding='utf-8')\n"
+            "sys.exit(0)\n"
+        )
+
+        started_at = time.monotonic()
+        exit_code = ProcessSupervisor(poll_interval=0.05).supervise(
+            [sys.executable, "-c", code],
+            stdin=self.prompt,
+            log=self.log,
+            stall=5,
+        )
+
+        self.assertGreaterEqual(time.monotonic() - started_at, 1.0)
+        self.assertEqual(0, exit_code)
+        self.assertEqual("done", marker.read_text(encoding="utf-8"))
+        text = self.log.read_text(encoding="utf-8")
+        self.assertNotIn("TIMEOUT_KILL_AFTER=", text)
+        self.assertNotIn("STALL_KILL_AFTER=", text)
+        self.assertIn("EXIT=0", text)
+
+    def test_natural_nonzero_exit_returns_real_exit_code(self) -> None:
+        exit_code = ProcessSupervisor(poll_interval=0.01).supervise(
+            [sys.executable, "-c", "import sys; sys.exit(23)"],
+            stdin=self.prompt,
+            log=self.log,
+            stall=5,
+        )
+
+        self.assertEqual(23, exit_code)
+        text = self.log.read_text(encoding="utf-8")
+        self.assertIn("EXIT=23", text)
+        self.assertNotIn("TIMEOUT_KILL_AFTER=", text)
+
+    def test_wall_clock_timeout_writes_exit_137_and_kills_process_group(self) -> None:
         marker = self.tmp_root / "child.pid"
         code = (
             "import os, subprocess, sys, time\n"
@@ -84,9 +124,11 @@ class SpawnSupervisorTests(unittest.TestCase):
             stall=1,
         )
 
-        self.assertEqual(137, exit_code)
+        self.assertEqual(TIMEOUT_EXIT_CODE, exit_code)
         text = self.log.read_text(encoding="utf-8")
-        self.assertIn("STALL_KILL_AFTER=1s", text)
+        self.assertIn("TIMEOUT_KILL_AFTER=1s", text)
+        self.assertIn("TIMEOUT_KILL_AT=", text)
+        self.assertNotIn("STALL_KILL_AFTER=", text)
         self.assertIn("EXIT=137", text)
         child_pid = int(marker.read_text(encoding="utf-8"))
         self.assert_process_dead(child_pid)

--- a/skills/codex-refactor-loop/scripts/test_spawn_supervisor.py
+++ b/skills/codex-refactor-loop/scripts/test_spawn_supervisor.py
@@ -20,6 +20,23 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from codex_refactor_loop.processes import TIMEOUT_EXIT_CODE, ProcessSupervisor, launch_spawn_codex_supervisor, prompt_file_from_text
 
 
+class _FakeProcess:
+    pid = 12345
+
+    def __init__(self, returncode: int | None = None) -> None:
+        self.returncode = returncode
+        self.wait_calls = 0
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def wait(self) -> int:
+        self.wait_calls += 1
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+
 class SpawnSupervisorTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp_root = Path(tempfile.mkdtemp(prefix="spawn-supervisor-test-"))
@@ -69,30 +86,72 @@ class SpawnSupervisorTests(unittest.TestCase):
         self.assertIn("SPAWN: still running", rotated[0].read_text(encoding="utf-8"))
 
     def test_silent_process_runs_past_old_log_idle_window_until_natural_exit(self) -> None:
-        marker = self.tmp_root / "silent.done"
-        code = (
-            "import pathlib, sys, time\n"
-            "sys.stdout.write('started\\n'); sys.stdout.flush()\n"
-            "time.sleep(1.2)\n"
-            f"pathlib.Path({str(marker)!r}).write_text('done', encoding='utf-8')\n"
-            "sys.exit(0)\n"
-        )
+        proc = _FakeProcess()
+        now = 0.0
 
-        started_at = time.monotonic()
-        exit_code = ProcessSupervisor(poll_interval=0.05).supervise(
-            [sys.executable, "-c", code],
-            stdin=self.prompt,
-            log=self.log,
-            stall=5,
-        )
+        def clock() -> float:
+            return now
 
-        self.assertGreaterEqual(time.monotonic() - started_at, 1.0)
+        def sleeper(_interval: float) -> None:
+            nonlocal now
+            now += 20.0
+            proc.returncode = 0
+
+        def fake_popen(*_args: object, **kwargs: object) -> _FakeProcess:
+            kwargs["stdout"].write(b"started\n")
+            return proc
+
+        with (
+            mock.patch("codex_refactor_loop.processes.subprocess.Popen", side_effect=fake_popen),
+            mock.patch("codex_refactor_loop.processes.kill_process_group") as kill_process_group,
+        ):
+            exit_code = ProcessSupervisor(poll_interval=0.05, clock=clock, sleeper=sleeper).supervise(
+                [sys.executable, "-c", "unused"],
+                stdin=self.prompt,
+                log=self.log,
+                stall=60,
+            )
+
         self.assertEqual(0, exit_code)
-        self.assertEqual("done", marker.read_text(encoding="utf-8"))
+        self.assertEqual(20.0, now)
+        self.assertEqual(1, proc.wait_calls)
+        kill_process_group.assert_not_called()
         text = self.log.read_text(encoding="utf-8")
+        self.assertIn("started", text)
         self.assertNotIn("TIMEOUT_KILL_AFTER=", text)
         self.assertNotIn("STALL_KILL_AFTER=", text)
         self.assertIn("EXIT=0", text)
+
+    def test_natural_exit_at_timeout_boundary_returns_real_exit_code(self) -> None:
+        proc = _FakeProcess()
+        now = 0.0
+
+        def clock() -> float:
+            return now
+
+        def sleeper(_interval: float) -> None:
+            nonlocal now
+            now = 1.01
+            proc.returncode = 23
+
+        with (
+            mock.patch("codex_refactor_loop.processes.subprocess.Popen", return_value=proc),
+            mock.patch("codex_refactor_loop.processes.kill_process_group") as kill_process_group,
+        ):
+            exit_code = ProcessSupervisor(poll_interval=0.2, clock=clock, sleeper=sleeper).supervise(
+                [sys.executable, "-c", "unused"],
+                stdin=self.prompt,
+                log=self.log,
+                stall=1,
+            )
+
+        self.assertEqual(23, exit_code)
+        self.assertEqual(1, proc.wait_calls)
+        kill_process_group.assert_not_called()
+        text = self.log.read_text(encoding="utf-8")
+        self.assertIn("EXIT=23", text)
+        self.assertNotIn("TIMEOUT_KILL_AFTER=", text)
+        self.assertNotIn("STALL_KILL_AFTER=", text)
 
     def test_natural_nonzero_exit_returns_real_exit_code(self) -> None:
         exit_code = ProcessSupervisor(poll_interval=0.01).supervise(

--- a/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_plan.py
@@ -1767,7 +1767,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             "cd": ".",
             "prompt": ".refactor-loop/prompts/phase9/phase9-issue330-r4-judge.md",
             "log": ".refactor-loop/logs/phase9-issue330-r4-judge.log",
-            "stall": 3600,
+            "stall": 5400,
             "reason": "test intent",
             "queued_at": "2026-05-31T00:00:00Z",
             "run_in_background_required": True,

--- a/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
+++ b/skills/codex-refactor-loop/scripts/test_wakeup_runner.py
@@ -1096,7 +1096,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             "cd": str(self.repo),
             "prompt": str(self.repo / ".refactor-loop/prompts/release-rollup-body.md"),
             "log": str(self.repo / ".refactor-loop/logs/release-rollup-body.log"),
-            "stall": 1800,
+            "stall": 5400,
         }
         action.update(overrides)
         return action
@@ -1136,7 +1136,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             "cd": str(self.repo),
             "prompt": str(self.repo / ".refactor-loop/prompts/implementation-pr-artifacts-issue-77.md"),
             "log": str(self.repo / ".refactor-loop/logs/implementation-pr-artifacts-issue-77.log"),
-            "stall": 1800,
+            "stall": 5400,
         }
         action.update(overrides)
         return action


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `2` commits
- 范围: `2e24b4b51364..1337d02f8c73`
- 涉及 issue: #711

## commit 摘要

- #711 fix: natural exit wins at timeout boundary + stronger silent/boundary tests
- #711: codex completion = process exit or wall-clock timeout (drop log-size stall)

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
