### PR TITLE
Fix phase9-router stalled-predicate missing evolving-but-same-split converge (#845)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/phase9/router.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/phase9/router.py
@@ -808,7 +808,7 @@ class Phase9Router:
         if payload.startswith("propose:") and self._propose_unreadable_source_signature(payload) is not None:
             return "source-unreachable/no-actionable-source"
         if payload.startswith("propose:"):
-            return payload
+            return self._propose_structural_signature(payload)
         return self._solver_verdict_text(marker)
 
     def _propose_unreadable_source_signature(self, payload: str) -> str | None:
@@ -817,6 +817,53 @@ class Phase9Router:
         if not re.search(r"\b(?:current-checkout|checkout|source|target|pr)\b", payload):
             return None
         return "source-unreachable/no-actionable-source"
+
+    def _propose_structural_signature(self, payload: str) -> str:
+        """Return stable implementation anchors for propose verdicts while ignoring prose churn."""
+        body = payload.removeprefix("propose:").strip()
+        if not body:
+            return payload
+        anchors: set[str] = set()
+        lower_body = body.lower()
+        anchors.update(f"path:{token}" for token in re.findall(r"\b[a-z0-9_.-]+(?:/[a-z0-9_.-]+)+\b", lower_body))
+        anchors.update(f"compound:{token}" for token in re.findall(r"\b[a-z0-9]+(?:-[a-z0-9]+)+\b", lower_body))
+        anchors.update(
+            f"identifier:{token.lower()}"
+            for token in re.findall(r"\b[A-Z][A-Za-z0-9]*(?:[A-Z][A-Za-z0-9]*)+[A-Za-z0-9]*\b", body)
+        )
+        for token in re.findall(r"\b[a-z][a-z0-9_]*\b", lower_body):
+            structural = self._propose_structural_keyword(token)
+            if structural is not None:
+                anchors.add(f"keyword:{structural}")
+        if len(anchors) < 2:
+            return payload
+        return "propose-structure:" + "|".join(sorted(anchors))
+
+    def _propose_structural_keyword(self, token: str) -> str | None:
+        if token.startswith("normaliz"):
+            return "normalize"
+        if token.startswith("canonicaliz"):
+            return "canonicalize"
+        keywords = {
+            "canonicalizer",
+            "contract",
+            "coordinate",
+            "gate",
+            "helper",
+            "policy",
+            "predicate",
+            "prompt",
+            "publication",
+            "reflector",
+            "release",
+            "renderer",
+            "router",
+            "stalled",
+            "test",
+            "tests",
+            "typed",
+        }
+        return token if token in keywords else None
 
     def _in_flight(self, log_path: Path) -> bool:
         return log_path.exists() or self._spawn_codex_in_flight(log_path)

--- a/skills/consensus-loop/scripts/test_phase9_router_daemon.py
+++ b/skills/consensus-loop/scripts/test_phase9_router_daemon.py
@@ -2165,6 +2165,75 @@ class Phase9RouterDaemonTests(unittest.TestCase):
         self.assertNotIn("756-4-structural", ledger_keys)
         self.assertNotIn("756-4-delete", ledger_keys)
 
+    def test_phase9_router_stalled_routes_evolving_same_split_propose_to_reflector(self) -> None:
+        verdicts = {
+            1: (
+                "propose:split scripts/codex_refactor_loop/phase9/router.py with Phase9Router "
+                "normalizing the stalled predicate while preserving source-unreachable handling"
+            ),
+            2: (
+                "propose:preserve source-unreachable handling; normalize stalled predicate "
+                "inside Phase9Router in scripts/codex_refactor_loop/phase9/router.py"
+            ),
+            3: (
+                "propose:Phase9Router change in scripts/codex_refactor_loop/phase9/router.py: "
+                "stalled predicate normalization, source-unreachable behavior unchanged"
+            ),
+        }
+        for round_no, verdict in verdicts.items():
+            self.solver_triplet(issue=845, round_no=round_no, verdict=verdict)
+        self.write_ledger_key("845-1-judge")
+        self.write_ledger_key("845-2-judge")
+        self.write_log(
+            "phase9-issue845-r3-judge.log",
+            "META_JUDGE_DONE:converge:round-3:implementation split unchanged between router signature and source gate",
+        )
+
+        self.assertTrue(self.router._stalled_predicate_holds("845", 3))
+
+        self.router.tick()
+
+        reflector_commands = [
+            command for command in self.commands if "phase9-issue845-r3-reflector.log" in self.intent_text(command)
+        ]
+        self.assertEqual(len(reflector_commands), 1)
+        ledger_keys = [entry["key"] for entry in self.ledger_entries()]
+        self.assertIn("845-3-reflector", ledger_keys)
+        self.assertNotIn("845-4-minimal", ledger_keys)
+        self.assertNotIn("845-4-structural", ledger_keys)
+        self.assertNotIn("845-4-delete", ledger_keys)
+
+    def test_phase9_router_stalled_rejects_changed_structural_split_propose(self) -> None:
+        verdicts = {
+            1: (
+                "propose:split scripts/codex_refactor_loop/phase9/router.py with Phase9Router "
+                "normalizing the stalled predicate while preserving source-unreachable handling"
+            ),
+            2: (
+                "propose:move the decision into skills/consensus-loop/prompts/meta-reflector-stalled.md "
+                "and update the stalled reflector prompt contract"
+            ),
+            3: (
+                "propose:add a release-gate coordinate policy check in "
+                "scripts/codex_refactor_loop/release/gate.py before release publication"
+            ),
+        }
+        for round_no, verdict in verdicts.items():
+            self.solver_triplet(issue=846, round_no=round_no, verdict=verdict)
+        self.write_ledger_key("846-1-judge")
+        self.write_ledger_key("846-2-judge")
+        self.write_log("phase9-issue846-r3-judge.log", "META_JUDGE_DONE:converge:round-3:proposal-still-moving")
+
+        self.assertFalse(self.router._stalled_predicate_holds("846", 3))
+
+        self.router.tick()
+
+        ledger_keys = [entry["key"] for entry in self.ledger_entries()]
+        self.assertNotIn("846-3-reflector", ledger_keys)
+        self.assertIn("846-4-minimal", ledger_keys)
+        self.assertIn("846-4-structural", ledger_keys)
+        self.assertIn("846-4-delete", ledger_keys)
+
     def test_phase9_router_stalled_rejects_implementation_bearing_propose_changes(self) -> None:
         verdicts = {
             1: "propose:add-router-helper",


### PR DESCRIPTION
## Summary

Fix the `phase9-router` stalled-predicate so it detects an **evolving-but-same-split** design-consensus stall.

`_solver_no_progress_signature` returned the **verbatim `propose:` payload**, and `_stalled_predicate_holds` requires exact set-equality of signatures across three consecutive rounds. When solvers keep proposing the **same structural split** but evolve their free-text wording each round, the signatures differ and the predicate never fires — so design-consensus loops indefinitely.

Real impact: this issue (#845) reached **round 22** and #835 burned **15 rounds to the 12h cap**, while the meta-judge itself repeatedly emitted `META_JUDGE_DONE:converge:round-N:implementation split unchanged ...`. The judge already detected the split was unchanged; the solver-text-based signature did not.

## Change

- `phase9/router.py`: for `propose:` verdicts, derive a stable **structural signature** from durable anchors (file paths, compound tokens, CamelCase identifiers, a small set of structural keywords) instead of the verbatim prose. Falls back to the verbatim payload when fewer than two anchors exist, so trivial proposes are not over-collapsed. The `source-unreachable/no-actionable-source` family is unchanged.
- `test_phase9_router_daemon.py`: adds a failing-then-passing reproduction test (three rounds, same split, different wording → predicate fires) and an over-trigger guard test (genuinely different structural proposals across rounds → predicate does NOT fire).

## Why this path

This issue's own design-consensus was **recursively deadlocked** by the very bug it tracks (the broken stalled-predicate could not escalate the issue about the broken stalled-predicate). Under the maintainer standing directive to hotfix a daemon stuck >1h, a single implementation worker produced this fix in an isolated worktree; it is gated by the normal review-gate (three independent reviewers) before merge.

## Verification

- `test_phase9_router_daemon.py` (107) + `test_phase9_router_package.py` / `test_phase9_router_open_state_gate.py` (32) pass; the new reproduction test fails before the fix and passes after.

Closes #845

⟦AI:AUTO-LOOP⟧
