### PR TITLE
Release rollup: integration ahead 1 commits (794f523ab57c)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -3313,10 +3313,29 @@ def _release_rollup_live_pr_view(repo_root: Path, pr_number: int) -> dict[str, A
     return result if isinstance(result, dict) else None
 
 
+def _release_rollup_pr_matches_integration(
+    item: object,
+    *,
+    review_base_branch: str,
+    integration_sha: str,
+    expected_head: str,
+) -> bool:
+    if not isinstance(item, dict):
+        return False
+    if str(item.get("baseRefName") or review_base_branch) != review_base_branch:
+        return False
+    head = safe_head_ref(str(item.get("headRefName") or ""))
+    if not head or not head.startswith("rollup/"):
+        return False
+    head_oid = str(item.get("headRefOid") or "").strip()
+    return head == expected_head or head_oid == integration_sha
+
+
 def _release_rollup_event_satisfied(repo_root: Path, event: dict[str, Any], integration_sha: str) -> bool:
     review_base_branch = safe_head_ref(str(event.get("review_base_branch") or ""))
     if not review_base_branch or not integration_sha:
         return False
+    expected_head = f"rollup/{integration_sha}"
     result = run_json(
         [
             "gh",
@@ -3336,19 +3355,46 @@ def _release_rollup_event_satisfied(repo_root: Path, event: dict[str, Any], inte
     )
     if not isinstance(result, list):
         return False
-    expected_head = f"rollup/{integration_sha}"
     for item in result:
+        if _release_rollup_pr_matches_integration(
+            item,
+            review_base_branch=review_base_branch,
+            integration_sha=integration_sha,
+            expected_head=expected_head,
+        ):
+            return True
+    merged_result = run_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--base",
+            review_base_branch,
+            "--head",
+            expected_head,
+            "--limit",
+            "5",
+            "--json",
+            "number,state,headRefName,headRefOid,baseRefName",
+        ],
+        cwd=repo_root,
+        timeout=RELEASE_ROLLUP_LIVE_PR_LIST_TIMEOUT_SECONDS,
+    )
+    if not isinstance(merged_result, list):
+        return False
+    for item in merged_result:
         if not isinstance(item, dict):
             continue
-        if str(item.get("baseRefName") or review_base_branch) != review_base_branch:
+        if str(item.get("state") or "").upper() != "MERGED":
             continue
-        head = safe_head_ref(str(item.get("headRefName") or ""))
-        if not head or not head.startswith("rollup/"):
-            continue
-        head_oid = str(item.get("headRefOid") or "").strip()
-        if head_oid != integration_sha:
-            continue
-        if head == expected_head or head.startswith("rollup/"):
+        if _release_rollup_pr_matches_integration(
+            item,
+            review_base_branch=review_base_branch,
+            integration_sha=integration_sha,
+            expected_head=expected_head,
+        ):
             return True
     return False
 

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -895,7 +895,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                   exit 0
                 fi
                 if [[ "$cmd1 $cmd2" == "pr list" ]]; then
-                  if [[ "$args" == *"--base review"* && "$args" == *"--json number,headRefName,baseRefName,headRefOid"* ]]; then
+                  if [[ "$args" == *"--state open"* && "$args" == *"--base review"* && "$args" == *"--json number,headRefName,baseRefName,headRefOid"* ]]; then
                     if [[ -n "${WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG:-}" ]]; then
                       printf '%s\n' "$args" >> "$WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG"
                     fi
@@ -910,6 +910,26 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                         printf '{"not":"a-list"}\n'
                         ;;
                       release_rollup_live_unavailable)
+                        exit 42
+                        ;;
+                      *)
+                        printf '[]\n'
+                        ;;
+                    esac
+                    exit 0
+                  fi
+                  if [[ "$args" == *"--state merged"* && "$args" == *"--base review"* && "$args" == *"--head rollup/integration-sha"* && "$args" == *"--json number,state,headRefName,headRefOid,baseRefName"* ]]; then
+                    if [[ -n "${WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG:-}" ]]; then
+                      printf '%s\n' "$args" >> "$WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG"
+                    fi
+                    case "$fixture" in
+                      release_rollup_merged_satisfied)
+                        printf '[{"number":792,"state":"MERGED","baseRefName":"review","headRefName":"rollup/integration-sha","headRefOid":"integration-sha"}]\n'
+                        ;;
+                      release_rollup_merged_changed_sha)
+                        printf '[{"number":792,"state":"MERGED","baseRefName":"review","headRefName":"rollup/old-integration-sha","headRefOid":"old-integration-sha"}]\n'
+                        ;;
+                      release_rollup_merged_probe_failure)
                         exit 42
                         ;;
                       *)
