### PR TITLE
Release rollup: integration ahead 5 commits (5ce21c5ea3de)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -51,7 +51,9 @@ from .secondary_mutation_backoff import (
 from .triage import apply_decision, load_triage_apply_config
 from .work_items import extract_closing_issue_numbers
 from .wakeup_plan import (
+    archived_invalid_harness_spawn_intent_markers,
     consensus_implementation_suppressed_reason,
+    live_valid_harness_spawn_intent,
     validate_harness_spawn_intent,
     zero_code_implementation_completion_proven,
 )
@@ -1623,6 +1625,7 @@ class ControllerActions:
             lines = self.ctx.paths.pending_events.read_text(encoding="utf-8", errors="replace").splitlines()
         except OSError:
             return False
+        archived_invalid_markers = archived_invalid_harness_spawn_intent_markers(lines)
         intent_id = f"dispatch-reviewers:{pr_target}:{role}:r{round_number}"
         for line in lines:
             if " HARNESS_SPAWN_INTENT " not in line:
@@ -1631,7 +1634,11 @@ class ControllerActions:
                 intent = json.loads(line.split(" HARNESS_SPAWN_INTENT ", 1)[1])
             except json.JSONDecodeError:
                 continue
-            if isinstance(intent, dict) and intent.get("intent_id") == intent_id:
+            if not isinstance(intent, dict):
+                continue
+            if not live_valid_harness_spawn_intent(self.ctx, line, intent, archived_invalid_markers):
+                continue
+            if intent.get("intent_id") == intent_id:
                 return True
         return False
 

--- a/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -50,7 +50,11 @@ from .secondary_mutation_backoff import (
 )
 from .triage import apply_decision, load_triage_apply_config
 from .work_items import extract_closing_issue_numbers
-from .wakeup_plan import consensus_implementation_suppressed_reason, zero_code_implementation_completion_proven
+from .wakeup_plan import (
+    consensus_implementation_suppressed_reason,
+    validate_harness_spawn_intent,
+    zero_code_implementation_completion_proven,
+)
 from .workflow_spec import WorkflowSpecError, load_validated_workflow_spec
 
 
@@ -2070,9 +2074,11 @@ class ControllerActions:
             "log": self.ctx.durable_artifact_path(log),
             "stall": stall,
             "reason": reason,
+            "queued_at": self._now(),
             "run_in_background_required": True,
             "no_lifecycle_authority": True,
         }
+        validate_harness_spawn_intent(self.ctx, intent)
         self._append_pending_event(
             f"{self._now()} HARNESS_SPAWN_INTENT {json.dumps(intent, ensure_ascii=False, sort_keys=True)}"
         )

--- a/skills/consensus-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -32,8 +32,8 @@ from ..state import read_json, write_json
 from ..task_spawn_claim import TaskSpawnClaimError, safe_task_id_from_task
 from ..update_check import parse_time
 from ..wakeup_plan import (
-    ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER,
-    harness_spawn_intent_line_digest,
+    archived_invalid_harness_spawn_intent_markers,
+    harness_spawn_intent_line_is_archived_invalid,
     validate_harness_spawn_intent,
 )
 from ..work_items import ManagedWorkProjection, has_open_actionable_managed_work, is_draft_release_rollup_pr
@@ -693,7 +693,7 @@ class ConcurrencyMonitor:
         zero_streak: int,
     ) -> tuple[bool, str, list[str]]:
         evidence: list[str] = []
-        archived_invalid_markers = self._archived_invalid_harness_spawn_intent_markers(lines)
+        archived_invalid_markers = archived_invalid_harness_spawn_intent_markers(lines)
         for line in lines:
             if " HARNESS_SPAWN_INTENT " not in line:
                 continue
@@ -701,11 +701,11 @@ class ConcurrencyMonitor:
             try:
                 payload = json.loads(payload_text)
             except json.JSONDecodeError:
-                if self._harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
+                if harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
                     continue
                 return False, "malformed-harness-spawn-intent", []
             if not isinstance(payload, dict):
-                if self._harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
+                if harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
                     continue
                 return False, "malformed-harness-spawn-intent", []
             created_at = self._line_time(ts)
@@ -713,7 +713,7 @@ class ConcurrencyMonitor:
                 return False, "malformed-harness-spawn-intent-ts", []
             validation_reason = self._harness_spawn_intent_validation_reason(payload)
             if validation_reason:
-                if self._harness_spawn_intent_line_is_archived_invalid(line, payload, archived_invalid_markers):
+                if harness_spawn_intent_line_is_archived_invalid(line, payload, archived_invalid_markers):
                     continue
                 return False, validation_reason, []
             if not self._intent_matches_active_target(payload, active_targets):
@@ -747,7 +747,7 @@ class ConcurrencyMonitor:
     ) -> HardGateTransientSupply:
         targets: list[str] = []
         evidence: list[str] = []
-        archived_invalid_markers = self._archived_invalid_harness_spawn_intent_markers(lines)
+        archived_invalid_markers = archived_invalid_harness_spawn_intent_markers(lines)
         for line in lines:
             if " HARNESS_SPAWN_INTENT " not in line:
                 continue
@@ -755,11 +755,11 @@ class ConcurrencyMonitor:
             try:
                 payload = json.loads(payload_text)
             except json.JSONDecodeError:
-                if self._harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
+                if harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
                     continue
                 return HardGateTransientSupply(0, (), (), "malformed-harness-spawn-intent")
             if not isinstance(payload, dict):
-                if self._harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
+                if harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
                     continue
                 return HardGateTransientSupply(0, (), (), "malformed-harness-spawn-intent")
             created_at = self._line_time(ts)
@@ -767,7 +767,7 @@ class ConcurrencyMonitor:
                 return HardGateTransientSupply(0, (), (), "malformed-harness-spawn-intent-ts")
             validation_reason = self._harness_spawn_intent_validation_reason(payload)
             if validation_reason:
-                if self._harness_spawn_intent_line_is_archived_invalid(line, payload, archived_invalid_markers):
+                if harness_spawn_intent_line_is_archived_invalid(line, payload, archived_invalid_markers):
                     continue
                 return HardGateTransientSupply(0, (), (), validation_reason)
             if payload.get("source") != "phase9-router":
@@ -794,30 +794,6 @@ class ConcurrencyMonitor:
                 return f"malformed-harness-spawn-intent:{detail}"
             return "malformed-harness-spawn-intent"
         return ""
-
-    def _archived_invalid_harness_spawn_intent_markers(self, lines: list[str]) -> tuple[str, ...]:
-        markers: list[str] = []
-        prefix = f"{ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER}:"
-        for line in lines:
-            if prefix not in line:
-                continue
-            tail = line.split(prefix, 1)[1].strip()
-            if tail:
-                markers.append(tail)
-        return tuple(markers)
-
-    def _harness_spawn_intent_line_is_archived_invalid(
-        self,
-        line: str,
-        payload: dict[str, object] | None,
-        archived_invalid_markers: tuple[str, ...],
-    ) -> bool:
-        identities = {harness_spawn_intent_line_digest(line)}
-        if payload is not None:
-            intent_id = payload.get("intent_id")
-            if isinstance(intent_id, str) and intent_id:
-                identities.add(intent_id)
-        return any(marker.startswith(f"{identity}:") or marker == identity for marker in archived_invalid_markers for identity in identities)
 
     def _phase9_ledger_intent_evidence(
         self,

--- a/skills/consensus-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -31,7 +31,11 @@ from ..safe_progress_scheduler import (
 from ..state import read_json, write_json
 from ..task_spawn_claim import TaskSpawnClaimError, safe_task_id_from_task
 from ..update_check import parse_time
-from ..wakeup_plan import validate_harness_spawn_intent
+from ..wakeup_plan import (
+    ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER,
+    harness_spawn_intent_line_digest,
+    validate_harness_spawn_intent,
+)
 from ..work_items import ManagedWorkProjection, has_open_actionable_managed_work, is_draft_release_rollup_pr
 from ..worker_markers import log_has_terminal_exit, read_worker_terminal_marker, read_worker_visible_terminal_marker
 
@@ -689,6 +693,7 @@ class ConcurrencyMonitor:
         zero_streak: int,
     ) -> tuple[bool, str, list[str]]:
         evidence: list[str] = []
+        archived_invalid_markers = self._archived_invalid_harness_spawn_intent_markers(lines)
         for line in lines:
             if " HARNESS_SPAWN_INTENT " not in line:
                 continue
@@ -696,14 +701,20 @@ class ConcurrencyMonitor:
             try:
                 payload = json.loads(payload_text)
             except json.JSONDecodeError:
+                if self._harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
+                    continue
                 return False, "malformed-harness-spawn-intent", []
             if not isinstance(payload, dict):
+                if self._harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
+                    continue
                 return False, "malformed-harness-spawn-intent", []
             created_at = self._line_time(ts)
             if created_at is None:
                 return False, "malformed-harness-spawn-intent-ts", []
             validation_reason = self._harness_spawn_intent_validation_reason(payload)
             if validation_reason:
+                if self._harness_spawn_intent_line_is_archived_invalid(line, payload, archived_invalid_markers):
+                    continue
                 return False, validation_reason, []
             if not self._intent_matches_active_target(payload, active_targets):
                 continue
@@ -736,6 +747,7 @@ class ConcurrencyMonitor:
     ) -> HardGateTransientSupply:
         targets: list[str] = []
         evidence: list[str] = []
+        archived_invalid_markers = self._archived_invalid_harness_spawn_intent_markers(lines)
         for line in lines:
             if " HARNESS_SPAWN_INTENT " not in line:
                 continue
