### PR TITLE
Unify prompt language rendering for controller and phase9

### DIFF
--- a/skills/consensus-loop/prompts/patrol-analysis.md
+++ b/skills/consensus-loop/prompts/patrol-analysis.md
@@ -36,3 +36,5 @@ Required fields:
 ```
 
 Use `is_real_issue=false` when the signal is only prompt/fixture/prose noise or lacks a clear repository-owned failure. Still fill every string field with a concise explanation.
+
+Public-facing natural-language fields (`summary`, `root_cause`, `recommendation`, and `rationale`) follow `${HOST_WORK_LANGUAGE}`; do not add a mandatory parallel English section. Code identifiers, paths, schema fields, labels, and marker strings remain literal.

--- a/skills/consensus-loop/prompts/triage-external-issue.md
+++ b/skills/consensus-loop/prompts/triage-external-issue.md
@@ -97,6 +97,7 @@ Artifact profile: marker-only-work-unit
 ## GitHub post
 
 遵循渲染期内联的共享规则。
+Public-facing natural-language prose follows `${HOST_WORK_LANGUAGE}`; do not add a mandatory parallel English section. Code identifiers, paths, schema fields, labels, and marker strings remain literal.
 
 {{GITHUB_POST_RULES_CONTRACT}}
 

--- a/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -10,13 +10,12 @@ import sys
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from string import Template
 from typing import Any, Mapping, Sequence
 
 from .active_controller import require_active_controller, write_active_controller_status
 from . import labels
 from .banners import BannerRequest, build_status_banner, gh_comment_command
-from .context import LoopContext, normalize_host_work_language
+from .context import LoopContext
 from .cross_instance_stand_down import CrossInstanceAdmission, check_cross_instance_admission
 from .default_issue_intake import DefaultIssueIntakeClaim, DefaultIssueIntakeResult
 from .gh_invoke import build_gh_argv
@@ -32,7 +31,7 @@ from .implementation_pr_artifacts import (
 from .implement_lifecycle import classify_implement_attempt, clear_redispatchable_implement_log
 from .issue_decomposition import issue_decomposition_plan_file_digest, load_issue_decomposition_plan
 from .managed_work_snapshot import invalidate_open_managed_work_snapshot
-from .prompt_contracts import inline_prompt_contracts
+from .prompt_rendering import render_prompt_text
 from .processes import launch_spawn_codex_supervisor
 from .release.publisher import ReleasePublisher
 from .release.required_checks import ReleaseRequiredChecksProjection, required_release_checks
@@ -2219,31 +2218,14 @@ class ControllerActions:
         return None
 
     def render_template(self, input_path: str, output_path: str, env: Mapping[str, str] | None = None) -> None:
-        values = dict(os.environ)
-        values["HOST_WORK_LANGUAGE"] = normalize_host_work_language(
-            raw=self.ctx.host_env.get("HOST_WORK_LANGUAGE") or values.get("HOST_WORK_LANGUAGE"),
-            env=values,
-        )
-        if env:
-            values.update(env)
-            values["HOST_WORK_LANGUAGE"] = normalize_host_work_language(env=values)
-        aliases = {
-            "work_unit_id": values.get("WORK_UNIT_ID") or values.get("CLUSTER_ID") or "",
-            "cluster_id": values.get("CLUSTER_ID", ""),
-            "iteration": values.get("ITERATION", ""),
-            "worktree_path": values.get("WORKTREE_PATH", ""),
-            "branch": values.get("BRANCH", ""),
-            "old_pattern": values.get("OLD_PATTERN", ""),
-            "new_principle": values.get("NEW_PRINCIPLE", ""),
-            "scope_paths": values.get("SCOPE_PATHS", ""),
-            "verification_hints": values.get("VERIFICATION_HINTS", ""),
-        }
         template_path = self._resolve_template_input(input_path)
         template = template_path.read_text(encoding="utf-8")
-        for key, value in aliases.items():
-            template = template.replace("{{" + key + "}}", value)
-        rendered = inline_prompt_contracts(Template(template).safe_substitute(values), skill_root=self.ctx.skill_root)
-        rendered = rendered.replace("${HOST_WORK_LANGUAGE}", values.get("HOST_WORK_LANGUAGE") or "en")
+        rendered = render_prompt_text(
+            template,
+            skill_root=self.ctx.skill_root,
+            values=env,
+            host_env=self.ctx.host_env,
+        )
         Path(output_path).write_text(rendered, encoding="utf-8")
 
     def _review_fix_pr_facts(self, pr_number: str, existing: Mapping[str, str]) -> dict[str, str]:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -22,8 +22,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from string import Template
-from typing import Any, Callable, Iterable, Literal, cast
+from typing import Any, Callable, Iterable, Literal, Mapping, cast
 
 from ..active_controller import require_active_controller, write_active_controller_status
 from ..context import LoopContext
@@ -31,7 +30,7 @@ from ..github_budget import graphql_headroom_ok
 from ..heartbeat import DaemonHeartbeatLease
 from ..managed_work_snapshot import load_open_managed_work_snapshot
 from ..managed_work_snapshot import ManagedWorkSnapshotItem
-from ..prompt_contracts import inline_prompt_contracts
+from ..prompt_rendering import render_prompt_text
 from ..transition_assessment import TransitionAssessment, TransitionAssessmentReader, projection_lines
 from ..worker_markers import log_has_clean_exit, read_worker_terminal_marker
 from ..workflow_stages import format_stage
@@ -194,25 +193,9 @@ class DesignConsensusIssue:
 
 
 class MetaJudgePromptRenderer:
-    PLACEHOLDERS = {
-        "ISSUE_NUMBER",
-        "WORK_UNIT_ID",
-        "CLUSTER_ID",
-        "WORK_UNIT_PRODUCER",
-        "WORK_UNIT_SOURCE_REF",
-        "CONVERGENCE_ROUND",
-        "CONVERGENCE_ROUND_PLUS_ONE",
-        "SOLVER_MINIMAL_PATH",
-        "SOLVER_STRUCTURAL_PATH",
-        "SOLVER_DELETE_PATH",
-        "META_JUDGE_OUTPUT_PATH",
-        "TRANSITION_TYPE",
-        "TRANSITION_CONFIDENCE",
-        "TRANSITION_EVIDENCE_REFS",
-    }
-
-    def __init__(self, template_path: Path) -> None:
+    def __init__(self, template_path: Path, *, host_env: Mapping[str, str] | None = None) -> None:
         self.template_path = template_path
+        self.host_env = host_env
 
     def render(self, context: MetaJudgePromptContext) -> str:
         template = self.template_path.read_text(encoding="utf-8")
@@ -232,10 +215,12 @@ class MetaJudgePromptRenderer:
             "TRANSITION_CONFIDENCE": f"{context.transition_assessment.confidence:g}",
             "TRANSITION_EVIDENCE_REFS": context.transition_assessment.evidence_refs_text,
         }
-        rendered = template
-        for key in self.PLACEHOLDERS:
-            rendered = rendered.replace("${" + key + "}", values[key])
-        return inline_prompt_contracts(rendered, skill_root=self.template_path.parents[1])
+        return render_prompt_text(
+            template,
+            skill_root=self.template_path.parents[1],
+            values=values,
+            host_env=self.host_env,
+        )
 
 
 PHASE9_LOG_RE = re.compile(
@@ -1735,7 +1720,7 @@ class Phase9Router:
             return None
         template_path = self.skill_root / "prompts" / "meta-judge.md"
         try:
-            prompt = MetaJudgePromptRenderer(template_path).render(context)
+            prompt = MetaJudgePromptRenderer(template_path, host_env=self.ctx.host_env).render(context)
         except OSError:
             self._append_meta_judge_prompt_fallback_event(
                 issue,
@@ -1827,7 +1812,12 @@ class Phase9Router:
             "CONVERGENCE_ROUND": str(round_no),
             "SOLVER_OUTPUT_PATH": f".refactor-loop/runs/phase9-issue{issue}-r{round_no}-{role}.md",
         }
-        return inline_prompt_contracts(Template(template).safe_substitute(values), skill_root=self.skill_root)
+        return render_prompt_text(
+            template,
+            skill_root=self.skill_root,
+            values=values,
+            host_env=self.ctx.host_env,
+        )
 
     def _solver_work_unit_header(self, issue: str, round_no: int, role: str) -> str:
         output_path = f".refactor-loop/runs/phase9-issue{issue}-r{round_no}-{role}.md"

--- a/skills/consensus-loop/scripts/codex_refactor_loop/prompt_rendering.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/prompt_rendering.py
@@ -1,0 +1,83 @@
+"""Shared render-time prompt binding surface."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from string import Template
+from typing import Mapping
+
+from .context import normalize_host_work_language
+from .prompt_contracts import inline_prompt_contracts
+
+
+CONTROLLER_ALIAS_NAMES = (
+    "work_unit_id",
+    "cluster_id",
+    "iteration",
+    "worktree_path",
+    "branch",
+    "old_pattern",
+    "new_principle",
+    "scope_paths",
+    "verification_hints",
+)
+
+
+def render_prompt_text(
+    template: str,
+    *,
+    skill_root: Path,
+    values: Mapping[str, str] | None = None,
+    host_env: Mapping[str, str] | None = None,
+    base_env: Mapping[str, str] | None = None,
+) -> str:
+    bindings = prompt_render_bindings(values=values, host_env=host_env, base_env=base_env)
+    rendered = _replace_controller_aliases(template, bindings)
+    rendered = Template(rendered).safe_substitute(bindings)
+    rendered = inline_prompt_contracts(rendered, skill_root=skill_root)
+    return _replace_final_host_work_language(rendered, bindings["HOST_WORK_LANGUAGE"])
+
+
+def prompt_render_bindings(
+    *,
+    values: Mapping[str, str] | None = None,
+    host_env: Mapping[str, str] | None = None,
+    base_env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    bindings = {str(key): str(value) for key, value in dict(os.environ if base_env is None else base_env).items()}
+    host_values = {str(key): str(value) for key, value in (host_env or {}).items()}
+    caller_values = {str(key): str(value) for key, value in (values or {}).items()}
+    bindings.update(host_values)
+    bindings.update(caller_values)
+    bindings["HOST_WORK_LANGUAGE"] = normalize_host_work_language(
+        raw=caller_values.get("HOST_WORK_LANGUAGE") or host_values.get("HOST_WORK_LANGUAGE") or bindings.get("HOST_WORK_LANGUAGE"),
+        env=bindings,
+    )
+    bindings.update(_controller_alias_values(bindings))
+    return bindings
+
+
+def _controller_alias_values(bindings: Mapping[str, str]) -> dict[str, str]:
+    return {
+        "work_unit_id": bindings.get("WORK_UNIT_ID") or bindings.get("CLUSTER_ID") or "",
+        "cluster_id": bindings.get("CLUSTER_ID", ""),
+        "iteration": bindings.get("ITERATION", ""),
+        "worktree_path": bindings.get("WORKTREE_PATH", ""),
+        "branch": bindings.get("BRANCH", ""),
+        "old_pattern": bindings.get("OLD_PATTERN", ""),
+        "new_principle": bindings.get("NEW_PRINCIPLE", ""),
+        "scope_paths": bindings.get("SCOPE_PATHS", ""),
+        "verification_hints": bindings.get("VERIFICATION_HINTS", ""),
+    }
+
+
+def _replace_controller_aliases(template: str, bindings: Mapping[str, str]) -> str:
+    rendered = template
+    for key in CONTROLLER_ALIAS_NAMES:
+        rendered = rendered.replace("{{" + key + "}}", bindings.get(key, ""))
+    return rendered
+
+
+def _replace_final_host_work_language(text: str, language: str) -> str:
+    return text.replace("${HOST_WORK_LANGUAGE}", language)

--- a/skills/consensus-loop/scripts/test_phase9_router_package.py
+++ b/skills/consensus-loop/scripts/test_phase9_router_package.py
@@ -18,12 +18,15 @@ from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.managed_work_snapshot import ManagedWorkSnapshotItem, ManagedWorkSnapshotResult
 from codex_refactor_loop.monitors.concurrency import ConcurrencyMonitor
 from codex_refactor_loop.phase9.router import (
+    MetaJudgePromptContext,
+    MetaJudgePromptRenderer,
     Phase9Router,
     Phase9SourceIssueDecision,
     main,
     parse_phase9_log_identity,
 )
 from codex_refactor_loop.prompt_contracts import GITHUB_POST_RULES_CONTRACT_TOKEN
+from codex_refactor_loop.transition_assessment import TransitionAssessment
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -130,6 +133,14 @@ class Phase9RouterPackageTests(unittest.TestCase):
             data["roles"][0]["command"] = "gh pr merge 224"
         (self.repo / "workflow.json").write_text(json.dumps(data), encoding="utf-8")
         return LoopContext.load(repo_root=self.repo, env={"REPO_ROOT": str(self.repo), "HOST_WORKFLOW_SPEC": "workflow.json"})
+
+    def context_with_host_language(self, language: str) -> LoopContext:
+        host_env = self.repo / "host.env"
+        host_env.write_text(f'export HOST_WORK_LANGUAGE="{language}"\n', encoding="utf-8")
+        return LoopContext.load(
+            repo_root=self.repo,
+            env={"REPO_ROOT": str(self.repo), "CONSENSUS_RND_HOST_ENV": str(host_env)},
+        )
 
     def test_package_router_uses_loop_context_paths(self) -> None:
         self.assertEqual(self.router.loop_dir, self.ctx.paths.refactor_loop)
@@ -576,6 +587,7 @@ class Phase9RouterPackageTests(unittest.TestCase):
             "prompts/meta-judge.md",
             "MetaJudgePromptContext",
             "MetaJudgePromptRenderer",
+            "render_prompt_text",
             "phase9-meta-judge-template-unavailable",
             "phase9-meta-judge-scope-invalid",
             "phase9-triplet-evidence-invalid",
@@ -635,6 +647,7 @@ class Phase9RouterPackageTests(unittest.TestCase):
         for required in (
             "prompts/meta-judge.md",
             "MetaJudgePromptRenderer",
+            "render_prompt_text",
             "full `prompts/meta-judge.md`",
             "Router template bindings",
             '"WORK_UNIT_PRODUCER"',
@@ -647,6 +660,46 @@ class Phase9RouterPackageTests(unittest.TestCase):
             with self.subTest(required=required):
                 self.assertIn(required, combined)
         self.assertNotIn("Read the three completed solver logs and emit META_JUDGE_DONE", src)
+
+    def test_phase9_solver_prompt_uses_shared_host_work_language_rendering(self) -> None:
+        router = Phase9Router(ctx=self.context_with_host_language("zh"), command_runner=self.commands.append)
+
+        rendered = router._render_solver_template("740", 3, "minimal")
+
+        self.assertIn("Follow zh per SKILL.md", rendered)
+        self.assertIn("follow `zh`", rendered)
+        self.assertNotIn("${HOST_WORK_LANGUAGE}", rendered)
+        self.assertNotIn("$HOST_WORK_LANGUAGE", rendered)
+
+    def test_phase9_meta_judge_prompt_uses_shared_host_work_language_rendering(self) -> None:
+        ctx = self.context_with_host_language("zh")
+        context = MetaJudgePromptContext(
+            issue="740",
+            round=3,
+            solver_paths={
+                "minimal": ".refactor-loop/logs/phase9-issue740-r3-minimal.log",
+                "structural": ".refactor-loop/logs/phase9-issue740-r3-structural.log",
+                "delete": ".refactor-loop/logs/phase9-issue740-r3-delete.log",
+            },
+            output_path=".refactor-loop/runs/phase9-issue740-r3-judge.md",
+            transition_assessment=TransitionAssessment(transition_type="unknown", confidence=0.0),
+        )
+
+        rendered = MetaJudgePromptRenderer(
+            REPO_ROOT / "skills" / "consensus-loop" / "prompts" / "meta-judge.md",
+            host_env=ctx.host_env,
+        ).render(context)
+
+        self.assertIn("Follow zh per SKILL.md", rendered)
+        self.assertIn("follow `zh`", rendered)
+        self.assertNotIn("${HOST_WORK_LANGUAGE}", rendered)
+        self.assertNotIn("$HOST_WORK_LANGUAGE", rendered)
+
+    def test_phase9_invalid_host_work_language_fails_closed_through_shared_render_path(self) -> None:
+        router = Phase9Router(ctx=self.context_with_host_language("fr"), command_runner=self.commands.append)
+
+        with self.assertRaisesRegex(RuntimeError, "invalid HOST_WORK_LANGUAGE"):
+            router._render_solver_template("740", 3, "minimal")
 
     def test_router_source_uses_standalone_marker_matching(self) -> None:
         src = PACKAGE_ROUTER.read_text(encoding="utf-8")

--- a/skills/consensus-loop/scripts/test_prompt_contract_inliner.py
+++ b/skills/consensus-loop/scripts/test_prompt_contract_inliner.py
@@ -32,6 +32,7 @@ DIRECT_POST_PROMPTS = (
     "solver-delete.md",
     "meta-judge.md",
     "design-issue-reply.md",
+    "triage-external-issue.md",
 )
 
 

--- a/skills/consensus-loop/scripts/test_prompt_language_inventory.py
+++ b/skills/consensus-loop/scripts/test_prompt_language_inventory.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Prompt language-policy inventory tests."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_ROOT = SCRIPT_DIR.parent
+PROMPTS_DIR = SKILL_ROOT / "prompts"
+
+PUBLIC_LANGUAGE_PROMPTS = {
+    "triage-external-issue.md": "writes GitHub-facing triage comments and reshaped issue body artifacts",
+    "patrol-analysis.md": "produces public fields for patrol-owned issue create/update bodies",
+}
+INTERNAL_OR_MARKER_ONLY_EXEMPTIONS = {
+    "meta-reflector-stalled.md": "controller-private stalled reflection artifact consumed by router/controller",
+    "publish-implementation-fallback.md": "marker-only repair artifact consumed by controller",
+    "rebase-resolve.md": "marker-only rebase resolution artifact consumed by controller",
+    "remote-ci-fix.md": "marker-only CI fix artifact consumed by controller/review flow",
+    "test-add.md": "marker-only test augmentation artifact consumed by controller",
+    "verify.md": "marker-only verification artifact consumed by controller",
+}
+
+
+class PromptLanguageInventoryTests(unittest.TestCase):
+    def test_public_language_prompts_declare_host_work_language(self) -> None:
+        for prompt, reason in PUBLIC_LANGUAGE_PROMPTS.items():
+            with self.subTest(prompt=prompt, reason=reason):
+                body = (PROMPTS_DIR / prompt).read_text(encoding="utf-8")
+                self.assertIn("${HOST_WORK_LANGUAGE}", body)
+                self.assertIn("Public-facing natural-language", body)
+                self.assertIn("do not add a mandatory parallel English section", body)
+
+    def test_internal_marker_only_exemptions_are_explicit_and_current(self) -> None:
+        for prompt, reason in INTERNAL_OR_MARKER_ONLY_EXEMPTIONS.items():
+            with self.subTest(prompt=prompt, reason=reason):
+                self.assertTrue((PROMPTS_DIR / prompt).exists())
+                self.assertGreater(len(reason), 20)
+
+        self.assertEqual(
+            set(INTERNAL_OR_MARKER_ONLY_EXEMPTIONS),
+            {
+                "meta-reflector-stalled.md",
+                "publish-implementation-fallback.md",
+                "rebase-resolve.md",
+                "remote-ci-fix.md",
+                "test-add.md",
+                "verify.md",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/consensus-loop/scripts/test_prompt_rendering.py
+++ b/skills/consensus-loop/scripts/test_prompt_rendering.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Behavior tests for shared prompt render-time binding."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.context import LoopContextError
+from codex_refactor_loop.prompt_rendering import render_prompt_text
+
+SKILL_ROOT = SCRIPT_DIR.parent
+
+
+class PromptRenderingTests(unittest.TestCase):
+    def test_controller_aliases_and_prompt_contract_language_resolve_together(self) -> None:
+        template = (
+            "{{work_unit_id}}\n"
+            "{{cluster_id}}\n"
+            "{{iteration}}\n"
+            "{{worktree_path}}\n"
+            "{{branch}}\n"
+            "{{old_pattern}}\n"
+            "{{new_principle}}\n"
+            "{{scope_paths}}\n"
+            "{{verification_hints}}\n"
+            "{{GITHUB_POST_RULES_CONTRACT}}\n"
+        )
+
+        rendered = render_prompt_text(
+            template,
+            skill_root=SKILL_ROOT,
+            base_env={},
+            host_env={"HOST_WORK_LANGUAGE": "zh"},
+            values={
+                "WORK_UNIT_ID": "issue-740",
+                "CLUSTER_ID": "issue-740",
+                "ITERATION": "740",
+                "WORKTREE_PATH": "/tmp/worktree",
+                "BRANCH": "refactor/iter740-issue-740",
+                "OLD_PATTERN": "private phase9 rendering",
+                "NEW_PRINCIPLE": "shared prompt rendering",
+                "SCOPE_PATHS": "prompt_rendering.py",
+                "VERIFICATION_HINTS": "pytest prompt rendering",
+            },
+        )
+
+        for expected in (
+            "issue-740",
+            "740",
+            "/tmp/worktree",
+            "refactor/iter740-issue-740",
+            "private phase9 rendering",
+            "shared prompt rendering",
+            "prompt_rendering.py",
+            "pytest prompt rendering",
+            "follow `zh`",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, rendered)
+        self.assertNotIn("${HOST_WORK_LANGUAGE}", rendered)
+        self.assertNotIn("$HOST_WORK_LANGUAGE", rendered)
+        self.assertNotIn("{{GITHUB_POST_RULES_CONTRACT}}", rendered)
+
+    def test_invalid_host_work_language_fails_closed(self) -> None:
+        with self.assertRaisesRegex(LoopContextError, "invalid HOST_WORK_LANGUAGE"):
+            render_prompt_text(
+                "${HOST_WORK_LANGUAGE}",
+                skill_root=SKILL_ROOT,
+                base_env={},
+                host_env={"HOST_WORK_LANGUAGE": "fr"},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changed files
- Added a shared prompt rendering helper for controller aliases, caller bindings, HOST_WORK_LANGUAGE normalization, prompt contract inlining, and final language substitution.
- Routed ControllerActions and phase9 solver/meta-judge prompt rendering through that helper.
- Added language inventory and render behavior tests for public prompts and phase9 zh rendering.

## Test results
- `python3 -m compileall skills/consensus-loop/scripts skills/sshx -q` passed.
- Full configured pytest passed: 2000 consensus-loop tests, 1 skipped, 5891 subtests; 26 sshx tests, 6 subtests.
- Targeted prompt rendering tests passed: 36 tests, 123 subtests.

## Deviations
No scope extension. refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none).

Closes #740

⟦AI:AUTO-LOOP⟧
