### PR TITLE
Release rollup: integration ahead 1 commits (7616f1dbde55)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -342,7 +342,7 @@ class WakeupRunner:
         action_id = str(action.get("action_id") or "")
         if not action_id:
             return self._blocked(action, "missing_action_id")
-        if self._ledger_has(action):
+        if self._ledger_suppresses_retry(action):
             return self._record(RunnerResult(action_id, "skipped", "duplicate"), action)
         error = self._validate_action(action)
         if error:
@@ -366,6 +366,8 @@ class WakeupRunner:
             return self._blocked(action, f"exception:{exc}")
         status = "applied" if exit_code == 0 else "blocked"
         reason = "" if exit_code == 0 else f"helper_exit:{exit_code}"
+        if exit_code == 0 and controller_action == "dispatch_consensus_implementation":
+            self._append_consensus_implementation_dispatch_receipt(action)
         if exit_code != 0:
             self._append_pending_event(f"WAKEUP_RUNNER_HELPER_EXIT:{action_id}:{controller_action}:{exit_code}")
         return self._record(RunnerResult(action_id, status, reason), action)
@@ -1806,7 +1808,7 @@ class WakeupRunner:
         full = build_gh_argv(self.ctx.gh_repo_slug, command)
         return subprocess.run(full, cwd=str(self.ctx.repo_root), capture_output=True, text=True, check=False)
 
-    def _ledger_has(self, action: Mapping[str, Any]) -> bool:
+    def _ledger_suppresses_retry(self, action: Mapping[str, Any]) -> bool:
         action_id = str(action.get("action_id") or "")
         if not self.ledger_path.exists():
             return False
@@ -1821,20 +1823,96 @@ class WakeupRunner:
             if status == "dry-run":
                 return True
             if status == "applied":
-                if _is_remote_ci_red_dispatch(action):
-                    continue
-                if self._release_dispatch_stale_ledger_reason(action):
+                stale_release_reason = self._release_dispatch_stale_ledger_reason(action)
+                if stale_release_reason:
                     self._append_pending_event(
-                        f"WAKEUP_RUNNER_STALE_RELEASE_DISPATCH_LEDGER:{action_id}:{self._release_dispatch_stale_ledger_reason(action)}"
+                        f"WAKEUP_RUNNER_STALE_RELEASE_DISPATCH_LEDGER:{action_id}:{stale_release_reason}"
                     )
                     continue
                 stale_spawn_reason = self._applied_spawn_stale_reason(action)
                 if stale_spawn_reason:
                     self._append_pending_event(f"WAKEUP_RUNNER_STALE_SPAWN_LEDGER:{action_id}:{stale_spawn_reason}")
                     continue
-                return True
+                if self._applied_row_current_effect_suppresses_retry(action):
+                    return True
             if status == "blocked" and _terminal_blocked_reason(str(row.get("reason") or "")):
                 return True
