### PR TITLE
发布 rollup: integration ahead 1 commits (8435fba9a5e3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "consensus-rnd",
-      "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
+      "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
       "version": "1.0.0-beta.13",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎，可注入任意 host 仓库做自主研发循环",
+  "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎，可注入 host 仓库做 repo-owned managed GitHub issue/PR 自治解决循环；audit/refactor 仅 fallback producer",
   "version": "1.0.0-beta.13",
   "author": {
     "name": "auric",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "consensus-rnd",
   "version": "1.0.0-beta.13",
-  "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
+  "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io",
@@ -24,7 +24,7 @@
   "interface": {
     "displayName": "Consensus R&D",
     "shortDescription": "偏置独立的多角度共识构建引擎",
-    "longDescription": "把任意持续向仓库提交状态的活动当作研发：多 solver 先验对立、互不可见，meta-judge 仲裁收敛，验证侧同构。当前内置 consensus-loop 是 Consensus R&D work-unit 循环的稳定入口；audit/refactor 保留为兼容 intake。",
+    "longDescription": "把 repo-owned GitHub issue/PR work 当作可共识推进的研发单元：先解决 actionable managed GitHub issue/PR，经过 design-consensus、implementation、review、merge、release 的窄授权主路径；只有没有 actionable managed work 时，audit/refactor 才作为 fallback issue producer。多 solver 先验对立、互不可见，meta-judge 仲裁收敛，验证侧同构。",
     "developerName": "auric",
     "category": "Coding",
     "capabilities": [
@@ -33,7 +33,7 @@
       "Write"
     ],
     "defaultPrompt": [
-      "对本仓库跑一轮无人值守 Consensus R&D work-unit 循环；audit/refactor 可作为兼容 intake。"
+      "对本仓库跑一轮无人值守 Consensus R&D work-unit 循环：优先解决 actionable managed GitHub issue/PR；只有没有 actionable managed work 时，audit/refactor 才作为 fallback intake。"
     ],
     "websiteURL": "https://github.com/ChronoAIProject/consensus-rnd"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "consensus-rnd",
   "displayName": "Consensus R&D",
-  "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
+  "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "version": "1.0.0-beta.13",
   "author": {
     "name": "auric",

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,7 +4,7 @@
 
 当前 skills：
 
-- `consensus-loop` — Consensus R&D work-unit 循环的稳定 skill 入口，codex CLI 驱动，GitHub 为状态唯一显示面；audit/refactor 保留为兼容 intake。当用户想要对照 host 规则文档做全自主多角度共识研发时使用。
+- `consensus-loop` — Consensus R&D work-unit 循环的稳定 skill 入口，codex CLI 驱动，GitHub 为状态唯一显示面；用于无人值守解决 managed GitHub issue/PR 并持续推进 repository work；audit/refactor 仅在没有 actionable managed work 时作为 fallback intake。
 - `sshx` — 高风险决策、设计取舍或需要 worker-delegated inline consensus，但不需要 daemon/GitHub/git 编排时使用。
 
 当任务匹配某 skill 的触发条件时，先读对应 `skills/<name>/SKILL.md` 再行动。仓库结构与维护约定见 `CLAUDE.md`。

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 English canonical public identity document. 中文 companion: [README.zh-CN.md](./README.zh-CN.md).
 
-`consensus-rnd` is a cross-platform Agent Skills publication repository. Its product identity is a **consensus engine** for repository work: biased independent solvers produce candidate plans, a meta-judge converges them into one concrete plan, implementation runs, independent reviewers apply the same consensus discipline, and only then may the work proceed to merge.
+`consensus-rnd` is a cross-platform Agent Skills publication repository. Its product identity is a **consensus engine** for repo-owned GitHub issue/PR work: biased independent solvers produce candidate plans, a meta-judge converges them into one concrete plan, implementation runs, independent reviewers apply the same consensus discipline, and only then may the work proceed to merge.
 
 This repository is not an application runtime. Its deliverables are skills under `skills/<name>/` plus the platform manifests that expose the same skill tree to Claude Code, Codex, Cursor, and Gemini.
 
@@ -10,7 +10,7 @@ This repository is not an application runtime. Its deliverables are skills under
 
 | skill | What it is for | Runtime shape |
 |---|---|---|
-| `consensus-loop` | Heavy autonomous Consensus R&D work-unit loop for issue/PR resolution, ongoing repository R&D, daemon supervision, Codex workers, GitHub orchestration, review gates, and automated release publication when the host opts in. Audit/refactor is a fallback issue producer when no actionable managed work is open. | Uses checked-in scripts, `.refactor-loop/` state, GitHub, git, and host-provided `host.env` facts. |
+| `consensus-loop` | Heavy autonomous Consensus R&D work-unit loop for repo-owned GitHub issue/PR resolution, ongoing repository R&D, daemon supervision, Codex workers, GitHub orchestration, review gates, and automated release publication when the host opts in. Audit/refactor is a fallback issue producer when no actionable managed work is open. | Uses checked-in scripts, `.refactor-loop/` state, GitHub, git, and host-provided `host.env` facts. |
 | `sshx` | Lightweight worker-delegated inline consensus methodology (轻量 worker-delegated inline 共识方法论) for high-risk decisions or implementation plans that need isolated perspectives but do not need daemon, GitHub, or git orchestration. | WorkerMode dispatches isolated thinking and review workers; no daemon, no lifecycle authority, no runtime control plane, and not a duplicate alias for `consensus-loop`. |
 
 ## Core
@@ -84,9 +84,11 @@ Platform manifests point different agents at the same skills:
 
 Host projects inject runtime facts through `host.env`: repository root, GitHub slug, review and integration branches, project rules, build/test commands, release opt-in, and related surfaces. The skill repository must not hardcode host facts or modify host configuration directly.
 
+Capability boundary: `consensus-loop` supports bounded repo-owned work expressible as managed GitHub issues or PRs, including feature, bug, documentation, governance, and refactor work. It does not provide arbitrary GitHub administration such as Projects, milestones, assignee management, Discussions, label-taxonomy mutation outside the catalog, issue/PR body edits outside named helpers, tag/release operations outside the release allowlist, or custom lifecycle authority.
+
 ## Roadmap
 
-The public product identity is Consensus R&D. Refactoring, issue-solving, and repository R&D are different entry surfaces for the same work-unit loop. `consensus-loop` remains the stable heavy autonomous loop entrypoint, while `sshx` carries the same consensus philosophy as a lightweight worker-delegated inline method, not as a duplicate alias for the heavy loop. Future work should continue generalizing host/project assumptions and producer inputs while keeping runtime authority narrow enough to verify mechanically.
+The public product identity is Consensus R&D. Managed repo-owned GitHub issue/PR work is the main path; audit/refactor is a fallback producer that creates or updates work for that same loop when no actionable managed work is open. Refactoring, issue-solving, and repository R&D are different entry surfaces for the same loop, not separate systems. `consensus-loop` remains the stable heavy autonomous loop entrypoint, while `sshx` carries the same consensus philosophy as a lightweight worker-delegated inline method, not as a duplicate alias for the heavy loop. Future work should continue generalizing host/project assumptions and producer inputs while keeping runtime authority narrow enough to verify mechanically.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 中文 companion public identity document. English canonical: [README.md](./README.md).
 
-`consensus-rnd` 是一个跨平台 Agent Skills 发布仓库。它的产品身份是**共识引擎**:偏置独立的多角度 solver 先给出候选方案,meta-judge 收敛成一个 concrete plan,随后实现,再由多 reviewer 过同构共识 gate,最后才进入 merge。
+`consensus-rnd` 是一个跨平台 Agent Skills 发布仓库。它的产品身份是面向 repo-owned GitHub issue/PR work 的**共识引擎**:偏置独立的多角度 solver 先给出候选方案,meta-judge 收敛成一个 concrete plan,随后实现,再由多 reviewer 过同构共识 gate,最后才进入 merge。
 
 本仓库不是应用运行时代码。唯一产物是 `skills/<name>/` 下的 skill 及根目录中让 Claude Code / Codex / Cursor / Gemini 指向同一份 `skills/` 的平台清单。
 
@@ -10,7 +10,7 @@
 
 | skill | 用途 | 运行形态 |
 |---|---|---|
-| `consensus-loop` | 重型自治 loop:daemon 监督、Codex worker、GitHub 编排、review gate,以及 host opt-in 后的自动发版。 | 使用 checked-in scripts、`.refactor-loop/` state、GitHub、git 和 host 通过 `host.env` 注入的事实。 |
+| `consensus-loop` | 重型自治 Consensus R&D work-unit loop:解决 repo-owned GitHub issue/PR、持续推进 repository R&D、daemon 监督、Codex worker、GitHub 编排、review gate,以及 host opt-in 后的自动发版。audit/refactor 仅在没有 actionable managed work 时作为 fallback issue producer。 | 使用 checked-in scripts、`.refactor-loop/` state、GitHub、git 和 host 通过 `host.env` 注入的事实。 |
 | `sshx` | 轻量纯 prompt 共识方法论:高风险决策或实现方案需要隔离多角度判断,但不需要 daemon/GitHub/git 编排时使用。 | 纯 prompt contract:无 daemon、无 lifecycle authority、无 runtime control plane。 |
 
 ## 核心
@@ -82,9 +82,11 @@
 
 host 项目通过 `host.env` 注入运行时事实:仓库根、GitHub slug、review/integration 分支、项目规则、构建/测试命令、release opt-in 等。skill 仓库不得硬编码 host 事实,也不得直接修改 host 配置。
 
+能力边界:`consensus-loop` 支持可表达为 managed GitHub issue/PR 的 bounded repo-owned work,包括 feature、bug、documentation、governance、refactor/重构。不支持任意 GitHub admin,例如 Projects、milestones、assignee 管理、Discussions、catalog 外 label-taxonomy mutation、named helper 外 issue/PR body edit、release allowlist 外 tag/release、或任意 custom lifecycle authority。
+
 ## 路线
 
-公开产品身份是 Consensus R&D。`consensus-loop` 保留为重型自治 loop 入口,`sshx` 则把同一套共识哲学压缩成轻量纯 prompt 方法。后续工作应继续抽出 engine spine、把 host 主张参数化,并把 runtime authority 收窄到可机械验证的边界。
+公开产品身份是 Consensus R&D。managed repo-owned GitHub issue/PR work 是主路径;audit/refactor 只在没有 actionable managed work 时作为 fallback producer,创建或更新进入同一 loop 的 work。`consensus-loop` 保留为重型自治 loop 入口,`sshx` 则把同一套共识哲学压缩成轻量纯 prompt 方法。后续工作应继续 generalize host/project assumptions 和 producer inputs,并把 runtime authority 收窄到可机械验证的边界。
 
 ## License
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
+  "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "version": "1.0.0-beta.13",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "consensus-rnd",
   "version": "1.0.0-beta.13",
-  "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎",
+  "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "license": "MIT",
   "author": "auric <loning.ma@aelf.io>",
   "homepage": "https://github.com/ChronoAIProject/consensus-rnd",

--- a/skills/consensus-loop/SKILL.md
+++ b/skills/consensus-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consensus-loop
-description: Use when the user wants an unattended Consensus R&D issue/PR resolution and work-unit loop driven by codex CLI in isolated git worktrees, with audit/refactor as a fallback compatibility issue producer, dynamic /loop wakeups, GitHub status, and per-work-unit merges.
+description: Use when the user wants an unattended multi-perspective consensus engine to resolve repo-owned GitHub issues/PRs end-to-end (design-consensus, implementation, review, merge, release) with Codex workers in isolated worktrees and GitHub-visible status; audit/refactor is only a fallback issue producer when no actionable managed work is open.
 ---
 > Refactor (iter319/issue-319): Old pattern: 物理拆 REFERENCE.md 后跨平台加载/维护退化.
 > New principle: 单文件 SKILL.md 用 Controller Contract Index + Detailed reference anchors 分层,禁止重新拆 REFERENCE.md 作为默认修复.
@@ -49,6 +49,8 @@ The default main path is open actionable catalog-managed GitHub issue/PR resolut
 `issue-driven / Path A` is the main-path issue entry surface: create or reuse a concrete GitHub issue, apply the catalog-derived design issue label bundle (`crnd:lifecycle:managed`, `crnd:phase:design-solving`, and `crnd:human:auto`), then let the controller sweep dispatch Consensus-rnd Phase design-consensus directly. Historical non-`crnd:*` issue-entry labels are unmanaged residue and must not be written, queried, normalized, or cleaned up by the loop.
 
 `audit` remains a stable compatibility producer value and fallback issue producer. It runs only after no open actionable managed issue/PR, queued dispatch, clean marker route, CI/no-gap route, maintainer-comment route, or higher-priority wakeup route exists. Audit produces or updates issues that feed back into the main path; it is not a co-equal entry mode or a parallel R&D lane. Issue-driven work uses the router-injected GitHub issue source snapshot as the work-unit source when no local audit artifact is provided; `gh issue view <N>` is fallback-only when that snapshot is unavailable. Concrete plans still require Consensus-rnd Phase design-consensus solver consensus and meta-judge consensus before implementation.
+
+Capability boundary: the loop supports bounded repo-owned work expressible as managed GitHub issues or PRs, including feature, bug, documentation, governance, and refactor work. It does not provide arbitrary GitHub administration: no Projects, milestones, assignee management, Discussions, label-taxonomy mutation outside the catalog, issue/PR body edits outside named helpers, tag/release operations outside the release allowlist, or custom lifecycle authority.
 
 Workflow stage display names are sourced from `scripts/codex_refactor_loop/workflow_stages.py`. The built-in registry remains the default compatibility vocabulary; public built-in stage display must use `Consensus-rnd Phase <stage>`. Legacy `phase9-router` and `phase9-issue...` strings are compatibility command and artifact dialects only.
 
@@ -2805,7 +2807,7 @@ Policy:the loop continues until Step 3 truth-table consensus, true stall reaches
 <a id="concurrency-floor-details"></a>
 ## Concurrency floor details
 
-### This is an INFINITE refactor loop — never idle on "iter done"
+### This is an infinite work-unit loop — never idle on "iter done"
 
 Policy. An iteration completing is NEVER a stop signal. The loop's only legitimate stops are:
 1. Audit returns 0 candidates (codebase has no flagged violations under current rules) — extremely rare.

--- a/skills/consensus-loop/prompts/design-issue-reply.md
+++ b/skills/consensus-loop/prompts/design-issue-reply.md
@@ -43,22 +43,22 @@ NyxId API keys / secrets / 内部 URL 之类敏感信息绝对禁止出现在 re
 
 1. `$REPO_ROOT/${PROJECT_RULES:-CLAUDE.md}` 全部条款（特别 cluster 引用的 rule_ids）。
 2. issue body（含 cluster YAML / evidence / fix boundary / human_brief）—— 用 `gh issue view ${ISSUE_NUMBER}` 拉。
-3. cluster 在 `.refactor-loop/runs/audit-iter-${ITERATION}.md` 的原文。
+3. 当前 work-unit 的 source snapshot / consensus 决策 artifact / cited source / repo 规则。优先读 issue source snapshot、judge/solver decision artifact、评论或 issue 引用的 source 文件、以及 repo 规则；只有当 `source_ref` / `WORK_UNIT_SOURCE_REF` 指向 audit artifact 时，才读取 `.refactor-loop/runs/audit-iter-${ITERATION}.md` 或对应 audit section。
 4. 评论中引用的具体文件 + 行号（**必须打开通读**，不只看 line refs）。
 5. SKILL.md 中的工作语言规则 —— 你的 GitHub reply follows `${HOST_WORK_LANGUAGE}`；可原样引用英文代码、错误、路径和条款。
 
 ## 流程
 
 1. **分类评论**（决定回复 shape）：
-   - **(a) 否决 audit framing**：reviewer 觉得 audit 错框了问题（如 "性能 vs 架构必有一方错"）→ 你必须用具体数字/代码论证：架构与性能哪些方面共存，哪些方面冲突，给量化成本。
+   - **(a) 否决 source framing**：reviewer 觉得 issue source、consensus decision、cited source、repo rule 或 audit-backed source 错框了问题（如 "性能 vs 架构必有一方错"）→ 你必须用具体数字/代码论证：架构与性能哪些方面共存，哪些方面冲突，给量化成本。
    - **(b) 要更多上下文**：reviewer 问 "为什么"、"在哪里有具体例子" → 你深入读代码，列文件 + 行号 + 真实代码片段。
-   - **(c) 提供设计决定**：reviewer 给了具体方案 → 你检查方案完整性（覆盖 audit 的 6 项 checklist？）；若完整，回评"理解你的决策；等加 `crnd:triage:resume-requested` label 即开实施"；若缺，列出缺项请补。
+   - **(c) 提供设计决定**：reviewer 给了具体方案 → 你检查方案完整性（是否覆盖当前 source snapshot / consensus decision / cited source / repo rules 要求；若 source_ref 是 audit artifact,还要覆盖对应 audit checklist）；若完整，回评"理解你的决策；等加 `crnd:triage:resume-requested` label 即开实施"；若缺，列出缺项请补。
    - **(d) 拒绝**：reviewer 倾向不修 → 总结他们的理由，**不要反驳**，提议 close issue + 加 `wontfix` label。
 
 2. **回复必须包含**（适用 (a)(b)(c)）：
    - **不空喊"我会研究"**：每段陈述必须有具体证据（文件:行号 / 测量数字 / 引用条款）
    - **不替 reviewer 决策**：列出 2-3 个合理 framing，每个的成本/收益，让 reviewer 选。也可以推荐你倾向的，但要说明 *为什么*
-   - **承认 audit 的局限**：如果 audit framing 有歧义或没覆盖 reviewer 的关切，明说"audit 这里没做好"。诚实优先
+   - **承认 source 的局限**：如果 issue source、consensus decision、cited source、repo rule 或 audit-backed framing 有歧义或没覆盖 reviewer 的关切，明说具体 source 哪里没做好。诚实优先。
    - **量化**：能用数字的不用形容词（"延迟 0.02%–0.4% 节流窗口" 优于 "可以忽略不计"）
    - **下一步动作明确**：结尾必须有 "我需要你回答：…" 或 "下次见到 `crnd:triage:resume-requested` label 我就 ..."。reviewer 不应在你回复后还要猜下一步
 

--- a/skills/consensus-loop/prompts/meta-judge.md
+++ b/skills/consensus-loop/prompts/meta-judge.md
@@ -2,7 +2,7 @@
 
 Artifact profile: phase9-meta-judge
 
-You are the **4th codex** for design-issue **${ISSUE_NUMBER}** (work unit `${WORK_UNIT_ID}`, audit cluster alias `${CLUSTER_ID}`). You did NOT propose a solution. Your job: read all 3 solver outputs and decide ONE of:
+You are the **4th codex** for design-issue **${ISSUE_NUMBER}** (work unit `${WORK_UNIT_ID}`, compatibility cluster alias `${CLUSTER_ID}`). You did NOT propose a solution. Your job: read all 3 solver outputs and decide ONE of:
 
 1. **Consensus reached** → auto-dispatch implement (same implementation-bearing framing across all required solver outputs; this is sufficient authorization for any file or tier)
 2. **Convergence round needed** → re-dispatch the 3 solvers with a narrowed question (no hard round cap; router evaluates stall after ≥3 no-progress rounds)

--- a/skills/consensus-loop/prompts/solver-minimal.md
+++ b/skills/consensus-loop/prompts/solver-minimal.md
@@ -4,7 +4,7 @@ Artifact profile: phase9-solver
 
 You are **one of 3 independent design solvers** evaluating issue **${ISSUE_NUMBER}** (cluster `${CLUSTER_ID}`). You see only the issue + repo, NOT the other solvers' outputs. Reach your own conclusion.
 
-Your bias: **smallest viable change** that resolves the audit's flagged violation. You may propose a documented rule exception if the violation reduces to "rule too broad for this narrow case". You explicitly do NOT over-engineer.
+Your bias: **smallest viable change** that resolves the current work unit's problem / violation / desired end state. You may propose a documented rule exception if the issue reduces to "rule too broad for this narrow case". You explicitly do NOT over-engineer.
 
 ## Inputs
 

--- a/skills/consensus-loop/scripts/test_repository_public_docs.py
+++ b/skills/consensus-loop/scripts/test_repository_public_docs.py
@@ -1,183 +1,102 @@
 #!/usr/bin/env python3
-"""Repository public documentation boundary tests."""
+"""Source-regression tests for public consensus-loop positioning."""
 
 from __future__ import annotations
 
+import json
+import re
 import unittest
 from pathlib import Path
 
 
-SCRIPT_PATH = Path(__file__)
-REPO_ROOT = SCRIPT_PATH.parents[3]
-README = REPO_ROOT / "README.md"
-README_ZH = REPO_ROOT / "README.zh-CN.md"
-CLAUDE = REPO_ROOT / "CLAUDE.md"
-AGENTS = REPO_ROOT / "AGENTS.md"
-SKILL = REPO_ROOT / "skills" / "consensus-loop" / "SKILL.md"
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+SKILL_ROOT = REPO_ROOT / "skills" / "consensus-loop"
 
 
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def heading_order(markdown: str) -> list[str]:
-    return [line.strip() for line in markdown.splitlines() if line.startswith("## ")]
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", " ", text.lower())
+
+
+def frontmatter(text: str) -> str:
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        raise AssertionError("missing SKILL.md frontmatter")
+    return parts[1]
 
 
 class RepositoryPublicDocsTests(unittest.TestCase):
-    def test_readme_pair_exists_and_cross_links(self) -> None:
-        self.assertTrue(README.exists())
-        self.assertTrue(README_ZH.exists())
-        self.assertIn("[README.zh-CN.md](./README.zh-CN.md)", read(README))
-        self.assertIn("[README.md](./README.md)", read(README_ZH))
-        self.assertIn("English canonical public identity document", read(README))
-        self.assertIn("中文 companion public identity document", read(README_ZH))
-
-    def test_language_boundary_visible(self) -> None:
-        skill = read(SKILL)
-        for needle in (
-            "README.md` is English canonical",
-            "README.zh-CN.md` is the 中文 companion",
-            "external user-facing artifact language comes from host-owned `$HOST_WORK_LANGUAGE`",
-            "Public identity README pair",
-        ):
-            with self.subTest(needle=needle):
-                self.assertIn(needle, skill)
-
-    def test_root_markdown_closure_and_agents_symlink(self) -> None:
-        allowed = {
-            "AGENTS.md",
-            "CLAUDE.md",
-            "GEMINI.md",
-            "README.md",
-            "README.zh-CN.md",
-        }
-        if (REPO_ROOT / "CHANGELOG.md").exists():
-            allowed.add("CHANGELOG.md")
-        actual = {path.name for path in REPO_ROOT.glob("*.md")}
-        self.assertEqual(actual, allowed)
-        self.assertTrue(AGENTS.is_symlink())
-        self.assertEqual(AGENTS.readlink(), Path("CLAUDE.md"))
-        self.assertIn("README.zh-CN.md", read(CLAUDE))
-
-    def test_public_identity_carveout_bounded_in_claude_and_skill(self) -> None:
-        claude = read(CLAUDE)
-        skill = read(SKILL)
-        for text in (claude, skill):
-            with self.subTest(document=("CLAUDE.md" if text == claude else "SKILL.md")):
-                self.assertIn("README pair", text)
-                self.assertIn("only English-canonical public-doc carve-out", text)
-                self.assertIn("GitHub issue/PR/commit/design artifact", text)
-        self.assertNotIn("INSTALL.md", read(README))
-        self.assertEqual(1, read(README).count("SKILL.md#downstream-install-walkthrough"))
-
-    def test_readme_pair_introduces_consensus_engine_and_skills(self) -> None:
-        readme = read(README)
-        readme_zh = read(README_ZH)
-        for needle in (
-            "cross-platform Agent Skills publication repository",
-            "product identity is a **consensus engine**",
-            "biased independent solvers",
-            "meta-judge converges",
-            "implementation runs",
-            "independent reviewers",
-            "`consensus-loop`",
-            "`sshx`",
-            "Claude Code, Codex, Cursor, and Gemini",
-            "host-provided `host.env` facts",
-        ):
-            with self.subTest(readme_needle=needle):
-                self.assertIn(needle, readme)
-        for needle in (
-            "跨平台 Agent Skills 发布仓库",
-            "产品身份是**共识引擎**",
-            "偏置独立的多角度 solver",
-            "meta-judge 收敛",
-            "随后实现",
-            "多 reviewer",
-            "`consensus-loop`",
-            "`sshx`",
-            "Claude Code / Codex / Cursor / Gemini",
-            "host 通过 `host.env` 注入",
-        ):
-            with self.subTest(readme_zh_needle=needle):
-                self.assertIn(needle, readme_zh)
-
-    def test_readme_pair_has_prominent_risk_warning(self) -> None:
-        readme = read(README)
-        readme_zh = read(README_ZH)
-        self.assertIn("## Risks", readme)
-        self.assertIn("## ⚠️ 风险提示", readme_zh)
-        for needle in (
-            "Autonomous writes",
-            "Controller-owned paths may commit, push, open PRs, merge PRs, and publish releases",
-            "after their respective gates and allowlists pass",
-            "Agent workers only produce implementation diffs in isolated worktrees; they do not commit or push",
-            "without per-action human confirmation",
-            "API and compute cost",
-            "six GitHub-polling daemons",
-            "Automatic releases",
-            "RELEASE_AUTO_ENABLE=true",
-            "Bad published tags are abandoned",
-            "Host boundary",
-            "active-controller lease",
-            "Experimental scope",
-            "opt in",
-        ):
-            with self.subTest(readme_risk=needle):
-                self.assertIn(needle, readme)
-        for needle in (
-            "自治写操作",
-            "controller-owned 路径在相应 gate 与 allowlist 通过后",
-            "可执行 commit、push、open PR、merge PR、release publish",
-            "agent worker 只在隔离 worktree 产出实现 diff,不 commit/push",
-            "没有逐动作人工确认",
-            "API/算力成本",
-            "6 个 daemon 轮询 GitHub",
-            "自动发版",
-            "RELEASE_AUTO_ENABLE=true",
-            "坏版即弃",
-            "host 边界",
-            "active-controller lease",
-            "适用范围",
-            "opt in",
-        ):
-            with self.subTest(readme_zh_risk=needle):
-                self.assertIn(needle, readme_zh)
-        self.assertNotIn("agent workers commit/push", readme)
-        self.assertNotIn("let agent workers commit/push", readme)
-        self.assertNotIn("agent worker commit/push", readme_zh)
-        self.assertNotIn("让 agent worker commit/push", readme_zh)
-
-    def test_readme_links_downstream_walkthrough_once(self) -> None:
-        readme = read(README)
-        self.assertEqual(1, readme.count("./skills/consensus-loop/SKILL.md#downstream-install-walkthrough"))
-        self.assertEqual(0, read(README_ZH).count("SKILL.md#downstream-install-walkthrough"))
-        self.assertIn("Downstream Host Setup", readme)
-        self.assertEqual(
-            heading_order(readme),
-            [
-                "## What It Provides",
-                "## Core",
-                "## Risks",
-                "## Quick Start",
-                "## Architecture",
-                "## Roadmap",
-                "## License",
-            ],
+    def assert_issue_pr_engine_positioning(self, text: str, *, label: str) -> None:
+        body = normalized(text)
+        self.assertRegex(
+            body,
+            r"repo-owned github issues?/prs?|repo-owned github issue/pr|managed github issue/pr",
+            msg=f"{label} must lead with repo-owned managed GitHub issue/PR work",
         )
-        self.assertEqual(
-            heading_order(read(README_ZH)),
-            [
-                "## 提供什么",
-                "## 核心",
-                "## ⚠️ 风险提示",
-                "## 快速开始",
-                "## 架构",
-                "## 路线",
-                "## License",
-            ],
+        self.assertIn("managed", body, msg=f"{label} must keep the managed-work boundary visible")
+        self.assertRegex(
+            body,
+            r"audit/refactor[^.|\n]*fallback|audit[^.|\n]*fallback[^.|\n]*producer",
+            msg=f"{label} must keep audit/refactor as fallback producer, not the main path",
         )
+
+    def assert_honest_scope_boundary(self, text: str, *, label: str) -> None:
+        body = normalized(text)
+        self.assertIn("bounded repo-owned work", body, msg=f"{label} must state bounded scope")
+        self.assertRegex(body, r"feature.*bug.*documentation.*governance.*refactor")
+        self.assertRegex(body, r"projects.*milestones.*assignee.*discussions")
+        for boundary in ("label-taxonomy", "issue/pr body", "tag/release"):
+            self.assertIn(boundary, body, msg=f"{label} must name {boundary} as out of scope")
+        self.assertRegex(body, r"custom lifecycle|自定义 lifecycle")
+        for forbidden in (
+            "any github situation",
+            "any github work",
+            "arbitrary github situation",
+            "任何 github 情况",
+            "任意 github 情况",
+        ):
+            self.assertNotIn(forbidden, body, msg=f"{label} overclaims scope")
+
+    def test_skill_frontmatter_positions_consensus_loop_as_issue_pr_engine(self) -> None:
+        fm = frontmatter(read(SKILL_ROOT / "SKILL.md"))
+
+        self.assertLessEqual(len(fm), 1024)
+        self.assert_issue_pr_engine_positioning(fm, label="SKILL frontmatter")
+
+    def test_readme_pair_positions_main_path_and_honest_boundary(self) -> None:
+        for path in (REPO_ROOT / "README.md", REPO_ROOT / "README.zh-CN.md"):
+            text = read(path)
+            with self.subTest(path=path.name):
+                self.assert_issue_pr_engine_positioning(text, label=path.name)
+                self.assert_honest_scope_boundary(text, label=path.name)
+
+    def test_skill_trigger_section_states_honest_boundary(self) -> None:
+        skill = read(SKILL_ROOT / "SKILL.md")
+        section = skill.split("## Main path and fallback producer", 1)[1].split("## Operational names", 1)[0]
+
+        self.assert_issue_pr_engine_positioning(section, label="SKILL trigger section")
+        self.assert_honest_scope_boundary(section, label="SKILL trigger section")
+
+    def test_platform_manifests_expose_issue_pr_first_copy(self) -> None:
+        manifest_paths = (
+            REPO_ROOT / ".codex-plugin/plugin.json",
+            REPO_ROOT / ".claude-plugin/plugin.json",
+            REPO_ROOT / ".claude-plugin/marketplace.json",
+            REPO_ROOT / ".cursor-plugin/plugin.json",
+            REPO_ROOT / "gemini-extension.json",
+            REPO_ROOT / "package.json",
+        )
+        for path in manifest_paths:
+            text = json.dumps(json.loads(read(path)), ensure_ascii=False)
+            with self.subTest(path=path.as_posix()):
+                self.assert_issue_pr_engine_positioning(text, label=path.as_posix())
+
+        gemini = read(REPO_ROOT / "GEMINI.md")
+        self.assert_issue_pr_engine_positioning(gemini, label="GEMINI.md")
 
 
 if __name__ == "__main__":

--- a/skills/consensus-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/consensus-loop/scripts/test_skill_entrypoint_contract.py
@@ -61,8 +61,8 @@ class SkillEntrypointContractTests(unittest.TestCase):
         top = "\n".join(self.skill.splitlines()[:120])
 
         self.assertIn("name: consensus-loop", body)
-        self.assertIn("issue/PR resolution and work-unit loop", body)
-        self.assertIn("audit/refactor as a fallback compatibility issue producer", body)
+        self.assertIn("repo-owned GitHub issues/PRs end-to-end", body)
+        self.assertIn("audit/refactor is only a fallback issue producer", body)
         self.assertIn("# Consensus R&D Work-Unit Loop", top)
         self.assertIn("## Main path and fallback producer", top)
         self.assertIn("open actionable catalog-managed GitHub issue/PR resolution", top)


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `216b12c684a1..8435fba9a5e3`

## commit 摘要

- Reposition consensus-loop as general repo-owned GitHub issue/PR work engine (audit/refactor fallback); honest scope + source-regression

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
