### PR TITLE
Fix reviewer evidence recovery dispatch

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from string import Template
@@ -73,6 +74,7 @@ SAFE_WORKTREE_CLUSTER_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 GITHUB_LIFECYCLE_TARGET_RE = re.compile(r"^[1-9][0-9]*$")
 BODY_CLOSING_ISSUE_TARGET_RE = re.compile(r"(?im)\bCloses\s+#([^\s,;:.)\]}\\]*)")
 REVIEW_ROLES = ("architect", "tests", "quality")
+REVIEW_PENDING_SECONDS = 90
 PUBLISH_IMPLEMENTATION_FALLBACK_DELEGATED_EXIT = 75
 MANAGED_PR_HEAD_RE = re.compile(r"^refactor/iter([1-9][0-9]*)-([A-Za-z0-9._-]+)$")
 REBASE_RESOLVE_DONE_RE = re.compile(r"^REBASE_RESOLVE_DONE:([1-9][0-9]*):([A-Za-z0-9._-]+)$")
@@ -1618,6 +1620,11 @@ class ControllerActions:
             return False
         log_path = self.ctx.paths.logs / f"review-pr{pr_target}-{role}-r{round_number}.log"
         if not log_path.exists():
+            return False
+        try:
+            if time.time() - log_path.stat().st_mtime >= REVIEW_PENDING_SECONDS:
+                return False
+        except OSError:
             return False
         try:
             text = log_path.read_text(encoding="utf-8", errors="replace")

--- a/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -1573,6 +1573,8 @@ class ControllerActions:
             roles = REVIEW_ROLES
         for role in roles:
             round_number = self._next_review_round(pr_target, role)
+            if self._review_round_is_pending(pr_target, role, round_number - 1):
+                continue
             if self._pending_review_spawn_exists(pr_target, role, round_number):
                 continue
             prompt = self.ctx.paths.prompts / f"review-pr{pr_target}-{role}-r{round_number}.md"
@@ -1610,6 +1612,20 @@ class ControllerActions:
                 if match:
                     rounds.append(int(match.group(1)))
         return (max(rounds) if rounds else 0) + 1