+        return False
+
+    def _applied_row_current_effect_suppresses_retry(self, action: Mapping[str, Any]) -> bool:
+        controller_action = str(action.get("controller_action") or "")
+        if controller_action == "spawn_codex_harness_background":
+            return self._applied_spawn_stale_reason(action) == ""
+        if controller_action == "dispatch_release_candidate":
+            return self._release_dispatch_stale_ledger_reason(action) == ""
+        if controller_action == "dispatch_consensus_implementation":
+            return self._consensus_implementation_current_effect_suppresses_retry(action)
+        if controller_action == "publish_review_fix_output_from_action":
+            return self._publish_review_fix_current_effect_suppresses_retry(action)
+        if controller_action == "dispatch_reviewers":
+            return self._dispatch_reviewers_current_effect_suppresses_retry(action)
+        if _is_remote_ci_red_dispatch(action):
+            return False
+        return False
+
+    def _consensus_implementation_current_effect_suppresses_retry(self, action: Mapping[str, Any]) -> bool:
+        if consensus_implementation_suppressed_reason(dict(action), self.ctx.repo_root):
+            return True
+        receipt = self._consensus_implementation_dispatch_receipt(action)
+        try:
+            text = self.pending_events_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return False
+        return receipt in text.splitlines()
+
+    def _append_consensus_implementation_dispatch_receipt(self, action: Mapping[str, Any]) -> None:
+        self._append_pending_event(self._consensus_implementation_dispatch_receipt(action))
+
+    def _consensus_implementation_dispatch_receipt(self, action: Mapping[str, Any]) -> str:
+        action_id = str(action.get("action_id") or "")
+        target = action.get("target_number")
+        cluster_id = str(action.get("cluster_id") or "").strip()
+        return f"WAKEUP_RUNNER_CONSENSUS_IMPLEMENTATION_DISPATCHED:{target}:{cluster_id}:{action_id}"
+
+    def _publish_review_fix_current_effect_suppresses_retry(self, action: Mapping[str, Any]) -> bool:
+        target = action.get("target_number")
+        if not isinstance(target, int) or target <= 0:
+            return False
+        projected_head = str(action.get("head_sha") or "").strip()
+        live_head = self._pr_head_sha(target)
+        if not live_head:
+            return False
+        if projected_head and live_head != projected_head:
+            return True
+        worktree = self._review_fix_worktree(target)
+        if worktree is None:
+            return False
+        status = self.command_runner(["git", "-C", str(worktree), "status", "--porcelain"])
+        if status.returncode != 0:
+            return False
+        return not status.stdout.strip()
+
+    def _dispatch_reviewers_current_effect_suppresses_retry(self, action: Mapping[str, Any]) -> bool:
+        target = action.get("target_number")
+        if not isinstance(target, int) or target <= 0:
+            return False
+        marker = str(action.get("source_marker") or "")
+        if marker.startswith("FIX_DONE:"):
+            return self._publish_review_fix_current_effect_suppresses_retry(action)
+        if action.get("kind") == "review-evidence-redispatch" or action.get("stale_review_roles"):
+            projected_head = str(action.get("head_sha") or "").strip()
+            if not projected_head:
+                return False
+            gate = self._review_gate(target)
+            live_head = str(gate.get("live_head_sha") or "").strip()
+            if live_head and live_head != projected_head:
+                return True
+            stale_roles = action.get("stale_review_roles")
+            roles = [str(role) for role in stale_roles] if isinstance(stale_roles, list) else list(REQUIRED_REVIEW_ROLES)
+            heads = gate.get("heads_by_role")
+            if not isinstance(heads, Mapping):
+                return False
+            return all(str(heads.get(role) or "") == projected_head for role in roles)
         return False
 
     def _release_dispatch_stale_ledger_reason(self, action: Mapping[str, Any]) -> str:

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -22,6 +22,7 @@ from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.issue_decomposition import issue_decomposition_plan_file_digest
 from codex_refactor_loop import labels
 from codex_refactor_loop.cross_instance_stand_down import CrossInstanceAdmission
