### PR TITLE
Release rollup: integration ahead 1 commits (5be370e6d039)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/daemon_status.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/daemon_status.py
@@ -37,7 +37,11 @@ class DaemonStatusProjection:
     duplicate_canonical_wrappers: int
     active_controller: str
     managed_child_pids: tuple[int, ...] = ()
+    canonical_child_pids: tuple[int, ...] = ()
+    orphan_child_pids: tuple[int, ...] = ()
     bounded_lock_holder_pids: tuple[int, ...] = ()
+    process_inventory_status: str = "available"
+    process_inventory_error: str = ""
     heartbeat_status: str = ""
     stale_reason: str = ""
     current_github_login: str = ""
@@ -55,7 +59,11 @@ class DaemonStatusProjection:
             "fingerprint_current": self.fingerprint_current,
             "duplicate_canonical_wrappers": self.duplicate_canonical_wrappers,
             "managed_child_pids": list(self.managed_child_pids),
+            "canonical_child_pids": list(self.canonical_child_pids),
+            "orphan_child_pids": list(self.orphan_child_pids),
             "bounded_lock_holder_pids": list(self.bounded_lock_holder_pids),
+            "process_inventory_status": self.process_inventory_status,
+            "process_inventory_error": self.process_inventory_error,
             "active_controller": self.active_controller,
             "current_github_login": self.current_github_login,
             "identity_authority": self.identity_authority,