+
+    def _review_round_is_pending(self, pr_target: str, role: str, round_number: int) -> bool:
+        if round_number < 1:
+            return False
+        log_path = self.ctx.paths.logs / f"review-pr{pr_target}-{role}-r{round_number}.log"
+        if not log_path.exists():
+            return False
+        try:
+            text = log_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return False
+        if "EXIT=" in text:
+            return False
+        return (self.ctx.paths.prompts / f"review-pr{pr_target}-{role}-r{round_number}.md").exists()
 
     def _pending_review_spawn_exists(self, pr_target: str, role: str, round_number: int) -> bool:
         try:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -193,6 +193,7 @@ CONSENSUS_JUDGE_LOG_RE = re.compile(r"^phase9-issue([1-9][0-9]*)-r([1-9][0-9]*)-
 DESIGN_CONSENSUS_LOG_RE = re.compile(r"^phase9-issue([1-9][0-9]*)-r([1-9][0-9]*)-(minimal|structural|delete|judge|reflector)\.log$")
 IMPLEMENT_PENDING_INTENT_PREFIX = "dispatch-consensus-implementation:"
 IMPLEMENT_TASK_PREFIX = "implement-"
+REVIEW_PENDING_SECONDS = 90
 
 
 @dataclass(frozen=True)
@@ -1976,6 +1977,22 @@ def _reviewer_log_has_exit_zero(path: Path) -> bool:
     return any(line.strip() == "EXIT=0" for line in lines)
 
 
+def _reviewer_log_terminal_failed(path: Path) -> bool:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return False
+    for line in reversed(lines):
+        text = line.strip()
+        if not text.startswith("EXIT="):
+            continue
+        try:
+            return int(text.removeprefix("EXIT=")) != 0
+        except ValueError:
+            return True
+    return False
+
+
 def _reviewer_log_has_valid_marker(path: Path, pr_number: int, role: str) -> bool:
     try:
         lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -2025,6 +2042,93 @@ def latest_reviewer_heads(repo_root: Path, pr_number: int) -> dict[str, str]:
     return {role: head_sha for role, (_round_number, head_sha) in by_role.items()}
 
 
+def latest_valid_reviewer_rounds(repo_root: Path, pr_number: int) -> dict[str, tuple[int, str]]:
+    by_role: dict[str, tuple[int, str]] = {}
+    artifact_keys: set[tuple[str, int]] = set()
+    runs_dir = repo_root / ".refactor-loop" / "runs"
+    logs_dir = repo_root / ".refactor-loop" / "logs"
+    prompts_dir = repo_root / ".refactor-loop" / "prompts"
+    for path in sorted(runs_dir.glob(f"review-pr{pr_number}-*-r*.md")):
+        match = REVIEW_ARTIFACT_RE.match(path.name)
+        if not match or int(match.group(1)) != pr_number:
+            continue
+        role = match.group(2)
+        round_number = int(match.group(3))
+        artifact_keys.add((role, round_number))
+        log_path = logs_dir / f"review-pr{pr_number}-{role}-r{round_number}.log"
+        if not _reviewer_log_has_exit_zero(log_path):
+            continue
+        head_sha = _reviewed_head_sha_from_file(path) or _reviewed_head_sha_from_file(prompts_dir / path.name) or _reviewed_head_sha_from_file(log_path)
+        if head_sha and _reviewer_log_has_valid_marker(log_path, pr_number, role):
+            existing = by_role.get(role)
+            if existing is None or round_number >= existing[0]:
+                by_role[role] = (round_number, head_sha)
+    for path in sorted(logs_dir.glob(f"review-pr{pr_number}-*-r*.log")):
+        match = REVIEW_LOG_RE.match(path.name)
+        if not match or int(match.group(1)) != pr_number:
+            continue
+        role = match.group(2)
+        round_number = int(match.group(3))
+        if (role, round_number) in artifact_keys:
+            continue
+        if not _reviewer_log_has_exit_zero(path) or not _reviewer_log_has_valid_marker(path, pr_number, role):
+            continue
+        prompt_path = prompts_dir / path.with_suffix(".md").name
+        head_sha = _reviewed_head_sha_from_file(path) or _reviewed_head_sha_from_file(prompt_path)
+        if head_sha:
+            existing = by_role.get(role)
+            if existing is None or round_number >= existing[0]:
+                by_role[role] = (round_number, head_sha)
+    return by_role
+
+
+def pending_or_fresh_review_evidence_exists(repo_root: Path, pr_number: int) -> bool:
+    now = time.time()
+    for path in sorted((repo_root / ".refactor-loop" / "logs").glob(f"review-pr{pr_number}-*-r*.log")):
+        match = REVIEW_LOG_RE.match(path.name)
+        if not match or int(match.group(1)) != pr_number:
+            continue
+        if _reviewer_log_has_exit_zero(path) or _reviewer_log_terminal_failed(path):
+            continue
+        if now - path.stat().st_mtime < REVIEW_PENDING_SECONDS:
+            return True
+    return False
+
+
+def dead_reviewer_roles(repo_root: Path, pr_number: int) -> set[str]:
+    dead: set[str] = set()
+    now = time.time()
+    for path in sorted((repo_root / ".refactor-loop" / "logs").glob(f"review-pr{pr_number}-*-r*.log")):
+        match = REVIEW_LOG_RE.match(path.name)
+        if not match or int(match.group(1)) != pr_number:
+            continue
+        role = match.group(2)
+        if _reviewer_log_terminal_failed(path):
+            dead.add(role)
+            continue
+        if not _reviewer_log_has_exit_zero(path) and now - path.stat().st_mtime >= REVIEW_PENDING_SECONDS:
+            dead.add(role)
+    return dead
+
+
+def reviewer_roles_with_evidence(repo_root: Path, pr_number: int) -> set[str]:
+    roles: set[str] = set()
+    for path in sorted((repo_root / ".refactor-loop" / "runs").glob(f"review-pr{pr_number}-*-r*.md")):
+        match = REVIEW_ARTIFACT_RE.match(path.name)
+        if match and int(match.group(1)) == pr_number:
+            roles.add(match.group(2))
+    for path in sorted((repo_root / ".refactor-loop" / "logs").glob(f"review-pr{pr_number}-*-r*.log")):
+        match = REVIEW_LOG_RE.match(path.name)
+        if match and int(match.group(1)) == pr_number:
+            roles.add(match.group(2))
+    return roles
+
+
+def valid_required_review_round_complete(repo_root: Path, pr_number: int, head_sha: str) -> bool:
+    rounds = latest_valid_reviewer_rounds(repo_root, pr_number)
+    return all(rounds.get(role, (0, ""))[1] == head_sha for role in REQUIRED_REVIEW_ROLES)
+
+
 def pending_review_spawn_exists(repo_root: Path, pr_number: int) -> bool:
     pending_path = repo_root / ".refactor-loop" / ".controller-pending-events.log"
     try:
@@ -2067,8 +2171,18 @@ def review_evidence_redispatch_actions(repo_root: Path, gh_items: list[GhItem], 
             continue
         if not item.head_sha or pending_review_spawn_exists(repo_root, item.number):
             continue
+        if valid_required_review_round_complete(repo_root, item.number, item.head_sha):
+            continue
+        if pending_or_fresh_review_evidence_exists(repo_root, item.number):
+            continue
         heads = latest_reviewer_heads(repo_root, item.number)
-        stale_roles = [role for role in REQUIRED_REVIEW_ROLES if heads.get(role, "") != item.head_sha]
+        dead_roles = dead_reviewer_roles(repo_root, item.number)
+        evidence_roles = reviewer_roles_with_evidence(repo_root, item.number)
+        stale_roles = [
+            role
+            for role in REQUIRED_REVIEW_ROLES
+            if heads.get(role, "") != item.head_sha and (heads.get(role, "") or role in dead_roles or role in evidence_roles)
+        ]
         if not stale_roles:
             continue
         actions.append(

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -181,6 +181,8 @@ class ReviewEvidence:
     source: str
     valid: bool = True
     reason: str = ""
+    terminal_failed: bool = False
+    pending: bool = False
 
 
 @dataclass(frozen=True)
@@ -189,6 +191,8 @@ class ReviewGateSnapshot:
     heads_by_role: dict[str, str]
     live_head_sha: str
     invalid: list[str]
+    pending: list[str]
+    terminal_failed_roles: list[str]
 
     @property
     def all_present(self) -> bool:
@@ -226,6 +230,8 @@ class ReviewGateSnapshot:
             "reviewed_head_sha": self.reviewed_head_sha,
             "live_head_sha": self.live_head_sha,
             "invalid": self.invalid,
+            "pending": self.pending,
+            "terminal_failed_roles": self.terminal_failed_roles,
         }
 
 
@@ -1538,6 +1544,8 @@ class WakeupRunner:
         if not isinstance(target, int):
             return {"decision": "WAIT_OR_REDISPATCH", "reason": "review_target_missing"}
         gate = self._review_gate(target)
+        if gate.get("pending"):
+            return {"decision": "WAIT_OR_REDISPATCH", "reason": f"pending_reviewer_evidence:{gate['pending'][0]}", "gate": gate}
         if gate["invalid"]:
             return {"decision": "WAIT_OR_REDISPATCH", "reason": f"invalid_reviewer_evidence:{gate['invalid'][0]}", "gate": gate}
         if not gate["all_present"]:
@@ -1567,6 +1575,8 @@ class WakeupRunner:
         evidences = self._latest_review_evidence_by_role(pr_number)
         verdicts = {role: evidence.verdict for role, evidence in evidences.items() if evidence.valid}
         invalid = [evidence.reason or f"invalid:{evidence.role}" for evidence in evidences.values() if not evidence.valid]
+        pending = [evidence.reason or f"pending:{evidence.role}" for evidence in evidences.values() if evidence.pending]
+        terminal_failed_roles = [evidence.role for evidence in evidences.values() if evidence.terminal_failed]
         heads = {role: evidence.head_sha for role, evidence in evidences.items() if evidence.valid and evidence.head_sha}
         live_head = self._pr_head_sha(pr_number)
         for role in REQUIRED_REVIEW_ROLES:
@@ -1582,6 +1592,8 @@ class WakeupRunner:
             heads_by_role=heads,
             live_head_sha=live_head,
             invalid=invalid,
+            pending=pending,
+            terminal_failed_roles=terminal_failed_roles,
         ).as_dict()
 
     def _latest_review_evidence_by_role(self, pr_number: int) -> dict[str, ReviewEvidence]:
@@ -1638,7 +1650,9 @@ class WakeupRunner:
         if marker_read.reason == "log_unreadable":
             return ReviewEvidence(role, round_number, "", "", str(path), False, f"log_unreadable:{role}")
         if marker_read.reason == "missing_exit_zero":
-            return ReviewEvidence(role, round_number, "", "", str(path), False, f"missing_exit_zero:{role}")
+            if _reviewer_log_terminal_failed(companion_log):
+                return ReviewEvidence(role, round_number, "", "", str(path), False, f"terminal_failed:{role}", terminal_failed=True)
+            return ReviewEvidence(role, round_number, "", "", str(path), False, f"pending_exit_zero:{role}", pending=True)
         verdict_lines = re.findall(r"(?m)^verdict:\s*([A-Za-z][A-Za-z0-9_-]*)\s*$", text)
         if len(verdict_lines) != 1:
             return ReviewEvidence(role, round_number, "", "", str(path), False, f"invalid_verdict_count:{role}")
@@ -1658,7 +1672,9 @@ class WakeupRunner:
         if marker_read.reason == "log_unreadable":
             return ReviewEvidence(role, round_number, "", "", str(path), False, f"log_unreadable:{role}")
         if marker_read.reason == "missing_exit_zero":
-            return ReviewEvidence(role, round_number, "", "", str(path), False, f"missing_exit_zero:{role}")
+            if _reviewer_log_terminal_failed(path):
+                return ReviewEvidence(role, round_number, "", "", str(path), False, f"terminal_failed:{role}", terminal_failed=True)
+            return ReviewEvidence(role, round_number, "", "", str(path), False, f"pending_exit_zero:{role}", pending=True)
         if marker_read.reason in {"duplicate_or_conflicting_log_marker", "duplicate_or_conflicting_artifact_marker"}:
             return ReviewEvidence(role, round_number, "", "", str(path), False, f"invalid_review_marker:{role}")
         match = REVIEW_DONE_RE.match(marker_read.marker)
@@ -2162,6 +2178,22 @@ def _log_tick_status(daemon: str, action: str) -> None:
 
 def _single_line(value: str) -> str:
     return " ".join(str(value).split())[:240]
+
+
+def _reviewer_log_terminal_failed(path: Path) -> bool:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return False
+    for line in reversed(lines):
+        text = line.strip()
+        if not text.startswith("EXIT="):
+            continue
+        try:
+            return int(text.removeprefix("EXIT=")) != 0
+        except ValueError:
+            return True
+    return False
 
 
 if __name__ == "__main__":

--- a/skills/consensus-loop/scripts/test_controller_actions.py
+++ b/skills/consensus-loop/scripts/test_controller_actions.py
@@ -2899,6 +2899,54 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertEqual(tests_intent["cd"], str(self.tmp.resolve()))
         self.assertTrue(Path(str(tests_intent["cd"])).is_absolute())
 
+    def test_dispatch_reviewers_does_not_advance_round_while_same_role_log_is_pending(self) -> None:
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-reviewers", lease_id="lease", expires_at="soon")
+        (self.tmp / ".refactor-loop" / "prompts").mkdir(parents=True, exist_ok=True)
+        (self.tmp / ".refactor-loop" / "logs").mkdir(parents=True, exist_ok=True)
+        (self.tmp / ".refactor-loop" / "prompts" / "review-pr77-architect-r1.md").write_text(
+            f"head_sha: {'a' * 40}\n",
+            encoding="utf-8",
+        )
+        (self.tmp / ".refactor-loop" / "logs" / "review-pr77-architect-r1.log").write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:77:architect:approve\n",
+            encoding="utf-8",
+        )
+        render_envs: list[dict[str, str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            if args == ["pr", "view", "77", "--json", "title,baseRefName,headRefName,headRefOid"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps({"title": "Fix wakeup runner", "baseRefName": "dev", "headRefName": "refactor/issue735", "headRefOid": "a" * 40}),
+                    stderr="",
+                )
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        def fake_render(_template: str, output_path: str, env: Mapping[str, str] | None = None) -> None:
+            assert env is not None
+            render_envs.append(dict(env))
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(output_path).write_text("review prompt\n", encoding="utf-8")
+
+        with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
+            with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+                with mock.patch.object(self.actions, "render_template", side_effect=fake_render):
+                    self.assertEqual(
+                        0,
+                        self.actions.dispatch_reviewers(
+                            {
+                                "target_kind": "PR",
+                                "target_number": 77,
+                                "stale_review_roles": ["architect", "tests"],
+                            }
+                        ),
+                    )
+
+        self.assertEqual([".refactor-loop/runs/review-pr77-tests-r1.md"], [env["REVIEW_OUTPUT_PATH"] for env in render_envs])
+        pending = self.pending_events()
+        self.assertNotIn('"intent_id": "dispatch-reviewers:77:architect:r2"', pending)
+        self.assertIn('"intent_id": "dispatch-reviewers:77:tests:r1"', pending)
+
     def test_dispatch_reviewers_fails_closed_when_pr_head_missing(self) -> None:
         decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-reviewers", lease_id="lease", expires_at="soon")
 

--- a/skills/consensus-loop/scripts/test_controller_actions.py
+++ b/skills/consensus-loop/scripts/test_controller_actions.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -2946,6 +2947,55 @@ class ControllerActionsTests(unittest.TestCase):
         pending = self.pending_events()
         self.assertNotIn('"intent_id": "dispatch-reviewers:77:architect:r2"', pending)
         self.assertIn('"intent_id": "dispatch-reviewers:77:tests:r1"', pending)
+
+    def test_dispatch_reviewers_advances_round_for_stale_same_role_log_without_exit(self) -> None:
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-reviewers", lease_id="lease", expires_at="soon")
+        (self.tmp / ".refactor-loop" / "prompts").mkdir(parents=True, exist_ok=True)
+        (self.tmp / ".refactor-loop" / "logs").mkdir(parents=True, exist_ok=True)
+        (self.tmp / ".refactor-loop" / "prompts" / "review-pr77-quality-r1.md").write_text(
+            f"head_sha: {'a' * 40}\n",
+            encoding="utf-8",
+        )
+        stale_log = self.tmp / ".refactor-loop" / "logs" / "review-pr77-quality-r1.log"
+        stale_log.write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:77:quality:comment\n",
+            encoding="utf-8",
+        )
+        old_mtime = time.time() - 120
+        os.utime(stale_log, (old_mtime, old_mtime))
+        render_envs: list[dict[str, str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            if args == ["pr", "view", "77", "--json", "title,baseRefName,headRefName,headRefOid"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps({"title": "Fix wakeup runner", "baseRefName": "dev", "headRefName": "refactor/issue735", "headRefOid": "a" * 40}),
+                    stderr="",
+                )
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        def fake_render(_template: str, output_path: str, env: Mapping[str, str] | None = None) -> None:
+            assert env is not None
+            render_envs.append(dict(env))
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(output_path).write_text("review prompt\n", encoding="utf-8")
+
+        with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
+            with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+                with mock.patch.object(self.actions, "render_template", side_effect=fake_render):
+                    self.assertEqual(
+                        0,
+                        self.actions.dispatch_reviewers(
+                            {
+                                "target_kind": "PR",
+                                "target_number": 77,
+                                "stale_review_roles": ["quality"],
+                            }
+                        ),
+                    )
+
+        self.assertEqual([".refactor-loop/runs/review-pr77-quality-r2.md"], [env["REVIEW_OUTPUT_PATH"] for env in render_envs])
+        self.assertIn('"intent_id": "dispatch-reviewers:77:quality:r2"', self.pending_events())
 
     def test_dispatch_reviewers_fails_closed_when_pr_head_missing(self) -> None:
         decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-reviewers", lease_id="lease", expires_at="soon")

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -4058,6 +4058,64 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(action["stale_review_roles"], ["architect"])
         self.assertNotIn("status_only", action)
 
+    def test_reviewing_pr_with_fresh_pending_reviewer_log_does_not_redispatch(self) -> None:
+        for role, verdict in (("architect", "approve"), ("tests", "approve")):
+            (self.repo / ".refactor-loop" / "runs").mkdir(parents=True, exist_ok=True)
+            (self.repo / ".refactor-loop" / "runs" / f"review-pr480-{role}-r1.md").write_text(
+                f"---\nhead_sha: {'a' * 40}\nverdict: {verdict}\n---\nREVIEW_DONE:480:{role}:{verdict}\n",
+                encoding="utf-8",
+            )
+            (self.logs / f"review-pr480-{role}-r1.log").write_text(
+                f"head_sha: {'a' * 40}\nREVIEW_DONE:480:{role}:{verdict}\nEXIT=0\n",
+                encoding="utf-8",
+            )
+        (self.logs / "review-pr480-quality-r1.log").write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:480:quality:comment\n",
+            encoding="utf-8",
+        )
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+
+    def test_reviewing_pr_with_terminal_failed_reviewer_log_redispatches_only_that_role(self) -> None:
+        for role, verdict in (("architect", "approve"), ("tests", "approve")):
+            (self.repo / ".refactor-loop" / "runs").mkdir(parents=True, exist_ok=True)
+            (self.repo / ".refactor-loop" / "runs" / f"review-pr480-{role}-r1.md").write_text(
+                f"---\nhead_sha: {'a' * 40}\nverdict: {verdict}\n---\nREVIEW_DONE:480:{role}:{verdict}\n",
+                encoding="utf-8",
+            )
+            (self.logs / f"review-pr480-{role}-r1.log").write_text(
+                f"head_sha: {'a' * 40}\nREVIEW_DONE:480:{role}:{verdict}\nEXIT=0\n",
+                encoding="utf-8",
+            )
+        (self.logs / "review-pr480-quality-r1.log").write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:480:quality:comment\nEXIT=1\n",
+            encoding="utf-8",
+        )
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["quality"])
+        self.assertNotIn("status_only", action)
+
+    def test_reviewing_pr_with_complete_same_head_round_suppresses_duplicate_redispatch(self) -> None:
+        for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):
+            (self.repo / ".refactor-loop" / "runs").mkdir(parents=True, exist_ok=True)
+            (self.repo / ".refactor-loop" / "runs" / f"review-pr480-{role}-r1.md").write_text(
+                f"---\nhead_sha: {'a' * 40}\nverdict: {verdict}\n---\nREVIEW_DONE:480:{role}:{verdict}\n",
+                encoding="utf-8",
+            )
+            (self.logs / f"review-pr480-{role}-r1.log").write_text(
+                f"head_sha: {'a' * 40}\nREVIEW_DONE:480:{role}:{verdict}\nEXIT=0\n",
+                encoding="utf-8",
+            )
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+
     def test_review_redispatch_next_round_intent_projects_despite_stale_exit_zero_r1_log(self) -> None:
         stale = "b" * 40
         for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -1515,6 +1515,29 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             encoding="utf-8",
         )
 
