### PR TITLE
Recover false rebase-resolve DONE markers

### DIFF
--- a/skills/consensus-loop/prompts/rebase-resolve.md
+++ b/skills/consensus-loop/prompts/rebase-resolve.md
@@ -21,7 +21,10 @@ You are a focused conflict-resolution worker. Preserve the PR intent, keep chang
 2. Resolve conflicts by preserving the PR's intended behavior on top of the new base.
 3. Run the smallest relevant local verification command available for the touched files.
 4. Write a short artifact to `${REBASE_RESOLVE_OUTPUT_PATH}` when provided, including changed files, verification command, and any unresolved risk.
-5. Leave commit, push, PR update, and merge decisions to the controller.
+5. Before emitting `REBASE_RESOLVE_DONE`, mechanically verify both:
+   - `git diff --name-only --diff-filter=U` is empty.
+   - `git status --porcelain` shows a commit-ready merge state with no unmerged or unstaged paths.
+6. Leave commit, push, PR update, and merge decisions to the controller.
 
 If the rebase cannot be resolved safely, stop and emit a blocked marker with the reason category.
 

--- a/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -1823,6 +1823,9 @@ class ControllerActions:
         if unmerged:
             sys.stderr.write(f"commit_push_resolved_pr_rebase: unresolved conflicts: {','.join(unmerged)}\n")
             return 2