+from codex_refactor_loop.github_budget import reset_graphql_budget_cache
 from codex_refactor_loop.github_actor import GitHubActorAdmission
 from codex_refactor_loop.release.gate import canonical_digest, isoformat
 from codex_refactor_loop.wakeup_runner import (
@@ -277,6 +278,9 @@ class FakeReviewFixActions(FakeActions):
 
 class WakeupRunnerBehaviorTests(unittest.TestCase):
     def setUp(self) -> None:
+        reset_graphql_budget_cache()
+        self.graphql_headroom_patch = mock.patch("codex_refactor_loop.wakeup_runner.graphql_headroom_ok", return_value=True)
+        self.graphql_headroom_patch.start()
         self.tmp = tempfile.TemporaryDirectory()
         self.repo = Path(self.tmp.name)
         for rel in (".refactor-loop/state", ".refactor-loop/logs", ".refactor-loop/prompts", ".refactor-loop/runs"):
@@ -295,6 +299,8 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.tmp.cleanup()
+        self.graphql_headroom_patch.stop()
+        reset_graphql_budget_cache()
 
     def test_run_command_injects_gh_repo_only_in_valid_subcommand_position(self) -> None:
         calls: list[list[str]] = []
@@ -1572,6 +1578,71 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual([result.status for result in results], ["skipped", "applied"])
         self.assertEqual([result.action_id for result in results], ["spawn:duplicate", "spawn:later"])
         launch.assert_called_once()
+
+    def test_unsupported_applied_ledger_row_does_not_suppress_retry(self) -> None:
+        action = self.worker_output_action(action_id="safe-push:stale-applied-ledger")
+        ledger = self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl"
+        ledger.write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": "", "kind": "unpushed-worker-output"})
+            + "\n",
+            encoding="utf-8",
+        )
+        actions = FakeActions()
+
+        results = self.run_result(self.base_plan(action), actions=actions)
+
+        self.assertEqual(results[0].status, "applied")
+        self.assertEqual([call[0] for call in actions.calls], ["safe_push"])
+
+    def test_consensus_implementation_applied_row_retries_without_dispatch_effect(self) -> None:
+        action = self.consensus_action(action_id="consensus-implementation:stale-applied")
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": "", "kind": "completed-marker"})
+            + "\n",
+            encoding="utf-8",
+        )
+        actions = FakeActions()
+
+        results = self.run_result(self.base_plan(action), actions=actions)
+
+        self.assertEqual(results[0].status, "applied")
+        self.assertEqual([call[0] for call in actions.calls], ["dispatch_consensus_implementation"])
+
+    def test_consensus_implementation_success_records_dispatch_receipt_for_next_tick(self) -> None:
+        action = self.consensus_action(action_id="consensus-implementation:receipt-written")
+        actions = FakeActions()
+
+        first = self.run_result(self.base_plan(action), actions=actions)
+        second_actions = FakeActions()
+        second = self.run_result(self.base_plan(action), actions=second_actions)
+
+        receipt = "WAKEUP_RUNNER_CONSENSUS_IMPLEMENTATION_DISPATCHED:20:issue-20:consensus-implementation:receipt-written"
+        pending = (self.repo / ".refactor-loop/.controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertEqual(first[0].status, "applied")
+        self.assertIn(receipt, pending.splitlines())
+        self.assertEqual([call[0] for call in actions.calls], ["dispatch_consensus_implementation"])
+        self.assertEqual(second[0].status, "skipped")
+        self.assertEqual(second[0].reason, "duplicate")
+        self.assertEqual(second_actions.calls, [])
+
+    def test_consensus_implementation_applied_row_suppresses_after_dispatch_receipt(self) -> None:
+        action = self.consensus_action(action_id="consensus-implementation:receipt")
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": "", "kind": "completed-marker"})
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.repo / ".refactor-loop/.controller-pending-events.log").write_text(
+            "WAKEUP_RUNNER_CONSENSUS_IMPLEMENTATION_DISPATCHED:20:issue-20:consensus-implementation:receipt\n",
+            encoding="utf-8",
+        )
+        actions = FakeActions()
+
+        results = self.run_result(self.base_plan(action), actions=actions)
+
+        self.assertEqual(results[0].status, "skipped")
+        self.assertEqual(results[0].reason, "duplicate")
+        self.assertEqual(actions.calls, [])
 
     def test_wakeup_runner_missing_or_invalid_budget_keeps_single_apply_compatibility(self) -> None:
         cases = (
@@ -3393,6 +3464,179 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual(actions.calls[0][0], "safe_push")
         self.assertEqual(actions.calls[-1][0], "dispatch_reviewers")
 
+    def test_publish_review_fix_applied_row_retries_when_fix_worktree_dirty(self) -> None:
+        action = self.reviewer_dispatch_action(
+            action_id="publish-review-fix-output:77:dirty",
+            controller_action="publish_review_fix_output_from_action",
+            target_number=77,
+            head_sha="a" * 40,
+        )
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": "", "kind": "completed-marker"})
+            + "\n",
+            encoding="utf-8",
+        )
+        worktree = self.repo / ".worktrees" / "iter77-worker"
+        worktree.mkdir(parents=True, exist_ok=True)
+        actions = FakeActions()
+
+        def command_runner(command):
+            if command[:2] == ["gh", "api"]:
+                endpoint = str(command[2]) if len(command) > 2 else ""
+                if endpoint == "user":
+                    return subprocess.CompletedProcess(command, 0, json.dumps({"login": "current-user"}), "")
+                if endpoint.startswith("repos/owner/repo/collaborators/") and endpoint.endswith("/permission"):
+                    return subprocess.CompletedProcess(command, 0, json.dumps({"permission": "write"}), "")
+                if "/pulls/" in endpoint:
+                    return subprocess.CompletedProcess(command, 0, json.dumps({"state": "open"}), "")
+                return subprocess.CompletedProcess(command, 0, "{}", "")
+            if command[:3] == ["gh", "pr", "view"]:
+                if "headRefOid" in command or ".headRefOid" in command:
+                    return subprocess.CompletedProcess(command, 0, "a" * 40 + "\n", "")
+                if "headRefName" in command:
+                    if "--jq" not in command:
+                        return subprocess.CompletedProcess(command, 0, json.dumps({"headRefName": "refactor/iter77-worker"}), "")
+                    return subprocess.CompletedProcess(command, 0, "refactor/iter77-worker\n", "")
+                return subprocess.CompletedProcess(command, 0, "OPEN\n", "")
+            if command[:2] == ["git", "-C"] and command[3:] == ["worktree", "list", "--porcelain"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    f"worktree {self.repo}\nbranch refs/heads/auto-refact-dev\n\n"
+                    f"worktree {worktree}\nbranch refs/heads/refactor/iter77-worker\n\n",
+                    "",
+                )
+            if command[:2] == ["git", "-C"] and command[3:] == ["status", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, " M skills/x.py\n", "")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        runner = WakeupRunner(
+            self.ctx,
+            plan_loader=lambda _repo: self.base_plan(action),
+            actions=actions,
+            supervisor=self.supervisor,
+            command_runner=command_runner,
+        )
+
+        results = runner.run_once()
+
+        self.assertEqual(results[0].status, "applied")
+        self.assertEqual([call[0] for call in actions.calls], ["safe_push", "dispatch_reviewers"])
+
+    def test_publish_review_fix_applied_row_retries_when_live_pr_head_unknown(self) -> None:
+        action = self.reviewer_dispatch_action(
+            action_id="publish-review-fix-output:77:unknown-head",
+            controller_action="publish_review_fix_output_from_action",
+            target_number=77,
+            head_sha="a" * 40,
+        )
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": "", "kind": "completed-marker"})
+            + "\n",
+            encoding="utf-8",
+        )
+        worktree = self.repo / ".worktrees" / "iter77-worker"
+        worktree.mkdir(parents=True, exist_ok=True)
+
+        def command_runner(command):
+            if command[:3] == ["gh", "pr", "view"]:
+                if "headRefOid" in command or ".headRefOid" in command:
+                    return subprocess.CompletedProcess(command, 1, "", "not found")
+                if "headRefName" in command:
+                    if "--jq" not in command:
+                        return subprocess.CompletedProcess(command, 0, json.dumps({"headRefName": "refactor/iter77-worker"}), "")
+                    return subprocess.CompletedProcess(command, 0, "refactor/iter77-worker\n", "")
+                return subprocess.CompletedProcess(command, 0, "OPEN\n", "")
+            if command[:2] == ["gh", "api"]:
+                endpoint = str(command[2]) if len(command) > 2 else ""
+                if endpoint == "user":
+                    return subprocess.CompletedProcess(command, 0, json.dumps({"login": "current-user"}), "")
+                if endpoint.startswith("repos/owner/repo/collaborators/") and endpoint.endswith("/permission"):
+                    return subprocess.CompletedProcess(command, 0, json.dumps({"permission": "write"}), "")
+                if "/pulls/" in endpoint:
+                    return subprocess.CompletedProcess(command, 0, json.dumps({"state": "open"}), "")
+                return subprocess.CompletedProcess(command, 0, "{}", "")
+            if command[:2] == ["git", "-C"] and command[3:] == ["worktree", "list", "--porcelain"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    f"worktree {self.repo}\nbranch refs/heads/auto-refact-dev\n\n"
+                    f"worktree {worktree}\nbranch refs/heads/refactor/iter77-worker\n\n",
+                    "",
+                )
+            if command[:2] == ["git", "-C"] and command[3:] == ["status", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, " M skills/x.py\n", "")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        actions = FakeActions()
+        runner = WakeupRunner(
+            self.ctx,
+            plan_loader=lambda _repo: self.base_plan(action),
+            actions=actions,
+            supervisor=self.supervisor,
+            command_runner=command_runner,
+        )
+
+        results = runner.run_once()
+
+        self.assertEqual(results[0].status, "applied")
+        self.assertEqual([call[0] for call in actions.calls], ["safe_push", "dispatch_reviewers"])
+
+    def test_publish_review_fix_applied_row_suppresses_after_clean_worktree(self) -> None:
+        action = self.reviewer_dispatch_action(
+            action_id="publish-review-fix-output:77:clean",
+            controller_action="publish_review_fix_output_from_action",
+            target_number=77,
+            head_sha="a" * 40,
+        )
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": "", "kind": "completed-marker"})
+            + "\n",
+            encoding="utf-8",
+        )
+        worktree = self.repo / ".worktrees" / "iter77-worker"
+        worktree.mkdir(parents=True, exist_ok=True)
+        actions = FakeActions()
+
+        results = self.run_result(self.base_plan(action), implementation_status="", actions=actions)
+
+        self.assertEqual(results[0].status, "skipped")
+        self.assertEqual(results[0].reason, "duplicate")
+        self.assertEqual(actions.calls, [])
+
+    def test_publish_review_fix_applied_row_suppresses_after_live_head_advanced(self) -> None:
+        action = self.reviewer_dispatch_action(
+            action_id="publish-review-fix-output:77:advanced",
+            controller_action="publish_review_fix_output_from_action",
+            target_number=77,
+            head_sha="a" * 40,
+        )
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": "", "kind": "completed-marker"})
+            + "\n",
+            encoding="utf-8",
+        )
+        actions = FakeActions()
+
+        def command_runner(command):
+            if command[:3] == ["gh", "pr", "view"] and ("headRefOid" in command or ".headRefOid" in command):
+                return subprocess.CompletedProcess(command, 0, "b" * 40 + "\n", "")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        runner = WakeupRunner(
+            self.ctx,
+            plan_loader=lambda _repo: self.base_plan(action),
+            actions=actions,
+            supervisor=self.supervisor,
+            command_runner=command_runner,
+        )
+
+        results = runner.run_once()
+
+        self.assertEqual(results[0].status, "skipped")
+        self.assertEqual(results[0].reason, "duplicate")
+        self.assertEqual(actions.calls, [])
+
     def test_publish_implementation_output_routes_to_named_helper(self) -> None:
         actions = FakeActions()
 
