### PR TITLE
Deduplicate release rollup wakeup effects

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -328,8 +328,13 @@ class WakeupRunner:
 
     def _actions_for_apply(self, actions: Sequence[Any], budget: WakeupApplyBudget) -> list[Any]:
         if not budget.hard_gate_active:
-            return list(actions)
+            return sorted(actions, key=self._ordinary_apply_priority)
         return sorted(actions, key=self._hard_gate_apply_priority)
+
+    def _ordinary_apply_priority(self, action: Any) -> int:
+        if isinstance(action, Mapping) and _is_invalid_harness_cleanup(action):
+            return 0
+        return 1
 
     def _hard_gate_apply_priority(self, action: Any) -> tuple[int, int]:
         if not isinstance(action, Mapping):

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -119,6 +119,7 @@ REMOTE_CI_FIX_ATTEMPT_CAP = 2
 REMOTE_CI_FIX_DONE_RE = re.compile(r"^REMOTE_CI_FIX_DONE:([^:]+):(ok|infra|blocked)$")
 SAFE_CI_CHECK_TOKEN_RE = re.compile(r"[^A-Za-z0-9._-]+")
 NON_BLOCKING_VALIDATION_REASONS = frozenset({"publish_implementation_empty_scoped_diff"})
+INVALID_HARNESS_CLEANUP_LIMIT_PER_TICK = 5
 STAND_DOWN_MANAGED_WRITE_ACTIONS = frozenset(
     {
         "safe_push",
@@ -288,24 +289,35 @@ class WakeupRunner:
         results: list[RunnerResult] = []
         applied_spawns = 0
         applied_medium_non_spawns = 0
+        applied_invalid_harness_cleanups = 0
         worker_top_up_only = False
         for action in self._actions_for_apply(plan.get("actions", []), budget):
             if not isinstance(action, dict) or action.get("status_only") is True:
+                continue
+            is_invalid_harness_cleanup = _is_invalid_harness_cleanup(action)
+            if (
+                is_invalid_harness_cleanup
+                and applied_invalid_harness_cleanups >= INVALID_HARNESS_CLEANUP_LIMIT_PER_TICK
+            ):
                 continue
             is_spawn_action = budget.is_spawn_action(action)
             consumes_spawn_budget = is_spawn_action or self._uses_spawn_budget(action)
             if (
                 action.get("risk_tier") == "medium"
                 and not consumes_spawn_budget
+                and not is_invalid_harness_cleanup
                 and applied_medium_non_spawns >= MEDIUM_NON_SPAWN_LIMIT_PER_TICK
             ):
                 continue
-            if worker_top_up_only and not consumes_spawn_budget and not _is_invalid_harness_cleanup(action):
+            if worker_top_up_only and not consumes_spawn_budget and not is_invalid_harness_cleanup:
                 continue
             if consumes_spawn_budget and applied_spawns >= budget.spawn_budget:
                 continue
             result = self.apply_action(action)
             results.append(result)
+            if is_invalid_harness_cleanup and result.status == "skipped":
+                applied_invalid_harness_cleanups += 1
+                continue
             if result.status == "skipped" and consumes_spawn_budget:
                 continue
             if result.status != "applied":
@@ -1937,10 +1949,11 @@ class WakeupRunner:
                         f"WAKEUP_RUNNER_STALE_RELEASE_DISPATCH_LEDGER:{action_id}:{stale_release_reason}"
                     )
                     continue
-                stale_spawn_reason = self._applied_spawn_stale_reason(action)
-                if stale_spawn_reason:
-                    self._append_pending_event(f"WAKEUP_RUNNER_STALE_SPAWN_LEDGER:{action_id}:{stale_spawn_reason}")
-                    continue
+                if action.get("controller_action") == "spawn_codex_harness_background":
+                    stale_spawn_reason = self._applied_spawn_stale_reason(action)
+                    if stale_spawn_reason:
+                        self._append_pending_event(f"WAKEUP_RUNNER_STALE_SPAWN_LEDGER:{action_id}:{stale_spawn_reason}")
+                        continue
                 if self._applied_row_current_effect_suppresses_retry(action):
                     return True
             if status == "blocked" and _terminal_blocked_reason(str(row.get("reason") or "")):
@@ -1965,9 +1978,54 @@ class WakeupRunner:
             return self._publish_review_fix_current_effect_suppresses_retry(action)
         if controller_action == "dispatch_reviewers":
             return self._dispatch_reviewers_current_effect_suppresses_retry(action)
+        if controller_action == "open_release_rollup_pr_from_action":
+            return self._release_rollup_current_effect_suppresses_retry(action)
         if _is_remote_ci_red_dispatch(action):
             return False
         return False
+
+    def _release_rollup_current_effect_suppresses_retry(self, action: Mapping[str, Any]) -> bool:
+        integration_sha = _release_rollup_integration_sha(action)
+        if not integration_sha:
+            return False
+        rollup_head = f"rollup/{integration_sha}"
+        if any(
+            _release_rollup_pr_matches_integration_sha(row, integration_sha, rollup_head)
+            for row in self._open_release_rollup_prs(rollup_head)
+        ):
+            return True
+        result = self.command_runner(["git", "ls-remote", "--exit-code", "--heads", "origin", rollup_head])
+        if result.returncode != 0:
+            return False
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[0] == integration_sha and parts[1] == f"refs/heads/{rollup_head}":
+                return True
+        return False
+
+    def _open_release_rollup_prs(self, rollup_head: str) -> list[Mapping[str, Any]]:
+        result = self.command_runner(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--head",
+                rollup_head,
+                "--json",
+                "number,headRefName,headRefOid",
+            ]
+        )
+        if result.returncode != 0:
+            return []
+        try:
+            payload = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError:
+            return []
+        if not isinstance(payload, list):
+            return []
+        return [row for row in payload if isinstance(row, Mapping)]
 
     def _consensus_implementation_current_effect_suppresses_retry(self, action: Mapping[str, Any]) -> bool:
         if consensus_implementation_suppressed_reason(dict(action), self.ctx.repo_root):