+    def write_review_evidence(
+        self,
+        *,
+        role: str,
+        verdict: str,
+        pr_number: int = 480,
+        head_sha: str = "a" * 40,
+        round_number: int = 1,
+        exit_text: str = "EXIT=0",
+    ) -> None:
+        (self.repo / ".refactor-loop" / "runs").mkdir(parents=True, exist_ok=True)
+        (self.repo / ".refactor-loop" / "runs" / f"review-pr{pr_number}-{role}-r{round_number}.md").write_text(
+            f"---\nhead_sha: {head_sha}\nverdict: {verdict}\n---\nREVIEW_DONE:{pr_number}:{role}:{verdict}\n",
+            encoding="utf-8",
+        )
+        log_lines = [f"head_sha: {head_sha}", f"REVIEW_DONE:{pr_number}:{role}:{verdict}"]
+        if exit_text:
+            log_lines.append(exit_text)
+        (self.logs / f"review-pr{pr_number}-{role}-r{round_number}.log").write_text(
+            "\n".join(log_lines) + "\n",
+            encoding="utf-8",
+        )
+
     def write_issue_decomposition_artifacts(self, *, issue: int = 403, round_no: int = 6) -> tuple[str, str]:
         runs = self.repo / ".refactor-loop" / "runs"
         runs.mkdir(parents=True, exist_ok=True)
