### PR TITLE
Release rollup: integration ahead 1 commits (2e8648bab06b)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -912,9 +912,11 @@ class ControllerActions:
         head = str(pr.get("headRefName") or "").strip()
         if not GITHUB_LIFECYCLE_TARGET_RE.fullmatch(pr_target) or not head.startswith(ROLLUP_HEAD_PREFIX):
             raise RuntimeError("update release rollup singleton: invalid live rollup PR")
-        pushed = self.git(["push", "--force-with-lease", "origin", f"{integration_sha}:refs/heads/{head}"], check=False)
-        if pushed.returncode != 0:
-            raise RuntimeError(pushed.stderr.strip() or pushed.stdout.strip() or f"failed to update {head}")
+        head_sha = str(pr.get("headRefOid") or "").strip()
+        if head_sha != integration_sha:
+            pushed = self.git(["push", "--force-with-lease", "origin", f"{integration_sha}:refs/heads/{head}"], check=False)
+            if pushed.returncode != 0:
+                raise RuntimeError(pushed.stderr.strip() or pushed.stdout.strip() or f"failed to update {head}")
         edited = self.gh(["pr", "edit", pr_target, "--title", title, "--body-file", body_file], check=False)
         if edited.returncode != 0:
             raise RuntimeError(edited.stderr.strip() or edited.stdout.strip() or f"failed to refresh rollup PR #{pr_target}")

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -264,8 +264,16 @@ class ReviewRoundCompletion:
     heads_by_role: dict[str, str]
 
 
-def run_json(cmd: list[str], *, cwd: Path) -> Any:
-    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
+RELEASE_ROLLUP_LIVE_PR_LIST_TIMEOUT_SECONDS = 15
+
+
+def run_json(cmd: list[str], *, cwd: Path, timeout: float | None = None) -> Any:
+    try:
+        result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        if timeout is None:
+            raise
+        return None
     if result.returncode != 0:
         return None
     text = result.stdout.strip()
@@ -3302,6 +3310,46 @@ def _release_rollup_live_pr_view(repo_root: Path, pr_number: int) -> dict[str, A
     return result if isinstance(result, dict) else None
 
 
+def _release_rollup_event_satisfied(repo_root: Path, event: dict[str, Any], integration_sha: str) -> bool:
+    review_base_branch = safe_head_ref(str(event.get("review_base_branch") or ""))
+    if not review_base_branch or not integration_sha:
+        return False
+    result = run_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--base",
+            review_base_branch,
+            "--limit",
+            "100",
+            "--json",
+            "number,headRefName,baseRefName,headRefOid",
+        ],
+        cwd=repo_root,
+        timeout=RELEASE_ROLLUP_LIVE_PR_LIST_TIMEOUT_SECONDS,
+    )
+    if not isinstance(result, list):
+        return False
+    expected_head = f"rollup/{integration_sha}"
+    for item in result:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("baseRefName") or review_base_branch) != review_base_branch:
+            continue
+        head = safe_head_ref(str(item.get("headRefName") or ""))
+        if not head or not head.startswith("rollup/"):
+            continue
+        head_oid = str(item.get("headRefOid") or "").strip()
+        if head_oid != integration_sha:
+            continue
+        if head == expected_head or head.startswith("rollup/"):
+            return True
+    return False
+
+
 def _ci_check_action_token(check_name: str) -> str:
     token = re.sub(r"[^A-Za-z0-9._-]+", "-", check_name.strip()).strip("-")
     return token or "check"
@@ -3336,6 +3384,8 @@ def release_rollup_actions(repo_root: Path) -> list[dict[str, Any]]:
         latest_by_integration_sha[integration_sha] = (event, event_json, line)
     for integration_sha, (event, event_json, line) in latest_by_integration_sha.items():
         if not _release_rollup_event_is_fresh(repo_root, event, integration_sha):