@@ -2436,6 +2494,29 @@ def _single_line(value: str) -> str:
 
 def _is_invalid_harness_cleanup(action: Mapping[str, Any]) -> bool:
     return action.get("kind") == "harness-spawn-intent-invalid"
+
+
+def _release_rollup_integration_sha(action: Mapping[str, Any]) -> str:
+    event = action.get("event")
+    if isinstance(event, Mapping):
+        integration_sha = str(event.get("integration_sha") or "").strip()
+        if integration_sha:
+            return integration_sha
+    target = action.get("target")
+    if isinstance(target, Mapping):
+        integration_sha = str(target.get("integration_sha") or "").strip()
+        if integration_sha:
+            return integration_sha
+    action_id = str(action.get("action_id") or "")
+    if action_id.startswith("release-rollup-needed:"):
+        return action_id.removeprefix("release-rollup-needed:").strip()
+    return ""
+
+
+def _release_rollup_pr_matches_integration_sha(row: Mapping[str, Any], integration_sha: str, rollup_head: str) -> bool:
+    head_ref = str(row.get("headRefName") or "").strip()
+    head_sha = str(row.get("headRefOid") or "").strip()
+    return head_ref == rollup_head and head_sha == integration_sha
 
 
 def _reviewer_log_terminal_failed(path: Path) -> bool:

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -5113,8 +5113,10 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
     def test_legacy_malformed_review_intent_for_merged_pr_projects_invalid_quarantine_once(self) -> None:
         malformed_intent = self.valid_review_harness_spawn_intent(774, "quality", 6)
+        malformed_intent["cd"] = "/Users/auric/consensus-rnd"
+        malformed_intent["reason"] = "review PR #774 as quality"
         malformed_intent.pop("queued_at")
-        line = "2026-05-31T00:00:00Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
+        line = "2026-06-10T11:48:43Z HARNESS_SPAWN_INTENT " + json.dumps(malformed_intent, sort_keys=True)
         pending = self.repo / ".refactor-loop" / ".controller-pending-events.log"
         pending.write_text(line + "\n", encoding="utf-8")
 
@@ -5124,6 +5126,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(1, len(actions))
         self.assertEqual("missing-queued_at", actions[0]["reason"])
         self.assertEqual(harness_spawn_intent_line_digest(line), actions[0]["evidence_digest"])
