### PR TITLE
Honor pending phase9 spawn intents in hard-gate pressure

### DIFF
--- a/skills/consensus-loop/SKILL.md
+++ b/skills/consensus-loop/SKILL.md
@@ -690,6 +690,7 @@ The floor is local because it prevents loop stalls.
 - `$CODEX_FLOOR` defaults to 5 and has a hard minimum of 2.
 - Use `FLOOR=$(( ${CODEX_FLOOR:-5} < 2 ? 2 : ${CODEX_FLOOR:-5} ))`.
 - Count only this repository's loop codexes: command line contains `consensus-rnd-cli spawn-codex` and the absolute `$REPO_ROOT`.
+- `actual` counts only live `spawn-codex` processes; fresh unconsumed harness spawn intents may reduce hard-gate dispatch pressure as bounded transient local supply and grant no process-spawn, GitHub, git, or lifecycle authority.
 - Exclude shell ` -c ` wrapper rows so each real codex counts once.
 <!-- Refactor (iter4/skill-count-cli-canonical): Old pattern: controller 手 ps | grep consensus-rnd-cli spawn-codex 重新实现 count_in_flight_codex 逻辑,容易跟 daemon 算法漂移。 New principle: 直接调 `python3 <skill-root>/scripts/consensus-rnd-cli concurrency --count-only` 拿 canonical 整数,或 `--list-codex` 拿每条 supervisor cmdline。禁止 controller 临时 ps/awk pipeline。(2026-05-26 maintainer-directive 等价 Consensus-rnd Phase design-consensus 共识) -->
 - **Canonical CLI**(controller 强制使用,**禁止**手 `ps | grep`):

--- a/skills/consensus-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -83,6 +83,14 @@ class Phase9DispatchTarget:
     role: str
 
 
+@dataclass(frozen=True)
+class HardGateTransientSupply:
+    supply: int
+    targets: tuple[str, ...]
+    evidence: tuple[str, ...]
+    blocked_reason: str | None = None
+
+
 def utc_ts() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -573,6 +581,69 @@ class ConcurrencyMonitor:
             return True, "fresh-item-matching-intent", evidence
         return False, "missing-fresh-item-matching-intent", []
 
