### PR TITLE
Reap lockless orphan daemon children before restart skip

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/restart.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/restart.py
@@ -217,6 +217,13 @@ class DaemonInstanceProjection:
         return self.bounded_lock_holder_pids
 
     @property
+    def stale_lockless_orphan_child_pids(self) -> tuple[int, ...]:
+        excluded = set(self.bounded_lock_holder_pids)
+        if self.pid_file_pid is not None:
+            excluded.add(self.pid_file_pid)
+        return tuple(sorted(pid for pid in self.orphan_child_pids if pid not in excluded))
+
+    @property
     def repair_pids(self) -> tuple[int, ...]:
         pids = set(self.live_wrapper_pids)
         pids.update(self.bounded_lock_holder_pids)
@@ -655,6 +662,7 @@ class RestartDaemons:
             lock_files=daemon_lock_files(self.ctx, name),
             is_alive=self.runtime.pid_alive,
         )
+        self._terminate_pids(instance.stale_lockless_orphan_child_pids)
         if instance.has_singleton_wrapper and self._singleton_check_fresh(target, current_fingerprint, instance):
             self._log(f"{name} skip: alive pid={pid_file.read_text(encoding='utf-8').strip()} heartbeat=fresh")
             return
@@ -772,10 +780,13 @@ class RestartDaemons:
         return heartbeat_is_fresh(target, self.config, now=self.runtime.now())
 
     def _stop_existing_daemon(self, target: DaemonTarget, *, instance: DaemonInstanceProjection) -> None:
-        for existing_pid in instance.repair_pids:
+        self._terminate_pids(instance.repair_pids)
+        target.pid_file.unlink(missing_ok=True)
+
+    def _terminate_pids(self, pids: Sequence[int]) -> None:
+        for existing_pid in pids:
             if self.runtime.pid_alive(existing_pid):
                 self.runtime.terminate_pid(existing_pid, self.config.stop_grace_seconds)
-        target.pid_file.unlink(missing_ok=True)
 
     def _fingerprint_path(self, name: str) -> Path:
         return self.ctx.paths.refactor_loop / "locks" / f"{name}.fingerprint.json"

--- a/skills/consensus-loop/scripts/test_restart_daemons.py
+++ b/skills/consensus-loop/scripts/test_restart_daemons.py
@@ -869,6 +869,36 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         self.assertEqual((222, 333), projection.live_managed_child_pids)
         self.assertEqual((222,), projection.bounded_lock_holder_pids)
         self.assertEqual((111, 222), projection.repair_pids)
+        self.assertEqual((333,), projection.stale_lockless_orphan_child_pids)
+
+    def test_daemon_instance_projects_lockless_orphans_excluding_pid_file_and_locks(self) -> None:
+        target = restart.daemon_target(self.ctx, "phase9_router_daemon", FAKE_COMMAND)
+        target.pid_file.parent.mkdir(parents=True, exist_ok=True)
+        target.pid_file.write_text("333\n", encoding="utf-8")
+        lock_holder = self.repo / ".refactor-loop" / "phase9-router.lock"
+        lock_holder.write_text("pid=444\n", encoding="utf-8")
+        inventory = DaemonProcessInventory(
+            (
+                DaemonProcess(333, " ".join(target.command), 1),
+                DaemonProcess(444, " ".join(target.command), 1),
+                DaemonProcess(555, " ".join(target.command), 1),
+            )
+        )
+        self.runtime.live_pids.update({333, 444, 555})
+
+        projection = inventory.daemon_instance(
+            name="phase9_router_daemon",
+            repo_root=self.ctx.repo_root,
+            pid_file=target.pid_file,
+            died_file=target.died_file,
+            command=target.command,
+            lock_files=(lock_holder,),
+            is_alive=self.runtime.pid_alive,
+        )
+
+        self.assertEqual((333, 444, 555), projection.orphan_child_pids)
+        self.assertEqual((444,), projection.bounded_lock_holder_pids)
+        self.assertEqual((555,), projection.stale_lockless_orphan_child_pids)
 
     def test_daemon_instance_detects_macos_shaped_wrapper_child_by_ppid(self) -> None:
         target = restart.daemon_target(self.ctx, "phase9_router_daemon", FAKE_COMMAND)
@@ -1077,6 +1107,26 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         self.assertEqual(pid, self.read_pid("concurrency_monitor"))
         self.assert_start_count("concurrency_monitor", 0)
         self.assertEqual([], self.runtime.terminated)
+
+    def test_fresh_singleton_reaps_lockless_orphan_child_without_restart(self) -> None:
+        self.run_helper()
+        wrapper_pid = self.read_pid("concurrency_monitor")
+        orphan_child_pid = 535353
+        target = restart.daemon_target(self.ctx, "concurrency_monitor", FAKE_COMMAND)
+        self.runtime.live_pids.add(orphan_child_pid)
+        self.runtime.inventory_override = DaemonProcessInventory(
+            (
+                DaemonProcess(wrapper_pid, self.runtime.canonical_command(self.ctx, "concurrency_monitor", FAKE_COMMAND), 1),
+                DaemonProcess(orphan_child_pid, " ".join(target.command), 1),
+            )
+        )
+
+        helper = RestartDaemons(self.ctx, self.config, runtime=self.runtime)
+        helper.start_daemon("concurrency_monitor", FAKE_COMMAND)
+
+        self.assertEqual(wrapper_pid, self.read_pid("concurrency_monitor"))
+        self.assertEqual([(orphan_child_pid, self.config.stop_grace_seconds)], self.runtime.terminated)
+        self.assert_start_count("concurrency_monitor", 1)
 
     def test_macos_framework_python_orphan_child_lock_holder_is_reaped_and_restarted_once(self) -> None:
         self.run_helper()


### PR DESCRIPTION
## Changed files
- `skills/consensus-loop/scripts/codex_refactor_loop/restart.py`: adds a private restart-side stale lockless orphan child subset and terminates those pids before the fresh singleton skip.
- `skills/consensus-loop/scripts/test_restart_daemons.py`: covers the private projection exclusions and the fresh singleton skip regression.

## Test results
- `python3 -m pytest skills/consensus-loop/scripts/test_restart_daemons.py -k "lockless_orphan or daemon_instance_projects" -q -p no:cacheprovider -o addopts=`: 3 passed, 49 deselected.
- `bash -lc "python3 -m compileall skills/consensus-loop/scripts skills/sshx -q"`: passed.
- Full configured tests: consensus-loop 2162 passed, 1 skipped, 6108 subtests passed; sshx 27 passed, 6 subtests passed.
- Architecture guards: guards skipped: CI_GUARDS unset.

## Deviations
- No scope extensions.
- No schema/protocol regeneration was required.
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

Closes #835

⟦AI:AUTO-LOOP⟧