+        if not self._merge_commit_ready(worktree):
+            sys.stderr.write("commit_push_resolved_pr_rebase: merge not commit-ready\n")
+            return 2
         commit = self._git_in(worktree, ["commit", "--no-edit"], check=False)
         if commit.returncode != 0:
             sys.stderr.write(
@@ -1932,6 +1935,22 @@ class ControllerActions:
         if result.returncode != 0:
             return []
         return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def _merge_commit_ready(self, worktree: Path) -> bool:
+        status = self._git_in(worktree, ["status", "--porcelain"], check=False)
+        if status.returncode != 0:
+            return False
+        rows = [line for line in status.stdout.splitlines() if line.strip()]
+        if not rows:
+            return False
+        for row in rows:
+            if len(row) < 3:
+                return False
+            index_status = row[0]
+            worktree_status = row[1]
+            if index_status == "?" or worktree_status not in {" ", "?"}:
+                return False
+        return True
 
     def _branch_is_base_behind(self, worktree: Path, base_ref: str) -> bool:
         merge_base = self._git_in(worktree, ["merge-base", "HEAD", base_ref], check=False)

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -1361,7 +1361,22 @@ def rebase_resolve_completed_marker_actions(repo_root: Path, gh_items: list[GhIt
         if worktree is not None:
             action["worktree"] = str(worktree)
         if not _worktree_merge_in_progress_resolved(repo_root, worktree):
-            retry_count, archived_artifact = _record_rebase_resolve_false_done(repo_root, log_path, pr_number, head_ref, marker)
+            recovery = _record_rebase_resolve_false_done(repo_root, log_path, pr_number, head_ref, marker)
+            if recovery.error_reason is not None:
+                action["status_only"] = True
+                action["no_lifecycle_authority"] = True
+                action["reason"] = recovery.error_reason
+                action["diagnostic"] = recovery.diagnostic
+                action["evidence"] = recovery.archived_artifact
+                action["source_artifact"] = recovery.archived_artifact
+                print(recovery.diagnostic, file=sys.stderr)
+                action.pop("controller_action", None)
+                action.pop("runner_authority", None)
+                action.pop("no_generic_command", None)
+                actions.append(action)
+                continue
+            retry_count = recovery.retry_count
+            archived_artifact = recovery.archived_artifact
             action["evidence"] = archived_artifact
             action["source_artifact"] = archived_artifact
             if retry_count > REBASE_RESOLVE_FALSE_DONE_RETRY_LIMIT:
@@ -1394,37 +1409,115 @@ def rebase_resolve_completed_marker_actions(repo_root: Path, gh_items: list[GhIt
     return actions
 
 
-def _record_rebase_resolve_false_done(repo_root: Path, log_path: Path, pr_number: int, head_ref: str, marker: str) -> tuple[int, str]:
+@dataclass(frozen=True)
+class RebaseResolveFalseDoneRecovery:
+    retry_count: int
+    archived_artifact: str
+    error_reason: str | None = None
+    diagnostic: str | None = None
+
+
+def _record_rebase_resolve_false_done(
+    repo_root: Path, log_path: Path, pr_number: int, head_ref: str, marker: str
+) -> RebaseResolveFalseDoneRecovery:
     state_dir = repo_root / ".refactor-loop" / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
     state_path = state_dir / "rebase-resolve-false-done-recovery.json"
-    archived_log = _archive_rebase_resolve_false_done_log(log_path)
+    archived_log, archive_error = _archive_rebase_resolve_false_done_log(log_path)
     archived_artifact = str(archived_log.relative_to(repo_root))
+    if archive_error is not None:
+        reason = "rebase_resolve_false_done_archive_failed"
+        archive_path = log_path.with_name(f"{log_path.name}.false-done")
+        return RebaseResolveFalseDoneRecovery(
+            retry_count=0,
+            archived_artifact=archived_artifact,
+            error_reason=reason,
+            diagnostic=(
+                f"{reason}: pr={pr_number} head_ref={head_ref} log_path={log_path.relative_to(repo_root)} "
+                f"archive_path={archive_path.relative_to(repo_root)} error={archive_error}"
+            ),
+        )
     try:
         state = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except FileNotFoundError:
         state = {}
+    except (OSError, json.JSONDecodeError) as exc:
+        reason = "rebase_resolve_false_done_state_unreadable"
+        return RebaseResolveFalseDoneRecovery(
+            retry_count=0,
+            archived_artifact=archived_artifact,
+            error_reason=reason,
+            diagnostic=(
+                f"{reason}: pr={pr_number} head_ref={head_ref} state_path={state_path.relative_to(repo_root)} "
+                f"log_path={archived_artifact} error={type(exc).__name__}:{exc}"
+            ),
+        )
     if not isinstance(state, dict):
-        state = {}
+        reason = "rebase_resolve_false_done_state_invalid"
+        return RebaseResolveFalseDoneRecovery(
+            retry_count=0,
+            archived_artifact=archived_artifact,
+            error_reason=reason,
+            diagnostic=(
+                f"{reason}: pr={pr_number} head_ref={head_ref} state_path={state_path.relative_to(repo_root)} "
+                f"log_path={archived_artifact} error=top-level-json-is-not-object"
+            ),
+        )
     key = f"PR:{pr_number}:{head_ref}"
     record = state.get(key)
-    if not isinstance(record, dict):
+    if record is None:
         record = {"count": 0}
-    record["count"] = int(record.get("count") or 0) + 1
+    elif not isinstance(record, dict):
+        reason = "rebase_resolve_false_done_state_invalid"
+        return RebaseResolveFalseDoneRecovery(
+            retry_count=0,
+            archived_artifact=archived_artifact,
+            error_reason=reason,
+            diagnostic=(
+                f"{reason}: pr={pr_number} head_ref={head_ref} state_path={state_path.relative_to(repo_root)} "
+                f"log_path={archived_artifact} error=retry-record-is-not-object"
+            ),
+        )
+    try:
+        retry_count = int(record.get("count") or 0) + 1
+    except (TypeError, ValueError) as exc:
+        reason = "rebase_resolve_false_done_state_invalid"
+        return RebaseResolveFalseDoneRecovery(
+            retry_count=0,
+            archived_artifact=archived_artifact,
+            error_reason=reason,
+            diagnostic=(
+                f"{reason}: pr={pr_number} head_ref={head_ref} state_path={state_path.relative_to(repo_root)} "
+                f"log_path={archived_artifact} error=count:{type(exc).__name__}:{exc}"
+            ),
+        )
+    record["count"] = retry_count
     record["source_artifact"] = archived_artifact
     record["source_marker"] = marker
     state[key] = record
-    state_path.write_text(json.dumps(state, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-    return int(record["count"]), archived_artifact
+    try:
+        state_path.write_text(json.dumps(state, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:
+        reason = "rebase_resolve_false_done_state_write_failed"
+        return RebaseResolveFalseDoneRecovery(
+            retry_count=0,
+            archived_artifact=archived_artifact,
+            error_reason=reason,
+            diagnostic=(
+                f"{reason}: pr={pr_number} head_ref={head_ref} state_path={state_path.relative_to(repo_root)} "
+                f"log_path={archived_artifact} error={type(exc).__name__}:{exc}"
+            ),
+        )
+    return RebaseResolveFalseDoneRecovery(retry_count=int(record["count"]), archived_artifact=archived_artifact)
 
 
-def _archive_rebase_resolve_false_done_log(log_path: Path) -> Path:
+def _archive_rebase_resolve_false_done_log(log_path: Path) -> tuple[Path, str | None]:
     archive = log_path.with_name(f"{log_path.name}.false-done")
     try:
         log_path.replace(archive)
-    except OSError:
-        return log_path
-    return archive
+    except OSError as exc:
+        return log_path, f"{type(exc).__name__}:{exc}"
+    return archive, None
 
 
 def _rebase_resolve_marker_from_log(log_path: Path) -> str:
@@ -2626,7 +2719,22 @@ def _worktree_merge_in_progress_resolved(repo_root: Path, worktree: Path | None)
     unmerged = git_text(["git", "-C", str(worktree), "diff", "--name-only", "--diff-filter=U"], cwd=repo_root)
     if unmerged.returncode != 0:
         return False
-    return not any(line.strip() for line in unmerged.stdout.splitlines())
+    if any(line.strip() for line in unmerged.stdout.splitlines()):
+        return False
+    status = git_text(["git", "-C", str(worktree), "status", "--porcelain"], cwd=repo_root)
+    if status.returncode != 0:
+        return False
+    rows = [line for line in status.stdout.splitlines() if line.strip()]
+    if not rows:
+        return False
+    for row in rows:
+        if len(row) < 3:
+            return False
+        index_status = row[0]
+        worktree_status = row[1]
+        if index_status == "?" or worktree_status not in {" ", "?"}:
+            return False
+    return True
 
 
 def safe_head_ref(value: str | None) -> str | None:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -107,6 +107,7 @@ HARNESS_SPAWN_TARGET_TEXT_PATTERNS = (
 )
 TERMINAL_HARNESS_SPAWN_INTENT_BLOCKED_REASONS = {"target_not_open:CLOSED", "target_not_open:MERGED"}
 RUNNER_AUTHORITY = "wakeup-runner-396"
+REBASE_RESOLVE_FALSE_DONE_RETRY_LIMIT = 2
 PLAN_AUTHORIZATION = "skills/consensus-loop/authorizations/runtime-exceptions.md#wakeup-runner-396"
 READ_ONLY_PLAN_AUTHORIZATION = "skills/consensus-loop/authorizations/runtime-exceptions.md#maintainer-directive-wakeup-plan-script"
 RUNNER_NAMED_HELPER_ACTIONS = {
@@ -1360,14 +1361,70 @@ def rebase_resolve_completed_marker_actions(repo_root: Path, gh_items: list[GhIt
         if worktree is not None:
             action["worktree"] = str(worktree)
         if not _worktree_merge_in_progress_resolved(repo_root, worktree):
-            action["status_only"] = True
-            action["no_lifecycle_authority"] = True
-            action["reason"] = "rebase_resolve_done_without_resolved_merge"
-            action.pop("controller_action", None)
-            action.pop("runner_authority", None)
-            action.pop("no_generic_command", None)
+            retry_count, archived_artifact = _record_rebase_resolve_false_done(repo_root, log_path, pr_number, head_ref, marker)
+            action["evidence"] = archived_artifact
+            action["source_artifact"] = archived_artifact
+            if retry_count > REBASE_RESOLVE_FALSE_DONE_RETRY_LIMIT:
+                action["status_only"] = True
+                action["no_lifecycle_authority"] = True
+                action["reason"] = "rebase_resolve_false_done_retry_limit_exceeded"
+                action.pop("controller_action", None)
+                action.pop("runner_authority", None)
+                action.pop("no_generic_command", None)
+            else:
+                action.update(
+                    {
+                        "kind": "stale-base-conflicting-pr",
+                        "action_id": f"dispatch-pr-rebase-resolve:false-done:{pr_number}:{head_ref}:{retry_count}",
+                        "phase": "review-gate",
+                        "route": "dispatch-pr-rebase-resolve",
+                        "reason": "rebase_resolve_done_without_resolved_merge",
+                        "controller_action": "dispatch_pr_rebase_resolve",
+                        "preconditions": [
+                            "active_controller_owner",
+                            "clean_exit_source_marker",
+                            "live_managed_target",
+                            "false_done_unresolved_or_not_commit_ready",
+                        ],
+                        "runner_authority": RUNNER_AUTHORITY,
+                        "no_generic_command": True,
+                    }
+                )
         actions.append(action)
     return actions
+
+
+def _record_rebase_resolve_false_done(repo_root: Path, log_path: Path, pr_number: int, head_ref: str, marker: str) -> tuple[int, str]:
+    state_dir = repo_root / ".refactor-loop" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    state_path = state_dir / "rebase-resolve-false-done-recovery.json"
+    archived_log = _archive_rebase_resolve_false_done_log(log_path)
+    archived_artifact = str(archived_log.relative_to(repo_root))
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        state = {}
+    if not isinstance(state, dict):
+        state = {}
+    key = f"PR:{pr_number}:{head_ref}"
+    record = state.get(key)
+    if not isinstance(record, dict):
+        record = {"count": 0}
+    record["count"] = int(record.get("count") or 0) + 1
+    record["source_artifact"] = archived_artifact
+    record["source_marker"] = marker
+    state[key] = record
+    state_path.write_text(json.dumps(state, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    return int(record["count"]), archived_artifact
+
+
+def _archive_rebase_resolve_false_done_log(log_path: Path) -> Path:
+    archive = log_path.with_name(f"{log_path.name}.false-done")
+    try:
+        log_path.replace(archive)
+    except OSError:
+        return log_path
+    return archive
 
 
 def _rebase_resolve_marker_from_log(log_path: Path) -> str:
@@ -2688,21 +2745,6 @@ def _rebase_resolve_in_flight(repo_root: Path, pr_number: int, monitor: Any | No
         if _rebase_resolve_marker_from_log(log):
             continue
         if _harness_spawn_intent_log_suppresses_retry(log) or _canonical_in_flight_for_log(log, monitor):
-            return True
-    pending = repo_root / ".refactor-loop" / ".controller-pending-events.log"
-    try:
-        lines = pending.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError:
-        return False
-    prefix = f"dispatch-pr-rebase-resolve:{pr_number}:"
-    for line in lines:
-        if " HARNESS_SPAWN_INTENT " not in line:
-            continue
-        try:
-            intent = json.loads(line.split(" HARNESS_SPAWN_INTENT ", 1)[1])
-        except json.JSONDecodeError:
-            continue
-        if isinstance(intent, dict) and str(intent.get("intent_id") or "").startswith(prefix):
             return True
     return False
 

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -959,8 +959,15 @@ class WakeupRunner:
                 "false_done_unresolved_or_not_commit_ready",
             ),
         )
-        if not any(all(required in preconditions for required in required_set) for required_set in required_sets):
-            missing = [required for required in required_sets[0] if required not in preconditions]
+        recovery_marker = str(action.get("source_marker") or "")
+        is_false_done_recovery = (
+            str(action.get("action_id") or "").startswith("dispatch-pr-rebase-resolve:false-done:")
+            or action.get("reason") == "rebase_resolve_done_without_resolved_merge"
+            or recovery_marker.startswith("REBASE_RESOLVE_DONE:")
+        )
+        allowed_required_sets = (required_sets[1],) if is_false_done_recovery else (required_sets[0],)
+        if not any(all(required in preconditions for required in required_set) for required_set in allowed_required_sets):
+            missing = [required for required in allowed_required_sets[0] if required not in preconditions]
             return f"dispatch_pr_rebase_resolve_missing_precondition:{missing[0]}"
         target = int(action["target_number"])
         if not self._live_target_has_managed_label("pr", target):

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -416,7 +416,7 @@ class WakeupRunner:
             and action.get("controller_action") != "publish_release_candidate"
         ):
             path = self.ctx.repo_root / source_artifact
-            if action.get("controller_action") == "commit_push_resolved_pr_rebase":
+            if action.get("controller_action") in {"commit_push_resolved_pr_rebase", "dispatch_pr_rebase_resolve"}:
                 if _source_log_has_clean_rebase_resolve_marker(path, source_marker):
                     return None
                 return "clean_exit_marker_missing"
@@ -950,9 +950,18 @@ class WakeupRunner:
         preconditions = action.get("preconditions")
         if not isinstance(preconditions, list):
             return "dispatch_pr_rebase_resolve_missing_preconditions"
-        for required in ("active_controller_owner", "live_managed_target", "base_ahead_pr_branch"):
-            if required not in preconditions:
-                return f"dispatch_pr_rebase_resolve_missing_precondition:{required}"
+        required_sets = (
+            ("active_controller_owner", "live_managed_target", "base_ahead_pr_branch"),
+            (
+                "active_controller_owner",
+                "clean_exit_source_marker",
+                "live_managed_target",
+                "false_done_unresolved_or_not_commit_ready",
+            ),
+        )
+        if not any(all(required in preconditions for required in required_set) for required_set in required_sets):
+            missing = [required for required in required_sets[0] if required not in preconditions]
+            return f"dispatch_pr_rebase_resolve_missing_precondition:{missing[0]}"
         target = int(action["target_number"])
         if not self._live_target_has_managed_label("pr", target):
             return "dispatch_pr_rebase_resolve_target_not_managed"

--- a/skills/consensus-loop/scripts/test_controller_actions.py
+++ b/skills/consensus-loop/scripts/test_controller_actions.py
@@ -698,6 +698,20 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertEqual([], push.mock_calls)
         self.assertTrue(self.actions._merge_in_progress(worktree))
 
+    def test_commit_push_resolved_pr_rebase_blocks_non_merge_dirty_state(self) -> None:
+        worktree, head_ref = self.init_rebase_repo(conflict=True)
+        owner_patch, gh_patch = self.patch_rebase_owner_and_gh(head_ref)
+        self.run_git(worktree, ["fetch", "origin"])
+        subprocess.run(["git", "-C", str(worktree), "merge", "--no-commit", "--no-ff", "origin/canonical-integration"], capture_output=True, text=True, check=False)
+        (worktree / "file.txt").write_text("resolved but unstaged\n", encoding="utf-8")
+        with owner_patch, gh_patch, mock.patch.object(self.actions, "safe_push") as push:
+            rc = self.actions.commit_push_resolved_pr_rebase(
+                {"target_kind": "PR", "target_number": 77, "head_ref": head_ref, "worktree": str(worktree), "source_marker": "REBASE_RESOLVE_DONE:77:ok"}
+            )
+        self.assertEqual(2, rc)
+        self.assertEqual([], push.mock_calls)
+        self.assertTrue(self.actions._merge_in_progress(worktree))
+
     def test_commit_push_resolved_pr_rebase_blocked_marker_aborts_and_surfaces_event(self) -> None:
         worktree, head_ref = self.init_rebase_repo(conflict=True)
         owner_patch, gh_patch = self.patch_rebase_owner_and_gh(head_ref)

--- a/skills/consensus-loop/scripts/test_marker_emission_contract.py
+++ b/skills/consensus-loop/scripts/test_marker_emission_contract.py
@@ -249,6 +249,14 @@ class MarkerEmissionContractTests(unittest.TestCase):
                         f"{filename} allowlist must not list other role marker token {token}",
                     )
 
+    def test_rebase_resolve_done_requires_mechanical_readiness_checks(self) -> None:
+        body = (PROMPTS_DIR / "rebase-resolve.md").read_text(encoding="utf-8")
+
+        self.assertIn("Before emitting `REBASE_RESOLVE_DONE`", body)
+        self.assertIn("git diff --name-only --diff-filter=U", body)
+        self.assertIn("git status --porcelain", body)
+        self.assertIn("commit-ready merge state", body)
+
     def test_no_prompt_missing_from_contract(self) -> None:
         role_prompt_files = {
             path.name for path in PROMPTS_DIR.glob("*.md")

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -273,6 +273,37 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual("rebase_resolve_in_flight", actions[0]["reason"])
         self.assertTrue(actions[0]["status_only"])
 
+    def test_rebase_resolve_actions_ignore_historical_pending_spawn_intent(self) -> None:
+        item = GhItem(
+            kind="PR",
+            number=77,
+            title="stale",
+            labels=(label_catalog.MANAGED, label_catalog.PHASE_REVIEWING),
+            head_ref="refactor/iter77-stale",
+            head_sha="abc123",
+            mergeable="CONFLICTING",
+        )
+        pending = {
+            "intent_id": "dispatch-pr-rebase-resolve:77:old-head",
+            "controller_action": "dispatch_pr_rebase_resolve",
+        }
+        (self.repo / ".refactor-loop" / ".controller-pending-events.log").write_text(
+            f"2026-05-31T00:00:00Z HARNESS_SPAWN_INTENT {json.dumps(pending, sort_keys=True)}\n",
+            encoding="utf-8",
+        )
+        ctx = mock.Mock(host_env={"INTEGRATION_BRANCH": "auto-refact-dev"})
+        with mock.patch("codex_refactor_loop.wakeup_plan.git_text") as git_text_mock:
+            git_text_mock.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+                subprocess.CompletedProcess([], 0, stdout="head\n", stderr=""),
+                subprocess.CompletedProcess([], 0, stdout="base\n", stderr=""),
+                subprocess.CompletedProcess([], 0, stdout="oldbase\n", stderr=""),
+            ]
+            actions = rebase_resolve_actions(self.repo, ctx, [item], monitor=None)
+
+        self.assertEqual("dispatch_pr_rebase_resolve", actions[0]["controller_action"])
+        self.assertFalse(actions[0].get("status_only", False))
+
     def test_rebase_resolve_completed_marker_projects_commit_push_action(self) -> None:
         log = self.logs / "rebase-resolve-pr77-r1.log"
         log.write_text("resolved\nREBASE_RESOLVE_DONE:77:ok\nEXIT=0\n", encoding="utf-8")
@@ -306,6 +337,87 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual("commit_push_resolved_pr_rebase", action["controller_action"])
         self.assertEqual("REBASE_RESOLVE_DONE:77:ok", action["source_marker"])
         self.assertEqual(str(worktree), action["worktree"])
+
+    def test_rebase_resolve_false_done_projects_recovery_dispatch_and_archives_log(self) -> None:
+        log = self.logs / "rebase-resolve-pr77-r1.log"
+        log.write_text("resolved\nREBASE_RESOLVE_DONE:77:ok\nEXIT=0\n", encoding="utf-8")
+        worktree = self.repo / ".worktrees" / "iter77-stale"
+        worktree.mkdir(parents=True)
+        item = GhItem(
+            kind="PR",
+            number=77,
+            title="stale",
+            labels=(label_catalog.MANAGED, label_catalog.PHASE_REVIEWING),
+            head_ref="refactor/iter77-stale",
+            head_sha="abc123",
+        )
+        porcelain = f"worktree {worktree}\nbranch refs/heads/refactor/iter77-stale\n"
+
+        def fake_git(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+            if command == ["git", "-C", str(self.repo), "worktree", "list", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, stdout=porcelain, stderr="")
+            if command == ["git", "-C", str(worktree), "rev-parse", "--git-dir"]:
+                return subprocess.CompletedProcess(command, 0, stdout=str(worktree / ".git") + "\n", stderr="")
+            return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected")
+
+        with mock.patch("codex_refactor_loop.wakeup_plan.git_text", side_effect=fake_git):
+            actions = rebase_resolve_completed_marker_actions(self.repo, [item])
+
+        action = actions[0]
+        self.assertEqual("dispatch_pr_rebase_resolve", action["controller_action"])
+        self.assertEqual("rebase_resolve_done_without_resolved_merge", action["reason"])
+        self.assertEqual(".refactor-loop/logs/rebase-resolve-pr77-r1.log.false-done", action["source_artifact"])
+        self.assertEqual("REBASE_RESOLVE_DONE:77:ok", action["source_marker"])
+        self.assertEqual(str(worktree), action["worktree"])
+        self.assertEqual("PR", action["target_kind"])
+        self.assertEqual(77, action["target_number"])
+        self.assertEqual("refactor/iter77-stale", action["head_ref"])
+        self.assertNotIn("mode", action)
+        self.assertEqual(
+            [
+                "active_controller_owner",
+                "clean_exit_source_marker",
+                "live_managed_target",
+                "false_done_unresolved_or_not_commit_ready",
+            ],
+            action["preconditions"],
+        )
+        self.assertFalse(log.exists())
+        self.assertTrue((self.logs / "rebase-resolve-pr77-r1.log.false-done").exists())
+
+    def test_rebase_resolve_false_done_retry_limit_is_status_only(self) -> None:
+        item = GhItem(
+            kind="PR",
+            number=77,
+            title="stale",
+            labels=(label_catalog.MANAGED, label_catalog.PHASE_REVIEWING),
+            head_ref="refactor/iter77-stale",
+            head_sha="abc123",
+        )
+        worktree = self.repo / ".worktrees" / "iter77-stale"
+        worktree.mkdir(parents=True)
+        porcelain = f"worktree {worktree}\nbranch refs/heads/refactor/iter77-stale\n"
+        state = {"PR:77:refactor/iter77-stale": {"count": 2}}
+        (self.repo / ".refactor-loop" / "state" / "rebase-resolve-false-done-recovery.json").write_text(
+            json.dumps(state), encoding="utf-8"
+        )
+        log = self.logs / "rebase-resolve-pr77-r3.log"
+        log.write_text("resolved\nREBASE_RESOLVE_DONE:77:ok\nEXIT=0\n", encoding="utf-8")
+
+        def fake_git(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+            if command == ["git", "-C", str(self.repo), "worktree", "list", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, stdout=porcelain, stderr="")
+            if command == ["git", "-C", str(worktree), "rev-parse", "--git-dir"]:
+                return subprocess.CompletedProcess(command, 0, stdout=str(worktree / ".git") + "\n", stderr="")
+            return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected")
+
+        with mock.patch("codex_refactor_loop.wakeup_plan.git_text", side_effect=fake_git):
+            actions = rebase_resolve_completed_marker_actions(self.repo, [item])
+
+        self.assertEqual("rebase_resolve_false_done_retry_limit_exceeded", actions[0]["reason"])
+        self.assertTrue(actions[0]["status_only"])
+        self.assertNotIn("controller_action", actions[0])
+        self.assertTrue((self.logs / "rebase-resolve-pr77-r3.log.false-done").exists())
 
     def test_wakeup_plan_projects_conflicting_stale_base_pr_dispatch_as_executable(self) -> None:
         plan = self.run_plan(fixture="stale_base_conflicting_pr")

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -329,6 +329,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                 return subprocess.CompletedProcess(command, 0, stdout=str(git_dir) + "\n", stderr="")
             if command == ["git", "-C", str(worktree), "diff", "--name-only", "--diff-filter=U"]:
                 return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            if command == ["git", "-C", str(worktree), "status", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, stdout="M  skills/example.py\n", stderr="")
             return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected")
 
         with mock.patch("codex_refactor_loop.wakeup_plan.git_text", side_effect=fake_git):
@@ -337,6 +339,58 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual("commit_push_resolved_pr_rebase", action["controller_action"])
         self.assertEqual("REBASE_RESOLVE_DONE:77:ok", action["source_marker"])
         self.assertEqual(str(worktree), action["worktree"])
+
+    def test_rebase_resolve_done_dirty_merge_projects_recovery_not_commit_push(self) -> None:
+        log = self.logs / "rebase-resolve-pr77-r1.log"
+        log.write_text("resolved\nREBASE_RESOLVE_DONE:77:ok\nEXIT=0\n", encoding="utf-8")
+        worktree = self.repo / ".worktrees" / "iter77-stale"
+        worktree.mkdir(parents=True)
+        porcelain = f"worktree {worktree}\nbranch refs/heads/refactor/iter77-stale\n"
+        item = GhItem(
+            kind="PR",
+            number=77,
+            title="stale",
+            labels=(label_catalog.MANAGED, label_catalog.PHASE_REVIEWING),
+            head_ref="refactor/iter77-stale",
+            head_sha="abc123",
+        )
+        git_dir = self.repo / ".git" / "worktrees" / "iter77-stale"
+        git_dir.mkdir(parents=True)
+        (git_dir / "MERGE_HEAD").write_text("base\n", encoding="utf-8")
+
+        def fake_git(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+            if command == ["git", "-C", str(self.repo), "worktree", "list", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, stdout=porcelain, stderr="")
+            if command == ["git", "-C", str(worktree), "rev-parse", "--git-dir"]:
+                return subprocess.CompletedProcess(command, 0, stdout=str(git_dir) + "\n", stderr="")
+            if command == ["git", "-C", str(worktree), "diff", "--name-only", "--diff-filter=U"]:
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            if command == ["git", "-C", str(worktree), "status", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, stdout=" M skills/example.py\n", stderr="")
+            return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected")
+
+        with mock.patch("codex_refactor_loop.wakeup_plan.git_text", side_effect=fake_git):
+            actions = rebase_resolve_completed_marker_actions(self.repo, [item])
+
+        commit_pushes = [
+            action
+            for action in actions
+            if action.get("controller_action") == "commit_push_resolved_pr_rebase" and not action.get("status_only", False)
+        ]
+        self.assertEqual([], commit_pushes)
+        action = actions[0]
+        self.assertEqual("dispatch_pr_rebase_resolve", action["controller_action"])
+        self.assertEqual("rebase_resolve_done_without_resolved_merge", action["reason"])
+        self.assertEqual(".refactor-loop/logs/rebase-resolve-pr77-r1.log.false-done", action["source_artifact"])
+        self.assertEqual(
+            [
+                "active_controller_owner",
+                "clean_exit_source_marker",
+                "live_managed_target",
+                "false_done_unresolved_or_not_commit_ready",
+            ],
+            action["preconditions"],
+        )
 
     def test_rebase_resolve_false_done_projects_recovery_dispatch_and_archives_log(self) -> None:
         log = self.logs / "rebase-resolve-pr77-r1.log"
@@ -419,6 +473,82 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertNotIn("controller_action", actions[0])
         self.assertTrue((self.logs / "rebase-resolve-pr77-r3.log.false-done").exists())
 
+    def test_rebase_resolve_false_done_corrupt_retry_state_is_diagnostic_status_only(self) -> None:
+        item = GhItem(
+            kind="PR",
+            number=77,
+            title="stale",
+            labels=(label_catalog.MANAGED, label_catalog.PHASE_REVIEWING),
+            head_ref="refactor/iter77-stale",
+            head_sha="abc123",
+        )
+        worktree = self.repo / ".worktrees" / "iter77-stale"
+        worktree.mkdir(parents=True)
+        porcelain = f"worktree {worktree}\nbranch refs/heads/refactor/iter77-stale\n"
+        state_path = self.repo / ".refactor-loop" / "state" / "rebase-resolve-false-done-recovery.json"
+        state_path.write_text("{bad json", encoding="utf-8")
+        log = self.logs / "rebase-resolve-pr77-r1.log"
+        log.write_text("resolved\nREBASE_RESOLVE_DONE:77:ok\nEXIT=0\n", encoding="utf-8")
+
+        def fake_git(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+            if command == ["git", "-C", str(self.repo), "worktree", "list", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, stdout=porcelain, stderr="")
+            if command == ["git", "-C", str(worktree), "rev-parse", "--git-dir"]:
+                return subprocess.CompletedProcess(command, 0, stdout=str(worktree / ".git") + "\n", stderr="")
+            return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected")
+
+        with mock.patch("codex_refactor_loop.wakeup_plan.git_text", side_effect=fake_git):
+            actions = rebase_resolve_completed_marker_actions(self.repo, [item])
+
+        action = actions[0]
+        self.assertEqual("rebase_resolve_false_done_state_unreadable", action["reason"])
+        self.assertTrue(action["status_only"])
+        self.assertNotIn("controller_action", action)
+        self.assertIn("pr=77", action["diagnostic"])
+        self.assertIn("head_ref=refactor/iter77-stale", action["diagnostic"])
+        self.assertIn("state_path=.refactor-loop/state/rebase-resolve-false-done-recovery.json", action["diagnostic"])
+        self.assertIn("log_path=.refactor-loop/logs/rebase-resolve-pr77-r1.log.false-done", action["diagnostic"])
+        self.assertTrue((self.logs / "rebase-resolve-pr77-r1.log.false-done").exists())
+        self.assertEqual("{bad json", state_path.read_text(encoding="utf-8"))
+
+    def test_rebase_resolve_false_done_archive_failure_is_diagnostic_status_only(self) -> None:
+        item = GhItem(
+            kind="PR",
+            number=77,
+            title="stale",
+            labels=(label_catalog.MANAGED, label_catalog.PHASE_REVIEWING),
+            head_ref="refactor/iter77-stale",
+            head_sha="abc123",
+        )
+        worktree = self.repo / ".worktrees" / "iter77-stale"
+        worktree.mkdir(parents=True)
+        porcelain = f"worktree {worktree}\nbranch refs/heads/refactor/iter77-stale\n"
+        log = self.logs / "rebase-resolve-pr77-r1.log"
+        log.write_text("resolved\nREBASE_RESOLVE_DONE:77:ok\nEXIT=0\n", encoding="utf-8")
+
+        def fake_git(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+            if command == ["git", "-C", str(self.repo), "worktree", "list", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, stdout=porcelain, stderr="")
+            if command == ["git", "-C", str(worktree), "rev-parse", "--git-dir"]:
+                return subprocess.CompletedProcess(command, 0, stdout=str(worktree / ".git") + "\n", stderr="")
+            return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected")
+
+        with (
+            mock.patch("codex_refactor_loop.wakeup_plan.git_text", side_effect=fake_git),
+            mock.patch.object(Path, "replace", side_effect=OSError("archive denied")),
+        ):
+            actions = rebase_resolve_completed_marker_actions(self.repo, [item])
+
+        action = actions[0]
+        self.assertEqual("rebase_resolve_false_done_archive_failed", action["reason"])
+        self.assertTrue(action["status_only"])
+        self.assertNotIn("controller_action", action)
+        self.assertIn("pr=77", action["diagnostic"])
+        self.assertIn("head_ref=refactor/iter77-stale", action["diagnostic"])
+        self.assertIn("log_path=.refactor-loop/logs/rebase-resolve-pr77-r1.log", action["diagnostic"])
+        self.assertIn("archive_path=.refactor-loop/logs/rebase-resolve-pr77-r1.log.false-done", action["diagnostic"])
+        self.assertTrue(log.exists())
+
     def test_wakeup_plan_projects_conflicting_stale_base_pr_dispatch_as_executable(self) -> None:
         plan = self.run_plan(fixture="stale_base_conflicting_pr")
 
@@ -453,10 +583,12 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             for item in plan["actions"]
             if item.get("controller_action") == "dispatch_pr_rebase_resolve"
             and item.get("target_number") == 177
+            and item.get("source_artifact") == ".refactor-loop/logs/rebase-resolve-pr177-r1.log.false-done"
             and not item.get("status_only", False)
         )
         self.assertEqual("stale-base-conflicting-pr", action["kind"])
-        self.assertEqual("CONFLICTING", action["mergeable"])
+        self.assertEqual("rebase_resolve_done_without_resolved_merge", action["reason"])
+        self.assertIn("false_done_unresolved_or_not_commit_ready", action["preconditions"])
 
     def test_wakeup_plan_projects_rebase_done_only_for_resolved_in_progress_merge(self) -> None:
         log = self.logs / "rebase-resolve-pr177-r1.log"
@@ -495,6 +627,33 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             and not item.get("status_only", False)
         ]
         self.assertEqual([], commit_pushes)
+
+    def test_wakeup_plan_rebase_done_with_dirty_porcelain_projects_recovery_dispatch(self) -> None:
+        log = self.logs / "rebase-resolve-pr177-r1.log"
+        log.write_text("resolved\nREBASE_RESOLVE_DONE:177:ok\nEXIT=0\n", encoding="utf-8")
+        self.write_rebase_resolve_worktree_state(merge_head=True, unmerged_paths=(), porcelain=" M skills/example.py\n")
+
+        plan = self.run_plan(fixture="stale_base_done_dirty_status")
+
+        commit_pushes = [
+            item
+            for item in plan["actions"]
+            if item.get("controller_action") == "commit_push_resolved_pr_rebase"
+            and item.get("target_number") == 177
+            and not item.get("status_only", False)
+        ]
+        self.assertEqual([], commit_pushes)
+        action = next(
+            item
+            for item in plan["actions"]
+            if item.get("controller_action") == "dispatch_pr_rebase_resolve"
+            and item.get("target_number") == 177
+            and item.get("source_artifact") == ".refactor-loop/logs/rebase-resolve-pr177-r1.log.false-done"
+            and not item.get("status_only", False)
+        )
+        self.assertEqual("rebase_resolve_done_without_resolved_merge", action["reason"])
+        self.assertEqual(".refactor-loop/logs/rebase-resolve-pr177-r1.log.false-done", action["source_artifact"])
+        self.assertIn("false_done_unresolved_or_not_commit_ready", action["preconditions"])
 
     def test_wakeup_plan_keeps_branch_current_rebase_resolve_status_only(self) -> None:
         plan = self.run_plan(fixture="stale_base_branch_current")
@@ -791,7 +950,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                         printf '[]\n'
                       fi
                       ;;
-                    stale_base_conflicting_pr|stale_base_branch_current|stale_base_done_clean|stale_base_done_resolved_merge|stale_base_done_unmerged)
+                    stale_base_conflicting_pr|stale_base_branch_current|stale_base_done_clean|stale_base_done_resolved_merge|stale_base_done_unmerged|stale_base_done_dirty_status)
                       if [[ "$label" == "crnd:lifecycle:managed" ]]; then
                         printf '[{"number":177,"title":"stale-base PR","headRefName":"refactor/iter177-stale","labels":[{"name":"crnd:lifecycle:managed"},{"name":"crnd:phase:reviewing"},{"name":"crnd:human:auto"}]}]\n'
                       else
@@ -1158,6 +1317,9 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             "stale_base_done_unmerged": [
                 pr(177, "stale-base PR", [managed, label_catalog.PHASE_REVIEWING, auto], head_ref="refactor/iter177-stale")
             ],
+            "stale_base_done_dirty_status": [
+                pr(177, "stale-base PR", [managed, label_catalog.PHASE_REVIEWING, auto], head_ref="refactor/iter177-stale")
+            ],
             "stale_base_branch_current": [
                 pr(177, "stale-base PR", [managed, label_catalog.PHASE_REVIEWING, auto], head_ref="refactor/iter177-stale")
             ],
@@ -1283,7 +1445,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                     printf 'worktree %s/.worktrees/iter581-issue-581\nbranch refs/heads/refactor/iter581-issue-581\n\n' "$WAKEUP_PLAN_REPO_ROOT"
                     exit 0
                   fi
-                  if [[ "$fixture" == "stale_base_done_clean" || "$fixture" == "stale_base_done_resolved_merge" || "$fixture" == "stale_base_done_unmerged" ]]; then
+                  if [[ "$fixture" == "stale_base_done_clean" || "$fixture" == "stale_base_done_resolved_merge" || "$fixture" == "stale_base_done_unmerged" || "$fixture" == "stale_base_done_dirty_status" ]]; then
                     printf 'worktree %s/.worktrees/iter177-stale\nbranch refs/heads/refactor/iter177-stale\n\n' "$WAKEUP_PLAN_REPO_ROOT"
                     exit 0
                   fi
@@ -1316,17 +1478,17 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                   exit 1
                 fi
                 if [[ "$*" == *"rev-parse --verify origin/refactor/iter177-stale"* ]]; then
-                  [[ "$fixture" == "stale_base_conflicting_pr" || "$fixture" == "stale_base_branch_current" || "$fixture" == "stale_base_done_clean" || "$fixture" == "stale_base_done_resolved_merge" || "$fixture" == "stale_base_done_unmerged" ]] && printf 'stale-head-sha\n' && exit 0
+                  [[ "$fixture" == "stale_base_conflicting_pr" || "$fixture" == "stale_base_branch_current" || "$fixture" == "stale_base_done_clean" || "$fixture" == "stale_base_done_resolved_merge" || "$fixture" == "stale_base_done_unmerged" || "$fixture" == "stale_base_done_dirty_status" ]] && printf 'stale-head-sha\n' && exit 0
                   exit 1
                 fi
                 if [[ "$*" == *"rev-parse --verify origin/auto-refact-dev"* ]]; then
-                  if [[ "$fixture" == "stale_base_conflicting_pr" || "$fixture" == "stale_base_branch_current" || "$fixture" == "stale_base_done_clean" || "$fixture" == "stale_base_done_resolved_merge" || "$fixture" == "stale_base_done_unmerged" ]]; then
+                  if [[ "$fixture" == "stale_base_conflicting_pr" || "$fixture" == "stale_base_branch_current" || "$fixture" == "stale_base_done_clean" || "$fixture" == "stale_base_done_resolved_merge" || "$fixture" == "stale_base_done_unmerged" || "$fixture" == "stale_base_done_dirty_status" ]]; then
                     printf 'base-sha\n'
                     exit 0
                   fi
                 fi
                 if [[ "$*" == *"merge-base origin/refactor/iter177-stale origin/auto-refact-dev"* ]]; then
-                  if [[ "$fixture" == "stale_base_conflicting_pr" || "$fixture" == "stale_base_done_clean" || "$fixture" == "stale_base_done_resolved_merge" || "$fixture" == "stale_base_done_unmerged" ]]; then
+                  if [[ "$fixture" == "stale_base_conflicting_pr" || "$fixture" == "stale_base_done_clean" || "$fixture" == "stale_base_done_resolved_merge" || "$fixture" == "stale_base_done_unmerged" || "$fixture" == "stale_base_done_dirty_status" ]]; then
                     printf 'old-base-sha\n'
                     exit 0
                   fi
@@ -1343,6 +1505,14 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                 if [[ "$*" == *".worktrees/iter177-stale"* && "$*" == *"diff --name-only --diff-filter=U"* ]]; then
                   if [[ -f "$WAKEUP_PLAN_REPO_ROOT/.refactor-loop/state/rebase-unmerged-paths.txt" ]]; then
                     cat "$WAKEUP_PLAN_REPO_ROOT/.refactor-loop/state/rebase-unmerged-paths.txt"
+                  fi
+                  exit 0
+                fi
+                if [[ "$*" == *".worktrees/iter177-stale"* && "$*" == *"status --porcelain"* ]]; then
+                  if [[ -f "$WAKEUP_PLAN_REPO_ROOT/.refactor-loop/state/rebase-status-porcelain.txt" ]]; then
+                    cat "$WAKEUP_PLAN_REPO_ROOT/.refactor-loop/state/rebase-status-porcelain.txt"
+                  else
+                    printf 'M  skills/example.py\n'
                   fi
                   exit 0
                 fi
@@ -1792,7 +1962,13 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         path.write_text("worker chatter with no standalone marker\nEXIT=0\n", encoding="utf-8")
         return path
 
-    def write_rebase_resolve_worktree_state(self, *, merge_head: bool, unmerged_paths: tuple[str, ...] = ()) -> None:
+    def write_rebase_resolve_worktree_state(
+        self,
+        *,
+        merge_head: bool,
+        unmerged_paths: tuple[str, ...] = (),
+        porcelain: str = "M  skills/example.py\n",
+    ) -> None:
         worktree = self.repo / ".worktrees" / "iter177-stale"
         worktree.mkdir(parents=True, exist_ok=True)
         git_dir = self.repo / ".git" / "worktrees" / "iter177-stale"
@@ -1804,6 +1980,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         unmerged = self.repo / ".refactor-loop" / "state" / "rebase-unmerged-paths.txt"
         unmerged.parent.mkdir(parents=True, exist_ok=True)
         unmerged.write_text("".join(f"{path}\n" for path in unmerged_paths), encoding="utf-8")
+        status = self.repo / ".refactor-loop" / "state" / "rebase-status-porcelain.txt"
+        status.write_text(porcelain, encoding="utf-8")
 
     def write_run_artifact(self, stem: str, *lines: str) -> Path:
         path = self.repo / ".refactor-loop" / "runs" / f"{stem}.md"

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -1614,6 +1614,27 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual([result.status for result in results], ["applied"])
         self.assertEqual([call[0] for call in actions.calls], ["dispatch_pr_rebase_resolve"])
 
+    def test_wakeup_runner_routes_false_done_rebase_recovery_dispatch(self) -> None:
+        log = self.repo / ".refactor-loop/logs/rebase-resolve-pr77-r1.log"
+        log.write_text("resolved\nREBASE_RESOLVE_DONE:77:ok\nEXIT=0\n", encoding="utf-8")
+        action = self.rebase_dispatch_action(
+            action_id="dispatch-pr-rebase-resolve:false-done:77:refactor/iter77-worker:1",
+            source_artifact=".refactor-loop/logs/rebase-resolve-pr77-r1.log",
+            source_marker="REBASE_RESOLVE_DONE:77:ok",
+            reason="rebase_resolve_done_without_resolved_merge",
+            preconditions=[
+                "active_controller_owner",
+                "clean_exit_source_marker",
+                "live_managed_target",
+                "false_done_unresolved_or_not_commit_ready",
+            ],
+        )
+        actions = FakeActions()
+        results = self.run_result(self.base_plan(action), gh_state="OPEN", actions=actions)
+        self.assertEqual([result.status for result in results], ["applied"])
+        self.assertEqual([call[0] for call in actions.calls], ["dispatch_pr_rebase_resolve"])
+        self.assertNotIn("mode", actions.calls[0][1])
+
     def test_hard_gate_dispatch_pr_rebase_resolve_is_not_starved_by_spawn_budget(self) -> None:
         spawns = [
             self.spawn_action(
@@ -1729,6 +1750,21 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         results = self.run_result(self.base_plan(action), gh_state="OPEN", actions=actions)
         self.assertEqual([result.status for result in results], ["applied"])
         self.assertEqual([call[0] for call in actions.calls], ["commit_push_resolved_pr_rebase"])
+
+    def test_wakeup_runner_blocks_false_done_recovery_without_recovery_precondition(self) -> None:
+        log = self.repo / ".refactor-loop/logs/rebase-resolve-pr77-r1.log"
+        log.write_text("resolved\nREBASE_RESOLVE_DONE:77:ok\nEXIT=0\n", encoding="utf-8")
+        action = self.rebase_dispatch_action(
+            action_id="dispatch-pr-rebase-resolve:false-done:77:refactor/iter77-worker:1",
+            source_artifact=".refactor-loop/logs/rebase-resolve-pr77-r1.log",
+            source_marker="REBASE_RESOLVE_DONE:77:ok",
+            preconditions=["active_controller_owner", "clean_exit_source_marker", "live_managed_target"],
+        )
+        actions = FakeActions()
+        results = self.run_result(self.base_plan(action), gh_state="OPEN", actions=actions)
+        self.assertEqual([result.status for result in results], ["blocked"])
+        self.assertEqual("dispatch_pr_rebase_resolve_missing_precondition:base_ahead_pr_branch", results[0].reason)
+        self.assertEqual([], actions.calls)
 
     def test_wakeup_runner_blocked_lifecycle_action_does_not_dead_stop_later_spawn_batch(self) -> None:
         blocked = self.implementation_output_action(

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -1751,19 +1751,38 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual([result.status for result in results], ["applied"])
         self.assertEqual([call[0] for call in actions.calls], ["commit_push_resolved_pr_rebase"])
 
-    def test_wakeup_runner_blocks_false_done_recovery_without_recovery_precondition(self) -> None:
+    def test_wakeup_runner_blocks_stale_base_dispatch_without_base_ahead_precondition(self) -> None:
+        action = self.rebase_dispatch_action(
+            action_id="dispatch-pr-rebase-resolve:77:abc123",
+            preconditions=["active_controller_owner", "live_managed_target"],
+        )
+        actions = FakeActions()
+        results = self.run_result(self.base_plan(action), gh_state="OPEN", actions=actions)
+        self.assertEqual([result.status for result in results], ["blocked"])
+        self.assertEqual("dispatch_pr_rebase_resolve_missing_precondition:base_ahead_pr_branch", results[0].reason)
+        self.assertEqual([], actions.calls)
+
+    def test_wakeup_runner_reports_missing_false_done_recovery_guard_for_recovery_shape(self) -> None:
         log = self.repo / ".refactor-loop/logs/rebase-resolve-pr77-r1.log"
         log.write_text("resolved\nREBASE_RESOLVE_DONE:77:ok\nEXIT=0\n", encoding="utf-8")
         action = self.rebase_dispatch_action(
             action_id="dispatch-pr-rebase-resolve:false-done:77:refactor/iter77-worker:1",
             source_artifact=".refactor-loop/logs/rebase-resolve-pr77-r1.log",
             source_marker="REBASE_RESOLVE_DONE:77:ok",
-            preconditions=["active_controller_owner", "clean_exit_source_marker", "live_managed_target"],
+            preconditions=[
+                "active_controller_owner",
+                "clean_exit_source_marker",
+                "live_managed_target",
+                "base_ahead_pr_branch",
+            ],
         )
         actions = FakeActions()
         results = self.run_result(self.base_plan(action), gh_state="OPEN", actions=actions)
         self.assertEqual([result.status for result in results], ["blocked"])
-        self.assertEqual("dispatch_pr_rebase_resolve_missing_precondition:base_ahead_pr_branch", results[0].reason)
+        self.assertEqual(
+            "dispatch_pr_rebase_resolve_missing_precondition:false_done_unresolved_or_not_commit_ready",
+            results[0].reason,
+        )
         self.assertEqual([], actions.calls)
 
     def test_wakeup_runner_blocked_lifecycle_action_does_not_dead_stop_later_spawn_batch(self) -> None:


### PR DESCRIPTION
## Changed files

- Tightened `rebase-resolve.md` so `REBASE_RESOLVE_DONE` requires mechanical no-UU and commit-ready checks.
- Updated wakeup planning to turn false clean DONE logs into bounded `dispatch_pr_rebase_resolve` recovery actions, archive active logs as `.false-done`, and ignore stale pending `HARNESS_SPAWN_INTENT` as live rebase evidence.
- Updated wakeup-runner and controller guards so recovery uses the existing dispatch action contract and commit/push fails closed for unresolved or non-commit-ready merge states.
- Added focused tests for the recovery payload, retry cap, stale-intent behavior, runner validation, prompt contract, and dirty-state fail-closed path.

## Test results

- `python3 -m compileall skills/consensus-loop/scripts skills/sshx -q`
- Focused pytest for marker contract, wakeup plan, wakeup runner, and controller actions: 593 passed, 534 subtests passed.
- Required pytest command: consensus-loop 2049 passed, 1 skipped, 5964 subtests passed; sshx 26 passed, 6 subtests passed.
- `git diff --check`

## Deviations

- Architecture guards were not run because the host-configured guard command is empty.
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)
- No scope expansion.

Closes #745

⟦AI:AUTO-LOOP⟧