+        self.assertEqual("dispatch-reviewers:774:quality:r6", actions[0]["item"])
+        self.assertEqual(line, actions[0]["evidence"])
         self.assertFalse(
             [
                 action

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -4875,6 +4875,28 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         )
         self.assertEqual(second_actions.calls, [])
 
+    def test_release_rollup_remote_head_suppresses_second_tick_retry(self) -> None:
+        first_actions = FakeActions()
+        action = self.release_rollup_action()
+
+        first = self.run_result(self.base_plan(action), actions=first_actions)
+
+        self.assertEqual(first[0].status, "applied")
+        self.assertEqual([call[0] for call in first_actions.calls], ["open_release_rollup_pr_from_action"])
+        second_actions = FakeActions()
+        second = self.run_result(
+            self.base_plan(action),
+            actions=second_actions,
+            open_rollup_prs=[],
+            remote_rollup_refs={"rollup/abc123": "abc123"},
+        )
+
+        self.assertEqual(
+            [(result.action_id, result.status, result.reason) for result in second],
+            [(action["action_id"], "skipped", "duplicate")],
+        )
+        self.assertEqual(second_actions.calls, [])
+
     def test_release_rollup_body_spawn_renders_prompt_and_does_not_open_pr(self) -> None:
         action = self.release_rollup_body_action()
         actions = FakeActions()

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -641,6 +641,59 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertIn(f"WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{digest}:missing-queued_at", self.ctx.paths.pending_events.read_text(encoding="utf-8"))
         self.assertEqual(["open_release_rollup_pr_from_action"], [name for name, _payload in actions.calls])
 
+    def test_ordinary_tick_archives_capped_invalid_harness_batch_then_allows_work(self) -> None:
+        invalid_actions = []
+        pending_lines = []
+        for index in range(7):
+            raw_line = "2026-06-10T11:48:39Z HARNESS_SPAWN_INTENT " + json.dumps(
+                {
+                    "cd": str(self.repo),
+                    "command": "spawn-codex",
+                    "controller_action": "spawn_codex_harness_background",
+                    "intent_id": f"invalid-review:{index}",
+                    "log": f".refactor-loop/logs/invalid-review-{index}.log",
+                    "no_lifecycle_authority": True,
+                    "prompt": f".refactor-loop/prompts/invalid-review-{index}.md",
+                    "run_in_background_required": True,
+                    "source": "controller-actions",
+                    "task_id": f"invalid-review-{index}",
+                },
+                sort_keys=True,
+            )
+            pending_lines.append(raw_line)
+            digest = harness_spawn_intent_line_digest(raw_line)
+            invalid_actions.append(
+                {
+                    "kind": "harness-spawn-intent-invalid",
+                    "action_id": f"harness-spawn-intent-invalid:{digest}",
+                    "runner_authority": "wakeup-runner-396",
+                    "preconditions": ["source_artifact_contains_evidence"],
+                    "source_artifact": ".refactor-loop/.controller-pending-events.log",
+                    "source_marker": "HARNESS_SPAWN_INTENT",
+                    "evidence_digest": digest,
+                    "reason": "missing-queued_at",
+                    "no_lifecycle_authority": True,
+                    "no_generic_command": True,
+                }
+            )
+        self.ctx.paths.pending_events.write_text("\n".join(pending_lines) + "\n", encoding="utf-8")
+        ordinary = self.release_rollup_action(action_id="release-rollup-needed:after-invalid-batch")
+        with self.ctx.paths.pending_events.open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(pending_lines) + "\n")
+        actions = FakeActions()
+
+        results = self.run_result(
+            self.batch_plan([ordinary, *invalid_actions], dispatch_required=0, deficit=0, active=False),
+            actions=actions,
+        )
+
+        archived = [result for result in results if result.reason.startswith("archived_invalid_harness_spawn_intent:")]
+        self.assertGreater(len(archived), 1)
+        self.assertLessEqual(len(archived), 5)
+        self.assertEqual(results[-1].action_id, "release-rollup-needed:after-invalid-batch")
+        self.assertEqual(results[-1].status, "applied")
+        self.assertEqual(["open_release_rollup_pr_from_action"], [name for name, _payload in actions.calls])
+
     def test_runner_applies_at_most_one_medium_non_spawn_per_tick(self) -> None:
         base = {
             "kind": "default-issue-intake-claim",
@@ -738,6 +791,8 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         implementation_base: tuple[str, str] = ("base-sha", "base-sha"),
         actions=None,
         issue_comments: list[dict] | None = None,
+        open_rollup_prs: list[dict] | None = None,
+        remote_rollup_refs: dict[str, str] | None = None,
     ) -> list:
         def command_runner(command):
             if command[:2] == ["gh", "api"]:
@@ -780,6 +835,11 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                     return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
                 return subprocess.CompletedProcess(command, 0, "{}", "")
             if command[:4] == ["gh", "pr", "list", "--state"]:
+                if "--head" in command:
+                    head = str(command[command.index("--head") + 1])
+                    payload = open_rollup_prs or []
+                    payload = [row for row in payload if row.get("headRefName") == head]
+                    return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
                 payload = duplicate_prs
                 if payload is None:
                     payload = [
@@ -842,6 +902,12 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
                     f"worktree {repo_root / '.worktrees' / 'iter77-worker'}\nbranch refs/heads/{gh_head_ref}\n\n",
                     "",
                 )
+            if command[:5] == ["git", "ls-remote", "--exit-code", "--heads", "origin"]:
+                ref = str(command[5])
+                sha = (remote_rollup_refs or {}).get(ref)
+                if sha:
+                    return subprocess.CompletedProcess(command, 0, f"{sha}\trefs/heads/{ref}\n", "")
+                return subprocess.CompletedProcess(command, 2, "", "")
             return subprocess.CompletedProcess(command, 0, "", "")
 
         runner = WakeupRunner(
@@ -4781,6 +4847,33 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
 
         self.assertEqual(results[0].status, "applied")
         self.assertEqual(actions.calls[0][0], "open_release_rollup_pr_from_action")
+
+    def test_release_rollup_current_open_pr_suppresses_second_tick_retry(self) -> None:
+        first_actions = FakeActions()
+        action = self.release_rollup_action()
+
+        first = self.run_result(self.base_plan(action), actions=first_actions)
+
+        self.assertEqual(first[0].status, "applied")
+        self.assertEqual([call[0] for call in first_actions.calls], ["open_release_rollup_pr_from_action"])
+        second_actions = FakeActions()
+        second = self.run_result(
+            self.base_plan(action),
+            actions=second_actions,
+            open_rollup_prs=[
+                {
+                    "number": 123,
+                    "headRefName": "rollup/abc123",
+                    "headRefOid": "abc123",
+                }
+            ],
+        )
+
+        self.assertEqual(
+            [(result.action_id, result.status, result.reason) for result in second],
+            [(action["action_id"], "skipped", "duplicate")],
+        )
+        self.assertEqual(second_actions.calls, [])
 
     def test_release_rollup_body_spawn_renders_prompt_and_does_not_open_pr(self) -> None:
         action = self.release_rollup_body_action()

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -570,7 +570,6 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             },
             sort_keys=True,
         )
-        self.ctx.paths.pending_events.write_text(raw_line + "\n", encoding="utf-8")
         digest = harness_spawn_intent_line_digest(raw_line)
         invalid = {
             "kind": "harness-spawn-intent-invalid",
@@ -585,12 +584,62 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             "no_generic_command": True,
         }
         spawn = self.spawn_action(action_id="spawn:hard-gate-top-up")
+        with self.ctx.paths.pending_events.open("a", encoding="utf-8") as handle:
+            handle.write(raw_line + "\n")
 
         results = self.run_result(self.batch_plan([spawn, invalid], dispatch_required=2, deficit=2), actions=FakeActions())
 
         self.assertIn(f"WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{digest}:missing-queued_at", self.ctx.paths.pending_events.read_text(encoding="utf-8"))
         self.assertEqual(["skipped", "applied"], [result.status for result in results])
         self.assertEqual("archived_invalid_harness_spawn_intent:missing-queued_at", results[0].reason)