@@ -4060,15 +4083,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
     def test_reviewing_pr_with_fresh_pending_reviewer_log_does_not_redispatch(self) -> None:
         for role, verdict in (("architect", "approve"), ("tests", "approve")):
-            (self.repo / ".refactor-loop" / "runs").mkdir(parents=True, exist_ok=True)
-            (self.repo / ".refactor-loop" / "runs" / f"review-pr480-{role}-r1.md").write_text(
-                f"---\nhead_sha: {'a' * 40}\nverdict: {verdict}\n---\nREVIEW_DONE:480:{role}:{verdict}\n",
-                encoding="utf-8",
-            )
-            (self.logs / f"review-pr480-{role}-r1.log").write_text(
-                f"head_sha: {'a' * 40}\nREVIEW_DONE:480:{role}:{verdict}\nEXIT=0\n",
-                encoding="utf-8",
-            )
+            self.write_review_evidence(role=role, verdict=verdict)
         (self.logs / "review-pr480-quality-r1.log").write_text(
             f"head_sha: {'a' * 40}\nREVIEW_DONE:480:quality:comment\n",
             encoding="utf-8",
@@ -4080,15 +4095,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
     def test_reviewing_pr_with_terminal_failed_reviewer_log_redispatches_only_that_role(self) -> None:
         for role, verdict in (("architect", "approve"), ("tests", "approve")):
-            (self.repo / ".refactor-loop" / "runs").mkdir(parents=True, exist_ok=True)
-            (self.repo / ".refactor-loop" / "runs" / f"review-pr480-{role}-r1.md").write_text(
-                f"---\nhead_sha: {'a' * 40}\nverdict: {verdict}\n---\nREVIEW_DONE:480:{role}:{verdict}\n",
-                encoding="utf-8",
-            )
-            (self.logs / f"review-pr480-{role}-r1.log").write_text(
-                f"head_sha: {'a' * 40}\nREVIEW_DONE:480:{role}:{verdict}\nEXIT=0\n",
-                encoding="utf-8",
-            )
+            self.write_review_evidence(role=role, verdict=verdict)
         (self.logs / "review-pr480-quality-r1.log").write_text(
             f"head_sha: {'a' * 40}\nREVIEW_DONE:480:quality:comment\nEXIT=1\n",
             encoding="utf-8",
@@ -4100,17 +4107,26 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(action["stale_review_roles"], ["quality"])
         self.assertNotIn("status_only", action)
 
+    def test_reviewing_pr_with_stale_pending_reviewer_log_redispatches_only_that_role(self) -> None:
+        for role, verdict in (("architect", "approve"), ("tests", "approve")):
+            self.write_review_evidence(role=role, verdict=verdict)
+        stale_log = self.logs / "review-pr480-quality-r1.log"
+        stale_log.write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:480:quality:comment\n",
+            encoding="utf-8",
+        )
+        old_mtime = time.time() - 120
+        os.utime(stale_log, (old_mtime, old_mtime))
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["quality"])
+        self.assertNotIn("status_only", action)
+
     def test_reviewing_pr_with_complete_same_head_round_suppresses_duplicate_redispatch(self) -> None:
         for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):
