### PR TITLE
Quiet non-release release countdown manifest diagnostics

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -3745,9 +3745,18 @@ def _release_countdown_score(repo_root: Path, scorer: Any | None = None) -> dict
         with contextlib.redirect_stdout(sys.stderr):
             score = (scorer or decide_release_artifact)(repo_root)
     except (KeyError, RuntimeError, ValueError) as exc:
-        print(f"release-countdown: release goal unavailable: {exc}", file=sys.stderr)
+        if not _release_countdown_quiet_unavailable(repo_root, exc):
+            print(f"release-countdown: release goal unavailable: {exc}", file=sys.stderr)
         return {}
     return score if isinstance(score, dict) else {}
+
+
+def _release_countdown_quiet_unavailable(repo_root: Path, exc: BaseException) -> bool:
+    if os.environ.get("RELEASE_AUTO_ENABLE") == "true":
+        return False
+    if not (repo_root / ".version-bump.json").exists():
+        return True
+    return ".version-bump.json: expected top-level files list" in str(exc)
 
 
 def has_dispatchable_action(actions: list[dict[str, Any]]) -> bool:

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -5618,7 +5618,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
     def test_release_countdown_fail_soft_when_version_manifest_has_no_files_list(self) -> None:
         (self.repo / ".version-bump.json").write_text(json.dumps({"version": "0.0.0"}), encoding="utf-8")
 
-        plan = self.run_plan(fixture="default_milestones")
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "false"}):
+            plan, _stdout, stderr = self.run_plan_with_streams(fixture="default_milestones")
 
         actions = [action for action in plan["actions"] if action["kind"] == "release-countdown"]
         self.assertEqual(len(actions), 1)
@@ -5631,12 +5632,14 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertFalse(action["ready"])
         self.assertEqual(action["red_signals"], [])
         self.assertEqual(action["blocked_reasons"], [])
+        self.assertNotIn("release-countdown: release goal unavailable", stderr)
         self.assertIn("api milestones", (self.repo / "gh-query-labels.log").read_text(encoding="utf-8"))
 
     def test_release_countdown_fail_soft_when_version_manifest_is_absent_with_open_milestone(self) -> None:
         (self.repo / ".version-bump.json").unlink()
 
-        plan = self.run_plan(fixture="default_milestones")
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "false"}):
+            plan, _stdout, stderr = self.run_plan_with_streams(fixture="default_milestones")
 
         actions = [action for action in plan["actions"] if action["kind"] == "release-countdown"]
         self.assertEqual(len(actions), 1)
@@ -5646,6 +5649,40 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertIsNone(action["goal"]["release"])
         self.assertTrue(action["status_only"])
         self.assertTrue(action["no_lifecycle_authority"])
+        self.assertFalse((self.repo / ".refactor-loop/state/release-decision.json").exists())
+        self.assertFalse((self.repo / ".refactor-loop/state/release-candidate.json").exists())
+        self.assertNotIn("release-countdown: release goal unavailable", stderr)
+
+    def test_release_countdown_keeps_release_enabled_diagnostic_when_version_manifest_is_absent(self) -> None:
+        (self.repo / ".version-bump.json").unlink()
+
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "true"}):
+            plan, _stdout, stderr = self.run_plan_with_streams(fixture="default_milestones")
+
+        actions = [action for action in plan["actions"] if action["kind"] == "release-countdown"]
+        self.assertEqual(len(actions), 1)
+        action = actions[0]
+        self.assertIsNone(action["goal"]["release"])
+        self.assertTrue(action["status_only"])
+        self.assertFalse(has_dispatchable_action(actions))
+        self.assertIn("release-countdown: release goal unavailable", stderr)
+        self.assertFalse((self.repo / ".refactor-loop/state/release-decision.json").exists())
+        self.assertFalse((self.repo / ".refactor-loop/state/release-candidate.json").exists())
+
+    def test_release_countdown_keeps_release_enabled_diagnostic_when_version_manifest_has_no_files_list(self) -> None:
+        (self.repo / ".version-bump.json").write_text(json.dumps({"version": "0.0.0"}), encoding="utf-8")
+
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "true"}):
+            plan, _stdout, stderr = self.run_plan_with_streams(fixture="default_milestones")
+
+        actions = [action for action in plan["actions"] if action["kind"] == "release-countdown"]
+        self.assertEqual(len(actions), 1)
+        action = actions[0]
+        self.assertIsNone(action["goal"]["release"])
+        self.assertFalse(action["ready"])
+        self.assertFalse(has_dispatchable_action(actions))
+        self.assertIn("release-countdown: release goal unavailable", stderr)
+        self.assertIn(".version-bump.json: expected top-level files list", stderr)
         self.assertFalse((self.repo / ".refactor-loop/state/release-decision.json").exists())
         self.assertFalse((self.repo / ".refactor-loop/state/release-candidate.json").exists())
 


### PR DESCRIPTION
## Changed files

- `skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py`: added quiet handling for non-release hosts when the release manifest is absent or lacks the top-level `files` list, while preserving release-enabled diagnostics.
- `skills/consensus-loop/scripts/test_wakeup_plan.py`: covered quiet non-release stderr behavior and release-enabled diagnostic behavior for unavailable manifests.

Closes #723

## Test results

- `python3 -m pytest skills/consensus-loop/scripts/test_wakeup_plan.py -k release_countdown -q -p no:cacheprovider -o addopts=`: passed.
- `bash -lc "python3 -m compileall skills/consensus-loop/scripts skills/sshx -q"`: passed.
- Required full pytest command: passed.

## Deviations

- SCOPE_EXTEND: none.
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)
- No host architecture guard command was configured in the prompt.

⟦AI:AUTO-LOOP⟧