+            continue
+        if _release_rollup_event_satisfied(repo_root, event, integration_sha):
             continue
         body_file = RELEASE_ROLLUP_BODY_FILE
         if not (repo_root / body_file).is_file():

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -61,6 +61,7 @@ from .worker_markers import read_worker_terminal_marker
 
 RUNNER_AUTHORITY = "wakeup-runner-396"
 APPLY_AUTHORITY = "wakeup-runner-396-only"
+INVALID_HARNESS_CLEANUP_LIMIT_PER_TICK = 50
 FORBIDDEN_ACTION_FIELDS = {
     "argv",
     "args",
@@ -288,9 +289,13 @@ class WakeupRunner:
         results: list[RunnerResult] = []
         applied_spawns = 0
         applied_medium_non_spawns = 0
+        archived_invalid_harness_cleanups = 0
         worker_top_up_only = False
         for action in self._actions_for_apply(plan.get("actions", []), budget):
             if not isinstance(action, dict) or action.get("status_only") is True:
+                continue
+            is_invalid_harness_cleanup = _is_invalid_harness_cleanup(action)
+            if is_invalid_harness_cleanup and archived_invalid_harness_cleanups >= INVALID_HARNESS_CLEANUP_LIMIT_PER_TICK:
                 continue
             is_spawn_action = budget.is_spawn_action(action)
             consumes_spawn_budget = is_spawn_action or self._uses_spawn_budget(action)
@@ -306,6 +311,9 @@ class WakeupRunner:
                 continue
             result = self.apply_action(action)
             results.append(result)
+            if is_invalid_harness_cleanup and result.reason.startswith("archived_invalid_harness_spawn_intent:"):
+                archived_invalid_harness_cleanups += 1
+                continue
             if result.status == "skipped" and consumes_spawn_budget:
                 continue
             if result.status != "applied":

--- a/skills/consensus-loop/scripts/test_controller_actions.py
+++ b/skills/consensus-loop/scripts/test_controller_actions.py
@@ -359,6 +359,46 @@ class ControllerActionsTests(unittest.TestCase):
         self.assertIn("Related issues: #12, #13", text)
         self.assertIn("⟦AI:RELEASE-ROLLUP⟧", text)
 
+    def test_update_existing_release_rollup_pr_skips_force_push_when_head_oid_matches(self) -> None:
+        body = self.tmp / ".refactor-loop" / "runs" / "release-rollup-pr-body.md"
+        event = {
+            "integration_branch": "canonical-integration",
+            "review_base_branch": "canonical-review",
+            "integration_sha": "abc123",
+            "review_base_sha": "def456",
+            "ahead_count": 3,
+        }
+        gh_calls: list[list[str]] = []
+        git_calls: list[list[str]] = []
+
+        def fake_gh(args: list[str], *, check: bool = True) -> mock.Mock:
+            gh_calls.append(args)
+            if args[:2] == ["pr", "list"]:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps([{"number": 88, "baseRefName": "canonical-review", "headRefName": "rollup/abc123", "headRefOid": "abc123"}]),
+                    stderr="",
+                )
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        def fake_git(args: list[str], *, check: bool = True) -> mock.Mock:
+            git_calls.append(args)
+            if args[:3] == ["ls-remote", "--exit-code", "--heads"]:
+                return mock.Mock(returncode=0, stdout="abc123\trefs/heads/canonical-integration\n", stderr="")
+            if args[:4] == ["log", "--no-merges", "--format=%s", "--max-count=25"]:
+                return mock.Mock(returncode=0, stdout="Fix #12 rollup singleton\n", stderr="")
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(self.actions, "_require_owner_or_raise", return_value=None):
+            with mock.patch.object(self.actions, "gh", side_effect=fake_gh), mock.patch.object(self.actions, "git", side_effect=fake_git):
+                pr_number, head = self.actions.open_release_rollup_pr_from_pending_event(json.dumps(event), str(body))
+
+        self.assertEqual((88, "rollup/abc123"), (pr_number, head))
+        self.assertFalse(any(call[:2] == ["push", "--force-with-lease"] for call in git_calls))
+        edit_call = next(call for call in gh_calls if call[:2] == ["pr", "edit"])
+        self.assertEqual("88", edit_call[2])
+        self.assertIn("--body-file", edit_call)
+
     def test_explicit_zh_release_rollup_preserves_existing_body_copy(self) -> None:
         body = self.tmp / ".refactor-loop" / "runs" / "release-rollup-pr-body.md"
         self.actions.ctx.host_env["HOST_WORK_LANGUAGE"] = "zh"

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -35,6 +35,8 @@ from codex_refactor_loop.wakeup_plan import (  # noqa: E402
     GhItem,
     INVALID_HARNESS_SPAWN_INTENT_SOURCE_ARTIFACT,
     INVALID_HARNESS_SPAWN_INTENT_SOURCE_MARKER,
+    RELEASE_ROLLUP_LIVE_PR_LIST_TIMEOUT_SECONDS,
+    _release_rollup_event_satisfied,
     _revive_stale_redispatchable_implement_log,
     ci_red_actions,
     close_projection_actions,
@@ -893,6 +895,29 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                   exit 0
                 fi
                 if [[ "$cmd1 $cmd2" == "pr list" ]]; then
+                  if [[ "$args" == *"--base review"* && "$args" == *"--json number,headRefName,baseRefName,headRefOid"* ]]; then
+                    if [[ -n "${WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG:-}" ]]; then
+                      printf '%s\n' "$args" >> "$WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG"
+                    fi
+                    case "$fixture" in
+                      release_rollup_satisfied)
+                        printf '[{"number":572,"baseRefName":"review","headRefName":"rollup/integration-sha","headRefOid":"integration-sha"}]\n'
+                        ;;
+                      release_rollup_changed_sha)
+                        printf '[{"number":572,"baseRefName":"review","headRefName":"rollup/old-integration-sha","headRefOid":"old-integration-sha"}]\n'
+                        ;;
+                      release_rollup_invalid_live_json)
+                        printf '{"not":"a-list"}\n'
+                        ;;
+                      release_rollup_live_unavailable)
+                        exit 42
+                        ;;
+                      *)
+                        printf '[]\n'
+                        ;;
+                    esac
+                    exit 0
+                  fi
                   case "$fixture" in
                     gh_failure)
                       exit 42
