### PR TITLE
发布 rollup: integration ahead 1 commits (6a5ce0357ee9)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -3790,9 +3790,18 @@ def _release_countdown_score(repo_root: Path, scorer: Any | None = None) -> dict
         with contextlib.redirect_stdout(sys.stderr):
             score = (scorer or decide_release_artifact)(repo_root)
     except (KeyError, RuntimeError, ValueError) as exc:
-        print(f"release-countdown: release goal unavailable: {exc}", file=sys.stderr)
+        if not _release_countdown_quiet_unavailable(repo_root, exc):
+            print(f"release-countdown: release goal unavailable: {exc}", file=sys.stderr)
         return {}
     return score if isinstance(score, dict) else {}
+
+
+def _release_countdown_quiet_unavailable(repo_root: Path, exc: BaseException) -> bool:
+    if os.environ.get("RELEASE_AUTO_ENABLE") == "true":
+        return False
+    if not (repo_root / ".version-bump.json").exists():
+        return True
+    return ".version-bump.json: expected top-level files list" in str(exc)
 
 
 def has_dispatchable_action(actions: list[dict[str, Any]]) -> bool:

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -5655,7 +5655,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
     def test_release_countdown_fail_soft_when_version_manifest_has_no_files_list(self) -> None:
         (self.repo / ".version-bump.json").write_text(json.dumps({"version": "0.0.0"}), encoding="utf-8")
 
-        plan = self.run_plan(fixture="default_milestones")
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "false"}):
+            plan, _stdout, stderr = self.run_plan_with_streams(fixture="default_milestones")
 
         actions = [action for action in plan["actions"] if action["kind"] == "release-countdown"]
         self.assertEqual(len(actions), 1)
@@ -5668,12 +5669,14 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertFalse(action["ready"])
         self.assertEqual(action["red_signals"], [])
         self.assertEqual(action["blocked_reasons"], [])
+        self.assertNotIn("release-countdown: release goal unavailable", stderr)
         self.assertIn("api milestones", (self.repo / "gh-query-labels.log").read_text(encoding="utf-8"))
 
     def test_release_countdown_fail_soft_when_version_manifest_is_absent_with_open_milestone(self) -> None:
         (self.repo / ".version-bump.json").unlink()
 
-        plan = self.run_plan(fixture="default_milestones")
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "false"}):
+            plan, _stdout, stderr = self.run_plan_with_streams(fixture="default_milestones")
 
         actions = [action for action in plan["actions"] if action["kind"] == "release-countdown"]
         self.assertEqual(len(actions), 1)
@@ -5683,6 +5686,40 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertIsNone(action["goal"]["release"])
         self.assertTrue(action["status_only"])
         self.assertTrue(action["no_lifecycle_authority"])
+        self.assertFalse((self.repo / ".refactor-loop/state/release-decision.json").exists())
+        self.assertFalse((self.repo / ".refactor-loop/state/release-candidate.json").exists())
+        self.assertNotIn("release-countdown: release goal unavailable", stderr)
+
+    def test_release_countdown_keeps_release_enabled_diagnostic_when_version_manifest_is_absent(self) -> None:
+        (self.repo / ".version-bump.json").unlink()
+
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "true"}):
+            plan, _stdout, stderr = self.run_plan_with_streams(fixture="default_milestones")
+
+        actions = [action for action in plan["actions"] if action["kind"] == "release-countdown"]
+        self.assertEqual(len(actions), 1)
+        action = actions[0]
+        self.assertIsNone(action["goal"]["release"])
+        self.assertTrue(action["status_only"])
+        self.assertFalse(has_dispatchable_action(actions))
+        self.assertIn("release-countdown: release goal unavailable", stderr)
+        self.assertFalse((self.repo / ".refactor-loop/state/release-decision.json").exists())
+        self.assertFalse((self.repo / ".refactor-loop/state/release-candidate.json").exists())
+
+    def test_release_countdown_keeps_release_enabled_diagnostic_when_version_manifest_has_no_files_list(self) -> None:
+        (self.repo / ".version-bump.json").write_text(json.dumps({"version": "0.0.0"}), encoding="utf-8")
+
+        with mock.patch.dict(os.environ, {"RELEASE_AUTO_ENABLE": "true"}):
+            plan, _stdout, stderr = self.run_plan_with_streams(fixture="default_milestones")
+
+        actions = [action for action in plan["actions"] if action["kind"] == "release-countdown"]
+        self.assertEqual(len(actions), 1)
+        action = actions[0]
+        self.assertIsNone(action["goal"]["release"])
+        self.assertFalse(action["ready"])
+        self.assertFalse(has_dispatchable_action(actions))
+        self.assertIn("release-countdown: release goal unavailable", stderr)
+        self.assertIn(".version-bump.json: expected top-level files list", stderr)
         self.assertFalse((self.repo / ".refactor-loop/state/release-decision.json").exists())
         self.assertFalse((self.repo / ".refactor-loop/state/release-candidate.json").exists())
 


### PR DESCRIPTION
## 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `16af7c388fc1..6a5ce0357ee9`
- 涉及 issue: #723, #732

## commit 摘要

- 实现 issue #723 (#732)

## 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
