### PR TITLE
修正 Phase9 普通 propose 停滞判定

### DIFF
--- a/skills/consensus-loop/SKILL.md
+++ b/skills/consensus-loop/SKILL.md
@@ -2566,7 +2566,7 @@ Meta-judge emits `META_JUDGE_DONE:<decision>:<...>`,**controller 路由表(强�
 
 结构性教训:曾出现多个 `escalate:stalled` 被直接 label 人,**没派 reflector**。现在 fresh judge 不再授权 stalled 输出;router predicate 从 clean converge 历史派生 stalled,legacy stalled marker 只读兼容且仍必须 reflector 优先。
 
-**stalled 判据铁律**:`stalled` 只能由 router 在 `CONVERGENCE_ROUND >= 3` 且 router-normalized no-progress signature 连续匹配时从 clean `converge` 派生；`source-location-missing-or-invalid`、`no-current-*target*`、以及窄匹配的 target/source/PR unreadable `propose:*` 归一为同一 no-actionable-source family，普通 implementation-bearing `propose:*` 阻止 stalled。round 1 / round 2 不可能 stalled;此时 solver 分歧应判 `converge` 并继续派下一轮,不能接受 meta-judge 在 r1/r2 输出的 `escalate:stalled` 作为事实。若 r1/r2 judge 输出 `escalate:stalled`,controller 必须按 legacy judge 异常处理:重派 judge(同输入,提示 fresh stalled 禁止),而不是派 reflector 或 label 人。
+**stalled 判据铁律**:`stalled` 只能由 router 在 `CONVERGENCE_ROUND >= 3` 且 router-normalized no-progress signature 连续匹配时从 clean `converge` 派生；`source-location-missing-or-invalid`、`no-current-*target*`、以及窄匹配的 target/source/PR unreadable `propose:*` 归一为同一 no-actionable-source family；普通 implementation-bearing `propose:*` 以保留 summary 的 router-normalized solver verdict text 参与 no-progress signature equality,仅当三轮 signature 发生变化时阻止 stalled。连续三轮相同 signature 的 implementation-bearing split 计入 no-progress 并触发 stalled reflector。round 1 / round 2 不可能 stalled;此时 solver 分歧应判 `converge` 并继续派下一轮,不能接受 meta-judge 在 r1/r2 输出的 `escalate:stalled` 作为事实。若 r1/r2 judge 输出 `escalate:stalled`,controller 必须按 legacy judge 异常处理:重派 judge(同输入,提示 fresh stalled 禁止),而不是派 reflector 或 label 人。
 
 **反面(❌ 严禁)**:
 - ❌ r1 三 solver 分歧,meta-judge 输出 `escalate:stalled`,controller 直接派 reflector。
@@ -3181,7 +3181,7 @@ If a push fails (network, conflict, branch protection): controller MUST surface 
 - CI same-check 失败 6 次(同 test 6 次 fix 仍红)
 - Cumulative PR diff size > 原 PR 200%(scope-runaway 信号)
 - Reviewer 同一类 evidence(test coverage / dead surface / self-doc)在 3 round 内反复出现 → meta-reflect "为什么 evidence 总是同类"
-- **Consensus-rnd Phase design-consensus design issue stall**:3 consecutive round 无 maintainer input AND router-normalized no-progress signature 匹配 → 也走 meta-layer
+- **Consensus-rnd Phase design-consensus design issue stall**:3 consecutive round 无 maintainer input AND router-normalized no-progress signature / solver verdict text 匹配 → 也走 meta-layer
 
 ### 派出 reflector codex
 

--- a/skills/consensus-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -799,7 +799,7 @@ class Phase9Router:
         if payload.startswith("propose:") and self._propose_unreadable_source_signature(payload) is not None:
             return "source-unreachable/no-actionable-source"
         if payload.startswith("propose:"):
-            return None
+            return payload
         return self._solver_verdict_text(marker)
 
     def _propose_unreadable_source_signature(self, payload: str) -> str | None:

--- a/skills/consensus-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/consensus-loop/scripts/test_phase9_router_daemon.py
@@ -2046,6 +2046,25 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertNotIn("708-4-structural", ledger_keys)
         self.assertNotIn("708-4-delete", ledger_keys)
 
+    def test_phase9_router_stalled_routes_repeated_ordinary_propose_to_reflector(self) -> None:
+        for round_no in (1, 2, 3):
+            self.solver_triplet(issue=756, round_no=round_no, verdict="propose:same-implementation-framing")
+        self.write_ledger_key("756-1-judge")
+        self.write_ledger_key("756-2-judge")
+        self.write_log("phase9-issue756-r3-judge.log", "META_JUDGE_DONE:converge:round-3:same-framing")
+
+        self.router.tick()
+
+        reflector_commands = [
+            command for command in self.commands if "phase9-issue756-r3-reflector.log" in self.intent_text(command)
+        ]
+        self.assertEqual(len(reflector_commands), 1)
+        ledger_keys = [entry["key"] for entry in self.ledger_entries()]
+        self.assertIn("756-3-reflector", ledger_keys)
+        self.assertNotIn("756-4-minimal", ledger_keys)
+        self.assertNotIn("756-4-structural", ledger_keys)
+        self.assertNotIn("756-4-delete", ledger_keys)
+
     def test_phase9_router_stalled_rejects_implementation_bearing_propose_changes(self) -> None:
         verdicts = {
             1: "propose:add-router-helper",

--- a/skills/consensus-loop/scripts/test_phase9_router_package.py
+++ b/skills/consensus-loop/scripts/test_phase9_router_package.py
@@ -475,6 +475,27 @@ class Phase9RouterPackageTests(unittest.TestCase):
         self.assertIn("708-3-reflector", ledger_keys)
         self.assertNotIn("708-4-minimal", ledger_keys)
 
+    def test_package_router_repeated_ordinary_propose_routes_stalled_reflector(self) -> None:
+        for round_no in (1, 2, 3):
+            for role in ("minimal", "structural", "delete"):
+                self.write_log(
+                    f"phase9-issue756-r{round_no}-{role}.log",
+                    f"SOLVER_DONE:{role}:propose:same-implementation-framing",
+                )
+        self.write_log("phase9-issue756-r3-judge.log", "META_JUDGE_DONE:converge:round-3:same-framing")
+
+        self.router.tick()
+
+        reflector_commands = [
+            command for command in self.commands if "phase9-issue756-r3-reflector.log" in self.intent_text(command)
+        ]
+        self.assertEqual(len(reflector_commands), 1)
+        ledger_keys = [entry["key"] for entry in self.ledger_entries()]
+        self.assertIn("756-3-reflector", ledger_keys)
+        self.assertNotIn("756-4-minimal", ledger_keys)
+        self.assertNotIn("756-4-structural", ledger_keys)
+        self.assertNotIn("756-4-delete", ledger_keys)
+
     def test_package_router_implementation_bearing_propose_blocks_stalled(self) -> None:
         verdicts = {
             1: "propose:add-router-helper",


### PR DESCRIPTION
## Changed files
- `skills/consensus-loop/scripts/codex_refactor_loop/phase9/router.py`: 让普通 `propose:*` 保留 normalized payload 参与 no-progress signature equality,同时保留 unreadable-source/no-current-target/source-location 归一。
- `skills/consensus-loop/SKILL.md`: 同步 stalled 合同,明确普通 implementation-bearing `propose:*` 只有 signature 变化时阻止 stalled。
- `skills/consensus-loop/scripts/test_phase9_router_daemon.py` 和 `skills/consensus-loop/scripts/test_phase9_router_package.py`: 覆盖三轮相同普通 propose 派 reflector、三轮不同 propose 继续派 solver triplet 的行为。

## Test results
- `python3 skills/consensus-loop/scripts/test_phase9_router_daemon.py`: passed.
- `python3 skills/consensus-loop/scripts/test_phase9_router_package.py`: passed.
- `bash -lc "python3 -m compileall skills/consensus-loop/scripts skills/sshx -q"`: passed.
- Required pytest command: passed, 2044 passed, 1 skipped, 5964 subtests passed; sshx 26 passed, 6 subtests passed.

## Deviations
- SCOPE_EXTEND: none.
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none).
- Architecture guards: guards skipped: CI_GUARDS unset.
- Closes #756

⟦AI:AUTO-LOOP⟧