@@ -5150,7 +5170,70 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         actions = [action for action in plan_without_matching_pr["actions"] if action["kind"] == "release-rollup-needed"]
         self.assertEqual(1, len(actions))
         self.assertEqual("open_release_rollup_pr_from_action", actions[0]["controller_action"])
-        self.assertEqual(1, len(live_probe_log.read_text(encoding="utf-8").splitlines()))
+        probe_calls = live_probe_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(2, len(probe_calls))
+        self.assertIn("pr list --state open --base review", probe_calls[0])
+        self.assertIn("pr list --state merged --base review --head rollup/integration-sha", probe_calls[1])
+
+    def test_wakeup_plan_release_rollup_suppresses_event_when_merged_rollup_head_matches_integration_sha(self) -> None:
+        self.append_release_rollup_event()
+        live_probe_log = self.repo / "release-rollup-live-pr-list.log"
+
+        plan, _stdout = self.run_plan_with_env(
+            {"WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG": str(live_probe_log)},
+            fixture="release_rollup_merged_satisfied",
+        )
+
+        self.assertFalse([action for action in plan["actions"] if action["kind"] == "release-rollup-needed"])
+        probe_calls = live_probe_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(2, len(probe_calls))
+        self.assertIn("pr list --state open --base review", probe_calls[0])
+        self.assertIn("pr list --state merged --base review --head rollup/integration-sha", probe_calls[1])
+        self.assertIn("--json number,state,headRefName,headRefOid,baseRefName", probe_calls[1])
+
+    def test_wakeup_plan_release_rollup_projects_when_merged_rollup_head_is_different_sha(self) -> None:
+        self.append_release_rollup_event(integration_sha="integration-sha")
+        body_file = self.repo / ".refactor-loop" / "runs" / "release-rollup-pr-body.md"
+        body_file.parent.mkdir(parents=True, exist_ok=True)
+        body_file.write_text(
+            "## rollup\n\nbody\n\n⟦AI:AUTO-LOOP⟧\n",
+            encoding="utf-8",
+        )
+        live_probe_log = self.repo / "release-rollup-live-pr-list.log"
+
+        plan, _stdout = self.run_plan_with_env(
+            {"WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG": str(live_probe_log)},
+            fixture="release_rollup_merged_changed_sha",
+        )
+
+        actions = [action for action in plan["actions"] if action["kind"] == "release-rollup-needed"]
+        self.assertEqual(1, len(actions))
+        self.assertEqual("open_release_rollup_pr_from_action", actions[0]["controller_action"])
+        probe_calls = live_probe_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(2, len(probe_calls))
+        self.assertIn("pr list --state merged --base review --head rollup/integration-sha", probe_calls[1])
+
+    def test_wakeup_plan_release_rollup_merged_probe_failure_fails_open(self) -> None:
+        self.append_release_rollup_event()
+        body_file = self.repo / ".refactor-loop" / "runs" / "release-rollup-pr-body.md"
+        body_file.parent.mkdir(parents=True, exist_ok=True)
+        body_file.write_text(
+            "## rollup\n\nbody\n\n⟦AI:AUTO-LOOP⟧\n",
+            encoding="utf-8",
+        )
+        live_probe_log = self.repo / "release-rollup-live-pr-list.log"
+
+        plan, _stdout = self.run_plan_with_env(
+            {"WAKEUP_PLAN_GH_RELEASE_ROLLUP_LOG": str(live_probe_log)},
+            fixture="release_rollup_merged_probe_failure",
+        )
+
+        actions = [action for action in plan["actions"] if action["kind"] == "release-rollup-needed"]
+        self.assertEqual(1, len(actions))
+        self.assertEqual("open_release_rollup_pr_from_action", actions[0]["controller_action"])
+        probe_calls = live_probe_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(2, len(probe_calls))
+        self.assertIn("pr list --state merged --base review --head rollup/integration-sha", probe_calls[1])
 
     def test_release_rollup_satisfied_probe_timeout_fails_open(self) -> None:
         event = {


### PR DESCRIPTION
### Release rollup

- Target: `auto-refact-dev` -> `dev`
- Integration branch ahead of review-base: `1` commits
- Range: `c07ae73dc373..794f523ab57c`

### Commit summary

- Treat merged rollup PR at integration SHA as satisfying release-rollup event

### Merge policy

- After required checks are green, controller auto squash-merges; when `ROLLUP_AUTO_MERGE=manual`, wait for human review/merge.
- This PR is the release rollup singleton; when an open rollup already exists, controller only updates its head and body instead of opening another PR.

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