+
+    def test_ordinary_tick_archives_legacy_malformed_review_intent_for_merged_pr_before_successful_action(self) -> None:
+        raw_line = "2026-06-10T11:48:39Z HARNESS_SPAWN_INTENT " + json.dumps(
+            {
+                "cd": "/Users/auric/consensus-rnd",
+                "command": "spawn-codex",
+                "controller_action": "spawn_codex_harness_background",
+                "intent_id": "dispatch-reviewers:774:architect:r5",
+                "log": ".refactor-loop/logs/review-pr774-architect-r5.log",
+                "no_lifecycle_authority": True,
+                "priority": "p1",
+                "prompt": ".refactor-loop/prompts/review-pr774-architect-r5.md",
+                "reason": "review PR #774 as architect",
+                "route": "dispatch-reviewers",
+                "run_in_background_required": True,
+                "source": "controller-actions",
+                "stall": 5400,
+                "task_id": "review-pr774-architect-r5",
+            },
+            sort_keys=True,
+        )
+        self.ctx.paths.pending_events.write_text(raw_line + "\n", encoding="utf-8")
+        digest = harness_spawn_intent_line_digest(raw_line)
+        invalid = {
+            "kind": "harness-spawn-intent-invalid",
+            "action_id": f"harness-spawn-intent-invalid:{digest}",
+            "runner_authority": "wakeup-runner-396",
+            "preconditions": ["source_artifact_contains_evidence"],
+            "source_artifact": ".refactor-loop/.controller-pending-events.log",
+            "source_marker": "HARNESS_SPAWN_INTENT",
+            "evidence_digest": digest,
+            "reason": "missing-queued_at",
+            "no_lifecycle_authority": True,
+            "no_generic_command": True,
+        }
+        successful = self.release_rollup_action(action_id="release-rollup-needed:ordinary-success")
+        with self.ctx.paths.pending_events.open("a", encoding="utf-8") as handle:
+            handle.write(raw_line + "\n")
+        actions = FakeActions()
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", side_effect=AssertionError("must not spawn")):
+            results = self.run_result(self.batch_plan([successful, invalid], dispatch_required=0, deficit=0, active=False), actions=actions)
+
+        self.assertEqual(["skipped", "applied"], [result.status for result in results])
+        self.assertEqual("archived_invalid_harness_spawn_intent:missing-queued_at", results[0].reason)
+        self.assertEqual("release-rollup-needed:ordinary-success", results[1].action_id)
+        self.assertIn(f"WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{digest}:missing-queued_at", self.ctx.paths.pending_events.read_text(encoding="utf-8"))
+        self.assertEqual(["open_release_rollup_pr_from_action"], [name for name, _payload in actions.calls])
 
     def test_runner_applies_at_most_one_medium_non_spawn_per_tick(self) -> None:
         base = {


### PR DESCRIPTION
## Changed files

- skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py: caps invalid intent quarantine per tick and skips duplicate release-rollup apply when live read-only evidence already matches the same integration SHA.
- skills/consensus-loop/scripts/test_wakeup_runner.py: covers repeated rollup ticks and bounded invalid-intent draining with ordinary work progress.

## Test results

- python3 -m pytest skills/consensus-loop/scripts/test_wakeup_runner.py -q -p no:cacheprovider -o addopts=
- python3 -m pytest skills/consensus-loop/scripts/test_wakeup_plan.py -q -p no:cacheprovider -o addopts=
- bash -lc "python3 -m compileall skills/consensus-loop/scripts skills/sshx -q"
- bash -lc "python3 -m pytest skills/consensus-loop/scripts -q -p no:cacheprovider -o addopts= --ignore=skills/consensus-loop/scripts/test_restart_daemons.py --ignore=skills/consensus-loop/scripts/test_restart_supervisor.py --ignore=skills/consensus-loop/scripts/test_daemon_heartbeat.py --ignore=skills/consensus-loop/scripts/test_cli_daemon_help_smoke.py --ignore=skills/consensus-loop/scripts/test_peek_status_lens.py --ignore=skills/consensus-loop/scripts/test_zz_daemon_leak_guard.py --ignore=skills/consensus-loop/scripts/test_anti_stop_restart_helper_contract.py && python3 -m pytest skills/sshx/tests -q -p no:cacheprovider -o addopts="

## Deviations

- None.

Closes #788

⟦AI:AUTO-LOOP⟧