@@ -4105,6 +4349,125 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual(results[0].status, "applied")
         self.assertEqual(actions.calls[0][0], "dispatch_reviewers")
         self.assertEqual(actions.calls[0][1]["stale_review_roles"], ["architect", "tests"])
+
+    def test_stale_review_dispatch_applied_row_retries_when_evidence_still_stale(self) -> None:
+        for role in ("architect", "tests"):
+            (self.repo / ".refactor-loop/prompts" / f"review-pr77-{role}-r1.md").write_text(
+                "reviewed-head-sha: " + "b" * 40 + "\n",
+                encoding="utf-8",
+            )
+            (self.repo / ".refactor-loop/runs" / f"review-pr77-{role}-r1.md").write_text(
+                f"---\nverdict: approve\n---\nREVIEW_DONE:77:{role}:approve\n",
+                encoding="utf-8",
+            )
+            (self.repo / ".refactor-loop/logs" / f"review-pr77-{role}-r1.log").write_text(
+                f"REVIEW_DONE:77:{role}:approve\nEXIT=0\n",
+                encoding="utf-8",
+            )
+        action = self.reviewer_dispatch_action(
+            kind="review-evidence-redispatch",
+            action_id="review-evidence-redispatch:77:" + "a" * 40,
+            source_artifact="wakeup-plan",
+            source_marker="review-evidence-redispatch",
+            head_sha="a" * 40,
+            stale_review_roles=["architect", "tests"],
+            preconditions=[
+                "active_controller_owner",
+                "live_open_target_if_present",
+                "missing_or_stale_reviewer_head_evidence",
+            ],
+        )
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": "", "kind": "review-evidence-redispatch"})
+            + "\n",
+            encoding="utf-8",
+        )
+        actions = FakeActions()
+
+        results = self.run_result(self.base_plan(action), actions=actions)
+
+        self.assertEqual(results[0].status, "applied")
+        self.assertEqual(actions.calls[0][0], "dispatch_reviewers")
+
+    def test_stale_review_dispatch_applied_row_suppresses_after_target_roles_current(self) -> None:
+        for role in ("architect", "tests"):
+            (self.repo / ".refactor-loop/prompts" / f"review-pr77-{role}-r2.md").write_text(
+                "reviewed-head-sha: " + "a" * 40 + "\n",
+                encoding="utf-8",
+            )
+            (self.repo / ".refactor-loop/runs" / f"review-pr77-{role}-r2.md").write_text(
+                f"---\nverdict: approve\n---\nREVIEW_DONE:77:{role}:approve\n",
+                encoding="utf-8",
+            )
+            (self.repo / ".refactor-loop/logs" / f"review-pr77-{role}-r2.log").write_text(
+                f"REVIEW_DONE:77:{role}:approve\nEXIT=0\n",
+                encoding="utf-8",
+            )
+        action = self.reviewer_dispatch_action(
+            kind="review-evidence-redispatch",
+            action_id="review-evidence-redispatch:77:" + "a" * 40,
+            source_artifact="wakeup-plan",
+            source_marker="review-evidence-redispatch",
+            head_sha="a" * 40,
+            stale_review_roles=["architect", "tests"],
+            preconditions=[
+                "active_controller_owner",
+                "live_open_target_if_present",
+                "missing_or_stale_reviewer_head_evidence",
+            ],
+        )
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": "", "kind": "review-evidence-redispatch"})
+            + "\n",
+            encoding="utf-8",
+        )
+        actions = FakeActions()
+
+        results = self.run_result(self.base_plan(action), actions=actions)
+
+        self.assertEqual(results[0].status, "skipped")
+        self.assertEqual(results[0].reason, "duplicate")
+        self.assertEqual(actions.calls, [])
+
+    def test_stale_review_dispatch_applied_row_suppresses_after_live_head_advanced(self) -> None:
+        action = self.reviewer_dispatch_action(
+            kind="review-evidence-redispatch",
+            action_id="review-evidence-redispatch:77:" + "a" * 40,
+            source_artifact="wakeup-plan",
+            source_marker="review-evidence-redispatch",
+            head_sha="a" * 40,
+            stale_review_roles=["architect", "tests"],
+            preconditions=[
+                "active_controller_owner",
+                "live_open_target_if_present",
+                "missing_or_stale_reviewer_head_evidence",
+            ],
+        )
+        (self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl").write_text(
+            json.dumps({"action_id": action["action_id"], "status": "applied", "reason": "", "kind": "review-evidence-redispatch"})
+            + "\n",
+            encoding="utf-8",
+        )
+        actions = FakeActions()
+
+        def command_runner(command):
+            if command[:3] == ["gh", "pr", "view"] and ".headRefOid" in command:
+                return subprocess.CompletedProcess(command, 0, "b" * 40 + "\n", "")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        runner = WakeupRunner(
+            self.ctx,
+            plan_loader=lambda _repo: self.base_plan(action),
+            actions=actions,
+            supervisor=self.supervisor,
+            command_runner=command_runner,
+        )
+
+        results = runner.run_once()
+
+        self.assertEqual(results[0].status, "skipped")
+        self.assertEqual(results[0].reason, "duplicate")
+        self.assertEqual(actions.calls, [])
 
     def test_dispatch_reviewers_blocks_missing_or_non_pr_target_before_helper(self) -> None:
         cases = (


### PR DESCRIPTION
### Release rollup

- Target: `auto-refact-dev` -> `dev`
- Integration branch ahead of review-base: `1` commits
- Range: `34752c46ae92..7616f1dbde55`
- Related issues: #774

### Commit summary

- Require current effects before suppressing wakeup retries (#774)

### Merge policy

- After required checks are green, controller auto squash-merges; when `ROLLUP_AUTO_MERGE=manual`, wait for human review/merge.
- This PR is the release rollup singleton; when an open rollup already exists, controller only updates its head and body instead of opening another PR.

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