@@ -743,14 +755,20 @@ class ConcurrencyMonitor:
             try:
                 payload = json.loads(payload_text)
             except json.JSONDecodeError:
+                if self._harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
+                    continue
                 return HardGateTransientSupply(0, (), (), "malformed-harness-spawn-intent")
             if not isinstance(payload, dict):
+                if self._harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
+                    continue
                 return HardGateTransientSupply(0, (), (), "malformed-harness-spawn-intent")
             created_at = self._line_time(ts)
             if created_at is None:
                 return HardGateTransientSupply(0, (), (), "malformed-harness-spawn-intent-ts")
             validation_reason = self._harness_spawn_intent_validation_reason(payload)
             if validation_reason:
+                if self._harness_spawn_intent_line_is_archived_invalid(line, payload, archived_invalid_markers):
+                    continue
                 return HardGateTransientSupply(0, (), (), validation_reason)
             if payload.get("source") != "phase9-router":
                 continue
@@ -776,6 +794,30 @@ class ConcurrencyMonitor:
                 return f"malformed-harness-spawn-intent:{detail}"
             return "malformed-harness-spawn-intent"
         return ""
+
+    def _archived_invalid_harness_spawn_intent_markers(self, lines: list[str]) -> tuple[str, ...]:
+        markers: list[str] = []
+        prefix = f"{ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER}:"
+        for line in lines:
+            if prefix not in line:
+                continue
+            tail = line.split(prefix, 1)[1].strip()
+            if tail:
+                markers.append(tail)
+        return tuple(markers)
+
+    def _harness_spawn_intent_line_is_archived_invalid(
+        self,
+        line: str,
+        payload: dict[str, object] | None,
+        archived_invalid_markers: tuple[str, ...],
+    ) -> bool:
+        identities = {harness_spawn_intent_line_digest(line)}
+        if payload is not None:
+            intent_id = payload.get("intent_id")
+            if isinstance(intent_id, str) and intent_id:
+                identities.add(intent_id)
+        return any(marker.startswith(f"{identity}:") or marker == identity for marker in archived_invalid_markers for identity in identities)
 
     def _phase9_ledger_intent_evidence(
         self,

--- a/skills/consensus-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -828,15 +828,28 @@ class Phase9Router:
         if not self.pending_events_path.exists():
             return logs
         try:
-            content = self.pending_events_path.read_text(encoding="utf-8", errors="replace")
+            lines = self.pending_events_path.read_text(encoding="utf-8", errors="replace").splitlines()
         except OSError:
             return logs
-        for line in content.splitlines():
+        from ..wakeup_plan import (
+            archived_invalid_harness_spawn_intent_markers,
+            harness_spawn_intent_line_is_archived_invalid,
+            live_valid_harness_spawn_intent,
+        )
+
+        archived_invalid_markers = archived_invalid_harness_spawn_intent_markers(lines)
+        for line in lines:
             if " HARNESS_SPAWN_INTENT " not in line:
+                continue
+            if harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
                 continue
             try:
                 event = json.loads(line.split(" HARNESS_SPAWN_INTENT ", 1)[1])
             except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            if not live_valid_harness_spawn_intent(self.ctx, line, event, archived_invalid_markers):
                 continue
             log = event.get("log")
             if isinstance(log, str):

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -925,6 +925,41 @@ def _invalid_harness_spawn_intent(reason: str, evidence: str, *, intent_id: str 
     }
 
 
+def archived_invalid_harness_spawn_intent_markers(lines: list[str]) -> tuple[str, ...]:
+    markers: list[str] = []
+    prefix = f"{ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER}:"
+    for line in lines:
+        if prefix not in line:
+            continue
+        tail = line.split(prefix, 1)[1].strip()
+        if tail:
+            markers.append(tail)
+    return tuple(markers)
+
+
+def harness_spawn_intent_line_is_archived_invalid(
+    line: str,
+    payload: Mapping[str, Any] | None,
+    archived_invalid_markers: tuple[str, ...],
+) -> bool:
+    identities = {harness_spawn_intent_line_digest(line)}
+    if payload is not None:
+        intent_id = payload.get("intent_id")
+        if isinstance(intent_id, str) and intent_id:
+            identities.add(intent_id)
+    return any(marker.startswith(f"{identity}:") or marker == identity for marker in archived_invalid_markers for identity in identities)
+
+
+def live_valid_harness_spawn_intent(ctx: LoopContext, line: str, intent: dict[str, Any], archived_invalid_markers: tuple[str, ...]) -> bool:
+    if harness_spawn_intent_line_is_archived_invalid(line, intent, archived_invalid_markers):
+        return False
+    try:
+        validate_harness_spawn_intent(ctx, intent)
+    except ValueError:
+        return False
+    return True
+
+
 def configured_floor() -> int:
     try:
         floor = int(os.environ.get("CODEX_FLOOR", "5"))
@@ -2347,12 +2382,15 @@ def valid_required_review_round_complete(repo_root: Path, pr_number: int, head_s
     return all(rounds.get(role, (0, ""))[1] == head_sha for role in REQUIRED_REVIEW_ROLES)
 
 
-def pending_review_spawn_exists(repo_root: Path, pr_number: int) -> bool:
+def pending_review_spawn_exists(repo_root: Path, pr_number: int, ctx: LoopContext | None = None) -> bool:
     pending_path = repo_root / ".refactor-loop" / ".controller-pending-events.log"
     try:
         lines = pending_path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
         return False
+    if ctx is None:
+        ctx = LoopContext.load(repo_root=repo_root, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}, cwd=repo_root, read_only=True)
+    archived_invalid_markers = archived_invalid_harness_spawn_intent_markers(lines)
     prefix = f"dispatch-reviewers:{pr_number}:"
     for line in lines:
         if " HARNESS_SPAWN_INTENT " not in line:
@@ -2362,6 +2400,8 @@ def pending_review_spawn_exists(repo_root: Path, pr_number: int) -> bool:
         except json.JSONDecodeError:
             continue
         if not isinstance(intent, dict):
+            continue
+        if not live_valid_harness_spawn_intent(ctx, line, intent, archived_invalid_markers):
             continue
         intent_id = str(intent.get("intent_id") or "")
         if not intent_id.startswith(prefix):
@@ -2387,7 +2427,7 @@ def review_evidence_redispatch_actions(repo_root: Path, gh_items: list[GhItem], 
         projection = label_catalog.normalize_label_set(item.labels)
         if projection.phase not in {label_catalog.PHASE_REVIEWING, label_catalog.PHASE_PR_OPEN}:
             continue
-        if not item.head_sha or pending_review_spawn_exists(repo_root, item.number):
+        if not item.head_sha or pending_review_spawn_exists(repo_root, item.number, ctx):
             continue
         if valid_required_review_round_complete(repo_root, item.number, item.head_sha):
             continue
@@ -3826,7 +3866,7 @@ def _open_pr_exists_for_branch(items: list[GhItem], head_ref: str) -> bool:
     return False
 
 
-def _pending_implement_intent_exists(repo_root: Path, issue: int, action: dict[str, Any]) -> bool:
+def _pending_implement_intent_exists(repo_root: Path, issue: int, action: dict[str, Any], ctx: LoopContext | None = None) -> bool:
     pending_path = repo_root / ".refactor-loop" / ".controller-pending-events.log"
     if not pending_path.exists():
         return False
@@ -3834,6 +3874,9 @@ def _pending_implement_intent_exists(repo_root: Path, issue: int, action: dict[s
         lines = pending_path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
         return False
+    if ctx is None:
+        ctx = LoopContext.load(repo_root=repo_root, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}, cwd=repo_root, read_only=True)
+    archived_invalid_markers = archived_invalid_harness_spawn_intent_markers(lines)
     cluster_id = str(action.get("cluster_id") or "").strip()
     expected_ids = {f"{IMPLEMENT_PENDING_INTENT_PREFIX}{issue}"}
     if cluster_id:
@@ -3846,6 +3889,8 @@ def _pending_implement_intent_exists(repo_root: Path, issue: int, action: dict[s
         except json.JSONDecodeError:
             continue
         if not isinstance(intent, dict):
+            continue
+        if not live_valid_harness_spawn_intent(ctx, line, intent, archived_invalid_markers):
             continue
         intent_values = {str(intent.get("intent_id") or ""), str(intent.get("task_id") or "")}
         if expected_ids.intersection(intent_values):

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -942,12 +942,9 @@ def harness_spawn_intent_line_is_archived_invalid(
     payload: Mapping[str, Any] | None,
     archived_invalid_markers: tuple[str, ...],
 ) -> bool:
-    identities = {harness_spawn_intent_line_digest(line)}
-    if payload is not None:
-        intent_id = payload.get("intent_id")
-        if isinstance(intent_id, str) and intent_id:
-            identities.add(intent_id)
-    return any(marker.startswith(f"{identity}:") or marker == identity for marker in archived_invalid_markers for identity in identities)
+    del payload
+    line_digest = harness_spawn_intent_line_digest(line)
+    return any(marker.startswith(f"{line_digest}:") or marker == line_digest for marker in archived_invalid_markers)
 
 
 def live_valid_harness_spawn_intent(ctx: LoopContext, line: str, intent: dict[str, Any], archived_invalid_markers: tuple[str, ...]) -> bool:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import importlib
 import json
 import os
@@ -210,6 +211,9 @@ DESIGN_CONSENSUS_LOG_RE = re.compile(r"^phase9-issue([1-9][0-9]*)-r([1-9][0-9]*)
 IMPLEMENT_PENDING_INTENT_PREFIX = "dispatch-consensus-implementation:"
 IMPLEMENT_TASK_PREFIX = "implement-"
 REVIEW_PENDING_SECONDS = 90
+INVALID_HARNESS_SPAWN_INTENT_SOURCE_ARTIFACT = ".refactor-loop/.controller-pending-events.log"
+INVALID_HARNESS_SPAWN_INTENT_SOURCE_MARKER = "HARNESS_SPAWN_INTENT"
+ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER = "WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT"
 
 
 @dataclass(frozen=True)
@@ -383,6 +387,10 @@ def harness_spawn_intent_actions(
             _harness_spawn_intent_action(intent, intent_id, cd, prompt, log_path, line)
         )
     return actions
+
+
+def harness_spawn_intent_line_digest(line: str) -> str:
+    return hashlib.sha256(line.encode("utf-8")).hexdigest()[:16]
 
 
 def _harness_spawn_intent_action(
@@ -862,6 +870,9 @@ def _harness_spawn_intent_invalid_reason(intent: dict[str, Any]) -> str | None:
         return "missing-background-requirement"
     if intent.get("no_lifecycle_authority") is not True:
         return "missing-no-lifecycle-authority"
+    queued_at = intent.get("queued_at")
+    if not isinstance(queued_at, str) or not queued_at:
+        return "missing-queued_at"
     return None
 
 
@@ -893,16 +904,24 @@ def validate_harness_spawn_intent(ctx: LoopContext, intent: dict[str, Any]) -> H
 
 
 def _invalid_harness_spawn_intent(reason: str, evidence: str, *, intent_id: str | None = None) -> dict[str, Any]:
+    identity = intent_id if intent_id else harness_spawn_intent_line_digest(evidence)
     return {
         "priority": 2,
         "kind": "harness-spawn-intent-invalid",
+        "action_id": f"harness-spawn-intent-invalid:{identity}",
         "item": intent_id,
         "phase": "bootstrap",
         "actor": "controller",
         "route": "harness-spawn-intent",
         "reason": reason,
         "evidence": evidence,
+        "source_artifact": INVALID_HARNESS_SPAWN_INTENT_SOURCE_ARTIFACT,
+        "source_marker": INVALID_HARNESS_SPAWN_INTENT_SOURCE_MARKER,
+        "evidence_digest": harness_spawn_intent_line_digest(evidence),
+        "runner_authority": RUNNER_AUTHORITY,
+        "preconditions": ["source_artifact_contains_evidence"],
         "no_lifecycle_authority": True,
+        "no_generic_command": True,
     }
 
 

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -322,11 +322,14 @@ def harness_spawn_intent_actions(
     actions: list[dict[str, Any]] = []
     seen: set[str] = set()
     terminal_blocked_intent_ids = _terminal_blocked_harness_spawn_intent_ids(lines)
+    archived_invalid_markers = archived_invalid_harness_spawn_intent_markers(lines)
     open_items = gh_items or []
     open_targets = _open_managed_targets(open_items) if gh_items_loaded else set()
     terminal_design_targets = _terminal_design_consensus_targets(open_items) if gh_items_loaded else set()
     for line in lines:
         if " HARNESS_SPAWN_INTENT " not in line:
+            continue
+        if harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
             continue
         raw_json = line.split(" HARNESS_SPAWN_INTENT ", 1)[1]
         try:
@@ -341,14 +344,14 @@ def harness_spawn_intent_actions(
         if not isinstance(intent_id, str) or not intent_id:
             actions.append(_invalid_harness_spawn_intent("missing-intent-id", line))
             continue
-        if intent_id in seen:
-            continue
-        seen.add(intent_id)
         try:
             validated = validate_harness_spawn_intent(ctx, intent)
         except ValueError as exc:
             actions.append(_invalid_harness_spawn_intent(str(exc), line, intent_id=intent_id))
             continue
+        if intent_id in seen:
+            continue
+        seen.add(intent_id)
         cd = validated.cd
         prompt = validated.prompt
         log_path = validated.log_path
@@ -904,7 +907,7 @@ def validate_harness_spawn_intent(ctx: LoopContext, intent: dict[str, Any]) -> H
 
 
 def _invalid_harness_spawn_intent(reason: str, evidence: str, *, intent_id: str | None = None) -> dict[str, Any]:
-    identity = intent_id if intent_id else harness_spawn_intent_line_digest(evidence)
+    identity = harness_spawn_intent_line_digest(evidence)
     return {
         "priority": 2,
         "kind": "harness-spawn-intent-invalid",

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -444,9 +444,11 @@ class WakeupRunner:
         error = self._validate_invalid_harness_spawn_intent(action)
         if error:
             return self._blocked(action, error)
-        identity = action_id.removeprefix("harness-spawn-intent-invalid:")
+        evidence_digest = str(action.get("evidence_digest") or "")
+        if not evidence_digest:
+            return self._blocked(action, "missing_evidence_digest")
         reason = _single_line(str(action.get("reason") or "unknown"))
-        self._append_pending_event(f"{ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER}:{identity}:{reason}")
+        self._append_pending_event(f"{ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER}:{evidence_digest}:{reason}")
         return self._record(RunnerResult(action_id, "skipped", f"archived_invalid_harness_spawn_intent:{reason}"), action)
 
     def _validate_invalid_harness_spawn_intent(self, action: Mapping[str, Any]) -> str | None:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -47,6 +47,9 @@ from .safe_progress_scheduler import MEDIUM_NON_SPAWN_LIMIT_PER_TICK, validate_r
 from .state import read_json
 from .work_items import extract_closing_issue_numbers
 from .wakeup_plan import (
+    ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER,
+    INVALID_HARNESS_SPAWN_INTENT_SOURCE_ARTIFACT,
+    INVALID_HARNESS_SPAWN_INTENT_SOURCE_MARKER,
     build_plan,
     consensus_implementation_suppressed_reason,
     zero_code_implementation_completion_proven,
@@ -344,6 +347,8 @@ class WakeupRunner:
             return self._blocked(action, "missing_action_id")
         if self._ledger_suppresses_retry(action):
             return self._record(RunnerResult(action_id, "skipped", "duplicate"), action)
+        if action.get("kind") == "harness-spawn-intent-invalid":
+            return self._apply_invalid_harness_spawn_intent(action, action_id)
         error = self._validate_action(action)
         if error:
             if error == "issue_decomposition_duplicate_sentinel" or error in NON_BLOCKING_VALIDATION_REASONS:
@@ -434,6 +439,36 @@ class WakeupRunner:
             if source_marker not in text:
                 return "source_marker_missing"
         return None
+
+    def _apply_invalid_harness_spawn_intent(self, action: Mapping[str, Any], action_id: str) -> RunnerResult:
+        error = self._validate_invalid_harness_spawn_intent(action)
+        if error:
+            return self._blocked(action, error)
+        identity = action_id.removeprefix("harness-spawn-intent-invalid:")
+        reason = _single_line(str(action.get("reason") or "unknown"))
+        self._append_pending_event(f"{ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER}:{identity}:{reason}")
+        return self._record(RunnerResult(action_id, "skipped", f"archived_invalid_harness_spawn_intent:{reason}"), action)
+
+    def _validate_invalid_harness_spawn_intent(self, action: Mapping[str, Any]) -> str | None:
+        safe_progress_error = validate_runner_action(action)
+        if safe_progress_error:
+            return safe_progress_error
+        forbidden = _forbidden_action_field_paths(action)
+        if forbidden:
+            return "forbidden_fields:" + ",".join(forbidden)
+        if action.get("runner_authority") != RUNNER_AUTHORITY:
+            return "runner_authority_mismatch"
+        if action.get("no_generic_command") is not True:
+            return "missing_no_generic_command"
+        if action.get("no_lifecycle_authority") is not True:
+            return "missing_no_lifecycle_authority"
+        if action.get("source_artifact") != INVALID_HARNESS_SPAWN_INTENT_SOURCE_ARTIFACT:
+            return "invalid_harness_spawn_intent_source_artifact_mismatch"
+        if action.get("source_marker") != INVALID_HARNESS_SPAWN_INTENT_SOURCE_MARKER:
+            return "invalid_harness_spawn_intent_source_marker_mismatch"
+        if not isinstance(action.get("evidence_digest"), str) or not action.get("evidence_digest"):
+            return "missing_evidence_digest"
+        return self._validate_evidence(action)
 
     def _validate_target(self, action: Mapping[str, Any]) -> str | None:
         target = self._github_target(action)
@@ -1836,6 +1871,12 @@ class WakeupRunner:
                 if self._applied_row_current_effect_suppresses_retry(action):
                     return True
             if status == "blocked" and _terminal_blocked_reason(str(row.get("reason") or "")):
+                return True
+            if (
+                status == "skipped"
+                and action.get("kind") == "harness-spawn-intent-invalid"
+                and str(row.get("reason") or "").startswith("archived_invalid_harness_spawn_intent:")
+            ):
                 return True
         return False
 

--- a/skills/consensus-loop/scripts/test_concurrency_monitor.py
+++ b/skills/consensus-loop/scripts/test_concurrency_monitor.py
@@ -916,7 +916,7 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
             now=1_779_780_600,
         )
 
-        self.assertIsNone(unblocked.blocked_reason)
+        self.assertEqual("malformed-harness-spawn-intent:missing-queued_at", unblocked.blocked_reason)
         self.assertEqual(0, unblocked.supply)
 
         pending.write_text(
@@ -936,6 +936,60 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
         )
 
         self.assertIsNone(digest_unblocked.blocked_reason)
+
+    def test_distinct_archived_invalid_harness_spawn_intents_same_id_recover_by_digest(self) -> None:
+        first = self.append_phase9_harness_spawn_intent("phase9-issue333-r4-minimal")
+        first.pop("queued_at")
+        first["reason"] = "first malformed"
+        second = dict(first)
+        second["reason"] = "second malformed"
+        first_line = "2026-05-26T07:29:00Z HARNESS_SPAWN_INTENT " + json.dumps(first, sort_keys=True)
+        second_line = "2026-05-26T07:29:01Z HARNESS_SPAWN_INTENT " + json.dumps(second, sort_keys=True)
+        pending = self.refactor_loop / ".controller-pending-events.log"
+        pending.write_text(
+            first_line
+            + "\n"
+            + second_line
+            + "\n"
+            + "WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:"
+            + self.harness_spawn_intent_line_digest(first_line)
+            + ":missing-queued_at\n",
+            encoding="utf-8",
+        )
+
+        still_blocked = self.monitor.hard_gate_transient_supply(
+            breakdown=[{"id": "#333", "kind": "issue", "phase": self.labels.PHASE_DESIGN_SOLVING, "expected": 1}],
+            target=3,
+            actual=0,
+            queue_empty=True,
+            now=1_779_780_600,
+        )
+
+        self.assertEqual("malformed-harness-spawn-intent:missing-queued_at", still_blocked.blocked_reason)
+
+        pending.write_text(
+            first_line
+            + "\n"
+            + second_line
+            + "\n"
+            + "WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:"
+            + self.harness_spawn_intent_line_digest(first_line)
+            + ":missing-queued_at\n"
+            + "WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:"
+            + self.harness_spawn_intent_line_digest(second_line)
+            + ":missing-queued_at\n",
+            encoding="utf-8",
+        )
+
+        recovered = self.monitor.hard_gate_transient_supply(
+            breakdown=[{"id": "#333", "kind": "issue", "phase": self.labels.PHASE_DESIGN_SOLVING, "expected": 1}],
+            target=3,
+            actual=0,
+            queue_empty=True,
+            now=1_779_780_600,
+        )
+
+        self.assertIsNone(recovered.blocked_reason)
 
     def test_tick_terminal_implement_result_does_not_trigger_no_gap_expected_worker(self) -> None:
         items = [

--- a/skills/consensus-loop/scripts/test_concurrency_monitor.py
+++ b/skills/consensus-loop/scripts/test_concurrency_monitor.py
@@ -28,7 +28,9 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
         from codex_refactor_loop import labels as label_catalog
         from codex_refactor_loop.monitors import concurrency as concurrency_module
         from codex_refactor_loop.monitors.concurrency import ConcurrencyMonitor
+        from codex_refactor_loop.wakeup_plan import harness_spawn_intent_line_digest
         self.module = concurrency_module
+        self.harness_spawn_intent_line_digest = harness_spawn_intent_line_digest
         self.labels = label_catalog
         self.ctx = LoopContext.load(repo_root=self.repo, env=os.environ)
         self.monitor = ConcurrencyMonitor(self.ctx)
@@ -878,6 +880,62 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
                 )
 
                 self.assertEqual(supply.supply, 0)
+
+    def test_archived_invalid_harness_spawn_intent_no_longer_blocks_hard_gate_supply(self) -> None:
+        malformed_intent = self.append_phase9_harness_spawn_intent("phase9-issue333-r4-minimal")
+        malformed_intent.pop("queued_at")
+        line = "2026-05-26T07:29:00Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
+        pending = self.refactor_loop / ".controller-pending-events.log"
+        pending.write_text(line + "\n", encoding="utf-8")
+
+        blocked = self.monitor.hard_gate_transient_supply(
+            breakdown=[{"id": "#333", "kind": "issue", "phase": self.labels.PHASE_DESIGN_SOLVING, "expected": 1}],
+            target=3,
+            actual=0,
+            queue_empty=True,
+            now=1_779_780_600,
+        )
+
+        self.assertEqual(0, blocked.supply)
+        self.assertEqual("malformed-harness-spawn-intent:missing-queued_at", blocked.blocked_reason)
+
+        pending.write_text(
+            line
+            + "\n"
+            + "WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:"
+            + str(malformed_intent["intent_id"])
+            + ":missing-queued_at\n",
+            encoding="utf-8",
+        )
+
+        unblocked = self.monitor.hard_gate_transient_supply(
+            breakdown=[{"id": "#333", "kind": "issue", "phase": self.labels.PHASE_DESIGN_SOLVING, "expected": 1}],
+            target=3,
+            actual=0,
+            queue_empty=True,
+            now=1_779_780_600,
+        )
+
+        self.assertIsNone(unblocked.blocked_reason)
+        self.assertEqual(0, unblocked.supply)
+
+        pending.write_text(
+            line
+            + "\n"
+            + "WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:"
+            + self.harness_spawn_intent_line_digest(line)
+            + ":missing-queued_at\n",
+            encoding="utf-8",
+        )
+        digest_unblocked = self.monitor.hard_gate_transient_supply(
+            breakdown=[{"id": "#333", "kind": "issue", "phase": self.labels.PHASE_DESIGN_SOLVING, "expected": 1}],
+            target=3,
+            actual=0,
+            queue_empty=True,
+            now=1_779_780_600,
+        )
+
+        self.assertIsNone(digest_unblocked.blocked_reason)
 
     def test_tick_terminal_implement_result_does_not_trigger_no_gap_expected_worker(self) -> None:
         items = [

--- a/skills/consensus-loop/scripts/test_controller_actions.py
+++ b/skills/consensus-loop/scripts/test_controller_actions.py
@@ -39,6 +39,7 @@ from codex_refactor_loop.prompt_contracts import GITHUB_POST_RULES_CONTRACT_TOKE
 from codex_refactor_loop.release.publisher import ReleasePublishResult
 from codex_refactor_loop.secondary_mutation_backoff import record_secondary_mutation_backoff
 from codex_refactor_loop.wakeup_plan import harness_spawn_intent_actions
+from codex_refactor_loop.wakeup_plan import harness_spawn_intent_line_digest
 
 
 class AllowingGitHubActor:
@@ -2928,10 +2929,11 @@ class ControllerActionsTests(unittest.TestCase):
             "controller_action": "spawn_codex_harness_background",
         }
         line = "2026-06-01T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
+        archived_digest = harness_spawn_intent_line_digest(line)
         (self.tmp / ".refactor-loop" / ".controller-pending-events.log").write_text(
             line
             + "\n"
-            + f"2026-06-01T00:00:01Z WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{malformed_intent['intent_id']}:missing-queued_at\n",
+            + f"2026-06-01T00:00:01Z WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{archived_digest}:missing-queued_at\n",
             encoding="utf-8",
         )
         render_envs: list[dict[str, str]] = []
@@ -2969,6 +2971,7 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertEqual([".refactor-loop/runs/review-pr77-architect-r1.md"], [env["REVIEW_OUTPUT_PATH"] for env in render_envs])
         pending = self.pending_events()
         self.assertEqual(2, pending.count('"intent_id": "dispatch-reviewers:77:architect:r1"'))
+        self.assertTrue(self.actions._pending_review_spawn_exists("77", "architect", 1))
 
     def test_dispatch_reviewers_redispatch_uses_next_round_after_completed_stale_logs(self) -> None:
         decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-reviewers", lease_id="lease", expires_at="soon")

--- a/skills/consensus-loop/scripts/test_controller_actions.py
+++ b/skills/consensus-loop/scripts/test_controller_actions.py
@@ -2579,6 +2579,8 @@ class ControllerActionsTests(unittest.TestCase):
         pending = self.pending_events()
         self.assertRegex(pending, r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z HARNESS_SPAWN_INTENT ")
         self.assertIn(" HARNESS_SPAWN_INTENT ", pending)
+        raw_intent = json.loads(next(line.split(" HARNESS_SPAWN_INTENT ", 1)[1] for line in pending.splitlines() if " HARNESS_SPAWN_INTENT " in line))
+        self.assertRegex(raw_intent["queued_at"], r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
 
         ctx = LoopContext.load(repo_root=self.tmp, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}, cwd=self.tmp, read_only=True)
         projected = harness_spawn_intent_actions(self.tmp, ctx, monitor=None, gh_items=[], gh_items_loaded=False)

--- a/skills/consensus-loop/scripts/test_controller_actions.py
+++ b/skills/consensus-loop/scripts/test_controller_actions.py
@@ -184,6 +184,44 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertEqual(str(self.tmp.resolve()), captured_env["REPO_ROOT"])
         self.assertEqual("owner/repo", captured_env["GH_REPO_SLUG"])
 
+    def valid_harness_spawn_intent(
+        self,
+        *,
+        intent_id: str,
+        task_id: str,
+        prompt: str,
+        log: str,
+        source: str = "test",
+        route: str = "test",
+    ) -> dict[str, object]:
+        return {
+            "intent_id": intent_id,
+            "source": source,
+            "route": route,
+            "task_id": task_id,
+            "priority": "p1",
+            "command": "spawn-codex",
+            "controller_action": "spawn_codex_harness_background",
+            "cd": str(self.tmp.resolve()),
+            "prompt": prompt,
+            "log": log,
+            "stall": 5400,
+            "reason": "test intent",
+            "queued_at": "2026-06-01T00:00:00Z",
+            "run_in_background_required": True,
+            "no_lifecycle_authority": True,
+        }
+
+    def valid_review_harness_spawn_intent(self, pr_number: int, role: str, round_number: int) -> dict[str, object]:
+        return self.valid_harness_spawn_intent(
+            intent_id=f"dispatch-reviewers:{pr_number}:{role}:r{round_number}",
+            source="dispatch-reviewers",
+            route="dispatch-reviewers",
+            task_id=f"review-pr{pr_number}-{role}-r{round_number}",
+            prompt=f".refactor-loop/prompts/review-pr{pr_number}-{role}-r{round_number}.md",
+            log=f".refactor-loop/logs/review-pr{pr_number}-{role}-r{round_number}.log",
+        )
+
     def test_controller_actions_source_locks_named_wakeup_runner_helpers(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "controller_actions.py").read_text(encoding="utf-8")
         for helper in (
@@ -2649,10 +2687,14 @@ class ControllerActionsTests(unittest.TestCase):
                 action = action_for(reason)
                 cluster_id = str(action["cluster_id"])
                 if reason == "pending_implement_intent":
-                    pending = {
-                        "intent_id": "dispatch-consensus-implementation:413",
-                        "task_id": f"implement-{cluster_id}",
-                    }
+                    pending = self.valid_harness_spawn_intent(
+                        intent_id="dispatch-consensus-implementation:413",
+                        source="dispatch-consensus-implementation",
+                        route="dispatch-consensus-implementation",
+                        task_id=f"implement-{cluster_id}",
+                        prompt=f".refactor-loop/prompts/implement-{cluster_id}.md",
+                        log=f".refactor-loop/logs/implement-{cluster_id}.log",
+                    )
                     (self.tmp / ".refactor-loop" / ".controller-pending-events.log").write_text(
                         f"2026-06-01T00:00:00Z HARNESS_SPAWN_INTENT {json.dumps(pending)}\n",
                         encoding="utf-8",
@@ -2835,10 +2877,7 @@ class ControllerActionsTests(unittest.TestCase):
 
     def test_dispatch_reviewers_redispatches_only_stale_roles_and_skips_pending_intents(self) -> None:
         decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-reviewers", lease_id="lease", expires_at="soon")
-        existing_intent = {
-            "intent_id": "dispatch-reviewers:77:architect:r1",
-            "controller_action": "spawn_codex_harness_background",
-        }
+        existing_intent = self.valid_review_harness_spawn_intent(77, "architect", 1)
         (self.tmp / ".refactor-loop" / ".controller-pending-events.log").write_text(
             f"2026-06-01T00:00:00Z HARNESS_SPAWN_INTENT {json.dumps(existing_intent, sort_keys=True)}\n",
             encoding="utf-8",
@@ -2882,6 +2921,55 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertIn('"intent_id": "dispatch-reviewers:77:tests:r1"', pending)
         self.assertNotIn('"intent_id": "dispatch-reviewers:77:quality:r1"', pending)
 
+    def test_dispatch_reviewers_ignores_archived_invalid_pending_intent(self) -> None:
+        decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-reviewers", lease_id="lease", expires_at="soon")
+        malformed_intent = {
+            "intent_id": "dispatch-reviewers:77:architect:r1",
+            "controller_action": "spawn_codex_harness_background",
+        }
+        line = "2026-06-01T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
+        (self.tmp / ".refactor-loop" / ".controller-pending-events.log").write_text(
+            line
+            + "\n"
+            + f"2026-06-01T00:00:01Z WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{malformed_intent['intent_id']}:missing-queued_at\n",
+            encoding="utf-8",
+        )
+        render_envs: list[dict[str, str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            if args == ["pr", "view", "77", "--json", "title,baseRefName,headRefName,headRefOid"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps({"title": "Fix wakeup runner", "baseRefName": "dev", "headRefName": "refactor/issue413", "headRefOid": "a" * 40}),
+                    stderr="",
+                )
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        def fake_render(_template: str, output_path: str, env: Mapping[str, str] | None = None) -> None:
+            assert env is not None
+            render_envs.append(dict(env))
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(output_path).write_text("review prompt\n", encoding="utf-8")
+
+        with mock.patch("codex_refactor_loop.controller_actions.require_active_controller", return_value=decision):
+            with mock.patch.object(self.actions, "gh", side_effect=fake_gh):
+                with mock.patch.object(self.actions, "render_template", side_effect=fake_render):
+                    self.assertEqual(
+                        0,
+                        self.actions.dispatch_reviewers(
+                            {
+                                "target_kind": "PR",
+                                "target_number": 77,
+                                "stale_review_roles": ["architect"],
+                                "head_sha": "b" * 40,
+                            }
+                        ),
+                    )
+
+        self.assertEqual([".refactor-loop/runs/review-pr77-architect-r1.md"], [env["REVIEW_OUTPUT_PATH"] for env in render_envs])
+        pending = self.pending_events()
+        self.assertEqual(2, pending.count('"intent_id": "dispatch-reviewers:77:architect:r1"'))
+
     def test_dispatch_reviewers_redispatch_uses_next_round_after_completed_stale_logs(self) -> None:
         decision = mock.Mock(allowed=True, owner_device="device-a", status="owner", action="dispatch-reviewers", lease_id="lease", expires_at="soon")
         for role in ("architect", "tests"):
@@ -2895,10 +2983,7 @@ class ControllerActionsTests(unittest.TestCase):
                 f"head_sha: {'b' * 40}\nREVIEW_DONE:77:{role}:approve\nEXIT=0\n",
                 encoding="utf-8",
             )
-        existing_intent = {
-            "intent_id": "dispatch-reviewers:77:architect:r2",
-            "controller_action": "spawn_codex_harness_background",
-        }
+        existing_intent = self.valid_review_harness_spawn_intent(77, "architect", 2)
         (self.tmp / ".refactor-loop" / ".controller-pending-events.log").write_text(
             f"2026-06-01T00:00:00Z HARNESS_SPAWN_INTENT {json.dumps(existing_intent, sort_keys=True)}\n",
             encoding="utf-8",

--- a/skills/consensus-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/consensus-loop/scripts/test_phase9_router_daemon.py
@@ -30,6 +30,10 @@ from codex_refactor_loop.phase9.router import (
     run_phase9_router_reconcile_tick,
 )
 from codex_refactor_loop.prompt_contracts import GITHUB_POST_RULES_CONTRACT_TOKEN
+from codex_refactor_loop.wakeup_plan import (
+    ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER,
+    harness_spawn_intent_line_digest,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -193,6 +197,25 @@ class Phase9RouterDaemonTests(unittest.TestCase):
 
     def intent_text(self, intent: dict[str, object]) -> str:
         return json.dumps(intent, ensure_ascii=False, sort_keys=True)
+
+    def valid_harness_spawn_intent_for_log(self, log: str) -> dict[str, object]:
+        return {
+            "intent_id": f"phase9-router-test:{Path(log).stem}",
+            "source": "phase9-router-test",
+            "route": "actor_health_recovery",
+            "task_id": Path(log).stem,
+            "priority": "p1",
+            "command": "spawn-codex",
+            "controller_action": "spawn_codex_harness_background",
+            "cd": str(self.repo.resolve()),
+            "prompt": ".refactor-loop/prompts/phase9/test.md",
+            "log": log,
+            "stall": 5400,
+            "reason": "test pending intent",
+            "queued_at": "2026-01-01T00:00:00Z",
+            "run_in_background_required": True,
+            "no_lifecycle_authority": True,
+        }
 
     def solver_triplet(self, issue: int = 37, round_no: int = 4, verdict: str = "same") -> None:
         for role in ("minimal", "structural", "delete"):
@@ -1316,7 +1339,12 @@ class Phase9RouterDaemonTests(unittest.TestCase):
                 self.repo / ".refactor-loop" / "logs" / "solver-issue262-r1-minimal.log"
             ).write_text("reserved by legacy solver log\n", encoding="utf-8")),
             ("pending-intent", lambda: (self.repo / ".refactor-loop/.controller-pending-events.log").write_text(
-                '2026-01-01T00:00:00Z HARNESS_SPAWN_INTENT {"log": ".refactor-loop/logs/phase9-issue262-r1-minimal.log"}\n',
+                "2026-01-01T00:00:00Z HARNESS_SPAWN_INTENT "
+                + json.dumps(
+                    self.valid_harness_spawn_intent_for_log(".refactor-loop/logs/phase9-issue262-r1-minimal.log"),
+                    sort_keys=True,
+                )
+                + "\n",
                 encoding="utf-8",
             )),
             ("in-flight", lambda: setattr(
@@ -1366,6 +1394,60 @@ class Phase9RouterDaemonTests(unittest.TestCase):
 
                 self.assertEqual(self.commands, [])
                 self.assertEqual([entry["key"] for entry in self.ledger_entries()], ["262-1-minimal"])
+
+    def test_phase9_router_malformed_pending_intent_does_not_block_stale_actor_recovery(self) -> None:
+        self.write_ledger_entry(
+            key="262-1-minimal",
+            marker="DesignConsensusIssueIntake",
+            log_path=".refactor-loop/logs/phase9-issue262-r1-minimal.log",
+            dispatched_at="2026-01-01T00:00:00Z",
+        )
+        self.router.ctx.host_env["STALE_REVIVAL_HOURS"] = "0.001"
+        pending = self.repo / ".refactor-loop/.controller-pending-events.log"
+        pending.write_text(
+            '2026-01-01T00:00:00Z HARNESS_SPAWN_INTENT {"log": ".refactor-loop/logs/phase9-issue262-r1-minimal.log"}\n',
+            encoding="utf-8",
+        )
+
+        self.router.tick()
+
+        self.assertEqual(len(self.commands), 1)
+        self.assertEqual(self.commands[0]["route"], "actor_health_recovery")
+        self.assertEqual(self.commands[0]["log"], ".refactor-loop/logs/phase9-issue262-r1-minimal.log")
+
+    def test_phase9_router_archived_invalid_pending_intent_does_not_block_stale_actor_recovery(self) -> None:
+        self.write_ledger_entry(
+            key="262-1-minimal",
+            marker="DesignConsensusIssueIntake",
+            log_path=".refactor-loop/logs/phase9-issue262-r1-minimal.log",
+            dispatched_at="2026-01-01T00:00:00Z",
+        )
+        self.router.ctx.host_env["STALE_REVIVAL_HOURS"] = "0.001"
+        pending = self.repo / ".refactor-loop/.controller-pending-events.log"
+        malformed_line = (
+            "2026-01-01T00:00:00Z HARNESS_SPAWN_INTENT "
+            + json.dumps(
+                {
+                    "intent_id": "phase9-router:262:1:minimal",
+                    "log": ".refactor-loop/logs/phase9-issue262-r1-minimal.log",
+                    "queued_at": None,
+                },
+                sort_keys=True,
+            )
+        )
+        archived_digest = harness_spawn_intent_line_digest(malformed_line)
+        pending.write_text(
+            malformed_line
+            + "\n"
+            + f"2026-01-01T00:00:01Z {ARCHIVED_INVALID_HARNESS_SPAWN_INTENT_MARKER}:{archived_digest}:missing-queued_at\n",
+            encoding="utf-8",
+        )
+
+        self.router.tick()
+
+        self.assertEqual(len(self.commands), 1)
+        self.assertEqual(self.commands[0]["route"], "actor_health_recovery")
+        self.assertEqual(self.commands[0]["log"], ".refactor-loop/logs/phase9-issue262-r1-minimal.log")
 
     def test_phase9_router_recovers_missing_ledgered_actor_during_capacity_hard_gate(self) -> None:
         now = datetime.now(timezone.utc)

--- a/skills/consensus-loop/scripts/test_restart_daemons.py
+++ b/skills/consensus-loop/scripts/test_restart_daemons.py
@@ -607,6 +607,46 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
                 self.assertIn("terminating child and restarting same command", died)
                 self.assertEqual(f"{self.runtime.now() + 4}\n", heartbeat.read_text(encoding="utf-8"))
 
+    def test_wrapper_rereads_heartbeat_each_cycle_and_fresh_touch_stops_stale_kill(self) -> None:
+        heartbeat = self.heartbeat_path("phase9_router_daemon")
+        heartbeat.parent.mkdir(parents=True, exist_ok=True)
+        heartbeat.write_text(f"{self.runtime.now() - 120}\n", encoding="utf-8")
+        launches: list[tuple[str, ...]] = []
+        child = FakeChild([None, None])
+
+        def popen(command: tuple[str, ...]) -> FakeChild:
+            launches.append(command)
+            return child
+
+        def sleeper(_seconds: float) -> None:
+            self.runtime._now += 31
+            heartbeat.write_text(f"{self.runtime.now()}\n", encoding="utf-8")
+
+        restart._run_restart_wrapper(
+            [
+                "phase9_router_daemon",
+                str(self.repo),
+                str(self.repo / ".refactor-loop" / "locks" / "phase9_router_daemon.pid"),
+                str(self.repo / ".refactor-loop" / "logs" / "phase9_router_daemon.died"),
+                *FAKE_COMMAND,
+            ],
+            env={
+                "RESTART_DAEMON_HEARTBEAT_FILE": str(heartbeat),
+                "RESTART_DAEMON_HEARTBEAT_INTERVAL": "1",
+                "RESTART_DAEMONS_HEARTBEAT_FRESH_SECONDS": "30",
+                "RESTART_DAEMONS_STOP_GRACE_SECONDS": "1",
+            },
+            popen=popen,
+            sleeper=sleeper,
+            clock=lambda: self.runtime.now(),
+            getpid=lambda: 22223,
+            max_supervision_cycles=2,
+        )
+
+        self.assertEqual([FAKE_COMMAND], launches)
+        self.assertEqual(0, child.terminated)
+        self.assertEqual(f"{self.runtime.now()}\n", heartbeat.read_text(encoding="utf-8"))
+
     def test_wrapper_restarts_immediately_for_malformed_and_future_heartbeat_without_writing_it(self) -> None:
         cases = {
             "malformed": "not-a-timestamp\n",

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -2096,6 +2096,25 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             handle.write(f"2026-05-31T00:00:00Z HARNESS_SPAWN_INTENT {json.dumps(intent, sort_keys=True)}\n")
         return intent
 
+    def valid_review_harness_spawn_intent(self, pr_number: int, role: str, round_number: int) -> dict[str, object]:
+        return {
+            "intent_id": f"dispatch-reviewers:{pr_number}:{role}:r{round_number}",
+            "source": "dispatch-reviewers",
+            "route": "dispatch-reviewers",
+            "task_id": f"review-pr{pr_number}-{role}-r{round_number}",
+            "priority": "p1",
+            "command": "spawn-codex",
+            "controller_action": "spawn_codex_harness_background",
+            "cd": ".",
+            "prompt": f".refactor-loop/prompts/review-pr{pr_number}-{role}-r{round_number}.md",
+            "log": f".refactor-loop/logs/review-pr{pr_number}-{role}-r{round_number}.log",
+            "stall": 5400,
+            "reason": "test review intent",
+            "queued_at": "2026-05-31T00:00:00Z",
+            "run_in_background_required": True,
+            "no_lifecycle_authority": True,
+        }
+
     def append_raw_harness_spawn_intent(self, payload: str) -> None:
         pending = self.repo / ".refactor-loop" / ".controller-pending-events.log"
         with pending.open("a", encoding="utf-8") as handle:
@@ -4972,6 +4991,59 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual([], review_actions)
         self.assertEqual([], ci_actions)
         checks_projection.assert_not_called()
+
+    def test_archived_invalid_review_spawn_intent_does_not_suppress_review_redispatch(self) -> None:
+        item = GhItem(
+            kind="PR",
+            number=77,
+            title="stale review",
+            labels=(label_catalog.MANAGED, label_catalog.PHASE_REVIEWING),
+            head_ref="impl/pr77",
+            head_sha="a" * 40,
+        )
+        malformed_intent = {
+            "intent_id": "dispatch-reviewers:77:architect:r1",
+            "controller_action": "spawn_codex_harness_background",
+        }
+        line = "2026-05-31T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
+        (self.repo / ".refactor-loop" / ".controller-pending-events.log").write_text(
+            line
+            + "\n"
+            + f"2026-05-31T00:00:01Z WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{malformed_intent['intent_id']}:missing-queued_at\n",
+            encoding="utf-8",
+        )
+        (self.logs / "review-pr77-architect-r1.log").write_text(
+            f"head_sha: {'b' * 40}\nEXIT=1\n",
+            encoding="utf-8",
+        )
+        ctx = LoopContext.load(repo_root=self.repo, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}, cwd=self.repo, read_only=True)
+
+        actions = review_evidence_redispatch_actions(self.repo, [item], ctx)
+
+        self.assertEqual(1, len(actions))
+        self.assertEqual("dispatch_reviewers", actions[0]["controller_action"])
+        self.assertEqual(["architect"], actions[0]["stale_review_roles"])
+
+    def test_live_valid_review_spawn_intent_suppresses_review_redispatch(self) -> None:
+        item = GhItem(
+            kind="PR",
+            number=77,
+            title="stale review",
+            labels=(label_catalog.MANAGED, label_catalog.PHASE_REVIEWING),
+            head_ref="impl/pr77",
+            head_sha="a" * 40,
+        )
+        intent = self.valid_review_harness_spawn_intent(77, "architect", 1)
+        self.append_raw_harness_spawn_intent(json.dumps(intent, sort_keys=True))
+        (self.logs / "review-pr77-architect-r1.log").write_text(
+            f"head_sha: {'b' * 40}\nEXIT=1\n",
+            encoding="utf-8",
+        )
+        ctx = LoopContext.load(repo_root=self.repo, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}, cwd=self.repo, read_only=True)
+
+        actions = review_evidence_redispatch_actions(self.repo, [item], ctx)
+
+        self.assertEqual([], actions)
 
     def test_rollup_pr_projects_ci_only_auto_merge_action(self) -> None:
         item = GhItem(

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -5006,10 +5006,11 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             "controller_action": "spawn_codex_harness_background",
         }
         line = "2026-05-31T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
+        archived_digest = harness_spawn_intent_line_digest(line)
         (self.repo / ".refactor-loop" / ".controller-pending-events.log").write_text(
             line
             + "\n"
-            + f"2026-05-31T00:00:01Z WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{malformed_intent['intent_id']}:missing-queued_at\n",
+            + f"2026-05-31T00:00:01Z WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{archived_digest}:missing-queued_at\n",
             encoding="utf-8",
         )
         (self.logs / "review-pr77-architect-r1.log").write_text(
@@ -5023,6 +5024,41 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(1, len(actions))
         self.assertEqual("dispatch_reviewers", actions[0]["controller_action"])
         self.assertEqual(["architect"], actions[0]["stale_review_roles"])
+
+    def test_valid_review_spawn_intent_after_archived_invalid_same_id_suppresses_review_redispatch(self) -> None:
+        item = GhItem(
+            kind="PR",
+            number=77,
+            title="stale review",
+            labels=(label_catalog.MANAGED, label_catalog.PHASE_REVIEWING),
+            head_ref="impl/pr77",
+            head_sha="a" * 40,
+        )
+        malformed_intent = {
+            "intent_id": "dispatch-reviewers:77:architect:r1",
+            "controller_action": "spawn_codex_harness_background",
+        }
+        bad_line = "2026-05-31T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
+        archived_digest = harness_spawn_intent_line_digest(bad_line)
+        valid_intent = self.valid_review_harness_spawn_intent(77, "architect", 1)
+        valid_line = "2026-05-31T00:00:02Z HARNESS_SPAWN_INTENT " + json.dumps(valid_intent, sort_keys=True)
+        (self.repo / ".refactor-loop" / ".controller-pending-events.log").write_text(
+            bad_line
+            + "\n"
+            + f"2026-05-31T00:00:01Z WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{archived_digest}:missing-queued_at\n"
+            + valid_line
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.logs / "review-pr77-architect-r1.log").write_text(
+            f"head_sha: {'b' * 40}\nEXIT=1\n",
+            encoding="utf-8",
+        )
+        ctx = LoopContext.load(repo_root=self.repo, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}, cwd=self.repo, read_only=True)
+
+        actions = review_evidence_redispatch_actions(self.repo, [item], ctx)
+
+        self.assertEqual([], actions)
 
     def test_live_valid_review_spawn_intent_suppresses_review_redispatch(self) -> None:
         item = GhItem(

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -33,6 +33,8 @@ from codex_refactor_loop.restart import restart_managed_daemon_names  # noqa: E4
 from codex_refactor_loop.workflow_stages import assert_stage_slug  # noqa: E402
 from codex_refactor_loop.wakeup_plan import (  # noqa: E402
     GhItem,
+    INVALID_HARNESS_SPAWN_INTENT_SOURCE_ARTIFACT,
+    INVALID_HARNESS_SPAWN_INTENT_SOURCE_MARKER,
     _revive_stale_redispatchable_implement_log,
     ci_red_actions,
     close_projection_actions,
@@ -42,6 +44,7 @@ from codex_refactor_loop.wakeup_plan import (  # noqa: E402
     consensus_implementation_suppressed_reason,
     existing_issue_actions,
     has_dispatchable_action,
+    harness_spawn_intent_line_digest,
     load_github_items_with_status,
     marker_from_completed_log,
     meta_escalation_stuck_seconds,
@@ -2366,6 +2369,30 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                 action = next(item for item in plan["actions"] if item["kind"] == "harness-spawn-intent-invalid")
                 self.assertEqual(action["kind"], "harness-spawn-intent-invalid")
                 self.assertEqual(action["reason"], expected_reason)
+                self.assertEqual(action["action_id"], f"harness-spawn-intent-invalid:{harness_spawn_intent_line_digest(action['evidence'])}")
+                self.assertEqual(action["source_artifact"], INVALID_HARNESS_SPAWN_INTENT_SOURCE_ARTIFACT)
+                self.assertEqual(action["source_marker"], INVALID_HARNESS_SPAWN_INTENT_SOURCE_MARKER)
+                self.assertEqual(action["evidence_digest"], harness_spawn_intent_line_digest(action["evidence"]))
+                self.assertEqual(action["runner_authority"], "wakeup-runner-396")
+                self.assertEqual(action["preconditions"], ["source_artifact_contains_evidence"])
+                self.assertTrue(action["no_generic_command"])
+
+    def test_harness_spawn_intent_rejects_missing_queued_at_with_stable_invalid_action(self) -> None:
+        self.append_harness_spawn_intent(intent_id="missing-queued-at", queued_at=None)
+
+        plan = self.run_plan()
+
+        action = next(item for item in plan["actions"] if item["kind"] == "harness-spawn-intent-invalid")
+        self.assertEqual("missing-queued_at", action["reason"])
+        self.assertEqual("harness-spawn-intent-invalid:missing-queued-at", action["action_id"])
+        self.assertEqual(INVALID_HARNESS_SPAWN_INTENT_SOURCE_ARTIFACT, action["source_artifact"])
+        self.assertEqual(INVALID_HARNESS_SPAWN_INTENT_SOURCE_MARKER, action["source_marker"])
+        self.assertEqual(harness_spawn_intent_line_digest(action["evidence"]), action["evidence_digest"])
+        self.assertEqual("wakeup-runner-396", action["runner_authority"])
+        self.assertEqual(["source_artifact_contains_evidence"], action["preconditions"])
+        self.assertTrue(action["no_lifecycle_authority"])
+        self.assertTrue(action["no_generic_command"])
+        self.assertNotIn("controller_action", action)
 
     def test_harness_spawn_intent_rejects_missing_path_fields_and_bad_path(self) -> None:
         for field in ("cd", "prompt", "log"):

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -2396,14 +2396,14 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                 self.assertEqual(action["preconditions"], ["source_artifact_contains_evidence"])
                 self.assertTrue(action["no_generic_command"])
 
-    def test_harness_spawn_intent_rejects_missing_queued_at_with_stable_invalid_action(self) -> None:
+    def test_harness_spawn_intent_rejects_missing_queued_at_with_digest_invalid_action(self) -> None:
         self.append_harness_spawn_intent(intent_id="missing-queued-at", queued_at=None)
 
         plan = self.run_plan()
 
         action = next(item for item in plan["actions"] if item["kind"] == "harness-spawn-intent-invalid")
         self.assertEqual("missing-queued_at", action["reason"])
-        self.assertEqual("harness-spawn-intent-invalid:missing-queued-at", action["action_id"])
+        self.assertEqual(f"harness-spawn-intent-invalid:{harness_spawn_intent_line_digest(action['evidence'])}", action["action_id"])
         self.assertEqual(INVALID_HARNESS_SPAWN_INTENT_SOURCE_ARTIFACT, action["source_artifact"])
         self.assertEqual(INVALID_HARNESS_SPAWN_INTENT_SOURCE_MARKER, action["source_marker"])
         self.assertEqual(harness_spawn_intent_line_digest(action["evidence"]), action["evidence_digest"])
@@ -2412,6 +2412,63 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertTrue(action["no_lifecycle_authority"])
         self.assertTrue(action["no_generic_command"])
         self.assertNotIn("controller_action", action)
+
+    def test_harness_spawn_intent_projects_valid_same_id_after_archived_invalid(self) -> None:
+        malformed_intent = {
+            "intent_id": "same-id-successor",
+            "controller_action": "spawn_codex_harness_background",
+        }
+        bad_line = "2026-05-31T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
+        archived_digest = harness_spawn_intent_line_digest(bad_line)
+        valid_intent = {
+            "intent_id": "same-id-successor",
+            "source": "controller-actions",
+            "route": "test-harness-spawn",
+            "task_id": "same-id-successor",
+            "priority": "p1",
+            "command": "spawn-codex",
+            "controller_action": "spawn_codex_harness_background",
+            "cd": ".",
+            "prompt": ".refactor-loop/prompts/same-id-successor.md",
+            "log": ".refactor-loop/logs/same-id-successor.log",
+            "stall": 5400,
+            "reason": "test review intent",
+            "queued_at": "2026-05-31T00:00:00Z",
+            "run_in_background_required": True,
+            "no_lifecycle_authority": True,
+        }
+        valid_line = "2026-05-31T00:00:02Z HARNESS_SPAWN_INTENT " + json.dumps(valid_intent, sort_keys=True)
+        (self.repo / ".refactor-loop" / ".controller-pending-events.log").write_text(
+            bad_line
+            + "\n"
+            + f"2026-05-31T00:00:01Z WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{archived_digest}:missing-queued_at\n"
+            + valid_line
+            + "\n",
+            encoding="utf-8",
+        )
+
+        plan = self.run_plan()
+        actions = self.harness_spawn_actions(plan)
+
+        self.assertEqual(1, len(actions))
+        self.assertEqual("same-id-successor", actions[0]["intent_id"])
+        self.assertEqual("harness-spawn-intent:same-id-successor", actions[0]["action_id"])
+        self.assertEqual(valid_line, actions[0]["evidence"])
+
+    def test_harness_spawn_intent_invalid_same_id_lines_are_digest_scoped(self) -> None:
+        self.append_harness_spawn_intent(intent_id="repeat-bad", queued_at=None, reason="first bad")
+        self.append_harness_spawn_intent(intent_id="repeat-bad", queued_at=None, reason="second bad")
+
+        plan = self.run_plan()
+        actions = [action for action in plan["actions"] if action["kind"] == "harness-spawn-intent-invalid"]
+
+        self.assertEqual(2, len(actions))
+        self.assertEqual(["missing-queued_at", "missing-queued_at"], [action["reason"] for action in actions])
+        self.assertEqual(
+            [f"harness-spawn-intent-invalid:{harness_spawn_intent_line_digest(action['evidence'])}" for action in actions],
+            [action["action_id"] for action in actions],
+        )
+        self.assertEqual(2, len({action["action_id"] for action in actions}))
 
     def test_harness_spawn_intent_rejects_missing_path_fields_and_bad_path(self) -> None:
         for field in ("cd", "prompt", "log"):

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -442,14 +442,15 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             sort_keys=True,
         )
         self.ctx.paths.pending_events.write_text(raw_line + "\n", encoding="utf-8")
+        digest = harness_spawn_intent_line_digest(raw_line)
         action = {
             "kind": "harness-spawn-intent-invalid",
-            "action_id": "harness-spawn-intent-invalid:bad:colon:id",
+            "action_id": f"harness-spawn-intent-invalid:{digest}",
             "runner_authority": "wakeup-runner-396",
             "preconditions": ["source_artifact_contains_evidence"],
             "source_artifact": ".refactor-loop/.controller-pending-events.log",
             "source_marker": "HARNESS_SPAWN_INTENT",
-            "evidence_digest": harness_spawn_intent_line_digest(raw_line),
+            "evidence_digest": digest,
             "reason": "missing-queued_at",
             "no_lifecycle_authority": True,
             "no_generic_command": True,
@@ -467,7 +468,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual([], actions.calls)
         launch.assert_not_called()
         pending = self.ctx.paths.pending_events.read_text(encoding="utf-8")
-        archived_marker = f"WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{harness_spawn_intent_line_digest(raw_line)}:missing-queued_at"
+        archived_marker = f"WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{digest}:missing-queued_at"
         self.assertIn(archived_marker, pending)
         self.assertEqual(1, pending.count(archived_marker))
         ledger_rows = [
@@ -477,13 +478,13 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual(
             [
                 {
-                    "action_id": "harness-spawn-intent-invalid:bad:colon:id",
+                    "action_id": f"harness-spawn-intent-invalid:{digest}",
                     "kind": "harness-spawn-intent-invalid",
                     "reason": "archived_invalid_harness_spawn_intent:missing-queued_at",
                     "status": "skipped",
                 },
                 {
-                    "action_id": "harness-spawn-intent-invalid:bad:colon:id",
+                    "action_id": f"harness-spawn-intent-invalid:{digest}",
                     "kind": "harness-spawn-intent-invalid",
                     "reason": "duplicate",
                     "status": "skipped",
@@ -491,6 +492,63 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             ],
             ledger_rows,
         )
+
+    def test_runner_quarantines_distinct_invalid_harness_spawn_intents_with_same_id(self) -> None:
+        def raw_line(reason: str) -> str:
+            payload = {
+                "intent_id": "dispatch-reviewers:77:architect:r1",
+                "source": "controller-actions",
+                "route": "dispatch-reviewers",
+                "task_id": "review-pr77-architect-r1",
+                "priority": "p1",
+                "command": "spawn-codex",
+                "controller_action": "spawn_codex_harness_background",
+                "cd": str(self.repo),
+                "prompt": ".refactor-loop/prompts/review-pr77-architect-r1.md",
+                "log": ".refactor-loop/logs/review-pr77-architect-r1.log",
+                "stall": 5400,
+                "reason": reason,
+                "queued_at": None,
+                "run_in_background_required": True,
+                "no_lifecycle_authority": True,
+            }
+            return "2026-06-01T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(payload, sort_keys=True)
+
+        lines = [raw_line("first malformed"), raw_line("second malformed")]
+        actions = [
+            {
+                "kind": "harness-spawn-intent-invalid",
+                "action_id": f"harness-spawn-intent-invalid:{harness_spawn_intent_line_digest(line)}",
+                "runner_authority": "wakeup-runner-396",
+                "preconditions": ["source_artifact_contains_evidence"],
+                "source_artifact": ".refactor-loop/.controller-pending-events.log",
+                "source_marker": "HARNESS_SPAWN_INTENT",
+                "evidence_digest": harness_spawn_intent_line_digest(line),
+                "reason": "missing-queued_at",
+                "no_lifecycle_authority": True,
+                "no_generic_command": True,
+            }
+            for line in lines
+        ]
+        self.ctx.paths.pending_events.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", side_effect=AssertionError("must not spawn")) as launch:
+            results = self.run_result({**self.base_plan(actions[0]), "actions": [self.annotate_safe_progress(action) for action in actions]}, actions=FakeActions())
+
+        self.assertEqual(["skipped", "skipped"], [result.status for result in results])
+        self.assertEqual(
+            ["archived_invalid_harness_spawn_intent:missing-queued_at", "archived_invalid_harness_spawn_intent:missing-queued_at"],
+            [result.reason for result in results],
+        )
+        launch.assert_not_called()
+        pending = self.ctx.paths.pending_events.read_text(encoding="utf-8")
+        for line in lines:
+            marker = (
+                "WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:"
+                + harness_spawn_intent_line_digest(line)
+                + ":missing-queued_at"
+            )
+            self.assertEqual(1, pending.count(marker))
 
     def test_runner_applies_at_most_one_medium_non_spawn_per_tick(self) -> None:
         base = {

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -35,6 +35,7 @@ from codex_refactor_loop.wakeup_runner import (
     _source_log_has_clean_marker,
     run_wakeup_runner_reconcile_tick,
 )
+from codex_refactor_loop.wakeup_plan import harness_spawn_intent_line_digest
 
 
 def release_decision(from_version: str, to_version: str) -> dict:
@@ -418,6 +419,77 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual("blocked", result[0].status)
         self.assertEqual("medium_requires_cautious_execution_policy", result[0].reason)
         self.assertEqual([], actions.calls)
+
+    def test_runner_archives_invalid_harness_spawn_intent_without_dispatch(self) -> None:
+        raw_line = "2026-06-01T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(
+            {
+                "intent_id": "bad:colon:id",
+                "source": "controller-actions",
+                "route": "dispatch-consensus-implementation",
+                "task_id": "implement-issue-771",
+                "priority": "p1",
+                "command": "spawn-codex",
+                "controller_action": "spawn_codex_harness_background",
+                "cd": str(self.repo),
+                "prompt": ".refactor-loop/prompts/implement-issue-771.md",
+                "log": ".refactor-loop/logs/implement-issue-771.log",
+                "stall": 5400,
+                "reason": "issue #771 consensus implementation",
+                "queued_at": None,
+                "run_in_background_required": True,
+                "no_lifecycle_authority": True,
+            },
+            sort_keys=True,
+        )
+        self.ctx.paths.pending_events.write_text(raw_line + "\n", encoding="utf-8")
+        action = {
+            "kind": "harness-spawn-intent-invalid",
+            "action_id": "harness-spawn-intent-invalid:bad:colon:id",
+            "runner_authority": "wakeup-runner-396",
+            "preconditions": ["source_artifact_contains_evidence"],
+            "source_artifact": ".refactor-loop/.controller-pending-events.log",
+            "source_marker": "HARNESS_SPAWN_INTENT",
+            "evidence_digest": harness_spawn_intent_line_digest(raw_line),
+            "reason": "missing-queued_at",
+            "no_lifecycle_authority": True,
+            "no_generic_command": True,
+        }
+        actions = FakeActions()
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", side_effect=AssertionError("must not spawn")) as launch:
+            results = self.run_result(self.base_plan(action), actions=actions)
+            duplicate = self.run_result(self.base_plan(action), actions=actions)
+
+        self.assertEqual("skipped", results[0].status)
+        self.assertEqual("archived_invalid_harness_spawn_intent:missing-queued_at", results[0].reason)
+        self.assertEqual("skipped", duplicate[0].status)
+        self.assertEqual("duplicate", duplicate[0].reason)
+        self.assertEqual([], actions.calls)
+        launch.assert_not_called()
+        pending = self.ctx.paths.pending_events.read_text(encoding="utf-8")
+        self.assertIn("WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:bad:colon:id:missing-queued_at", pending)
+        self.assertEqual(1, pending.count("WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:bad:colon:id:missing-queued_at"))
+        ledger_rows = [
+            json.loads(line)
+            for line in (self.ctx.paths.state / "wakeup-runner-ledger.jsonl").read_text(encoding="utf-8").splitlines()
+        ]
+        self.assertEqual(
+            [
+                {
+                    "action_id": "harness-spawn-intent-invalid:bad:colon:id",
+                    "kind": "harness-spawn-intent-invalid",
+                    "reason": "archived_invalid_harness_spawn_intent:missing-queued_at",
+                    "status": "skipped",
+                },
+                {
+                    "action_id": "harness-spawn-intent-invalid:bad:colon:id",
+                    "kind": "harness-spawn-intent-invalid",
+                    "reason": "duplicate",
+                    "status": "skipped",
+                },
+            ],
+            ledger_rows,
+        )
 
     def test_runner_applies_at_most_one_medium_non_spawn_per_tick(self) -> None:
         base = {

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -467,8 +467,9 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual([], actions.calls)
         launch.assert_not_called()
         pending = self.ctx.paths.pending_events.read_text(encoding="utf-8")
-        self.assertIn("WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:bad:colon:id:missing-queued_at", pending)
-        self.assertEqual(1, pending.count("WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:bad:colon:id:missing-queued_at"))
+        archived_marker = f"WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{harness_spawn_intent_line_digest(raw_line)}:missing-queued_at"
+        self.assertIn(archived_marker, pending)
+        self.assertEqual(1, pending.count(archived_marker))
         ledger_rows = [
             json.loads(line)
             for line in (self.ctx.paths.state / "wakeup-runner-ledger.jsonl").read_text(encoding="utf-8").splitlines()


### PR DESCRIPTION
### Release rollup

- Target: `auto-refact-dev` -> `dev`
- Integration branch ahead of review-base: `5` commits
- Range: `2796f38e5308..5ce21c5ea3de`

### Commit summary

- Apply digest-scoped intent validation to phase9 router recovery gate
- Scope all malformed-intent identity to bad-line digest across consumers
- Bind archived-invalid intent identity to bad-line digest
- Share archived-invalid intent check across redispatch guards
- Root-fix transient daemon failures: newborn grace, per-cycle heartbeat re-read, malformed spawn-intent quarantine

### Merge policy

- After required checks are green, controller auto squash-merges; when `ROLLUP_AUTO_MERGE=manual`, wait for human review/merge.
- This PR is the release rollup singleton; when an open rollup already exists, controller only updates its head and body instead of opening another PR.

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