@@ -134,6 +142,7 @@ def _project_target(
         and fingerprint_current
         and duplicate_count == 0
         and orphan_lock_holder_count == 0
+        and instance.process_inventory_status == "available"
     )
     status = _daemon_status(
         active_status["active_controller"],
@@ -143,6 +152,7 @@ def _project_target(
         fingerprint_current,
         duplicate_count,
         orphan_lock_holder_count,
+        instance.process_inventory_status,
     )
     stale_reason = _stale_reason(
         status=status,
@@ -152,6 +162,8 @@ def _project_target(
         fingerprint_current=fingerprint_current,
         duplicate_count=duplicate_count,
         orphan_lock_holder_count=orphan_lock_holder_count,
+        process_inventory_status=instance.process_inventory_status,
+        process_inventory_error=instance.process_inventory_error,
     )
     return DaemonStatusProjection(
         name=target.name,
@@ -162,7 +174,11 @@ def _project_target(
         fingerprint_current=fingerprint_current,
         duplicate_canonical_wrappers=duplicate_count,
         managed_child_pids=instance.live_managed_child_pids,
+        canonical_child_pids=instance.canonical_child_pids,
+        orphan_child_pids=instance.orphan_child_pids,
         bounded_lock_holder_pids=instance.bounded_lock_holder_pids,
+        process_inventory_status=instance.process_inventory_status,
+        process_inventory_error=instance.process_inventory_error,
         active_controller=active_status["active_controller"],
         heartbeat_status=heartbeat.state,
         stale_reason=stale_reason,
@@ -179,11 +195,14 @@ def _daemon_status(
     fingerprint_current: bool,
     duplicate_count: int,
     orphan_lock_holder_count: int,
+    process_inventory_status: str,
 ) -> str:
     if active_controller.startswith("noop:not-owner"):
         return "not-owner"
     if running:
         return "running"
+    if process_inventory_status != "available":
+        return "stale"
     if orphan_lock_holder_count:
         return "stale"
     if pid is None:
@@ -204,11 +223,16 @@ def _stale_reason(
     fingerprint_current: bool,
     duplicate_count: int,
     orphan_lock_holder_count: int,
+    process_inventory_status: str,
+    process_inventory_error: str,
 ) -> str:
     if status == "running":
         return ""
     if status == "not-owner":
         return "not-owner"
+    if process_inventory_status != "available":
+        reason = process_inventory_error or "unknown"
+        return f"process-inventory-unavailable:{reason}"
     if orphan_lock_holder_count:
         return f"orphan-lock-holders:{orphan_lock_holder_count}"
     if pid is None:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/restart.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/restart.py
@@ -184,6 +184,7 @@ class DaemonLaunchFingerprint:
 class DaemonProcess:
     pid: int
     command: str
+    ppid: int | None = None
 
 
 @dataclass(frozen=True)
@@ -191,8 +192,15 @@ class DaemonInstanceProjection:
     name: str
     pid_file_pid: int | None
     live_wrapper_pids: tuple[int, ...]
-    live_managed_child_pids: tuple[int, ...]
+    canonical_child_pids: tuple[int, ...]
+    orphan_child_pids: tuple[int, ...]
     bounded_lock_holder_pids: tuple[int, ...]
+    process_inventory_status: str = "available"
+    process_inventory_error: str = ""
+
+    @property
+    def live_managed_child_pids(self) -> tuple[int, ...]:
+        return tuple(sorted(set(self.canonical_child_pids).union(self.orphan_child_pids)))
 
     @property
     def duplicate_wrapper_count(self) -> int:
@@ -220,13 +228,19 @@ class DaemonInstanceProjection:
 @dataclass(frozen=True)
 class DaemonProcessInventory:
     processes: tuple[DaemonProcess, ...]
+    status: str = "available"
+    error: str = ""
 
     @classmethod
     def collect(cls, *, command_runner=None) -> "DaemonProcessInventory":
         runner = command_runner or run_process_inventory
-        result = runner(["ps", "-eo", "pid=,command="])
+        try:
+            result = runner(["ps", "-eo", "pid=,ppid=,command="])
+        except Exception as exc:
+            return cls((), status="unavailable", error=repr(exc))
         if result.returncode != 0:
-            return cls(())
+            reason = (result.stderr or result.stdout or f"exit={result.returncode}").strip()
+            return cls((), status="unavailable", error=reason or f"exit={result.returncode}")
         return cls(tuple(_parse_process_inventory(result.stdout)))
 
     def live_restart_wrappers(
@@ -278,14 +292,17 @@ class DaemonProcessInventory:
             command=command,
             is_alive=alive,
         )
-        child_pids = self.live_managed_children(
+        canonical_child_pids = self.canonical_child_pids(wrapper_pids=live_wrappers, is_alive=alive)
+        orphan_child_pids = self.orphan_child_pids(
             name=name,
             command=command,
+            canonical_child_pids=canonical_child_pids,
             is_alive=alive,
         )
+        managed_child_pids = tuple(sorted(set(canonical_child_pids).union(orphan_child_pids)))
         lock_holder_pids = self.bounded_lock_holder_pids(
             name=name,
-            command=command,
+            child_pids=managed_child_pids,
             lock_files=lock_files,
             is_alive=alive,
         )
@@ -293,9 +310,57 @@ class DaemonProcessInventory:
             name=name,
             pid_file_pid=_read_pid(pid_file),
             live_wrapper_pids=live_wrappers,
-            live_managed_child_pids=child_pids,
+            canonical_child_pids=canonical_child_pids,
+            orphan_child_pids=orphan_child_pids,
             bounded_lock_holder_pids=lock_holder_pids,
+            process_inventory_status=self.status,
+            process_inventory_error=self.error,
         )
+
+    def canonical_child_pids(
+        self,
+        *,
+        wrapper_pids: Sequence[int],
+        is_alive=None,
+    ) -> tuple[int, ...]:
+        alive = is_alive or pid_alive
+        wrappers = set(wrapper_pids)
+        if not wrappers:
+            return ()
+        return tuple(
+            sorted(
+                {
+                    process.pid
+                    for process in self.processes
+                    if process.pid > 0
+                    and process.ppid in wrappers
+                    and alive(process.pid)
+                }
+            )
+        )
+
+    def orphan_child_pids(
+        self,
+        *,
+        name: str,
+        command: Sequence[str],
+        canonical_child_pids: Sequence[int],
+        is_alive=None,
+    ) -> tuple[int, ...]:
+        if name not in restart_managed_daemon_names() and name != SUPERVISOR_DAEMON_COMMAND[0]:
+            return ()
+        alive = is_alive or pid_alive
+        canonical = set(canonical_child_pids)
+        pids = []
+        for process in self.processes:
+            if process.pid <= 0 or not alive(process.pid):
+                continue
+            if process.pid in canonical or process.ppid != 1:
+                continue
+            if not _restart_daemon_command_matches(process.command, command):
+                continue
+            pids.append(process.pid)
+        return tuple(sorted(set(pids)))
 
     def live_managed_children(
         self,
@@ -304,34 +369,29 @@ class DaemonProcessInventory:
         command: Sequence[str],
         is_alive=None,
     ) -> tuple[int, ...]:
-        if name not in restart_managed_daemon_names() and name != SUPERVISOR_DAEMON_COMMAND[0]:
-            return ()
-        alive = is_alive or pid_alive
-        pids = []
-        for process in self.processes:
-            if process.pid <= 0 or not alive(process.pid):
-                continue
-            if not ManagedChildCommandShape.matches(process.command, command):
-                continue
-            pids.append(process.pid)
-        return tuple(sorted(set(pids)))
+        return self.orphan_child_pids(
+            name=name,
+            command=command,
+            canonical_child_pids=(),
+            is_alive=is_alive,
+        )
 
     def bounded_lock_holder_pids(
         self,
         *,
         name: str,
-        command: Sequence[str],
+        child_pids: Sequence[int],
         lock_files: Sequence[Path],
         is_alive=None,
     ) -> tuple[int, ...]:
         if name not in restart_managed_daemon_names() and name != SUPERVISOR_DAEMON_COMMAND[0]:
             return ()
         alive = is_alive or pid_alive
-        child_pids = set(self.live_managed_children(name=name, command=command, is_alive=alive))
+        child_pid_set = set(child_pids)
         holders = []
         for lock_file in lock_files:
             holder = _read_lock_holder_pid(lock_file)
-            if holder is None or holder not in child_pids or not alive(holder):
+            if holder is None or holder not in child_pid_set or not alive(holder):
                 continue
             holders.append(holder)
         return tuple(sorted(set(holders)))
@@ -354,7 +414,6 @@ class DaemonProcessInventory:
             command=command,
             is_alive=is_alive,
         )
-
 
 @dataclass(frozen=True)
 class ManagedChildCommandShape:
@@ -960,12 +1019,12 @@ def _parse_process_inventory(stdout: str) -> list[DaemonProcess]:
         if not stripped:
             continue
         try:
-            raw_pid, command = stripped.split(None, 1)
+            raw_pid, raw_ppid, command = stripped.split(None, 2)
         except ValueError:
             continue
-        if not raw_pid.isdigit():
+        if not raw_pid.isdigit() or not raw_ppid.isdigit():
             continue
-        processes.append(DaemonProcess(int(raw_pid), command))
+        processes.append(DaemonProcess(int(raw_pid), command, int(raw_ppid)))
     return processes
 
 

--- a/skills/consensus-loop/scripts/test_anti_stop_restart_helper_contract.py
+++ b/skills/consensus-loop/scripts/test_anti_stop_restart_helper_contract.py
@@ -95,6 +95,8 @@ class AntiStopRestartHelperContractTests(unittest.TestCase):
             "RestartWrapperShape",
             "ManagedChildCommandShape",
             "live_restart_wrappers",
+            "canonical_child_pids",
+            "orphan_child_pids",
             "live_managed_children",
             "bounded_lock_holder_pids",
             "daemon_lock_files",

--- a/skills/consensus-loop/scripts/test_daemon_status.py
+++ b/skills/consensus-loop/scripts/test_daemon_status.py
@@ -152,7 +152,7 @@ class DaemonStatusProjectionTests(unittest.TestCase):
             json.dumps({"active_controller": "owner"}) + "\n",
             encoding="utf-8",
         )
-        inventory = restart.DaemonProcessInventory((restart.DaemonProcess(789, " ".join(target.command)),))
+        inventory = restart.DaemonProcessInventory((restart.DaemonProcess(789, " ".join(target.command), 1),))
 
         with mock.patch.dict(os.environ, env, clear=True):
             with mock.patch("codex_refactor_loop.daemon_status.DaemonProcessInventory.collect", return_value=inventory):
@@ -164,9 +164,102 @@ class DaemonStatusProjectionTests(unittest.TestCase):
         self.assertEqual("stale", daemon["status"])
         self.assertEqual("orphan-lock-holders:1", daemon["stale_reason"])
         self.assertEqual([789], daemon["managed_child_pids"])
+        self.assertEqual([], daemon["canonical_child_pids"])
+        self.assertEqual([789], daemon["orphan_child_pids"])
         self.assertEqual([789], daemon["bounded_lock_holder_pids"])
+        self.assertNotIn("orphan_managed_child_pids", daemon)
         self.assertEqual("999\n", pid.read_text(encoding="utf-8"))
         self.assertEqual("pid=789\n", lock_file.read_text(encoding="utf-8"))
+
+    def test_macos_wrapper_child_is_running_canonical_child_projection(self) -> None:
+        env = {"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}
+        ctx = LoopContext.load(
+            repo_root=self.tmp,
+            skill_root=SCRIPT_DIR.parent,
+            read_only=True,
+            env=env,
+        )
+        target = restart.daemon_target(
+            ctx,
+            "phase9_router_daemon",
+            ("python3", "{skill_root}/scripts/consensus-rnd-cli", "phase9-router", "--daemon", "--interval", "120"),
+        )
+        heartbeat = self.tmp / ".refactor-loop" / "heartbeats" / "phase9_router_daemon.ts"
+        heartbeat.parent.mkdir(parents=True, exist_ok=True)
+        heartbeat.write_text("1000\n", encoding="utf-8")
+        pid = self.tmp / ".refactor-loop" / "locks" / "phase9_router_daemon.pid"
+        pid.parent.mkdir(parents=True, exist_ok=True)
+        pid.write_text("848\n", encoding="utf-8")
+        fingerprint = restart.DaemonLaunchFingerprint.current(
+            ctx,
+            "phase9_router_daemon",
+            target.command,
+        )
+        fingerprint.write(self.tmp / ".refactor-loop" / "locks" / "phase9_router_daemon.fingerprint.json")
+        wrapper_command = " ".join(
+            (
+                sys.executable,
+                "-c",
+                restart.WRAPPER_CODE,
+                "phase9_router_daemon",
+                str(ctx.repo_root),
+                str(target.pid_file),
+                str(target.died_file),
+                *target.command,
+            )
+        )
+        inventory = restart.DaemonProcessInventory(
+            (
+                restart.DaemonProcess(848, wrapper_command, 1),
+                restart.DaemonProcess(857, "python3 /tmp/old/consensus-rnd-cli phase9-router --daemon", 848),
+            )
+        )
+        (self.tmp / ".refactor-loop" / "state" / "active-controller-status.json").write_text(
+            json.dumps({"active_controller": "owner"}) + "\n",
+            encoding="utf-8",
+        )
+
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch("codex_refactor_loop.daemon_status.DaemonProcessInventory.collect", return_value=inventory):
+                with mock.patch("codex_refactor_loop.restart.time.time", return_value=1001):
+                    with mock.patch("codex_refactor_loop.daemon_status.pid_alive", side_effect=lambda candidate: candidate in {848, 857}):
+                        report = daemon_status.collect(repo_root=self.tmp, skill_root=SCRIPT_DIR.parent)
+
+        daemon = next(item for item in report.to_json()["daemons"] if item["name"] == "phase9_router_daemon")
+        self.assertEqual("running", daemon["status"])
+        self.assertEqual([857], daemon["managed_child_pids"])
+        self.assertEqual([857], daemon["canonical_child_pids"])
+        self.assertEqual([], daemon["orphan_child_pids"])
+        self.assertEqual([], daemon["bounded_lock_holder_pids"])
+        self.assertEqual("available", daemon["process_inventory_status"])
+        self.assertEqual("", daemon["process_inventory_error"])
+        self.assertNotIn("orphan_managed_child_pids", daemon)
+
+    def test_inventory_collection_failure_is_stale_with_diagnostic_fields(self) -> None:
+        env = {"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}
+        heartbeat = self.tmp / ".refactor-loop" / "heartbeats" / "concurrency_monitor.ts"
+        heartbeat.parent.mkdir(parents=True, exist_ok=True)
+        heartbeat.write_text("1000\n", encoding="utf-8")
+        pid = self.tmp / ".refactor-loop" / "locks" / "concurrency_monitor.pid"
+        pid.parent.mkdir(parents=True, exist_ok=True)
+        pid.write_text("123\n", encoding="utf-8")
+        (self.tmp / ".refactor-loop" / "state" / "active-controller-status.json").write_text(
+            json.dumps({"active_controller": "owner"}) + "\n",
+            encoding="utf-8",
+        )
+        inventory = restart.DaemonProcessInventory((), status="unavailable", error="ps denied")
+
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch("codex_refactor_loop.daemon_status.DaemonProcessInventory.collect", return_value=inventory):
+                with mock.patch("codex_refactor_loop.restart.time.time", return_value=1001):
+                    with mock.patch("codex_refactor_loop.daemon_status.pid_alive", return_value=True):
+                        report = daemon_status.collect(repo_root=self.tmp, skill_root=SCRIPT_DIR.parent)
+
+        daemon = next(item for item in report.to_json()["daemons"] if item["name"] == "concurrency_monitor")
+        self.assertEqual("stale", daemon["status"])
+        self.assertEqual("process-inventory-unavailable:ps denied", daemon["stale_reason"])
+        self.assertEqual("unavailable", daemon["process_inventory_status"])
+        self.assertEqual("ps denied", daemon["process_inventory_error"])
 
 
 if __name__ == "__main__":

--- a/skills/consensus-loop/scripts/test_restart_daemons.py
+++ b/skills/consensus-loop/scripts/test_restart_daemons.py
@@ -42,6 +42,13 @@ class FakeWrapper:
     pid: int
 
 
+@dataclass
+class FakeCommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
 class FakeChild:
     def __init__(
         self,
@@ -107,7 +114,7 @@ class FakeRestartDaemonRuntime:
         if self.inventory_override is not None:
             return self.inventory_override
         return DaemonProcessInventory(
-            tuple(DaemonProcess(pid, command) for pid, command in sorted(self.wrapper_commands.items()))
+            tuple(DaemonProcess(pid, command, 1) for pid, command in sorted(self.wrapper_commands.items()))
         )
 
     def terminate_pid(self, pid: int, grace: int) -> None:
@@ -643,7 +650,7 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         command = self.runtime.canonical_command(self.ctx, "concurrency_monitor", FAKE_COMMAND)
         self.runtime.live_pids.update(duplicate_pids)
         full_inventory = list(self.runtime.collect_inventory().processes)
-        full_inventory.extend(DaemonProcess(pid, command) for pid in duplicate_pids)
+        full_inventory.extend(DaemonProcess(pid, command, 1) for pid in duplicate_pids)
         self.runtime.inventory_override = DaemonProcessInventory(
             tuple(full_inventory)
         )
@@ -666,7 +673,7 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         self.runtime.live_pids.discard(old_wrapper_pid)
         self.runtime.wrapper_commands.pop(old_wrapper_pid, None)
         self.runtime.live_pids.add(orphan_child_pid)
-        self.runtime.inventory_override = DaemonProcessInventory((DaemonProcess(orphan_child_pid, " ".join(target.command)),))
+        self.runtime.inventory_override = DaemonProcessInventory((DaemonProcess(orphan_child_pid, " ".join(target.command), 1),))
 
         helper = RestartDaemons(self.ctx, self.config, runtime=self.runtime)
         helper.start_daemon("phase9_router_daemon", FAKE_COMMAND)
@@ -682,9 +689,9 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         non_allowlist = self.runtime.canonical_command(self.ctx, "not_allowlisted", FAKE_COMMAND)
         inventory = DaemonProcessInventory(
             (
-                DaemonProcess(111, command),
-                DaemonProcess(222, other_repo),
-                DaemonProcess(333, non_allowlist),
+                DaemonProcess(111, command, 1),
+                DaemonProcess(222, other_repo, 1),
+                DaemonProcess(333, non_allowlist, 1),
             )
         )
         self.runtime.live_pids.update({111, 222, 333})
@@ -709,10 +716,10 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         other_lock.write_text("333\n", encoding="utf-8")
         inventory = DaemonProcessInventory(
             (
-                DaemonProcess(111, wrapper_command),
-                DaemonProcess(222, " ".join(target.command)),
-                DaemonProcess(333, " ".join(target.command)),
-                DaemonProcess(444, "python3 unrelated.py"),
+                DaemonProcess(111, wrapper_command, 1),
+                DaemonProcess(222, " ".join(target.command), 111),
+                DaemonProcess(333, " ".join(target.command), 1),
+                DaemonProcess(444, "python3 unrelated.py", 1),
             )
         )
         self.runtime.live_pids.update({111, 222, 333, 444})
@@ -728,9 +735,112 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         )
 
         self.assertEqual((111,), projection.live_wrapper_pids)
+        self.assertEqual((222,), projection.canonical_child_pids)
+        self.assertEqual((333,), projection.orphan_child_pids)
         self.assertEqual((222, 333), projection.live_managed_child_pids)
         self.assertEqual((222,), projection.bounded_lock_holder_pids)
         self.assertEqual((111, 222), projection.repair_pids)
+
+    def test_daemon_instance_detects_macos_shaped_wrapper_child_by_ppid(self) -> None:
+        target = restart.daemon_target(self.ctx, "phase9_router_daemon", FAKE_COMMAND)
+        wrapper_command = self.runtime.canonical_command(self.ctx, "phase9_router_daemon", FAKE_COMMAND)
+        inventory = DaemonProcessInventory(
+            (
+                DaemonProcess(848, wrapper_command, 1),
+                DaemonProcess(857, " ".join(("python3", "/different/install/consensus-rnd-cli", "phase9-router", "--daemon")), 848),
+            )
+        )
+        self.runtime.live_pids.update({848, 857})
+
+        projection = inventory.daemon_instance(
+            name="phase9_router_daemon",
+            repo_root=self.ctx.repo_root,
+            pid_file=target.pid_file,
+            died_file=target.died_file,
+            command=target.command,
+            lock_files=(),
+            is_alive=self.runtime.pid_alive,
+        )
+
+        self.assertEqual((848,), projection.live_wrapper_pids)
+        self.assertEqual((857,), projection.canonical_child_pids)
+        self.assertEqual((), projection.orphan_child_pids)
+        self.assertEqual((857,), projection.live_managed_child_pids)
+
+    def test_process_inventory_collect_parses_pid_ppid_and_command_rows(self) -> None:
+        calls: list[list[str]] = []
+
+        def runner(command: list[str]) -> FakeCommandResult:
+            calls.append(command)
+            return FakeCommandResult(
+                returncode=0,
+                stdout=(
+                    " 848     1 "
+                    "/usr/bin/python3 -c wrapper phase9_router_daemon /repo /pid /died python3 cli\n"
+                    " 857   848 python3 /tmp/consensus-rnd-cli "
+                    "phase9-router --daemon\n"
+                ),
+            )
+
+        inventory = DaemonProcessInventory.collect(command_runner=runner)
+
+        self.assertEqual([["ps", "-eo", "pid=,ppid=,command="]], calls)
+        self.assertEqual("available", inventory.status)
+        self.assertEqual("", inventory.error)
+        self.assertEqual(
+            (
+                DaemonProcess(
+                    848,
+                    "/usr/bin/python3 -c wrapper phase9_router_daemon /repo /pid /died python3 cli",
+                    1,
+                ),
+                DaemonProcess(
+                    857,
+                    "python3 /tmp/consensus-rnd-cli " + "phase9-router --daemon",
+                    848,
+                ),
+            ),
+            inventory.processes,
+        )
+
+    def test_process_inventory_collect_ignores_malformed_pid_or_ppid_rows(self) -> None:
+        def runner(_command: list[str]) -> FakeCommandResult:
+            return FakeCommandResult(
+                returncode=0,
+                stdout=(
+                    " 111 1 python3 good.py\n"
+                    "not-a-pid 1 python3 bad.py\n"
+                    "222 not-a-ppid python3 bad.py\n"
+                    "333\n"
+                    "444 1\n"
+                    "\n"
+                ),
+            )
+
+        inventory = DaemonProcessInventory.collect(command_runner=runner)
+
+        self.assertEqual((DaemonProcess(111, "python3 good.py", 1),), inventory.processes)
+        self.assertEqual("available", inventory.status)
+
+    def test_process_inventory_collect_nonzero_result_is_unavailable_with_diagnostic(self) -> None:
+        def runner(_command: list[str]) -> FakeCommandResult:
+            return FakeCommandResult(returncode=2, stderr="ps denied\n")
+
+        inventory = DaemonProcessInventory.collect(command_runner=runner)
+
+        self.assertEqual((), inventory.processes)
+        self.assertEqual("unavailable", inventory.status)
+        self.assertEqual("ps denied", inventory.error)
+
+    def test_process_inventory_collect_runner_exception_is_unavailable_with_diagnostic(self) -> None:
+        def runner(_command: list[str]) -> FakeCommandResult:
+            raise RuntimeError("ps exploded")
+
+        inventory = DaemonProcessInventory.collect(command_runner=runner)
+
+        self.assertEqual((), inventory.processes)
+        self.assertEqual("unavailable", inventory.status)
+        self.assertEqual("RuntimeError('ps exploded')", inventory.error)
 
     def test_restart_wrapper_matching_accepts_skill_root_and_command_normalization_variance(self) -> None:
         template = ("python3", "{skill_root}/scripts/consensus-rnd-cli", "phase9-router", "--daemon", "--interval", "120")
@@ -740,7 +850,7 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
             "/opt/old-skill/scripts/consensus-rnd-cli",
         )
         spaced_command = f"  {old_skill_command.replace(' ', '   ')}  "
-        inventory = DaemonProcessInventory((DaemonProcess(444, spaced_command),))
+        inventory = DaemonProcessInventory((DaemonProcess(444, spaced_command, 1),))
         self.runtime.live_pids.add(444)
 
         live = inventory.live_restart_wrappers(
@@ -757,7 +867,7 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
     def test_restart_wrapper_matching_rejects_unknown_daemon_even_with_matching_shape(self) -> None:
         command = self.runtime.canonical_command(self.ctx, "not_allowlisted", FAKE_COMMAND)
         target = restart.daemon_target(self.ctx, "concurrency_monitor", FAKE_COMMAND)
-        inventory = DaemonProcessInventory((DaemonProcess(555, command),))
+        inventory = DaemonProcessInventory((DaemonProcess(555, command, 1),))
         self.runtime.live_pids.add(555)
 
         live = inventory.live_restart_wrappers(
@@ -867,8 +977,8 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         self.runtime.live_pids.add(duplicate_pid)
         inventory = DaemonProcessInventory(
             (
-                DaemonProcess(old_pid, command),
-                DaemonProcess(duplicate_pid, command),
+                DaemonProcess(old_pid, command, 1),
+                DaemonProcess(duplicate_pid, command, 1),
             )
         )
 
@@ -894,7 +1004,7 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         self.runtime.live_pids.discard(old_pid)
         self.runtime.wrapper_commands.pop(old_pid, None)
         self.runtime.live_pids.add(orphan_child_pid)
-        inventory = DaemonProcessInventory((DaemonProcess(orphan_child_pid, " ".join(target.command)),))
+        inventory = DaemonProcessInventory((DaemonProcess(orphan_child_pid, " ".join(target.command), 1),))
 
         report = self.collect_status_with_fake_allowlist(inventory)
 
@@ -903,7 +1013,10 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         self.assertEqual("stale", daemon.status)
         self.assertEqual("orphan-lock-holders:1", daemon.stale_reason)
         self.assertEqual([orphan_child_pid], payload["managed_child_pids"])
+        self.assertEqual([], payload["canonical_child_pids"])
+        self.assertEqual([orphan_child_pid], payload["orphan_child_pids"])
         self.assertEqual([orphan_child_pid], payload["bounded_lock_holder_pids"])
+        self.assertNotIn("orphan_managed_child_pids", payload)
         self.assertEqual(old_pid, self.read_pid("phase9_router_daemon"))
         self.assert_start_count("phase9_router_daemon", 1)
 
@@ -949,6 +1062,8 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
             "expected_launch_fingerprint",
             "DaemonProcessInventory",
             "DaemonInstanceProjection",
+            "canonical_child_pids",
+            "orphan_child_pids",
             "live_managed_children",
             "bounded_lock_holder_pids",
             "_run_restart_wrapper",


### PR DESCRIPTION
### Release rollup

- Target: `auto-refact-dev` -> `dev`
- Integration branch ahead of review-base: `1` commits
- Range: `2c94198272ed..5be370e6d039`
- Related issues: #769

### Commit summary

- Project daemon child ownership from PPID inventory (#769)

### Merge policy

- After required checks are green, controller auto squash-merges; when `ROLLUP_AUTO_MERGE=manual`, wait for human review/merge.
- This PR is the release rollup singleton; when an open rollup already exists, controller only updates its head and body instead of opening another PR.

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