@@ -5059,6 +5084,84 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(1, len(actions))
         self.assertEqual(actions[0]["event"]["integration_sha"], "integration-sha")
 
+    def test_wakeup_plan_release_rollup_suppresses_event_when_open_rollup_head_matches_integration_sha(self) -> None:
+        self.append_release_rollup_event()
+        body_file = self.repo / ".refactor-loop" / "runs" / "release-rollup-pr-body.md"
+        body_file.parent.mkdir(parents=True, exist_ok=True)
+        body_file.write_text(
+            "## rollup\n\nbody\n\n⟦AI:AUTO-LOOP⟧\n",
+            encoding="utf-8",
+        )
+        live_probe_log = self.repo / "release-rollup-live-pr-list.log"
+
+        plan, _stdout = self.run_plan_with_env(
+            {"WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG": str(live_probe_log)},
+            fixture="release_rollup_satisfied",
+        )
+
+        self.assertFalse([action for action in plan["actions"] if action["kind"] == "release-rollup-needed"])
+        probe_calls = live_probe_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(1, len(probe_calls))
+        self.assertIn("pr list --state open --base review", probe_calls[0])
+        self.assertIn("--json number,headRefName,baseRefName,headRefOid", probe_calls[0])
+
+        live_probe_log.write_text("", encoding="utf-8")
+        plan_without_matching_pr, _stdout = self.run_plan_with_env(
+            {"WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG": str(live_probe_log)},
+            fixture="release_rollup",
+        )
+
+        actions = [action for action in plan_without_matching_pr["actions"] if action["kind"] == "release-rollup-needed"]
+        self.assertEqual(1, len(actions))
+        self.assertEqual("open_release_rollup_pr_from_action", actions[0]["controller_action"])
+        self.assertEqual(1, len(live_probe_log.read_text(encoding="utf-8").splitlines()))
+
+    def test_release_rollup_satisfied_probe_timeout_fails_open(self) -> None:
+        event = {
+            "review_base_branch": "review",
+            "integration_sha": "integration-sha",
+        }
+        with mock.patch("codex_refactor_loop.wakeup_plan.subprocess.run") as run_mock:
+            run_mock.side_effect = subprocess.TimeoutExpired(["gh", "pr", "list"], timeout=0.01)
+
+            self.assertFalse(_release_rollup_event_satisfied(self.repo, event, "integration-sha"))
+
+        run_mock.assert_called_once()
+        self.assertEqual(RELEASE_ROLLUP_LIVE_PR_LIST_TIMEOUT_SECONDS, run_mock.call_args.kwargs["timeout"])
+
+    def test_wakeup_plan_release_rollup_projects_when_rollup_pr_missing_or_unavailable(self) -> None:
+        for fixture in ("release_rollup", "release_rollup_live_unavailable", "release_rollup_invalid_live_json"):
+            with self.subTest(fixture=fixture):
+                (self.repo / ".refactor-loop" / ".controller-pending-events.log").write_text("", encoding="utf-8")
+                self.append_release_rollup_event()
+                body_file = self.repo / ".refactor-loop" / "runs" / "release-rollup-pr-body.md"
+                body_file.parent.mkdir(parents=True, exist_ok=True)
+                body_file.write_text(
+                    "## rollup\n\nbody\n\n⟦AI:AUTO-LOOP⟧\n",
+                    encoding="utf-8",
+                )
+
+                plan = self.run_plan(fixture=fixture)
+
+                actions = [action for action in plan["actions"] if action["kind"] == "release-rollup-needed"]
+                self.assertEqual(1, len(actions))
+                self.assertEqual("open_release_rollup_pr_from_action", actions[0]["controller_action"])
+
+    def test_wakeup_plan_release_rollup_projects_when_integration_sha_changes(self) -> None:
+        self.append_release_rollup_event(integration_sha="integration-sha")
+        body_file = self.repo / ".refactor-loop" / "runs" / "release-rollup-pr-body.md"
+        body_file.parent.mkdir(parents=True, exist_ok=True)
+        body_file.write_text(
+            "## rollup\n\nbody\n\n⟦AI:AUTO-LOOP⟧\n",
+            encoding="utf-8",
+        )
+
+        plan = self.run_plan(fixture="release_rollup_changed_sha")
+
+        actions = [action for action in plan["actions"] if action["kind"] == "release-rollup-needed"]
+        self.assertEqual(1, len(actions))
+        self.assertEqual("release-rollup-needed:integration-sha", actions[0]["action_id"])
+
     def test_rollup_pr_is_excluded_from_reviewer_and_ci_fix_projection(self) -> None:
         item = GhItem(
             kind="PR",
@@ -5853,17 +5956,16 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             with self.subTest(snapshot_token=token):
                 self.assertIn(token, snapshot_source)
         caller_source = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "wakeup_plan.py").read_text(encoding="utf-8")
