### PR TITLE
Document greenfield host bootstrap commands

### DIFF
--- a/skills/consensus-loop/SKILL.md
+++ b/skills/consensus-loop/SKILL.md
@@ -210,6 +210,14 @@ export CONSENSUS_RND_HOST_ENV=.config/consensus-rnd/host.env
 
 Fill the host-owned `host.env` according to the Host env surface matrix: required values must be set, defaulted values may keep their template defaults, optional/noop values may stay empty, and conditional fail-closed surfaces such as `MAINTAINER_WHITELIST` are required only when their surface is enabled. The optional `HOST_*` language-policy variables are empty by default and may stay empty unless the host has explicit policy text to inject. `CONSENSUS_RND_HOST_ENV` must point at this host-owned file before loop runtime commands run.
 
+### Greenfield host bootstrap path
+
+For a greenfield host, the maintainer must first create a minimal repository skeleton that can build and test without consensus-loop. Run the host-owned build and test commands successfully in the main checkout before enabling issue-driven / Path A.
+
+Only after that baseline is green, configure the host-owned `.config/consensus-rnd/host.env` from `host.env.example`. `BUILD_CMD` and `TEST_CMD` must be self-contained shell command strings that also work in a fresh isolated `$REPO_ROOT/.worktrees/<id>` checkout after `CONSENSUS_RND_HOST_ENV` is sourced. If ignored dependencies such as `node_modules/` are absent in that worktree, the commands must prepare them themselves, for example `npm ci --no-audit --no-fund && npm run build` and `npm ci --no-audit --no-fund && npm test`.
+
+This is documentation-only bootstrap guidance. It does not add a setup CLI, installer, Node-specific environment variable, runtime preinstall hook, README command matrix, host `.git` or CI edits, or host write authority. Once the minimal skeleton builds and tests in both the main checkout and a fresh isolated worktree, enter the normal issue-driven / Path A flow.
+
 <a id="github-workflow-portability-checklist"></a>
 ### GitHub workflow portability checklist
 

--- a/skills/consensus-loop/host.env.example
+++ b/skills/consensus-loop/host.env.example
@@ -33,15 +33,18 @@ export REPO_ROOT="/abs/path/to/your/repo"
 export GH_REPO_SLUG="your-org/your-repo"
 
 # Requirement: shell command string for build. May contain `cd`, `&&`, pipes,
-# and other shell syntax. Callers must execute it from a sourced host.env shell
-# with `bash -lc "$BUILD_CMD"` or an equivalent shell invocation, never by
-# splitting it into argv. Long flows may be wrapped in a host script.
-export BUILD_CMD="cargo build --workspace"        # example: bash scripts/build.sh
+# and other shell syntax. It must work in a fresh `$REPO_ROOT/.worktrees/<id>`
+# checkout after host.env is sourced, so include dependency preparation when
+# ignored dependencies are absent. Callers must execute it from a sourced
+# host.env shell with `bash -lc "$BUILD_CMD"` or an equivalent shell invocation,
+# never by splitting it into argv. Long flows may be wrapped in a host script.
+export BUILD_CMD="npm ci --no-audit --no-fund && npm run build"  # example: bash scripts/build.sh
 
 # Requirement: shell command string for tests; same execution contract as
-# BUILD_CMD. Callers use `bash -lc "$TEST_CMD"`. Dogfood must use unittest discovery.
+# BUILD_CMD. Include dependency preparation for fresh isolated worktrees.
+# Callers use `bash -lc "$TEST_CMD"`. Dogfood must use unittest discovery.
 # Rust host 提示:shared fs 状态并行会 race 出假失败,带 --test-threads=1。
-export TEST_CMD="cargo test --workspace -- --test-threads=1"
+export TEST_CMD="npm ci --no-audit --no-fund && npm test"
 
 # Requirement: 集成分支; cluster PRs land here before rollup to review base.
 export INTEGRATION_BRANCH="your-integration-branch"

--- a/skills/consensus-loop/scripts/test_host_env_surface_matrix.py
+++ b/skills/consensus-loop/scripts/test_host_env_surface_matrix.py
@@ -154,6 +154,38 @@ class HostEnvSurfaceMatrixTests(unittest.TestCase):
         self.assertIn("optional-empty-or-noop", self.exports["GH_OWNER"]["section"])
         self.assertIn("optional-empty-or-noop", self.exports["GH_REPO_NAME"]["section"])
 