-            (self.repo / ".refactor-loop" / "runs").mkdir(parents=True, exist_ok=True)
-            (self.repo / ".refactor-loop" / "runs" / f"review-pr480-{role}-r1.md").write_text(
-                f"---\nhead_sha: {'a' * 40}\nverdict: {verdict}\n---\nREVIEW_DONE:480:{role}:{verdict}\n",
-                encoding="utf-8",
-            )
-            (self.logs / f"review-pr480-{role}-r1.log").write_text(
-                f"head_sha: {'a' * 40}\nREVIEW_DONE:480:{role}:{verdict}\nEXIT=0\n",
-                encoding="utf-8",
-            )
+            self.write_review_evidence(role=role, verdict=verdict)
 
         plan = self.run_plan(fixture="open_pr_480")
 

--- a/skills/consensus-loop/scripts/test_wakeup_runner_review_gate.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner_review_gate.py
@@ -450,8 +450,35 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
         result = self.run_action()
 
         self.assertEqual(result.status, "blocked")
-        self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:invalid_reviewer_evidence:missing_exit_zero:quality")
+        self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:invalid_reviewer_evidence:terminal_failed:quality")
         self.assertEqual(self.actions.merged, [])
+
+    def test_pending_reviewer_log_waits_then_valid_completion_merges_original_round(self) -> None:
+        self.write_review("architect", "approve")
+        self.write_review("tests", "comment")
+        (self.repo / ".refactor-loop/logs" / "review-pr12-quality-r1.log").write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:12:quality:comment\n",
+            encoding="utf-8",
+        )
+
+        pending = self.run_action()
+        self.assertEqual(pending.status, "blocked")
+        self.assertEqual(pending.reason, "WAIT_OR_REDISPATCH:pending_reviewer_evidence:pending_exit_zero:quality")
+        self.assertEqual(self.actions.merged, [])
+
+        (self.repo / ".refactor-loop/runs" / "review-pr12-quality-r1.md").write_text(
+            f"---\nverdict: comment\n---\nhead_sha: {'a' * 40}\nREVIEW_DONE:12:quality:comment\n",
+            encoding="utf-8",
+        )
+        (self.repo / ".refactor-loop/logs" / "review-pr12-quality-r1.log").write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:12:quality:comment\nEXIT=0\n",
+            encoding="utf-8",
+        )
+
+        completed = self.run_action()
+        self.assertEqual(completed.status, "applied")
+        self.assertEqual(self.actions.merged, ["12"])
+        self.assertEqual(self.supervisor.calls, 0)
 
     def test_review_gate_source_locks_latest_evidence_per_role(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "wakeup_runner.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Changed files
- Updated reviewer gate handling so pending reviewer logs wait, terminal-failed evidence is treated as dead evidence, and valid same-head rounds are not redispatched.
- Kept reviewer recovery on the existing role-scoped dispatch path and added coverage across runner, planner, and controller action boundaries.

## Test results
- Compile command passed.
- Required consensus-loop and sshx pytest command passed.

## Deviations
- Closes #735
- Host architecture guard was skipped because no guard command was configured.
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

⟦AI:AUTO-LOOP⟧
