### PR TITLE
Release rollup: integration ahead 1 commits (f9db6ea41408)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -72,6 +72,7 @@ from .worker_markers import read_worker_terminal_marker
 RUNNER_AUTHORITY = "wakeup-runner-396"
 APPLY_AUTHORITY = "wakeup-runner-396-only"
 INVALID_HARNESS_CLEANUP_LIMIT_PER_TICK = 50
+REBASE_RESOLVE_HELPER_EXIT_SUPPRESSION_THRESHOLD = 3
 FORBIDDEN_ACTION_FIELDS = {
     "argv",
     "args",
@@ -381,6 +382,13 @@ class WakeupRunner:
         action_id = str(action.get("action_id") or "")
         if not action_id:
             return self._blocked(action, "missing_action_id")
+        suppressed_exit_count = self._rebase_resolve_helper_exit_2_blocked_count(action)
+        if suppressed_exit_count >= REBASE_RESOLVE_HELPER_EXIT_SUPPRESSION_THRESHOLD:
+            self._append_pending_event(
+                "WAKEUP_RUNNER_HELPER_EXIT_SUPPRESSED:"
+                f"{action_id}:dispatch_pr_rebase_resolve:2:{suppressed_exit_count}"
+            )
+            return self._record(RunnerResult(action_id, "skipped", "suppressed:helper_exit:2"), action)
         if self._ledger_suppresses_retry(action):
             return self._record(RunnerResult(action_id, "skipped", "duplicate"), action)
         if action.get("kind") == "harness-spawn-intent-invalid":
@@ -2031,6 +2039,24 @@ class WakeupRunner:
             ):
                 return True
         return False
+
+    def _rebase_resolve_helper_exit_2_blocked_count(self, action: Mapping[str, Any]) -> int:
+        action_id = str(action.get("action_id") or "")
+        if not action_id or action.get("controller_action") != "dispatch_pr_rebase_resolve":
+            return 0
+        if not self.ledger_path.exists():
+            return 0
+        count = 0
+        for line in self.ledger_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if row.get("action_id") != action_id:
+                continue
+            if row.get("status") == "blocked" and row.get("reason") == "helper_exit:2":
+                count += 1
+        return count
 
     def _applied_row_current_effect_suppresses_retry(self, action: Mapping[str, Any]) -> bool:
         controller_action = str(action.get("controller_action") or "")

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -2078,6 +2078,90 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual([result.status for result in results], ["applied"])
         self.assertEqual([call[0] for call in actions.calls], ["dispatch_pr_rebase_resolve"])
 
+    def test_wakeup_runner_suppresses_repeated_rebase_resolve_helper_exit_2(self) -> None:
+        action = self.rebase_dispatch_action()
+        ledger = self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl"
+        ledger.write_text(
+            "".join(
+                json.dumps(
+                    {
+                        "action_id": action["action_id"],
+                        "status": "blocked",
+                        "reason": "helper_exit:2",
+                        "kind": action["kind"],
+                    }
+                )
+                + "\n"
+                for _ in range(3)
+            ),
+            encoding="utf-8",
+        )
+        actions = FakeActions()
+
+        results = self.run_result(self.base_plan(action), gh_state="OPEN", actions=actions)
+
+        self.assertEqual([result.status for result in results], ["skipped"])
+        self.assertEqual(results[0].reason, "suppressed:helper_exit:2")
+        self.assertEqual([], actions.calls)
+        pending = (self.repo / ".refactor-loop/.controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertIn(
+            "WAKEUP_RUNNER_HELPER_EXIT_SUPPRESSED:dispatch-pr-rebase-resolve:77:abc123:dispatch_pr_rebase_resolve:2:3",
+            pending.splitlines(),
+        )
+        self.assertNotIn("WAKEUP_RUNNER_HELPER_EXIT:dispatch-pr-rebase-resolve:77:abc123", pending)
+        ledger_rows = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()]
+        self.assertEqual(ledger_rows[-1]["status"], "skipped")
+        self.assertEqual(ledger_rows[-1]["reason"], "suppressed:helper_exit:2")
+
+    def test_suppressed_rebase_resolve_does_not_consume_medium_non_spawn_slot(self) -> None:
+        suppressed = self.rebase_dispatch_action(action_id="dispatch-pr-rebase-resolve:77:suppressed")
+        later = self.rebase_dispatch_action(action_id="dispatch-pr-rebase-resolve:77:later")
+        ledger = self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl"
+        ledger.write_text(
+            "".join(
+                json.dumps(
+                    {
+                        "action_id": suppressed["action_id"],
+                        "status": "blocked",
+                        "reason": "helper_exit:2",
+                        "kind": suppressed["kind"],
+                    }
+                )
+                + "\n"
+                for _ in range(3)
+            ),
+            encoding="utf-8",
+        )
+        actions = FakeActions()
+
+        results = self.run_result(
+            self.batch_plan([suppressed, later], dispatch_required=1, deficit=1),
+            gh_state="OPEN",
+            actions=actions,
+        )
+
+        self.assertEqual([result.action_id for result in results], [suppressed["action_id"], later["action_id"]])
+        self.assertEqual([result.status for result in results], ["skipped", "applied"])
+        self.assertEqual([call[0] for call in actions.calls], ["dispatch_pr_rebase_resolve"])
+        self.assertEqual(actions.calls[0][1]["action_id"], later["action_id"])
+
+    def test_rebase_resolve_helper_exit_2_suppression_is_action_and_reason_scoped(self) -> None:
+        action = self.rebase_dispatch_action()
+        ledger = self.repo / ".refactor-loop/state/wakeup-runner-ledger.jsonl"
+        rows = [
+            {"action_id": action["action_id"], "status": "blocked", "reason": "helper_exit:2", "kind": action["kind"]},
+            {"action_id": action["action_id"], "status": "blocked", "reason": "helper_exit:3", "kind": action["kind"]},
+            {"action_id": "dispatch-pr-rebase-resolve:77:other", "status": "blocked", "reason": "helper_exit:2", "kind": action["kind"]},
+            {"action_id": action["action_id"], "status": "blocked", "reason": "helper_exit:2", "kind": action["kind"]},
+        ]
+        ledger.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+        actions = FakeActions()
+
+        results = self.run_result(self.base_plan(action), gh_state="OPEN", actions=actions)
+
+        self.assertEqual([result.status for result in results], ["applied"])
+        self.assertEqual([call[0] for call in actions.calls], ["dispatch_pr_rebase_resolve"])
+
     def test_wakeup_runner_routes_false_done_rebase_recovery_dispatch(self) -> None:
         log = self.repo / ".refactor-loop/logs/rebase-resolve-pr77-r1.log"
         log.write_text("resolved\nREBASE_RESOLVE_DONE:77:ok\nEXIT=0\n", encoding="utf-8")


### PR DESCRIPTION
### Release rollup

- Target: `auto-refact-dev` -> `dev`
- Integration branch ahead of review-base: `1` commits
- Range: `8691857ab138..f9db6ea41408`
- Related issues: #865

### Commit summary

- Suppress repeated rebase resolve helper exits (#865)

### Merge policy

- After required checks are green, controller auto squash-merges; when `ROLLUP_AUTO_MERGE=manual`, wait for human review/merge.
- This PR is the release rollup singleton; when an open rollup already exists, controller only updates its head and body instead of opening another PR.

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
