### PR TITLE
Release rollup: integration ahead 1 commits (6f6be560f93b)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -351,7 +351,12 @@ class ConcurrencyMonitor:
 
     def list_in_flight_codex_lines(self) -> list[str]:
         lines: list[str] = []
-        for line in self.run(["ps", "-eo", "command="]).stdout.splitlines():
+        try:
+            process_snapshot = self.run(["ps", "-eo", "command="])
+        except PermissionError as exc:
+            print(f"concurrency-monitor ps unavailable: {exc}", file=sys.stderr)
+            return []
+        for line in process_snapshot.stdout.splitlines():
             if "consensus-rnd-cli" not in line or "spawn-codex" not in line:
                 continue
             if " -c " in line:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/patrol.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/patrol.py
@@ -115,6 +115,9 @@ class PatrolInspector:
             reason = str(exc)
             self._write_state(status="failed", findings=(), published=(), reason=reason)
             print(f"patrol-inspector failed: {reason}", file=sys.stderr)
+            if beat is not None:
+                beat()
+                return 0
             raise
         if beat is not None:
             beat()
@@ -136,7 +139,14 @@ class PatrolInspector:
     def collect_findings(self) -> tuple[PatrolFinding, ...]:
         findings: list[PatrolFinding] = []
         for signal in self.collect_candidate_signals():
-            decision = self.analysis_provider.analyze(signal)
+            try:
+                decision = self.analysis_provider.analyze(signal)
+            except RuntimeError as exc:
+                print(
+                    f"patrol-inspector analysis skipped: source={_single_line(signal.source)} reason={_single_line(str(exc))}",
+                    file=sys.stderr,
+                )
+                continue
             if not decision.is_real_issue:
                 continue
             findings.append(_finding_from_decision(signal, decision))
@@ -527,6 +537,10 @@ def _positive_int(raw: str | None, default: int) -> int:
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _single_line(value: str) -> str:
+    return " ".join(str(value).split())[:240]
 
 
 def _patrol_daemon_heartbeat_lease(ctx: LoopContext) -> DaemonHeartbeatLease:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -257,6 +257,13 @@ class HarnessSpawnIntentValidation:
     stall: int
 
 
+@dataclass(frozen=True)
+class ReviewRoundCompletion:
+    round_number: int
+    head_sha: str
+    heads_by_role: dict[str, str]
+
+
 def run_json(cmd: list[str], *, cwd: Path) -> Any:
     result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
     if result.returncode != 0:
@@ -329,26 +336,13 @@ def harness_spawn_intent_actions(
     for line in lines:
         if " HARNESS_SPAWN_INTENT " not in line:
             continue
-        if harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
+        invalid_action, intent, validated = _invalid_harness_spawn_intent_action_for_line(ctx, line, archived_invalid_markers)
+        if invalid_action is not None:
+            actions.append(invalid_action)
             continue
-        raw_json = line.split(" HARNESS_SPAWN_INTENT ", 1)[1]
-        try:
-            intent = json.loads(raw_json)
-        except json.JSONDecodeError:
-            actions.append(_invalid_harness_spawn_intent("invalid-json", line))
+        if intent is None or validated is None:
             continue
-        if not isinstance(intent, dict):
-            actions.append(_invalid_harness_spawn_intent("intent-not-object", line))
-            continue
-        intent_id = intent.get("intent_id")
-        if not isinstance(intent_id, str) or not intent_id:
-            actions.append(_invalid_harness_spawn_intent("missing-intent-id", line))
-            continue
-        try:
-            validated = validate_harness_spawn_intent(ctx, intent)
-        except ValueError as exc:
-            actions.append(_invalid_harness_spawn_intent(str(exc), line, intent_id=intent_id))
-            continue
+        intent_id = str(intent["intent_id"])
         if intent_id in seen:
             continue
         seen.add(intent_id)
@@ -390,6 +384,30 @@ def harness_spawn_intent_actions(
             _harness_spawn_intent_action(intent, intent_id, cd, prompt, log_path, line)
         )
     return actions
+
+
+def _invalid_harness_spawn_intent_action_for_line(
+    ctx: LoopContext,
+    line: str,
+    archived_invalid_markers: tuple[str, ...],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, HarnessSpawnIntentValidation | None]:
+    if harness_spawn_intent_line_is_archived_invalid(line, None, archived_invalid_markers):
+        return None, None, None
+    raw_json = line.split(" HARNESS_SPAWN_INTENT ", 1)[1]
+    try:
+        intent = json.loads(raw_json)
+    except json.JSONDecodeError:
+        return _invalid_harness_spawn_intent("invalid-json", line), None, None
+    if not isinstance(intent, dict):
+        return _invalid_harness_spawn_intent("intent-not-object", line), None, None
+    intent_id = intent.get("intent_id")
+    if not isinstance(intent_id, str) or not intent_id:
+        return _invalid_harness_spawn_intent("missing-intent-id", line), None, None
+    try:
+        validated = validate_harness_spawn_intent(ctx, intent)
+    except ValueError as exc:
+        return _invalid_harness_spawn_intent(str(exc), line, intent_id=intent_id), None, None
+    return None, intent, validated
 
 
 def harness_spawn_intent_line_digest(line: str) -> str:
@@ -2202,15 +2220,12 @@ def _review_done_action_head_sha(repo_root: Path, log_path: Path, marker: str, g
     if match is None:
         return _reviewed_head_sha_from_log(log_path)
     pr_number = int(match.group(1))
-    role = match.group(2)
     live_head = _gh_item_head_sha(gh_items, pr_number)
-    heads = latest_reviewer_heads(repo_root, pr_number)
-    role_head = heads.get(role, "")
-    if role_head:
-        return role_head
-    if live_head and all(heads.get(required, "") == live_head for required in REQUIRED_REVIEW_ROLES):
+    if live_head and highest_complete_required_review_round(repo_root, pr_number, live_head) is not None:
         return live_head
-    return _reviewed_head_sha_from_log(log_path)
+    artifact_path = repo_root / ".refactor-loop" / "runs" / log_path.with_suffix(".md").name
+    prompt_path = repo_root / ".refactor-loop" / "prompts" / log_path.with_suffix(".md").name
+    return _reviewed_head_sha_from_file(artifact_path) or _reviewed_head_sha_from_file(prompt_path) or _reviewed_head_sha_from_log(log_path)
 
 
 def _gh_item_head_sha(gh_items: list[GhItem] | None, pr_number: int) -> str:
@@ -2335,6 +2350,54 @@ def latest_valid_reviewer_rounds(repo_root: Path, pr_number: int) -> dict[str, t
     return by_role
 
 
+def highest_complete_required_review_round(repo_root: Path, pr_number: int, head_sha: str) -> ReviewRoundCompletion | None:
+    if not head_sha:
+        return None
+    by_round: dict[int, dict[str, list[str]]] = {}
+    artifact_keys: set[tuple[str, int]] = set()
+    runs_dir = repo_root / ".refactor-loop" / "runs"
+    logs_dir = repo_root / ".refactor-loop" / "logs"
+    prompts_dir = repo_root / ".refactor-loop" / "prompts"
+    for path in sorted(runs_dir.glob(f"review-pr{pr_number}-*-r*.md")):
+        match = REVIEW_ARTIFACT_RE.match(path.name)
+        if not match or int(match.group(1)) != pr_number:
+            continue
+        role = match.group(2)
+        round_number = int(match.group(3))
+        artifact_keys.add((role, round_number))
+        log_path = logs_dir / f"review-pr{pr_number}-{role}-r{round_number}.log"
+        if not _reviewer_log_has_exit_zero(log_path) or not _reviewer_log_has_valid_marker(log_path, pr_number, role):
+            continue
+        reviewed_head = _reviewed_head_sha_from_file(path) or _reviewed_head_sha_from_file(prompts_dir / path.name) or _reviewed_head_sha_from_file(log_path)
+        by_round.setdefault(round_number, {}).setdefault(role, []).append(reviewed_head)
+    for path in sorted(logs_dir.glob(f"review-pr{pr_number}-*-r*.log")):
+        match = REVIEW_LOG_RE.match(path.name)
+        if not match or int(match.group(1)) != pr_number:
+            continue
+        role = match.group(2)
+        round_number = int(match.group(3))
+        if (role, round_number) in artifact_keys:
+            continue
+        if not _reviewer_log_has_exit_zero(path) or not _reviewer_log_has_valid_marker(path, pr_number, role):
+            continue
+        prompt_path = prompts_dir / path.with_suffix(".md").name
+        reviewed_head = _reviewed_head_sha_from_file(path) or _reviewed_head_sha_from_file(prompt_path)
+        by_round.setdefault(round_number, {}).setdefault(role, []).append(reviewed_head)
+    for round_number in sorted(by_round, reverse=True):
+        role_heads = by_round[round_number]
+        heads_by_role: dict[str, str] = {}
+        complete = True
+        for role in REQUIRED_REVIEW_ROLES:
+            heads = role_heads.get(role, [])
+            if len(heads) != 1 or heads[0] != head_sha:
+                complete = False
+                break
+            heads_by_role[role] = heads[0]
+        if complete:
+            return ReviewRoundCompletion(round_number=round_number, head_sha=head_sha, heads_by_role=heads_by_role)
+    return None
+
+
 def pending_or_fresh_review_evidence_exists(repo_root: Path, pr_number: int) -> bool:
     now = time.time()
     for path in sorted((repo_root / ".refactor-loop" / "logs").glob(f"review-pr{pr_number}-*-r*.log")):
@@ -2346,6 +2409,20 @@ def pending_or_fresh_review_evidence_exists(repo_root: Path, pr_number: int) -> 
         if now - path.stat().st_mtime < REVIEW_PENDING_SECONDS:
             return True
     return False
+
+
+def pending_or_fresh_review_evidence_roles(repo_root: Path, pr_number: int) -> set[str]:
+    roles: set[str] = set()
+    now = time.time()
+    for path in sorted((repo_root / ".refactor-loop" / "logs").glob(f"review-pr{pr_number}-*-r*.log")):
+        match = REVIEW_LOG_RE.match(path.name)
+        if not match or int(match.group(1)) != pr_number:
+            continue
+        if _reviewer_log_has_exit_zero(path) or _reviewer_log_terminal_failed(path):
+            continue
+        if now - path.stat().st_mtime < REVIEW_PENDING_SECONDS:
+            roles.add(match.group(2))
+    return roles
 
 
 def dead_reviewer_roles(repo_root: Path, pr_number: int) -> set[str]:
@@ -2378,11 +2455,17 @@ def reviewer_roles_with_evidence(repo_root: Path, pr_number: int) -> set[str]:
 
 
 def valid_required_review_round_complete(repo_root: Path, pr_number: int, head_sha: str) -> bool:
-    rounds = latest_valid_reviewer_rounds(repo_root, pr_number)
-    return all(rounds.get(role, (0, ""))[1] == head_sha for role in REQUIRED_REVIEW_ROLES)
+    return highest_complete_required_review_round(repo_root, pr_number, head_sha) is not None
 
 
-def pending_review_spawn_exists(repo_root: Path, pr_number: int, ctx: LoopContext | None = None) -> bool:
+def pending_review_spawn_exists(
+    repo_root: Path,
+    pr_number: int,
+    ctx: LoopContext | None = None,
+    *,
+    role: str | None = None,
+    head_sha: str | None = None,
+) -> bool:
     pending_path = repo_root / ".refactor-loop" / ".controller-pending-events.log"
     try:
         lines = pending_path.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -2406,6 +2489,20 @@ def pending_review_spawn_exists(repo_root: Path, pr_number: int, ctx: LoopContex
         intent_id = str(intent.get("intent_id") or "")
         if not intent_id.startswith(prefix):
             continue
+        if role is not None and intent_id.split(":")[2:3] != [role]:
+            continue
+        if head_sha is not None:
+            prompt_value = str(intent.get("prompt") or "")
+            prompt_path = Path(prompt_value)
+            if not prompt_path.is_absolute():
+                prompt_path = repo_root / prompt_path
+            log_value = str(intent.get("log") or "")
+            log_path_for_head = Path(log_value)
+            if not log_path_for_head.is_absolute():
+                log_path_for_head = repo_root / log_path_for_head
+            intent_head = _reviewed_head_sha_from_file(prompt_path) or _reviewed_head_sha_from_file(log_path_for_head)
+            if intent_head != head_sha:
+                continue
         log_value = str(intent.get("log") or "")
         log_path = Path(log_value)
         if not log_path.is_absolute():
@@ -2427,19 +2524,22 @@ def review_evidence_redispatch_actions(repo_root: Path, gh_items: list[GhItem], 
         projection = label_catalog.normalize_label_set(item.labels)
         if projection.phase not in {label_catalog.PHASE_REVIEWING, label_catalog.PHASE_PR_OPEN}:
             continue
-        if not item.head_sha or pending_review_spawn_exists(repo_root, item.number, ctx):
+        if not item.head_sha:
             continue
-        if valid_required_review_round_complete(repo_root, item.number, item.head_sha):
-            continue
-        if pending_or_fresh_review_evidence_exists(repo_root, item.number):
+        if highest_complete_required_review_round(repo_root, item.number, item.head_sha) is not None:
             continue
         heads = latest_reviewer_heads(repo_root, item.number)
         dead_roles = dead_reviewer_roles(repo_root, item.number)
         evidence_roles = reviewer_roles_with_evidence(repo_root, item.number)
+        pending_roles = pending_or_fresh_review_evidence_roles(repo_root, item.number)
+        live_head_roles = {role for role, head in heads.items() if head == item.head_sha}
         stale_roles = [
             role
             for role in REQUIRED_REVIEW_ROLES
-            if heads.get(role, "") != item.head_sha and (heads.get(role, "") or role in dead_roles or role in evidence_roles)
+            if heads.get(role, "") != item.head_sha
+            and role not in pending_roles
+            and (heads.get(role, "") or role in dead_roles or role in evidence_roles or live_head_roles)
+            and not pending_review_spawn_exists(repo_root, item.number, ctx, role=role, head_sha=item.head_sha)
         ]
         if not stale_roles:
             continue
@@ -2457,6 +2557,7 @@ def review_evidence_redispatch_actions(repo_root: Path, gh_items: list[GhItem], 
                 "target_number": item.number,
                 "target": {"kind": "PR", "number": item.number},
                 "stale_review_roles": stale_roles,
+                "head_sha": item.head_sha,
                 "preconditions": ["active_controller_owner", "live_open_target_if_present", "missing_or_stale_reviewer_head_evidence"],
                 "runner_authority": RUNNER_AUTHORITY,
                 "no_generic_command": True,

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -52,6 +52,8 @@ from .wakeup_plan import (
     INVALID_HARNESS_SPAWN_INTENT_SOURCE_MARKER,
     build_plan,
     consensus_implementation_suppressed_reason,
+    archived_invalid_harness_spawn_intent_markers,
+    live_valid_harness_spawn_intent,
     zero_code_implementation_completion_proven,
 )
 from .worker_markers import read_worker_terminal_marker
@@ -238,6 +240,15 @@ class ReviewGateSnapshot:
         }
 
 
+@dataclass(frozen=True)
+class ReviewGateCandidate:
+    evidences_by_role: dict[str, ReviewEvidence]
+    invalid: list[str]
+    pending: list[str]
+    terminal_failed_roles: list[str]
+    complete_round: int | None = None
+
+
 class WakeupRunner:
     def __init__(
         self,
@@ -289,7 +300,7 @@ class WakeupRunner:
                 and applied_medium_non_spawns >= MEDIUM_NON_SPAWN_LIMIT_PER_TICK
             ):
                 continue
-            if worker_top_up_only and not consumes_spawn_budget:
+            if worker_top_up_only and not consumes_spawn_budget and not _is_invalid_harness_cleanup(action):
                 continue
             if consumes_spawn_budget and applied_spawns >= budget.spawn_budget:
                 continue
@@ -323,13 +334,15 @@ class WakeupRunner:
     def _hard_gate_apply_priority(self, action: Any) -> tuple[int, int]:
         if not isinstance(action, Mapping):
             return (4, 0)
-        if _publishes_review_fix_output(action):
+        if _is_invalid_harness_cleanup(action):
             return (0, 0)
-        if _unblocks_pr_mergeability(action) or _unblocks_release_rollup(action):
+        if _publishes_review_fix_output(action):
             return (1, 0)
-        if _is_reviewer_harness_spawn_intent(action):
+        if _unblocks_pr_mergeability(action) or _unblocks_release_rollup(action):
             return (2, 0)
-        return (3, 0)
+        if _is_reviewer_harness_spawn_intent(action):
+            return (3, 0)
+        return (4, 0)
 
     def _uses_spawn_budget(self, action: Mapping[str, Any]) -> bool:
         controller_action = str(action.get("controller_action") or "")
@@ -1632,53 +1645,106 @@ class WakeupRunner:
         return {"decision": decision, "reason": "", "gate": gate}
 
     def _review_gate(self, pr_number: int) -> dict[str, Any]:
-        evidences = self._latest_review_evidence_by_role(pr_number)
-        verdicts = {role: evidence.verdict for role, evidence in evidences.items() if evidence.valid}
-        invalid = [evidence.reason or f"invalid:{evidence.role}" for evidence in evidences.values() if not evidence.valid]
-        pending = [evidence.reason or f"pending:{evidence.role}" for evidence in evidences.values() if evidence.pending]
-        terminal_failed_roles = [evidence.role for evidence in evidences.values() if evidence.terminal_failed]
-        heads = {role: evidence.head_sha for role, evidence in evidences.items() if evidence.valid and evidence.head_sha}
         live_head = self._pr_head_sha(pr_number)
-        for role in REQUIRED_REVIEW_ROLES:
-            if role not in verdicts:
-                continue
-            role_head = heads.get(role, "")
-            if not role_head:
-                invalid.append(f"missing_reviewed_head_sha:{role}")
-            elif live_head and role_head != live_head:
-                invalid.append(f"stale_reviewed_head_sha:{role}")
+        candidate = self._review_gate_candidate_evidence(pr_number, live_head)
+        evidences = candidate.evidences_by_role
+        verdicts = {role: evidence.verdict for role, evidence in evidences.items() if evidence.valid}
+        heads = {role: evidence.head_sha for role, evidence in evidences.items() if evidence.valid and evidence.head_sha}
         return ReviewGateSnapshot(
             verdicts_by_role=verdicts,
             heads_by_role=heads,
             live_head_sha=live_head,
-            invalid=invalid,
-            pending=pending,
-            terminal_failed_roles=terminal_failed_roles,
+            invalid=candidate.invalid,
+            pending=candidate.pending,
+            terminal_failed_roles=candidate.terminal_failed_roles,
         ).as_dict()
 
-    def _latest_review_evidence_by_role(self, pr_number: int) -> dict[str, ReviewEvidence]:
-        latest: dict[str, ReviewEvidence] = {}
-        duplicate_keys: set[tuple[str, int]] = set()
+    def _review_gate_candidate_evidence(self, pr_number: int, live_head_sha: str) -> ReviewGateCandidate:
+        rounds: dict[int, dict[str, list[ReviewEvidence]]] = {}
         for evidence in self._review_evidences(pr_number):
-            key = (evidence.role, evidence.round_number)
-            if key in duplicate_keys:
+            rounds.setdefault(evidence.round_number, {}).setdefault(evidence.role, []).append(evidence)
+        for round_number in sorted(rounds, reverse=True):
+            by_role = rounds[round_number]
+            selected: dict[str, ReviewEvidence] = {}
+            complete = True
+            for role in REQUIRED_REVIEW_ROLES:
+                items = by_role.get(role, [])
+                if len(items) != 1:
+                    complete = False
+                    break
+                evidence = items[0]
+                if not evidence.valid or evidence.pending or evidence.terminal_failed or evidence.head_sha != live_head_sha:
+                    complete = False
+                    break
+                selected[role] = evidence
+            if complete:
+                return ReviewGateCandidate(selected, [], [], [], complete_round=round_number)
+        if not rounds:
+            return ReviewGateCandidate({}, [], [], [])
+        candidate_round = self._highest_relevant_review_candidate_round(rounds, live_head_sha)
+        return self._diagnostic_review_gate_candidate(rounds[candidate_round], live_head_sha)
+
+    def _highest_relevant_review_candidate_round(
+        self,
+        rounds: Mapping[int, Mapping[str, list[ReviewEvidence]]],
+        live_head_sha: str,
+    ) -> int:
+        def score(round_number: int) -> tuple[int, int, int]:
+            by_role = rounds[round_number]
+            valid_live_roles = {
+                role
+                for role, evidences in by_role.items()
+                if len(evidences) == 1
+                and evidences[0].valid
+                and not evidences[0].pending
+                and not evidences[0].terminal_failed
+                and evidences[0].head_sha == live_head_sha
+            }
+            live_evidence_count = sum(
+                1
+                for evidences in by_role.values()
+                for evidence in evidences
+                if evidence.head_sha == live_head_sha
+            )
+            return (len(valid_live_roles), live_evidence_count, round_number)
+
+        return max(rounds, key=score)
+
+    def _diagnostic_review_gate_candidate(
+        self,
+        by_role: Mapping[str, list[ReviewEvidence]],
+        live_head_sha: str,
+    ) -> ReviewGateCandidate:
+        selected: dict[str, ReviewEvidence] = {}
+        invalid: list[str] = []
+        pending: list[str] = []
+        terminal_failed_roles: list[str] = []
+        for role in REQUIRED_REVIEW_ROLES:
+            items = list(by_role.get(role, []))
+            if len(items) > 1:
+                invalid.append(f"duplicate_reviewer_evidence:{role}")
                 continue
-            existing = latest.get(evidence.role)
-            if existing is not None and existing.round_number == evidence.round_number:
-                latest[evidence.role] = ReviewEvidence(
-                    role=evidence.role,
-                    round_number=evidence.round_number,
-                    verdict="",
-                    head_sha="",
-                    source=evidence.source,
-                    valid=False,
-                    reason=f"duplicate_reviewer_evidence:{evidence.role}",
-                )
-                duplicate_keys.add(key)
+            if not items:
                 continue
-            if existing is None or evidence.round_number > existing.round_number:
-                latest[evidence.role] = evidence
-        return latest
+            evidence = items[0]
+            if evidence.pending:
+                pending.append(evidence.reason or f"pending:{role}")
+                continue
+            if evidence.terminal_failed:
+                terminal_failed_roles.append(role)
+                invalid.append(evidence.reason or f"terminal_failed:{role}")
+                continue
+            if not evidence.valid:
+                invalid.append(evidence.reason or f"invalid:{role}")
+                continue
+            if not evidence.head_sha:
+                invalid.append(f"missing_reviewed_head_sha:{role}")
+                continue
+            if live_head_sha and evidence.head_sha != live_head_sha:
+                invalid.append(f"stale_reviewed_head_sha:{role}")
+                continue
+            selected[role] = evidence
+        return ReviewGateCandidate(selected, invalid, pending, terminal_failed_roles)
 
     def _review_evidences(self, pr_number: int) -> list[ReviewEvidence]:
         evidences: list[ReviewEvidence] = []
@@ -1955,8 +2021,43 @@ class WakeupRunner:
             heads = gate.get("heads_by_role")
             if not isinstance(heads, Mapping):
                 return False
-            return all(str(heads.get(role) or "") == projected_head for role in roles)
+            return all(
+                str(heads.get(role) or "") == projected_head
+                or self._pending_review_spawn_intent_exists(target, role, projected_head)
+                for role in roles
+            )
         return False
+
+    def _pending_review_spawn_intent_exists(self, pr_number: int, role: str, projected_head: str) -> bool:
+        try:
+            lines = self.pending_events_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            return False
+        archived_invalid_markers = archived_invalid_harness_spawn_intent_markers(lines)
+        prefix = f"dispatch-reviewers:{pr_number}:{role}:"
+        for line in lines:
+            if " HARNESS_SPAWN_INTENT " not in line:
+                continue
+            try:
+                intent = json.loads(line.split(" HARNESS_SPAWN_INTENT ", 1)[1])
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(intent, dict):
+                continue
+            if not live_valid_harness_spawn_intent(self.ctx, line, intent, archived_invalid_markers):
+                continue
+            if not str(intent.get("intent_id") or "").startswith(prefix):
+                continue
+            prompt_path = self._path_from_intent_value(intent.get("prompt"))
+            log_path = self._path_from_intent_value(intent.get("log"))
+            intent_head = self._review_head_sha_for(prompt_path, log_path, "")
+            if intent_head == projected_head:
+                return True
+        return False
+
+    def _path_from_intent_value(self, value: Any) -> Path:
+        path = Path(str(value or ""))
+        return path if path.is_absolute() else self.ctx.repo_root / path
 
     def _release_dispatch_stale_ledger_reason(self, action: Mapping[str, Any]) -> str:
         return self._current_release_dispatch_stale_reason(action)
@@ -2326,6 +2427,10 @@ def _log_tick_status(daemon: str, action: str) -> None:
 
 def _single_line(value: str) -> str:
     return " ".join(str(value).split())[:240]
+
+
+def _is_invalid_harness_cleanup(action: Mapping[str, Any]) -> bool:
+    return action.get("kind") == "harness-spawn-intent-invalid"
 
 
 def _reviewer_log_terminal_failed(path: Path) -> bool:

--- a/skills/consensus-loop/scripts/test_concurrency_monitor.py
+++ b/skills/consensus-loop/scripts/test_concurrency_monitor.py
@@ -991,6 +991,55 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
 
         self.assertIsNone(recovered.blocked_reason)
 
+    def test_archived_legacy_malformed_review_intent_no_longer_counts_as_transient_supply(self) -> None:
+        malformed_intent = {
+            "intent_id": "dispatch-reviewers:774:quality:r6",
+            "source": "dispatch-reviewers",
+            "route": "dispatch-reviewers",
+            "task_id": "review-pr774-quality-r6",
+            "priority": "p1",
+            "command": "spawn-codex",
+            "controller_action": "spawn_codex_harness_background",
+            "cd": str(self.repo),
+            "prompt": ".refactor-loop/prompts/review-pr774-quality-r6.md",
+            "log": ".refactor-loop/logs/review-pr774-quality-r6.log",
+            "stall": 5400,
+            "reason": "review PR #774 as quality",
+            "run_in_background_required": True,
+            "no_lifecycle_authority": True,
+        }
+        line = "2026-05-26T07:29:00Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
+        pending = self.refactor_loop / ".controller-pending-events.log"
+        pending.parent.mkdir(parents=True, exist_ok=True)
+        pending.write_text(line + "\n", encoding="utf-8")
+
+        blocked = self.monitor._fresh_unsuppressed_item_matching_intent(
+            active_targets={("pr", 774)},
+            now=1_779_780_600,
+            window=600,
+            zero_streak=1,
+        )
+
+        self.assertEqual((False, "malformed-harness-spawn-intent:missing-queued_at", []), blocked)
+
+        pending.write_text(
+            line
+            + "\n"
+            + "WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:"
+            + self.harness_spawn_intent_line_digest(line)
+            + ":missing-queued_at\n",
+            encoding="utf-8",
+        )
+
+        recovered = self.monitor._fresh_unsuppressed_item_matching_intent(
+            active_targets={("pr", 774)},
+            now=1_779_780_600,
+            window=600,
+            zero_streak=1,
+        )
+
+        self.assertNotEqual("malformed-harness-spawn-intent:missing-queued_at", recovered[1])
+
     def test_tick_terminal_implement_result_does_not_trigger_no_gap_expected_worker(self) -> None:
         items = [
             {

--- a/skills/consensus-loop/scripts/test_patrol_inspector.py
+++ b/skills/consensus-loop/scripts/test_patrol_inspector.py
@@ -61,6 +61,21 @@ class ExplodingAnalysisProvider:
         raise AssertionError(f"analysis provider should not run for {signal.source}")
 
 
+class RuntimeErrorAnalysisProvider:
+    def __init__(self, decisions: list[PatrolAnalysisDecision | RuntimeError] | None = None) -> None:
+        self.decisions = decisions or []
+        self.signals: list[PatrolCandidateSignal] = []
+
+    def analyze(self, signal: PatrolCandidateSignal) -> PatrolAnalysisDecision:
+        self.signals.append(signal)
+        if self.decisions:
+            decision = self.decisions.pop(0)
+            if isinstance(decision, RuntimeError):
+                raise decision
+            return decision
+        raise RuntimeError(f"patrol analysis failed: source={signal.source} exit=1 log=.refactor-loop/logs/patrol-analysis-test.log")
+
+
 def false_decision() -> PatrolAnalysisDecision:
     return PatrolAnalysisDecision(
         is_real_issue=False,
@@ -627,6 +642,68 @@ class PatrolInspectorTests(unittest.TestCase):
         self.assertEqual(1, len(state["findings"]))
         self.assertEqual(1, len(state["published"]))
 
+    def test_analysis_spawn_failure_is_tick_local_and_renews_heartbeat(self) -> None:
+        (self.tmp / ".refactor-loop" / "logs" / "router.log").write_text("RuntimeError: persistent failure\n", encoding="utf-8")
+        publisher = FakePublisher()
+        beats: list[str] = []
+        inspector = PatrolInspector(
+            self.ctx,
+            config=PatrolInspectorConfig(enabled=True, interval_seconds=7200, max_findings=25),
+            publisher=publisher,
+            analysis_provider=RuntimeErrorAnalysisProvider(),
+            github_items=(),
+        )
+
+        stderr = StringIO()
+        with redirect_stderr(stderr):
+            result = inspector.run_once(beat=lambda: beats.append("beat"))
+
+        self.assertEqual(0, result)
+        self.assertEqual(["beat"], beats)
+        self.assertEqual([], publisher.published)
+        self.assertIn("patrol-inspector analysis skipped:", stderr.getvalue())
+        self.assertIn("exit=1", stderr.getvalue())
+        state = json.loads((self.tmp / ".refactor-loop" / "state" / "patrol-inspector.json").read_text(encoding="utf-8"))
+        self.assertEqual("ok", state["status"])
+        self.assertEqual([], state["findings"])
+        self.assertEqual([], state["published"])
+
+    def test_mixed_analysis_failure_does_not_publish_raw_failure_text(self) -> None:
+        (self.tmp / ".refactor-loop" / "logs" / "first.log").write_text("RuntimeError: first failure\n", encoding="utf-8")
+        (self.tmp / ".refactor-loop" / "logs" / "second.log").write_text("RuntimeError: second failure\n", encoding="utf-8")
+        decision = PatrolAnalysisDecision(
+            is_real_issue=True,
+            summary="structured second finding",
+            severity="high",
+            root_cause="structured root cause",
+            recommendation="structured recommendation",
+            rationale="structured rationale",
+        )
+        publisher = FakePublisher()
+        inspector = PatrolInspector(
+            self.ctx,
+            config=PatrolInspectorConfig(enabled=True, interval_seconds=7200, max_findings=25),
+            publisher=publisher,
+            analysis_provider=RuntimeErrorAnalysisProvider(
+                [
+                    RuntimeError("patrol analysis failed: source=.refactor-loop/logs/first.log exit=1 log=.refactor-loop/logs/patrol-analysis-first.log"),
+                    decision,
+                ]
+            ),
+            github_items=(),
+        )
+
+        stderr = StringIO()
+        with redirect_stderr(stderr):
+            result = inspector.run_once()
+
+        self.assertEqual(0, result)
+        self.assertEqual(1, len(publisher.published))
+        _fingerprint, _title, body = publisher.published[0]
+        self.assertIn("structured root cause", body)
+        self.assertNotIn("patrol analysis failed", body)
+        self.assertIn("patrol-inspector analysis skipped:", stderr.getvalue())
+
     def test_snapshot_load_failure_is_visible_and_blocks_publication(self) -> None:
         (self.tmp / ".refactor-loop" / "logs" / "router.log").write_text("EXIT=1\n", encoding="utf-8")
         publisher = FakePublisher()
@@ -833,7 +910,7 @@ class PatrolInspectorTests(unittest.TestCase):
         self.assertEqual([3, 3], FakeLease.instance.sleeps)
         self.assertIsNotNone(FakePublisher.instance)
         self.assertEqual([], FakePublisher.instance.published)
-        self.assertIn("patrol-inspector daemon tick failed: RuntimeError:", stderr.getvalue())
+        self.assertIn("patrol-inspector failed:", stderr.getvalue())
         self.assertIn("loaded_ok_false", stderr.getvalue())
 
 

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -4464,7 +4464,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(action["controller_action"], "dispatch_reviewers")
         self.assertEqual(action["target_kind"], "PR")
         self.assertEqual(action["target_number"], 480)
-        self.assertNotIn("head_sha", action)
+        self.assertEqual(action["head_sha"], "a" * 40)
         self.assertEqual(action["action_id"], "review-evidence-redispatch:480:" + "a" * 40)
         self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
         self.assertIn("missing_or_stale_reviewer_head_evidence", action["preconditions"])
@@ -4489,7 +4489,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
         self.assertEqual(action["target_number"], 480)
-        self.assertNotIn("head_sha", action)
+        self.assertEqual(action["head_sha"], "a" * 40)
         self.assertEqual(action["stale_review_roles"], ["architect"])
         self.assertNotIn("status_only", action)
 
@@ -4543,6 +4543,35 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         plan = self.run_plan(fixture="open_pr_480")
 
         self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+
+    def test_complete_lower_review_round_suppresses_higher_inflight_redispatch_for_same_head(self) -> None:
+        for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):
+            self.write_review_evidence(role=role, verdict=verdict, round_number=4)
+        for role in ("architect", "tests"):
+            (self.logs / f"review-pr480-{role}-r5.log").write_text(
+                f"head_sha: {'a' * 40}\nREVIEW_DONE:480:{role}:approve\n",
+                encoding="utf-8",
+            )
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        gate = next(item for item in plan["actions"] if item.get("controller_action") == "review_gate")
+        self.assertEqual(gate["head_sha"], "a" * 40)
+        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+
+    def test_review_redispatch_targets_only_missing_role_for_candidate_round(self) -> None:
+        self.write_review_evidence(role="architect", verdict="approve", round_number=3)
+        self.write_review_evidence(role="tests", verdict="approve", round_number=3)
+        (self.logs / "review-pr480-quality-r3.log").write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:480:quality:comment\nEXIT=1\n",
+            encoding="utf-8",
+        )
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["head_sha"], "a" * 40)
+        self.assertEqual(action["stale_review_roles"], ["quality"])
 
     def test_review_redispatch_next_round_intent_projects_despite_stale_exit_zero_r1_log(self) -> None:
         stale = "b" * 40
@@ -5082,6 +5111,39 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual("dispatch_reviewers", actions[0]["controller_action"])
         self.assertEqual(["architect"], actions[0]["stale_review_roles"])
 
+    def test_legacy_malformed_review_intent_for_merged_pr_projects_invalid_quarantine_once(self) -> None:
+        malformed_intent = self.valid_review_harness_spawn_intent(774, "quality", 6)
+        malformed_intent.pop("queued_at")
+        line = "2026-05-31T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
+        pending = self.repo / ".refactor-loop" / ".controller-pending-events.log"
+        pending.write_text(line + "\n", encoding="utf-8")
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        actions = [action for action in plan["actions"] if action["kind"] == "harness-spawn-intent-invalid"]
+        self.assertEqual(1, len(actions))
+        self.assertEqual("missing-queued_at", actions[0]["reason"])
+        self.assertEqual(harness_spawn_intent_line_digest(line), actions[0]["evidence_digest"])
+        self.assertFalse(
+            [
+                action
+                for action in plan["actions"]
+                if action.get("kind") == "harness-spawn-intent"
+                and action.get("intent_id") == "dispatch-reviewers:774:quality:r6"
+            ]
+        )
+
+        pending.write_text(
+            line
+            + "\n"
+            + "2026-05-31T00:00:01Z WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:"
+            + harness_spawn_intent_line_digest(line)
+            + ":missing-queued_at\n",
+            encoding="utf-8",
+        )
+        archived_plan = self.run_plan(fixture="open_pr_480")
+        self.assertFalse([action for action in archived_plan["actions"] if action["kind"] == "harness-spawn-intent-invalid"])
+
     def test_valid_review_spawn_intent_after_archived_invalid_same_id_suppresses_review_redispatch(self) -> None:
         item = GhItem(
             kind="PR",
@@ -5099,6 +5161,9 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         archived_digest = harness_spawn_intent_line_digest(bad_line)
         valid_intent = self.valid_review_harness_spawn_intent(77, "architect", 1)
         valid_line = "2026-05-31T00:00:02Z HARNESS_SPAWN_INTENT " + json.dumps(valid_intent, sort_keys=True)
+        prompt_path = self.repo / ".refactor-loop" / "prompts" / "review-pr77-architect-r1.md"
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        prompt_path.write_text(f"head_sha: {'a' * 40}\n", encoding="utf-8")
         (self.repo / ".refactor-loop" / ".controller-pending-events.log").write_text(
             bad_line
             + "\n"
@@ -5128,6 +5193,9 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         )
         intent = self.valid_review_harness_spawn_intent(77, "architect", 1)
         self.append_raw_harness_spawn_intent(json.dumps(intent, sort_keys=True))
+        prompt_path = self.repo / ".refactor-loop" / "prompts" / "review-pr77-architect-r1.md"
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        prompt_path.write_text(f"head_sha: {'a' * 40}\n", encoding="utf-8")
         (self.logs / "review-pr77-architect-r1.log").write_text(
             f"head_sha: {'b' * 40}\nEXIT=1\n",
             encoding="utf-8",
@@ -5790,7 +5858,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             source.index("def review_evidence_redispatch_actions") : source.index("\ndef phase_from_marker", source.index("def review_evidence_redispatch_actions"))
         ]
         self.assertIn('"action_id": f"review-evidence-redispatch:{item.number}:{item.head_sha}"', function_source)
-        self.assertNotIn('"head_sha"', function_source)
+        self.assertIn('"head_sha": item.head_sha', function_source)
+        self.assertIn("highest_complete_required_review_round", function_source)
 
     def test_wakeup_plan_source_locks_stale_unexecutable_status_only_suppression(self) -> None:
         projection = wakeup_plan_projection()

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -550,6 +550,48 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             )
             self.assertEqual(1, pending.count(marker))
 
+    def test_hard_gate_archives_invalid_harness_intent_before_spawn_top_up(self) -> None:
+        raw_line = "2026-06-01T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(
+            {
+                "intent_id": "dispatch-reviewers:77:quality:r6",
+                "source": "dispatch-reviewers",
+                "route": "dispatch-reviewers",
+                "task_id": "review-pr77-quality-r6",
+                "priority": "p1",
+                "command": "spawn-codex",
+                "controller_action": "spawn_codex_harness_background",
+                "cd": str(self.repo),
+                "prompt": ".refactor-loop/prompts/review-pr77-quality-r6.md",
+                "log": ".refactor-loop/logs/review-pr77-quality-r6.log",
+                "stall": 5400,
+                "reason": "review PR #77 as quality",
+                "run_in_background_required": True,
+                "no_lifecycle_authority": True,
+            },
+            sort_keys=True,
+        )
+        self.ctx.paths.pending_events.write_text(raw_line + "\n", encoding="utf-8")
+        digest = harness_spawn_intent_line_digest(raw_line)
+        invalid = {
+            "kind": "harness-spawn-intent-invalid",
+            "action_id": f"harness-spawn-intent-invalid:{digest}",
+            "runner_authority": "wakeup-runner-396",
+            "preconditions": ["source_artifact_contains_evidence"],
+            "source_artifact": ".refactor-loop/.controller-pending-events.log",
+            "source_marker": "HARNESS_SPAWN_INTENT",
+            "evidence_digest": digest,
+            "reason": "missing-queued_at",
+            "no_lifecycle_authority": True,
+            "no_generic_command": True,
+        }
+        spawn = self.spawn_action(action_id="spawn:hard-gate-top-up")
+
+        results = self.run_result(self.batch_plan([spawn, invalid], dispatch_required=2, deficit=2), actions=FakeActions())
+
+        self.assertIn(f"WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{digest}:missing-queued_at", self.ctx.paths.pending_events.read_text(encoding="utf-8"))
+        self.assertEqual(["skipped", "applied"], [result.status for result in results])
+        self.assertEqual("archived_invalid_harness_spawn_intent:missing-queued_at", results[0].reason)
+
     def test_runner_applies_at_most_one_medium_non_spawn_per_tick(self) -> None:
         base = {
             "kind": "default-issue-intake-claim",

--- a/skills/consensus-loop/scripts/test_wakeup_runner_review_gate.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner_review_gate.py
@@ -287,12 +287,29 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
         self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:invalid_reviewer_evidence:stale_reviewed_head_sha:architect")
         self.assertEqual(self.actions.merged, [])
 
-    def test_review_gate_uses_latest_round_per_role_after_partial_redispatch(self) -> None:
-        stale = "b" * 40
-        self.write_review("architect", "approve", head_sha=stale, round_number=1)
-        self.write_review("tests", "approve", head_sha="a" * 40, round_number=1)
-        self.write_review("quality", "comment", head_sha="a" * 40, round_number=1)
-        self.write_review("architect", "reject", head_sha="a" * 40, round_number=2)
+    def test_review_gate_uses_complete_lower_round_despite_higher_inflight_same_head(self) -> None:
+        self.write_review("architect", "approve", head_sha="a" * 40, round_number=4)
+        self.write_review("tests", "approve", head_sha="a" * 40, round_number=4)
+        self.write_review("quality", "comment", head_sha="a" * 40, round_number=4)
+        (self.repo / ".refactor-loop/logs/review-pr12-architect-r5.log").write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:12:architect:approve\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_action()
+
+        self.assertEqual(result.status, "applied")
+        self.assertEqual(self.actions.merged, ["12"])
+        self.assertEqual(self.actions.rendered, [])
+
+    def test_review_gate_lower_complete_reject_is_not_masked_by_higher_pending(self) -> None:
+        self.write_review("architect", "reject", head_sha="a" * 40, round_number=4)
+        self.write_review("tests", "approve", head_sha="a" * 40, round_number=4)
+        self.write_review("quality", "comment", head_sha="a" * 40, round_number=4)
+        (self.repo / ".refactor-loop/logs/review-pr12-tests-r5.log").write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:12:tests:approve\n",
+            encoding="utf-8",
+        )
 
         with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
             result = self.run_action()
@@ -301,7 +318,23 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
         self.assertEqual(self.actions.merged, [])
         self.assertEqual(self.actions.rendered, [(12, 1)])
         launch.assert_called_once()
-        self.assertEqual(self.supervisor.calls, 0)
+
+    def test_review_gate_no_complete_round_waits_on_candidate_missing_role(self) -> None:
+        self.write_review("architect", "approve", head_sha="a" * 40, round_number=4)
+        self.write_review("tests", "approve", head_sha="a" * 40, round_number=4)
+        (self.repo / ".refactor-loop/logs/review-pr12-architect-r5.log").write_text(
+            f"head_sha: {'a' * 40}\nREVIEW_DONE:12:architect:approve\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_action()
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:missing_reviewers")
+        runner = WakeupRunner(self.ctx, actions=self.actions, supervisor=self.supervisor, command_runner=lambda command: subprocess.CompletedProcess(command, 0, "a" * 40 + "\n", ""))
+        gate = runner._review_gate(12)
+        self.assertEqual({"architect": "a" * 40, "tests": "a" * 40}, gate["heads_by_role"])
+        self.assertNotIn("quality", gate["heads_by_role"])
 
     def test_missing_artifact_head_recovers_from_controller_rendered_prompt(self) -> None:
         for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):
@@ -479,12 +512,6 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
         self.assertEqual(completed.status, "applied")
         self.assertEqual(self.actions.merged, ["12"])
         self.assertEqual(self.supervisor.calls, 0)
-
-    def test_review_gate_source_locks_latest_evidence_per_role(self) -> None:
-        source = (SCRIPT_DIR / "codex_refactor_loop" / "wakeup_runner.py").read_text(encoding="utf-8")
-        self.assertIn("def _latest_review_evidence_by_role(", source)
-        self.assertIn("evidences = self._latest_review_evidence_by_role(pr_number)", source)
-        self.assertIn("evidence.round_number > existing.round_number", source)
 
     def test_review_gate_source_does_not_treat_draft_as_mergeability_blocker(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "wakeup_runner.py").read_text(encoding="utf-8")


### PR DESCRIPTION
### Release rollup

- Target: `auto-refact-dev` -> `dev`
- Integration branch ahead of review-base: `1` commits
- Range: `208da518f405..6f6be560f93b`

### Commit summary

- Fix three daemon bugs: malformed-intent quarantine for legacy lines, review round truth-table livelock, patrol analysis-path survival

### Merge policy

- After required checks are green, controller auto squash-merges; when `ROLLUP_AUTO_MERGE=manual`, wait for human review/merge.
- This PR is the release rollup singleton; when an open rollup already exists, controller only updates its head and body instead of opening another PR.

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
