### PR TITLE
Lock Tier-0 runtime scaffold boundaries

### DIFF
--- a/skills/consensus-loop/SKILL.md
+++ b/skills/consensus-loop/SKILL.md
@@ -2183,7 +2183,7 @@ One-shot:`python3 <skill-root>/scripts/consensus-rnd-cli phase9-router --once --
 <a id="tier0-scaffold-inventory"></a>
 ### Tier 0 scaffold inventory
 
-This inventory is prose plus the single test-owned/data-only `controller_runtime_inventory.py`, and remains non-authoritative. It is a reader index for existing owner-local surfaces, not a runtime scaffold, package API, or executable registry. Runtime execution paths must not import/read `controller_runtime_inventory.py`; it has no dispatch, write, state-transition, pending-events, label mutation, GitHub/git, or authorization authority.
+This inventory is prose plus the single test-owned/data-only `controller_runtime_inventory.py`, and remains non-authoritative. It is a reader index for existing owner-local surfaces, not a runtime scaffold, package API, or executable registry. `restart.py::DAEMON_COMMANDS` remains the sole active seven-daemon command surface. Runtime execution paths must not import/read `controller_runtime_inventory.py`; it has no dispatch, write, state-transition, pending-events, label mutation, GitHub/git, or authorization authority.
 
 Owner-local fact sources stay where their behavior is owned:
 

--- a/skills/consensus-loop/scripts/test_controller_runtime_inventory.py
+++ b/skills/consensus-loop/scripts/test_controller_runtime_inventory.py
@@ -87,6 +87,21 @@ class ControllerRuntimeInventoryTests(unittest.TestCase):
             with self.subTest(path=path.relative_to(SCRIPT_DIR)):
                 self.assertNotIn("controller_runtime_inventory", path.read_text(encoding="utf-8"))
 
+    def test_inventory_does_not_define_generated_runtime_residue_or_cleanup_surface(self) -> None:
+        source = SCRIPT_DIR / "codex_refactor_loop" / "controller_runtime_inventory.py"
+        text = source.read_text(encoding="utf-8")
+
+        for token in (
+            "__pycache__",
+            "cleanup",
+            "retention",
+            ".refactor-loop",
+            "pending-events",
+            "pending_events",
+        ):
+            with self.subTest(token=token):
+                self.assertNotIn(token, text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/consensus-loop/scripts/test_restart_daemons.py
+++ b/skills/consensus-loop/scripts/test_restart_daemons.py
@@ -339,6 +339,7 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         self.assertIn("closed_label_reconciler", restart_managed_daemon_names())
         self.assertIn("wakeup_runner_daemon", restart_managed_daemon_names())
         self.assertNotIn("patrol_inspector_daemon", restart_managed_daemon_names())
+        self.assertNotIn("controller_tick_supervisor", restart_managed_daemon_names())
         patched = (
             ("first", ("python3", "first")),
             ("second", ("python3", "second")),

--- a/skills/consensus-loop/scripts/test_skill_reference_anchors.py
+++ b/skills/consensus-loop/scripts/test_skill_reference_anchors.py
@@ -2013,6 +2013,7 @@ class WakeupRunnerContractTests(unittest.TestCase):
 
     def test_restart_managed_daemon_list_projects_owner_local_command_surface(self) -> None:
         self.assertIn("restart.py::DAEMON_COMMANDS", self.skill)
+        self.assertIn("sole active seven-daemon command surface", self.skill)
         for daemon_name in restart_managed_daemon_names():
             with self.subTest(daemon_name=daemon_name):
                 self.assertIn(daemon_name, self.skill)
@@ -2046,6 +2047,7 @@ class WakeupRunnerContractTests(unittest.TestCase):
             "Runtime execution paths must not import/read `controller_runtime_inventory.py`",
             "no dispatch, write, state-transition, pending-events, label mutation, GitHub/git, or authorization authority",
             "restart.py::DAEMON_COMMANDS",
+            "sole active seven-daemon command surface",
             "restart_managed_daemon_names()",
             "daemon name, owner module/CLI command, tick import path, authority note, and test owner",
             "callable, argv/shell/cmd/env, git/gh, executor, dispatch, authorization, pending-events, state-transition, or lifecycle owner fields",

--- a/skills/consensus-loop/scripts/test_work_unit_contract.py
+++ b/skills/consensus-loop/scripts/test_work_unit_contract.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Contract tests for existing work-unit identity/provenance fields."""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_ROOT = SCRIPT_DIR.parent
+SKILL_MD = SKILL_ROOT / "SKILL.md"
+PACKAGE_ROOT = SCRIPT_DIR / "codex_refactor_loop"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from codex_refactor_loop.phase9.router import MetaJudgePromptContext  # noqa: E402
+from codex_refactor_loop.transition_assessment import ALLOWED_PRODUCERS, TransitionAssessment  # noqa: E402
+
+
+def read_skill() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def section_after_heading(markdown: str, heading: str) -> str:
+    pattern = re.compile(rf"(?m)^## {re.escape(heading)}$")
+    match = pattern.search(markdown)
+    if not match:
+        raise AssertionError(f"missing markdown heading: {heading}")
+    tail = markdown[match.start() :]
+    next_match = re.search(r"(?m)^##\s+", tail[1:])
+    return tail[: next_match.start() + 1] if next_match else tail
+
+
+def work_unit_contract_surface(markdown: str) -> str:
+    start_pattern = re.compile(r"(?m)^## Work-unit contract$")
+    end_pattern = re.compile(r"(?m)^<a id=\"specialized-state-artifacts\"></a>$")
+    start = start_pattern.search(markdown)
+    end = end_pattern.search(markdown)
+    if not start or not end or end.start() <= start.start():
+        raise AssertionError("missing work-unit contract surface")
+    return markdown[start.start() : end.start()]
+
+
+class WorkUnitContractTests(unittest.TestCase):
+    def test_skill_contract_keeps_existing_work_unit_fields_and_producers(self) -> None:
+        contract = work_unit_contract_surface(read_skill())
+
+        for needle in (
+            "`work_unit_id`: canonical work-unit identity",
+            "`kind`: work-unit type",
+            "`producer`: source producer",
+            "`source_ref`: stable pointer to the source material",
+            "`scope_paths`",
+            "`old_pattern`",
+            "`new_principle`",
+            "`verification_hints`",
+            "`dependencies`",
+            "`risk`",
+            "`leverage`",
+            "`work_unit_id == id == cluster_id == legacy_cluster_id`",
+            "`WORK_UNIT_ID=$CLUSTER_ID`",
+            "`audit`",
+            "`manual-issue`",
+            "`work_unit_id: issue-<N>`",
+            "`producer: manual-issue`",
+            "`source_ref: gh-issue-<N>`",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, contract)
+
+    def test_work_unit_contract_does_not_authorize_second_runtime_surface(self) -> None:
+        contract = work_unit_contract_surface(read_skill())
+
+        for forbidden in (
+            "migrated queue containers",
+            "normalizer helpers",
+            "root state migrations",
+            "producer abstractions",
+            "registry helpers",
+            "envelope wrappers",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertIn(forbidden, contract)
+
+        package_sources = "\n".join(path.read_text(encoding="utf-8") for path in PACKAGE_ROOT.rglob("*.py"))
+        for token in (
+            "WorkUnitRegistry",
+            "WorkUnitEnvelope",
+            "WorkUnitNormalizer",
+            "work_unit_registry",
+            "work_unit_envelope",
+            "work_unit_normalizer",
+        ):
+            with self.subTest(token=token):
+                self.assertNotIn(token, package_sources)
+
+    def test_manual_issue_prompt_context_projects_existing_provenance_fields(self) -> None:
+        context = MetaJudgePromptContext(
+            issue="838",
+            round=1,
+            solver_paths={
+                "minimal": ".refactor-loop/runs/phase9-issue838-r1-minimal.md",
+                "structural": ".refactor-loop/runs/phase9-issue838-r1-structural.md",
+                "delete": ".refactor-loop/runs/phase9-issue838-r1-delete.md",
+            },
+            output_path=".refactor-loop/runs/phase9-issue838-r1-judge.md",
+            transition_assessment=TransitionAssessment("unknown", 0.0),
+        )
+
+        self.assertEqual("issue-838", context.work_unit_id)
+        self.assertEqual("manual-issue (prompt-only provenance)", context.work_unit_producer)
+        self.assertEqual("gh-issue-838", context.work_unit_source_ref)
+        self.assertEqual(2, context.convergence_round_plus_one)
+
+    def test_transition_sidecar_producer_values_do_not_expand_work_unit_producers(self) -> None:
+        self.assertEqual(frozenset({"audit", "manual-issue"}), ALLOWED_PRODUCERS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changed files

- `skills/consensus-loop/SKILL.md`: documents `restart.py::DAEMON_COMMANDS` as the sole active seven-daemon command surface in the Tier-0 scaffold inventory.
- `skills/consensus-loop/scripts/test_controller_runtime_inventory.py`: adds boundary coverage proving the inventory does not grow cleanup, pending-event, or runtime-residue authority.
- `skills/consensus-loop/scripts/test_restart_daemons.py`: asserts the optional controller tick supervisor is not part of the restart-managed seven-daemon surface.
- `skills/consensus-loop/scripts/test_skill_reference_anchors.py`: locks the SKILL.md Tier-0 scaffold wording.
- `skills/consensus-loop/scripts/test_work_unit_contract.py`: adds focused coverage for existing audit/manual-issue work-unit fields and no registry/envelope expansion.

Closes #838

## Test results

- `python3 -m pytest skills/consensus-loop/scripts/test_controller_runtime_inventory.py skills/consensus-loop/scripts/test_skill_reference_anchors.py skills/consensus-loop/scripts/test_restart_daemons.py skills/consensus-loop/scripts/test_reconcile_tick_scaffold.py skills/consensus-loop/scripts/test_work_unit_contract.py -q -p no:cacheprovider -o addopts=` passed.
- `bash -lc "python3 -m compileall skills/consensus-loop/scripts skills/sshx -q"` passed.
- Host-configured consensus-loop and sshx pytest command passed: 2150 passed, 1 skipped, 6087 subtests; then 27 passed, 6 subtests.

## Deviations

- No scope expansion.
- No runtime behavior changed.
- No schema/protocol regeneration required.
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

⟦AI:AUTO-LOOP⟧