+    def test_build_and_test_examples_are_fresh_worktree_self_contained(self) -> None:
+        self.assertEqual("npm ci --no-audit --no-fund && npm run build", self.exports["BUILD_CMD"]["value"])
+        self.assertEqual("npm ci --no-audit --no-fund && npm test", self.exports["TEST_CMD"]["value"])
+
+        template = read(HOST_ENV_EXAMPLE)
+        skill = read(SKILL_MD)
+        for token in (
+            'bash -lc "$BUILD_CMD"',
+            'bash -lc "$TEST_CMD"',
+            "fresh `$REPO_ROOT/.worktrees/<id>`",
+            "ignored dependencies",
+            "dependency preparation",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, template)
+
+        for token in (
+            "Greenfield host bootstrap path",
+            "minimal repository skeleton",
+            "fresh isolated `$REPO_ROOT/.worktrees/<id>` checkout",
+            "npm ci --no-audit --no-fund && npm run build",
+            "npm ci --no-audit --no-fund && npm test",
+            "does not add a setup CLI, installer, Node-specific environment variable, runtime preinstall hook, README command matrix",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, skill)
+
+        combined = "\n".join((skill, template))
+        for forbidden in ("NODE_INSTALL_CMD", "NPM_INSTALL_CMD", "PREINSTALL_CMD"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, combined)
+
     def test_defaults_and_missing_behaviors_match(self) -> None:
         cases = {
             "RELEASE_AUTO_ENABLE": ("false", "false or empty exits 0 with noop reason"),

--- a/skills/consensus-loop/scripts/test_skill_entrypoint_contract.py
+++ b/skills/consensus-loop/scripts/test_skill_entrypoint_contract.py
@@ -636,6 +636,41 @@ class SkillEntrypointContractTests(unittest.TestCase):
             "Host command strings must be executed via bash -lc, not as bare lines",
         )
 
+    def test_downstream_install_walkthrough_covers_greenfield_bootstrap(self) -> None:
+        walkthrough = section_between(
+            self.skill,
+            r"^## Downstream install walkthrough$",
+            r"^<a id=\"github-workflow-portability-checklist\"></a>$",
+        )
+        self.assertTrue(walkthrough)
+        required = (
+            "### Greenfield host bootstrap path",
+            "create a minimal repository skeleton that can build and test without consensus-loop",
+            "Run the host-owned build and test commands successfully in the main checkout",
+            "configure the host-owned `.config/consensus-rnd/host.env` from `host.env.example`",
+            "fresh isolated `$REPO_ROOT/.worktrees/<id>` checkout",
+            "ignored dependencies such as `node_modules/` are absent",
+            "npm ci --no-audit --no-fund && npm run build",
+            "npm ci --no-audit --no-fund && npm test",
+            "documentation-only bootstrap guidance",
+            "does not add a setup CLI, installer, Node-specific environment variable, runtime preinstall hook, README command matrix",
+            "issue-driven / Path A",
+        )
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, walkthrough)
+
+        forbidden = (
+            "setup CLI command",
+            "NODE_INSTALL_CMD",
+            "NPM_INSTALL_CMD",
+            "PREINSTALL_CMD",
+            "runtime preinstall hook enabled",
+        )
+        for token in forbidden:
+            with self.subTest(token=token):
+                self.assertNotIn(token, walkthrough)
+
     def test_implement_and_verify_prompts_lock_touched_module_test_ratchet(self) -> None:
         implement = read(SKILL_ROOT / "prompts" / "implement.md")
         verify = read(SKILL_ROOT / "prompts" / "verify.md")


### PR DESCRIPTION
## Changed files
- `skills/consensus-loop/SKILL.md`: added documentation-only greenfield host bootstrap guidance to the downstream install walkthrough.
- `skills/consensus-loop/host.env.example`: made `BUILD_CMD` and `TEST_CMD` copyable Node/JS examples self-contained for fresh isolated worktrees.
- `skills/consensus-loop/scripts/test_skill_entrypoint_contract.py` and `skills/consensus-loop/scripts/test_host_env_surface_matrix.py`: locked the new runbook/template contract and forbidden runtime-surface expansion.

## Test results
- `python3 -m unittest skills.consensus-loop.scripts.test_skill_entrypoint_contract` passed.
- `python3 -m unittest skills.consensus-loop.scripts.test_host_env_surface_matrix` passed.
- Host `BUILD_CMD` and `TEST_CMD` passed with the current `skills/consensus-loop` path.

## Deviations
- Prompt-specified `skills/codex-refactor-loop` verification paths are stale in this worktree; those literal commands failed because that directory does not exist. Verified the current host-owned `skills/consensus-loop` commands instead.
- Closes #724

⟦AI:AUTO-LOOP⟧