-        self.assertNotIn("issue list", caller_source)
-        self.assertNotIn("pr list", caller_source)
+        redispatch_source = caller_source[
+            caller_source.index("def review_evidence_redispatch_actions") : caller_source.index("\ndef phase_from_marker", caller_source.index("def review_evidence_redispatch_actions"))
+        ]
+        self.assertNotIn("issue list", redispatch_source)
+        self.assertNotIn("pr list", redispatch_source)
         self.assertIn("review_evidence_redispatch_actions", projection.function_names)
         self.assertIn("review-evidence-redispatch", projection.set_members["EXECUTABLE_ACTION_KINDS"])
-        source = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "wakeup_plan.py").read_text(encoding="utf-8")
-        function_source = source[
-            source.index("def review_evidence_redispatch_actions") : source.index("\ndef phase_from_marker", source.index("def review_evidence_redispatch_actions"))
-        ]
-        self.assertIn('"action_id": f"review-evidence-redispatch:{item.number}:{item.head_sha}"', function_source)
-        self.assertIn('"head_sha": item.head_sha', function_source)
-        self.assertIn("highest_complete_required_review_round", function_source)
+        self.assertIn('"action_id": f"review-evidence-redispatch:{item.number}:{item.head_sha}"', redispatch_source)
+        self.assertIn('"head_sha": item.head_sha', redispatch_source)
+        self.assertIn("highest_complete_required_review_round", redispatch_source)
 
     def test_wakeup_plan_source_locks_stale_unexecutable_status_only_suppression(self) -> None:
         projection = wakeup_plan_projection()

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -641,6 +641,97 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertIn(f"WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:{digest}:missing-queued_at", self.ctx.paths.pending_events.read_text(encoding="utf-8"))
         self.assertEqual(["open_release_rollup_pr_from_action"], [name for name, _payload in actions.calls])
 