+    def hard_gate_transient_supply(
+        self,
+        *,
+        breakdown: list[dict],
+        target: int,
+        actual: int,
+        queue_empty: bool,
+        now: float | None = None,
+    ) -> HardGateTransientSupply:
+        if not queue_empty or target <= actual:
+            return HardGateTransientSupply(0, (), ())
+        active_targets = self._active_item_targets(breakdown)
+        if not active_targets:
+            return HardGateTransientSupply(0, (), ())
+        window = self.daemon_self_drive_consumption_window_seconds()
+        if now is None:
+            now = time.time()
+        return self._hard_gate_transient_supply_from_intents(
+            active_targets=active_targets,
+            limit=target - actual,
+            now=now,
+            window=window,
+        )
+
+    def _hard_gate_transient_supply_from_intents(
+        self,
+        *,
+        active_targets: set[tuple[str, int]],
+        limit: int,
+        now: float,
+        window: int,
+    ) -> HardGateTransientSupply:
+        try:
+            pending_lines = self.pending_events.read_text(encoding="utf-8", errors="replace").splitlines()
+        except FileNotFoundError:
+            pending_lines = []
+        except OSError as exc:
+            return HardGateTransientSupply(0, (), (), f"pending-events-read-error:{exc.__class__.__name__}")
+        blocked_intents = self._terminal_blocked_harness_spawn_intent_ids(pending_lines)
+        blocked_targets = self._targets_for_terminal_blocked_harness_spawn_intents(pending_lines)
+        pending_supply = self._pending_transient_supply(
+            lines=pending_lines,
+            active_targets=active_targets,
+            now=now,
+            window=window,
+            blocked_intents=blocked_intents,
+        )
+        if pending_supply.blocked_reason:
+            return pending_supply
+        ledger_supply = self._phase9_ledger_transient_supply(
+            active_targets=active_targets,
+            now=now,
+            window=window,
+            blocked_intents=blocked_intents,
+            blocked_targets=blocked_targets,
+        )
+        if ledger_supply.blocked_reason:
+            return ledger_supply
+        targets = tuple(dict.fromkeys([*pending_supply.targets, *ledger_supply.targets]))
+        evidence = tuple([*pending_supply.evidence, *ledger_supply.evidence])
+        supply = min(limit, len(targets))
+        return HardGateTransientSupply(supply, targets[:supply], evidence)
+
     def _pending_intent_evidence(
         self,
         *,
@@ -606,6 +677,45 @@ class ConcurrencyMonitor:
                 return False, f"stale-unconsumed-intent:{age}s", []
             evidence.append(f"pending:{payload.get('intent_id') or payload.get('task_id')}:{age}s")
         return True, "pending-ok", evidence
+
+    def _pending_transient_supply(
+        self,
+        *,
+        lines: list[str],
+        active_targets: set[tuple[str, int]],
+        now: float,
+        window: int,
+        blocked_intents: set[str],
+    ) -> HardGateTransientSupply:
+        targets: list[str] = []
+        evidence: list[str] = []
+        for line in lines:
+            if " HARNESS_SPAWN_INTENT " not in line:
+                continue
+            ts, payload_text = line.split(" HARNESS_SPAWN_INTENT ", 1)
+            try:
+                payload = json.loads(payload_text)
+            except json.JSONDecodeError:
+                return HardGateTransientSupply(0, (), (), "malformed-harness-spawn-intent")
+            if not isinstance(payload, dict):
+                return HardGateTransientSupply(0, (), (), "malformed-harness-spawn-intent")
+            if payload.get("source") != "phase9-router":
+                continue
+            created_at = self._line_time(ts)
+            if created_at is None:
+                return HardGateTransientSupply(0, (), (), "malformed-harness-spawn-intent-ts")
+            target_key = self._intent_active_target_key(payload, active_targets)
+            if target_key is None:
+                continue
+            suppressed = self._intent_suppression_reason(payload, blocked_intents=blocked_intents)
+            age = int(now - created_at)
+            if suppressed:
+                continue
+            if age > window:
+                continue
+            targets.append(target_key)
+            evidence.append(f"pending:{payload.get('intent_id') or payload.get('task_id')}:{age}s")
+        return HardGateTransientSupply(len(set(targets)), tuple(dict.fromkeys(targets)), tuple(evidence))
 
     def _phase9_ledger_intent_evidence(
         self,
@@ -652,6 +762,55 @@ class ConcurrencyMonitor:
                 return False, f"stale-unconsumed-intent:{age}s", []
             evidence.append(f"phase9-ledger:{entry.get('key') or '?'}:{age}s")
         return True, "phase9-ledger-ok", evidence
+
+    def _phase9_ledger_transient_supply(
+        self,
+        *,
+        active_targets: set[tuple[str, int]],
+        now: float,
+        window: int,
+        blocked_intents: set[str],
+        blocked_targets: set[Phase9DispatchTarget],
+    ) -> HardGateTransientSupply:
+        ledger = self.ctx.paths.refactor_loop / "phase9-router-ledger.jsonl"
+        if not ledger.exists():
+            return HardGateTransientSupply(0, (), ())
+        try:
+            lines = ledger.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError as exc:
+            return HardGateTransientSupply(0, (), (), f"phase9-ledger-read-error:{exc.__class__.__name__}")
+        targets: list[str] = []
+        evidence: list[str] = []
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                return HardGateTransientSupply(0, (), (), "malformed-phase9-ledger")
+            if not isinstance(entry, dict):
+                return HardGateTransientSupply(0, (), (), "malformed-phase9-ledger")
+            if entry.get("dispatch_state") != "harness-intent":
+                continue
+            created_at = self._line_time(str(entry.get("dispatched_at") or ""))
+            if created_at is None:
+                return HardGateTransientSupply(0, (), (), "malformed-phase9-ledger-ts")
+            target_key = self._intent_active_target_key(entry, active_targets)
+            if target_key is None:
+                continue
+            suppressed = self._phase9_ledger_suppression_reason(
+                entry,
+                blocked_intents=blocked_intents,
+                blocked_targets=blocked_targets,
+            )
+            age = int(now - created_at)
+            if suppressed:
+                continue
+            if age > window:
+                continue
+            targets.append(target_key)
+            evidence.append(f"phase9-ledger:{entry.get('key') or '?'}:{age}s")
+        return HardGateTransientSupply(len(set(targets)), tuple(dict.fromkeys(targets)), tuple(evidence))
 
     def _terminal_blocked_harness_spawn_intent_ids(self, lines: list[str]) -> set[str]:
         ids: set[str] = set()
@@ -744,16 +903,26 @@ class ConcurrencyMonitor:
         return log_path.exists()
 
     def _intent_matches_active_target(self, payload: dict[str, object], active_targets: set[tuple[str, int]]) -> bool:
+        return self._intent_active_target_key(payload, active_targets) is not None
+
+    def _intent_active_target_key(self, payload: dict[str, object], active_targets: set[tuple[str, int]]) -> str | None:
         text = " ".join(
             str(payload.get(field) or "")
             for field in ("task_id", "intent_id", "route", "reason", "key", "marker", "log", "log_path", "prompt")
         )
         for kind, number in self._targets_from_text(text):
             if (kind, number) in active_targets:
-                return True
+                return self._intent_distinct_supply_key(payload, f"{kind}:{number}")
             if kind == "unknown" and (("issue", number) in active_targets or ("pr", number) in active_targets):
-                return True
-        return False
+                return self._intent_distinct_supply_key(payload, f"unknown:{number}")
+        return None
+
+    def _intent_distinct_supply_key(self, payload: dict[str, object], fallback: str) -> str:
+        for field in ("task_id", "intent_id", "key", "log", "log_path", "prompt"):
+            value = payload.get(field)
+            if isinstance(value, str) and value:
+                return f"{field}:{value}"
+        return fallback
 
     def _targets_from_text(self, text: str) -> set[tuple[str, int]]:
         targets: set[tuple[str, int]] = set()
@@ -1024,6 +1193,13 @@ class ConcurrencyMonitor:
         if actual < target:
             if self.dispatch_queue_empty():
                 deficit = target - actual
+                transient_supply = self.hard_gate_transient_supply(
+                    breakdown=breakdown,
+                    target=target,
+                    actual=actual,
+                    queue_empty=True,
+                )
+                uncovered_deficit = max(0, deficit - transient_supply.supply)
                 boundary = None
                 if expected == 0:
                     boundary = single_active_audit_boundary(self.repo_root, self, items, True)
@@ -1035,10 +1211,25 @@ class ConcurrencyMonitor:
                     self.write_pending_event(event)
                     log(event)
                     tick_action = f"blocked:single-active-audit deficit={deficit}"
+                elif owner_allowed and expected > 0 and uncovered_deficit > 0:
+                    detail = (
+                        f"HARD_GATE:dispatch_required={uncovered_deficit}:actual={actual} "
+                        f"expected={expected} queue=0 transient_supply={transient_supply.supply} "
+                        f"uncovered_deficit={uncovered_deficit}"
+                    )
+                    self.write_pending_event(detail)
+                    log(detail)
+                    tick_action = (
+                        f"blocked:dispatch-required deficit={deficit} "
+                        f"transient_supply={transient_supply.supply} uncovered_deficit={uncovered_deficit}"
+                    )
                 elif owner_allowed and expected > 0:
-                    self.write_pending_event(f"HARD_GATE:dispatch_required={deficit}:actual={actual} expected={expected} queue=0")
-                    log(f"HARD_GATE:dispatch_required={deficit}:actual={actual} expected={expected} queue=0")
-                    tick_action = f"blocked:dispatch-required deficit={deficit}"
+                    log(
+                        "HARD_GATE:covered-by-transient-supply "
+                        f"actual={actual} expected={expected} queue=0 deficit={deficit} "
+                        f"transient_supply={transient_supply.supply}"
+                    )
+                    tick_action = f"noop:transient-supply-covered deficit={deficit}"
                 elif owner_allowed:
                     log(
                         "HARD_GATE:noop:zero-expected "

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -913,6 +913,38 @@ def canonical_actual_count(repo_root: Path, monitor: Any | None) -> int:
         return 0
 
 
+def hard_gate_transient_supply(
+    monitor: Any | None,
+    *,
+    breakdown: list[dict[str, Any]],
+    target: int,
+    actual: int,
+    queue_empty: bool,
+) -> dict[str, Any]:
+    if monitor is None:
+        return {"supply": 0, "targets": [], "evidence": [], "blocked_reason": None}
+    try:
+        projection = monitor.hard_gate_transient_supply(
+            breakdown=breakdown,
+            target=target,
+            actual=actual,
+            queue_empty=queue_empty,
+        )
+    except Exception as exc:
+        return {"supply": 0, "targets": [], "evidence": [], "blocked_reason": f"unavailable:{exc.__class__.__name__}"}
+    raw_supply = getattr(projection, "supply", 0)
+    supply = raw_supply if isinstance(raw_supply, int) else 0
+    raw_blocked_reason = getattr(projection, "blocked_reason", None)
+    raw_targets = getattr(projection, "targets", ())
+    raw_evidence = getattr(projection, "evidence", ())
+    return {
+        "supply": supply,
+        "targets": list(raw_targets) if isinstance(raw_targets, (list, tuple)) else [],
+        "evidence": list(raw_evidence) if isinstance(raw_evidence, (list, tuple)) else [],
+        "blocked_reason": raw_blocked_reason if isinstance(raw_blocked_reason, str) else None,
+    }
+
+
 def _exclude_draft_suppressed_release_rollups(
     items: list[dict[str, Any]],
     release_rollup_actions: list[Mapping[str, Any]] | None,
@@ -1075,8 +1107,19 @@ def concurrency_plan(
     floor = configured_floor()
     target = max(floor, expected)
     deficit = max(0, target - actual)
-    hard_gate_active = deficit > 0 and (expected > 0 or dispatch_queue_has_work or audit_fallback_eligible)
-    hard_gate_line = f"HARD_GATE:dispatch_required={deficit}" if hard_gate_active else None
+    queue_empty = not dispatch_queue_has_work
+    transient_supply = hard_gate_transient_supply(
+        monitor,
+        breakdown=breakdown,
+        target=target,
+        actual=actual,
+        queue_empty=queue_empty,
+    )
+    supply_count = int(transient_supply.get("supply", 0)) if queue_empty else 0
+    uncovered_deficit = max(0, deficit - supply_count)
+    dispatch_pressure = deficit if dispatch_queue_has_work else uncovered_deficit
+    hard_gate_active = dispatch_pressure > 0 and (expected > 0 or dispatch_queue_has_work or audit_fallback_eligible)
+    hard_gate_line = f"HARD_GATE:dispatch_required={dispatch_pressure}" if hard_gate_active else None
     boundary = None
     if deficit > 0 and expected == 0 and concurrency_module is not None:
         try:
@@ -1093,10 +1136,12 @@ def concurrency_plan(
         "floor": floor,
         "target": target,
         "deficit": deficit,
+        "transient_supply": transient_supply,
+        "uncovered_deficit": uncovered_deficit,
         "fixed_point": fixed_point,
         "hard_gate": {
             "active": hard_gate_active,
-            "dispatch_required": deficit if hard_gate_active else 0,
+            "dispatch_required": dispatch_pressure if hard_gate_active else 0,
             "line": hard_gate_line,
             "semantics": (
                 "controller must dispatch this many actionable managed issue/PR tasks or legal fallback issue production through audit before ending the wakeup"
@@ -4238,7 +4283,9 @@ def restore_hard_gate_for_dispatchable_actions(concurrency: dict[str, Any], acti
     hard_gate = concurrency.get("hard_gate", {})
     if not has_hard_gate_dispatch_action(actions):
         return
-    deficit = int(concurrency.get("deficit", 0))
+    uncovered_deficit = int(concurrency.get("uncovered_deficit", 0))
+    raw_deficit = int(concurrency.get("deficit", 0))
+    deficit = uncovered_deficit if uncovered_deficit > 0 else raw_deficit
     if deficit <= 0:
         return
     hard_gate.update(

--- a/skills/consensus-loop/scripts/test_concurrency_monitor.py
+++ b/skills/consensus-loop/scripts/test_concurrency_monitor.py
@@ -94,6 +94,38 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
             intents.append(json.loads(line.split(" HARNESS_SPAWN_INTENT ", 1)[1]))
         return intents
 
+    def append_phase9_harness_spawn_intent(
+        self,
+        task_id: str,
+        *,
+        ts: str = "2026-05-26T07:29:00Z",
+        intent_id: str | None = None,
+        log: str | None = None,
+        source: str = "phase9-router",
+    ) -> dict[str, object]:
+        intent = {
+            "intent_id": intent_id or f"phase9-router:{task_id}",
+            "source": source,
+            "route": "solver_triplet_to_judge",
+            "task_id": task_id,
+            "priority": "p1",
+            "command": "spawn-codex",
+            "controller_action": "spawn_codex_harness_background",
+            "cd": str(self.repo),
+            "prompt": f".refactor-loop/prompts/phase9/{task_id}.md",
+            "log": log or f".refactor-loop/logs/{task_id}.log",
+            "stall": 5400,
+            "reason": f"issue #{task_id.split('-r', 1)[0].removeprefix('phase9-issue')} dispatch",
+            "queued_at": ts,
+            "run_in_background_required": True,
+            "no_lifecycle_authority": True,
+        }
+        pending = self.refactor_loop / ".controller-pending-events.log"
+        pending.parent.mkdir(parents=True, exist_ok=True)
+        with pending.open("a", encoding="utf-8") as handle:
+            handle.write(f"{ts} HARNESS_SPAWN_INTENT {json.dumps(intent, sort_keys=True)}\n")
+        return intent
+
     def design_issue_item(self, issue: int) -> dict:
         return {
             "number": issue,
@@ -752,6 +784,100 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
         events = (self.refactor_loop / ".controller-pending-events.log").read_text(encoding="utf-8")
         self.assertIn("HARD_GATE:dispatch_required=1:actual=1 expected=1 queue=0", events)
         self.assertNotIn("WAIT:single-active-audit", events)
+
+    def test_tick_fresh_phase9_intent_reduces_queue_empty_hard_gate_pressure(self) -> None:
+        items = [
+            self.design_issue_item(330),
+            self.design_issue_item(331),
+            self.design_issue_item(332),
+        ]
+        self.append_phase9_harness_spawn_intent("phase9-issue330-r4-minimal")
+
+        with mock.patch.object(self.monitor, "list_auto_loop_issues", return_value=items):
+            with mock.patch.object(self.monitor, "count_in_flight_codex", return_value=1):
+                with mock.patch.object(self.module.time, "time", return_value=1_779_780_600):
+                    self.monitor.tick()
+
+        events = (self.refactor_loop / ".controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertIn(
+            "HARD_GATE:dispatch_required=1:actual=1 expected=3 queue=0 transient_supply=1 uncovered_deficit=1",
+            events,
+        )
+        self.assertNotIn("HARD_GATE:dispatch_required=2:actual=1 expected=3 queue=0", events)
+
+    def test_tick_fresh_phase9_intents_can_eliminate_queue_empty_hard_gate_pressure(self) -> None:
+        items = [
+            self.design_issue_item(330),
+            self.design_issue_item(331),
+            self.design_issue_item(332),
+        ]
+        self.append_phase9_harness_spawn_intent("phase9-issue330-r4-minimal")
+        self.append_phase9_harness_spawn_intent("phase9-issue331-r4-minimal")
+
+        with mock.patch.object(self.monitor, "list_auto_loop_issues", return_value=items):
+            with mock.patch.object(self.monitor, "count_in_flight_codex", return_value=1):
+                with mock.patch.object(self.module.time, "time", return_value=1_779_780_600):
+                    self.monitor.tick()
+
+        events = (self.refactor_loop / ".controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertNotIn("HARD_GATE:dispatch_required=", events)
+
+    def test_hard_gate_transient_supply_rejects_stale_malformed_logged_claimed_and_terminal_blocked_intents(self) -> None:
+        cases = (
+            ("stale", lambda task_id: self.append_phase9_harness_spawn_intent(task_id, ts="2026-05-26T07:00:00Z")),
+            (
+                "malformed",
+                lambda _task_id: (
+                    self.refactor_loop / ".controller-pending-events.log"
+                ).write_text("2026-05-26T07:29:00Z HARNESS_SPAWN_INTENT {bad-json\n", encoding="utf-8"),
+            ),
+            (
+                "logged",
+                lambda task_id: (
+                    self.append_phase9_harness_spawn_intent(task_id),
+                    (self.refactor_loop / "logs" / f"{task_id}.log").write_text("already targeted\n", encoding="utf-8"),
+                ),
+            ),
+            (
+                "claimed",
+                lambda task_id: (
+                    self.append_phase9_harness_spawn_intent(task_id),
+                    (self.refactor_loop / "locks" / "spawn-tasks").mkdir(parents=True, exist_ok=True),
+                    (self.refactor_loop / "locks" / "spawn-tasks" / f"{task_id}.lock").write_text("claimed\n", encoding="utf-8"),
+                ),
+            ),
+            (
+                "terminal-blocked",
+                lambda task_id: (
+                    self.append_phase9_harness_spawn_intent(task_id, intent_id=f"phase9-router:333:4:minimal"),
+                    (self.refactor_loop / ".controller-pending-events.log").write_text(
+                        (self.refactor_loop / ".controller-pending-events.log").read_text(encoding="utf-8")
+                        + "WAKEUP_RUNNER_BLOCKED:harness-spawn-intent:phase9-router:333:4:minimal:target_not_open:CLOSED\n",
+                        encoding="utf-8",
+                    ),
+                ),
+            ),
+        )
+        for case, setup in cases:
+            with self.subTest(case=case):
+                (self.refactor_loop / ".controller-pending-events.log").unlink(missing_ok=True)
+                (self.refactor_loop / "phase9-router-ledger.jsonl").unlink(missing_ok=True)
+                task_id = "phase9-issue333-r4-minimal"
+                (self.refactor_loop / "logs").mkdir(parents=True, exist_ok=True)
+                (self.refactor_loop / "locks" / "spawn-tasks").mkdir(parents=True, exist_ok=True)
+                (self.refactor_loop / "logs" / f"{task_id}.log").unlink(missing_ok=True)
+                (self.refactor_loop / "locks" / "spawn-tasks" / f"{task_id}.lock").unlink(missing_ok=True)
+                setup(task_id)
+
+                supply = self.monitor.hard_gate_transient_supply(
+                    breakdown=[{"id": "#333", "kind": "issue", "phase": self.labels.PHASE_DESIGN_SOLVING, "expected": 1}],
+                    target=3,
+                    actual=1,
+                    queue_empty=True,
+                    now=1_779_780_600,
+                )
+
+                self.assertEqual(supply.supply, 0)
 
     def test_tick_terminal_implement_result_does_not_trigger_no_gap_expected_worker(self) -> None:
         items = [

--- a/skills/consensus-loop/scripts/test_headless_dogfood_e2e.py
+++ b/skills/consensus-loop/scripts/test_headless_dogfood_e2e.py
@@ -523,6 +523,10 @@ class HeadlessDogfoodE2ETests(unittest.TestCase):
             fixture.add_issue(496, phase=label_catalog.PHASE_DESIGN_SOLVING)
             fixture.tick_router()
             self.assertEqual(3, fixture.pending_events().count("HARNESS_SPAWN_INTENT"))
+            plan = fixture.plan()
+            self.assertEqual(2, plan["hard_gate"]["dispatch_required"])
+            self.assertEqual(0, plan["concurrency"]["uncovered_deficit"])
+            self.assertEqual(3, len([action for action in plan["actions"] if action.get("kind") == "harness-spawn-intent"]))
 
             first_results = fixture.run_runner()
             second_results = fixture.run_runner()

--- a/skills/consensus-loop/scripts/test_package_concurrency_monitor.py
+++ b/skills/consensus-loop/scripts/test_package_concurrency_monitor.py
@@ -84,11 +84,12 @@ class PackageConcurrencyMonitorTests(unittest.TestCase):
         *,
         ts: str = "2026-05-26T07:25:00Z",
         intent_id: str | None = None,
+        source: str = "phase9-router",
     ) -> None:
         payload = {
             "intent_id": intent_id or f"harness-spawn-intent:test:{task_id}",
             "task_id": task_id,
-            "source": "test",
+            "source": source,
             "route": "test",
             "command": "spawn-codex",
             "controller_action": "spawn_codex_harness_background",
@@ -381,6 +382,44 @@ class PackageConcurrencyMonitorTests(unittest.TestCase):
                 alert = (self.refactor_loop / ".concurrency-alert.log").read_text(encoding="utf-8")
                 self.assertIn("P0 no-gap-violation: 0 codex with 1 active task(s)", alert)
                 self.assertIn(expected_reason, alert)
+
+    def test_hard_gate_transient_supply_counts_distinct_fresh_phase9_pending_targets(self) -> None:
+        now = datetime(2026, 5, 26, 7, 30, 0, tzinfo=timezone.utc)
+        self.append_pending_harness_intent("phase9-issue160-r1-minimal", ts="2026-05-26T07:29:00Z")
+        self.append_pending_harness_intent("phase9-issue161-r1-minimal", ts="2026-05-26T07:29:00Z")
+        self.append_pending_harness_intent("phase9-issue162-r1-minimal", ts="2026-05-26T07:29:00Z", source="concurrency-monitor")
+
+        supply = self.monitor.hard_gate_transient_supply(
+            breakdown=[
+                {"id": "#160", "kind": "issue", "phase": labels.PHASE_DESIGN_SOLVING, "expected": 1},
+                {"id": "#161", "kind": "issue", "phase": labels.PHASE_DESIGN_SOLVING, "expected": 1},
+                {"id": "#162", "kind": "issue", "phase": labels.PHASE_DESIGN_SOLVING, "expected": 1},
+            ],
+            target=3,
+            actual=1,
+            queue_empty=True,
+            now=now.timestamp(),
+        )
+
+        self.assertEqual(supply.supply, 2)
+        self.assertEqual(len(supply.targets), 2)
+
+    def test_hard_gate_transient_supply_ignores_consumed_phase9_intent(self) -> None:
+        now = datetime(2026, 5, 26, 7, 30, 0, tzinfo=timezone.utc)
+        task_id = "phase9-issue160-r1-minimal"
+        self.append_pending_harness_intent(task_id, ts="2026-05-26T07:29:00Z")
+        (self.refactor_loop / "logs" / f"{task_id}.log").write_text("already targeted\n", encoding="utf-8")
+
+        supply = self.monitor.hard_gate_transient_supply(
+            breakdown=[{"id": "#160", "kind": "issue", "phase": labels.PHASE_DESIGN_SOLVING, "expected": 1}],
+            target=3,
+            actual=1,
+            queue_empty=True,
+            now=now.timestamp(),
+        )
+
+        self.assertEqual(supply.supply, 0)
+        self.assertIsNone(supply.blocked_reason)
 
     def test_zero_codex_malformed_intent_fails_closed_to_p0(self) -> None:
         now = datetime(2026, 5, 26, 7, 30, 0, tzinfo=timezone.utc)

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -15,6 +15,7 @@ from contextlib import redirect_stderr
 from datetime import datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 
@@ -5444,6 +5445,42 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(hard_gate["blocked_deficit"], 4)
         self.assertEqual(hard_gate["dispatch_required"], 0)
 
+    def test_restore_hard_gate_uses_uncovered_deficit_when_present(self) -> None:
+        action = {
+            "kind": "harness-spawn-intent",
+            "controller_action": "spawn_codex_harness_background",
+        }
+        hard_gate = {
+            "active": False,
+            "reason": None,
+            "blocked_deficit": 0,
+            "dispatch_required": 0,
+        }
+        concurrency = {"deficit": 2, "uncovered_deficit": 1, "hard_gate": hard_gate}
+        restore_hard_gate_for_dispatchable_actions(concurrency, [action])
+
+        self.assertTrue(hard_gate["active"])
+        self.assertEqual(hard_gate["dispatch_required"], 1)
+        self.assertEqual(hard_gate["line"], "HARD_GATE:dispatch_required=1")
+
+    def test_restore_hard_gate_uses_raw_deficit_when_uncovered_deficit_is_zero(self) -> None:
+        action = {
+            "kind": "harness-spawn-intent",
+            "controller_action": "spawn_codex_harness_background",
+        }
+        hard_gate = {
+            "active": False,
+            "reason": None,
+            "blocked_deficit": 0,
+            "dispatch_required": 0,
+        }
+        concurrency = {"deficit": 2, "uncovered_deficit": 0, "hard_gate": hard_gate}
+        restore_hard_gate_for_dispatchable_actions(concurrency, [action])
+
+        self.assertTrue(hard_gate["active"])
+        self.assertEqual(hard_gate["dispatch_required"], 2)
+        self.assertEqual(hard_gate["line"], "HARD_GATE:dispatch_required=2")
+
     def test_wakeup_plan_source_does_not_make_dispatch_next_step_worker_executable(self) -> None:
         projection = wakeup_plan_projection()
 
@@ -6758,6 +6795,54 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(plan["hard_gate"]["reason"], None)
         self.assertNotEqual(plan.get("recommendation"), "WAIT:single-active-audit")
         self.assertEqual(plan["hard_gate"]["line"], "HARD_GATE:dispatch_required=4")
+
+    def test_fresh_phase9_intent_reduces_queue_empty_hard_gate_uncovered_deficit(self) -> None:
+        monitor = mock.Mock()
+        monitor.count_in_flight_codex.return_value = 1
+        monitor.dispatch_queue_empty.return_value = True
+        monitor.hard_gate_transient_supply.return_value = SimpleNamespace(
+            supply=1,
+            targets=("task_id:phase9-issue330-r4-judge",),
+            evidence=("pending:phase9-router:330:4:judge:60s",),
+            blocked_reason=None,
+        )
+
+        with mock.patch.dict(os.environ, {"CODEX_FLOOR": "2"}):
+            plan = concurrency_plan(
+                self.repo,
+                fixed_point=False,
+                gh_items=[
+                    GhItem(
+                        kind="issue",
+                        number=330,
+                        title="active",
+                        labels=(label_catalog.MANAGED, label_catalog.PHASE_DESIGN_SOLVING, label_catalog.HUMAN_AUTO),
+                    ),
+                    GhItem(
+                        kind="issue",
+                        number=331,
+                        title="active",
+                        labels=(label_catalog.MANAGED, label_catalog.PHASE_DESIGN_SOLVING, label_catalog.HUMAN_AUTO),
+                    ),
+                    GhItem(
+                        kind="issue",
+                        number=332,
+                        title="active",
+                        labels=(label_catalog.MANAGED, label_catalog.PHASE_DESIGN_SOLVING, label_catalog.HUMAN_AUTO),
+                    ),
+                ],
+                monitor=monitor,
+                concurrency_module=None,
+            )
+
+        self.assertEqual(plan["actual"], 1)
+        self.assertEqual(plan["expected_from_active_tasks"], 3)
+        self.assertEqual(plan["deficit"], 2)
+        self.assertEqual(plan["transient_supply"]["supply"], 1)
+        self.assertEqual(plan["uncovered_deficit"], 1)
+        self.assertTrue(plan["hard_gate"]["active"])
+        self.assertEqual(plan["hard_gate"]["dispatch_required"], 1)
+        self.assertEqual(plan["hard_gate"]["line"], "HARD_GATE:dispatch_required=1")
 
     def test_queued_work_bypasses_single_audit_wait(self) -> None:
         self.write_dispatch("p1", "fix-pr294-round-3")

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -1348,7 +1348,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual([result.action_id for result in results], ["spawn:0", "spawn:1", "spawn:2"])
         self.assertEqual(launch.call_count, 3)
 
-    def test_wakeup_runner_spawn_batch_does_not_overshoot_dispatch_required(self) -> None:
+    def test_wakeup_runner_spawn_batch_uses_projected_dispatch_required(self) -> None:
         actions = [self.spawn_action(action_id=f"spawn:{index}", log=str(self.repo / f".refactor-loop/logs/task-{index}.log")) for index in range(4)]
 
         with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
@@ -1357,6 +1357,18 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual([result.action_id for result in results], ["spawn:0", "spawn:1"])
         self.assertEqual([result.status for result in results], ["applied", "applied"])
         self.assertEqual(launch.call_count, 2)
+
+    def test_wakeup_runner_covered_transient_supply_keeps_single_apply_compatibility(self) -> None:
+        actions = [self.spawn_action(action_id=f"spawn:{index}", log=str(self.repo / f".refactor-loop/logs/task-{index}.log")) for index in range(3)]
+        plan = self.batch_plan(actions, dispatch_required=0, deficit=2, active=False)
+        plan["concurrency"]["transient_supply"] = {"supply": 2}
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
+            results = self.run_result(plan)
+
+        self.assertEqual([result.action_id for result in results], ["spawn:0"])
+        self.assertEqual([result.status for result in results], ["applied"])
+        self.assertEqual(launch.call_count, 1)
 
     def test_wakeup_runner_spawn_batch_uses_deficit_as_upper_bound(self) -> None:
         actions = [self.spawn_action(action_id=f"spawn:{index}", log=str(self.repo / f".refactor-loop/logs/task-{index}.log")) for index in range(3)]


### PR DESCRIPTION
## Changed files
- Added transient hard-gate supply in the concurrency monitor for fresh unconsumed phase9 harness spawn intents and phase9 ledger evidence.
- Updated wakeup-plan hard-gate projection so queue-empty dispatch pressure uses `uncovered_deficit`, while already-dispatchable pending spawn actions can still fill the runner batch.
- Added focused monitor, wakeup-plan, runner, packaged monitor, and headless e2e coverage.

## Test results
- `python3 skills/consensus-loop/scripts/test_concurrency_monitor.py`
- `python3 skills/consensus-loop/scripts/test_wakeup_plan.py`
- `python3 skills/consensus-loop/scripts/test_package_concurrency_monitor.py`
- `bash -lc 'source /Users/auric/consensus-rnd/.refactor-loop/host.env 2>/dev/null || true; python3 -m compileall skills/consensus-loop/scripts skills/sshx -q'`
- Full host pytest command: `1974 passed, 1 skipped, 5787 subtests passed`; `26 passed, 6 subtests passed`.

## Deviations
- Closes #725
- Scope was extended to `wakeup_runner.py`, `test_wakeup_runner.py`, and `test_headless_dogfood_e2e.py` to fix and verify the runner/planner interaction exposed by the full host suite.
- `refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)`

⟦AI:AUTO-LOOP⟧