+    def test_wakeup_runner_ordinary_tick_archives_bounded_invalid_harness_spawn_intent_batch(self) -> None:
+        raw_lines = [
+            "2026-06-10T11:48:39Z HARNESS_SPAWN_INTENT "
+            + json.dumps(
+                {
+                    "cd": str(self.repo),
+                    "command": "spawn-codex",
+                    "controller_action": "spawn_codex_harness_background",
+                    "intent_id": f"dispatch-reviewers:774:architect:r{index}",
+                    "log": f".refactor-loop/logs/review-pr774-architect-r{index}.log",
+                    "no_lifecycle_authority": True,
+                    "priority": "p1",
+                    "prompt": f".refactor-loop/prompts/review-pr774-architect-r{index}.md",
+                    "reason": "review PR #774 as architect",
+                    "route": "dispatch-reviewers",
+                    "run_in_background_required": True,
+                    "source": "controller-actions",
+                    "stall": 5400,
+                    "task_id": f"review-pr774-architect-r{index}",
+                },
+                sort_keys=True,
+            )
+            for index in range(55)
+        ]
+        self.ctx.paths.pending_events.write_text("\n".join(raw_lines) + "\n", encoding="utf-8")
+        actions = [self.invalid_harness_spawn_intent_action(raw_line) for raw_line in raw_lines]
+        runner_actions = FakeActions()
+
+        first_tick = self.run_result(self.batch_plan(actions, dispatch_required=0, deficit=0, active=False), actions=runner_actions)
+        second_tick = self.run_result(self.batch_plan(actions[50:], dispatch_required=0, deficit=0, active=False), actions=runner_actions)
+
+        self.assertEqual(50, len(first_tick))
+        self.assertTrue(all(result.reason == "archived_invalid_harness_spawn_intent:missing-queued_at" for result in first_tick))
+        self.assertEqual(55, len(first_tick) + len(second_tick))
+        pending = self.ctx.paths.pending_events.read_text(encoding="utf-8")
+        for raw_line in raw_lines:
+            self.assertEqual(
+                1,
+                pending.count(
+                    "WAKEUP_RUNNER_ARCHIVED_INVALID_HARNESS_SPAWN_INTENT:"
+                    + harness_spawn_intent_line_digest(raw_line)
+                    + ":missing-queued_at"
+                ),
+            )
+        self.assertEqual([], runner_actions.calls)
+
+    def test_wakeup_runner_cleanup_batch_cap_preserves_single_lifecycle_apply(self) -> None:
+        raw_lines = [
+            "2026-06-10T11:48:39Z HARNESS_SPAWN_INTENT "
+            + json.dumps(
+                {
+                    "cd": str(self.repo),
+                    "command": "spawn-codex",
+                    "controller_action": "spawn_codex_harness_background",
+                    "intent_id": f"dispatch-reviewers:775:quality:r{index}",
+                    "log": f".refactor-loop/logs/review-pr775-quality-r{index}.log",
+                    "no_lifecycle_authority": True,
+                    "priority": "p1",
+                    "prompt": f".refactor-loop/prompts/review-pr775-quality-r{index}.md",
+                    "reason": "review PR #775 as quality",
+                    "route": "dispatch-reviewers",
+                    "run_in_background_required": True,
+                    "source": "controller-actions",
+                    "stall": 5400,
+                    "task_id": f"review-pr775-quality-r{index}",
+                },
+                sort_keys=True,
+            )
+            for index in range(50)
+        ]
+        self.ctx.paths.pending_events.write_text("\n".join(raw_lines) + "\n", encoding="utf-8")
+        cleanup_actions = [self.invalid_harness_spawn_intent_action(raw_line) for raw_line in raw_lines]
+        rollup_one = self.release_rollup_action(action_id="release-rollup-needed:first")
+        rollup_two = self.release_rollup_action(action_id="release-rollup-needed:second")
+        with self.ctx.paths.pending_events.open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(raw_lines) + "\n")
+        actions = FakeActions()
+
+        results = self.run_result(
+            self.batch_plan([rollup_two, rollup_one, *cleanup_actions], dispatch_required=0, deficit=0, active=False),
+            actions=actions,
+        )
+
+        self.assertEqual(51, len(results))
+        self.assertEqual(
+            ["open_release_rollup_pr_from_action"],
+            [name for name, _payload in actions.calls],
+        )
+        self.assertEqual(50, sum(1 for result in results if result.reason == "archived_invalid_harness_spawn_intent:missing-queued_at"))
+        self.assertEqual(1, sum(1 for result in results if result.status == "applied"))
+
     def test_runner_applies_at_most_one_medium_non_spawn_per_tick(self) -> None:
         base = {
             "kind": "default-issue-intake-claim",
@@ -963,6 +1054,23 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         if "execution_policy" not in annotated:
             annotated["execution_policy"] = "cautious" if annotated["risk_tier"] == "medium" else "auto"
         return annotated
+
+    def invalid_harness_spawn_intent_action(self, raw_line: str, **overrides) -> dict:
+        digest = harness_spawn_intent_line_digest(raw_line)
+        action = {
+            "kind": "harness-spawn-intent-invalid",
+            "action_id": f"harness-spawn-intent-invalid:{digest}",
+            "runner_authority": "wakeup-runner-396",
+            "preconditions": ["source_artifact_contains_evidence"],
+            "source_artifact": ".refactor-loop/.controller-pending-events.log",
+            "source_marker": "HARNESS_SPAWN_INTENT",
+            "evidence_digest": digest,
+            "reason": "missing-queued_at",
+            "no_lifecycle_authority": True,
+            "no_generic_command": True,
+        }
+        action.update(overrides)
+        return action
 
     def spawn_action(self, **overrides) -> dict:
         prompt = self.repo / ".refactor-loop/prompts/task.md"


### PR DESCRIPTION
### Release rollup

- Target: `auto-refact-dev` -> `dev`
- Integration branch ahead of review-base: `1` commits
- Range: `a3e711b571bf..2e8648bab06b`

### Commit summary

- Fix runner starvation chain: live-state rollup event suppression, bounded invalid-intent cleanup batch, redundant force-push skip

### Merge policy

- After required checks are green, controller auto squash-merges; when `ROLLUP_AUTO_MERGE=manual`, wait for human review/merge.
- This PR is the release rollup singleton; when an open rollup already exists, controller only updates its head and body instead of opening another PR.

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
