### PR TITLE
Release rollup: integration ahead 1 commits (72144f79050b)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/review_gate_selection.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/review_gate_selection.py
@@ -1,0 +1,106 @@
+"""Shared review-gate evidence selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Sequence
+
+
+class ReviewEvidenceLike(Protocol):
+    role: str
+    round_number: int
+    head_sha: str
+    valid: bool
+    pending: bool
+    terminal_failed: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class SelectedReviewEvidence:
+    by_role: dict[str, ReviewEvidenceLike]
+    invalid: list[str]
+    pending: list[str]
+    terminal_failed_roles: list[str]
+    complete_round: int | None
+
+
+def select_latest_live_head_review_evidence(
+    evidences: Sequence[ReviewEvidenceLike],
+    *,
+    live_head_sha: str,
+    required_roles: Sequence[str],
+) -> SelectedReviewEvidence:
+    selected: dict[str, ReviewEvidenceLike] = {}
+    invalid: list[str] = []
+    pending: list[str] = []
+    terminal_failed_roles: list[str] = []
+    max_round: int | None = None
+
+    for role in required_roles:
+        role_items = [evidence for evidence in evidences if evidence.role == role]
+        live_items = [evidence for evidence in role_items if evidence.head_sha and evidence.head_sha == live_head_sha]
+        selectable = [
+            evidence
+            for evidence in live_items
+            if evidence.valid and not evidence.pending and not evidence.terminal_failed
+        ]
+        if selectable:
+            highest_round = max(evidence.round_number for evidence in selectable)
+            latest = [evidence for evidence in selectable if evidence.round_number == highest_round]
+            if len(latest) > 1:
+                invalid.append(f"duplicate_reviewer_evidence:{role}")
+                continue
+            evidence = latest[0]
+            selected[role] = evidence
+            max_round = evidence.round_number if max_round is None else max(max_round, evidence.round_number)
+            continue
+
+        if live_items:
+            highest_live_round = max(evidence.round_number for evidence in live_items)
+            latest_live = [evidence for evidence in live_items if evidence.round_number == highest_live_round]
+            evidence = latest_live[0]
+            if evidence.pending:
+                pending.append(evidence.reason or f"pending:{role}")
+            elif evidence.terminal_failed:
+                terminal_failed_roles.append(role)
+                invalid.append(evidence.reason or f"terminal_failed:{role}")
+            elif not evidence.valid:
+                invalid.append(evidence.reason or f"invalid:{role}")
+            continue
+
+        missing_head_valid = [
+            evidence
+            for evidence in role_items
+            if evidence.valid and not evidence.pending and not evidence.terminal_failed and not evidence.head_sha
+        ]
+        if missing_head_valid:
+            invalid.append(f"missing_reviewed_head_sha:{role}")
+            continue
+
+        invalid_items = [
+            evidence
+            for evidence in role_items
+            if not evidence.valid and not evidence.pending and not evidence.terminal_failed
+        ]
+        if invalid_items:
+            evidence = max(invalid_items, key=lambda item: item.round_number)
+            invalid.append(evidence.reason or f"invalid:{role}")
+            continue
+
+        stale_head_valid = [
+            evidence
+            for evidence in role_items
+            if evidence.valid and not evidence.pending and not evidence.terminal_failed and evidence.head_sha
+        ]
+        if stale_head_valid:
+            invalid.append(f"stale_reviewed_head_sha:{role}")
+
+    complete_round = max_round if all(role in selected for role in required_roles) else None
+    return SelectedReviewEvidence(
+        by_role=selected,
+        invalid=invalid,
+        pending=pending,
+        terminal_failed_roles=terminal_failed_roles,
+        complete_round=complete_round,
+    )

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -46,6 +46,7 @@ from codex_refactor_loop.issue_decomposition import (
 from codex_refactor_loop.managed_work_snapshot import load_open_managed_work_snapshot
 from codex_refactor_loop.phase9.progress import issue_has_terminal_consensus_judge
 from codex_refactor_loop.pr_checks import PrMergeReadinessProjection
+from codex_refactor_loop.review_gate_selection import select_latest_live_head_review_evidence
 from codex_refactor_loop.release.candidate_liveness import classify_release_candidate_liveness
 from codex_refactor_loop.release.required_checks import ReleaseRequiredChecksProjection, required_release_checks
 from codex_refactor_loop.release.gate import decide_release_artifact
@@ -261,6 +262,17 @@ class ReviewRoundCompletion:
     round_number: int
     head_sha: str
     heads_by_role: dict[str, str]
+
+
+@dataclass(frozen=True)
+class ReviewCompletionEvidence:
+    role: str
+    round_number: int
+    head_sha: str
+    valid: bool
+    pending: bool = False
+    terminal_failed: bool = False
+    reason: str = ""
 
 
 RELEASE_ROLLUP_LIVE_PR_LIST_TIMEOUT_SECONDS = 15
@@ -2449,7 +2461,7 @@ def latest_valid_reviewer_rounds(repo_root: Path, pr_number: int) -> dict[str, t
 def highest_complete_required_review_round(repo_root: Path, pr_number: int, head_sha: str) -> ReviewRoundCompletion | None:
     if not head_sha:
         return None
-    by_round: dict[int, dict[str, list[str]]] = {}
+    evidences: list[ReviewCompletionEvidence] = []
     artifact_keys: set[tuple[str, int]] = set()
     runs_dir = repo_root / ".refactor-loop" / "runs"
     logs_dir = repo_root / ".refactor-loop" / "logs"
@@ -2465,7 +2477,7 @@ def highest_complete_required_review_round(repo_root: Path, pr_number: int, head
         if not _reviewer_log_has_exit_zero(log_path) or not _reviewer_log_has_valid_marker(log_path, pr_number, role):
             continue
         reviewed_head = _reviewed_head_sha_from_file(path) or _reviewed_head_sha_from_file(prompts_dir / path.name) or _reviewed_head_sha_from_file(log_path)
-        by_round.setdefault(round_number, {}).setdefault(role, []).append(reviewed_head)
+        evidences.append(ReviewCompletionEvidence(role=role, round_number=round_number, head_sha=reviewed_head, valid=bool(reviewed_head)))
     for path in sorted(logs_dir.glob(f"review-pr{pr_number}-*-r*.log")):
         match = REVIEW_LOG_RE.match(path.name)
         if not match or int(match.group(1)) != pr_number:
@@ -2478,20 +2490,16 @@ def highest_complete_required_review_round(repo_root: Path, pr_number: int, head
             continue
         prompt_path = prompts_dir / path.with_suffix(".md").name
         reviewed_head = _reviewed_head_sha_from_file(path) or _reviewed_head_sha_from_file(prompt_path)
-        by_round.setdefault(round_number, {}).setdefault(role, []).append(reviewed_head)
-    for round_number in sorted(by_round, reverse=True):
-        role_heads = by_round[round_number]
-        heads_by_role: dict[str, str] = {}
-        complete = True
-        for role in REQUIRED_REVIEW_ROLES:
-            heads = role_heads.get(role, [])
-            if len(heads) != 1 or heads[0] != head_sha:
-                complete = False
-                break
-            heads_by_role[role] = heads[0]
-        if complete:
-            return ReviewRoundCompletion(round_number=round_number, head_sha=head_sha, heads_by_role=heads_by_role)
-    return None
+        evidences.append(ReviewCompletionEvidence(role=role, round_number=round_number, head_sha=reviewed_head, valid=bool(reviewed_head)))
+    selection = select_latest_live_head_review_evidence(
+        evidences,
+        live_head_sha=head_sha,
+        required_roles=REQUIRED_REVIEW_ROLES,
+    )
+    if selection.complete_round is None:
+        return None
+    heads_by_role = {role: evidence.head_sha for role, evidence in selection.by_role.items()}
+    return ReviewRoundCompletion(round_number=selection.complete_round, head_sha=head_sha, heads_by_role=heads_by_role)
 
 
 def pending_or_fresh_review_evidence_exists(repo_root: Path, pr_number: int) -> bool:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -48,6 +48,7 @@ from .issue_decomposition import (
 )
 from .pr_checks import PrMergeReadinessProjection
 from .processes import ProcessSupervisor, launch_spawn_codex_supervisor
+from .review_gate_selection import select_latest_live_head_review_evidence
 from .release.gate import AutoReleaseGate
 from .release.commits import write_release_commits
 from .release.candidate_liveness import classify_release_candidate_liveness
@@ -1752,91 +1753,18 @@ class WakeupRunner:
         ).as_dict()
 
     def _review_gate_candidate_evidence(self, pr_number: int, live_head_sha: str) -> ReviewGateCandidate:
-        rounds: dict[int, dict[str, list[ReviewEvidence]]] = {}
-        for evidence in self._review_evidences(pr_number):
-            rounds.setdefault(evidence.round_number, {}).setdefault(evidence.role, []).append(evidence)
-        for round_number in sorted(rounds, reverse=True):
-            by_role = rounds[round_number]
-            selected: dict[str, ReviewEvidence] = {}
-            complete = True
-            for role in REQUIRED_REVIEW_ROLES:
-                items = by_role.get(role, [])
-                if len(items) != 1:
-                    complete = False
-                    break
-                evidence = items[0]
-                if not evidence.valid or evidence.pending or evidence.terminal_failed or evidence.head_sha != live_head_sha:
-                    complete = False
-                    break
-                selected[role] = evidence
-            if complete:
-                return ReviewGateCandidate(selected, [], [], [], complete_round=round_number)
-        if not rounds:
-            return ReviewGateCandidate({}, [], [], [])
-        candidate_round = self._highest_relevant_review_candidate_round(rounds, live_head_sha)
-        return self._diagnostic_review_gate_candidate(rounds[candidate_round], live_head_sha)
-
-    def _highest_relevant_review_candidate_round(
-        self,
-        rounds: Mapping[int, Mapping[str, list[ReviewEvidence]]],
-        live_head_sha: str,
-    ) -> int:
-        def score(round_number: int) -> tuple[int, int, int]:
-            by_role = rounds[round_number]
-            valid_live_roles = {
-                role
-                for role, evidences in by_role.items()
-                if len(evidences) == 1
-                and evidences[0].valid
-                and not evidences[0].pending
-                and not evidences[0].terminal_failed
-                and evidences[0].head_sha == live_head_sha
-            }
-            live_evidence_count = sum(
-                1
-                for evidences in by_role.values()
-                for evidence in evidences
-                if evidence.head_sha == live_head_sha
-            )
-            return (len(valid_live_roles), live_evidence_count, round_number)
-
-        return max(rounds, key=score)
-
-    def _diagnostic_review_gate_candidate(
-        self,
-        by_role: Mapping[str, list[ReviewEvidence]],
-        live_head_sha: str,
-    ) -> ReviewGateCandidate:
-        selected: dict[str, ReviewEvidence] = {}
-        invalid: list[str] = []
-        pending: list[str] = []
-        terminal_failed_roles: list[str] = []
-        for role in REQUIRED_REVIEW_ROLES:
-            items = list(by_role.get(role, []))
-            if len(items) > 1:
-                invalid.append(f"duplicate_reviewer_evidence:{role}")
-                continue
-            if not items:
-                continue
-            evidence = items[0]
-            if evidence.pending:
-                pending.append(evidence.reason or f"pending:{role}")
-                continue
-            if evidence.terminal_failed:
-                terminal_failed_roles.append(role)
-                invalid.append(evidence.reason or f"terminal_failed:{role}")
-                continue
-            if not evidence.valid:
-                invalid.append(evidence.reason or f"invalid:{role}")
-                continue
-            if not evidence.head_sha:
-                invalid.append(f"missing_reviewed_head_sha:{role}")
-                continue
-            if live_head_sha and evidence.head_sha != live_head_sha:
-                invalid.append(f"stale_reviewed_head_sha:{role}")
-                continue
-            selected[role] = evidence
-        return ReviewGateCandidate(selected, invalid, pending, terminal_failed_roles)
+        selection = select_latest_live_head_review_evidence(
+            self._review_evidences(pr_number),
+            live_head_sha=live_head_sha,
+            required_roles=REQUIRED_REVIEW_ROLES,
+        )
+        return ReviewGateCandidate(
+            dict(selection.by_role),
+            selection.invalid,
+            selection.pending,
+            selection.terminal_failed_roles,
+            complete_round=selection.complete_round,
+        )
 
     def _review_evidences(self, pr_number: int) -> list[ReviewEvidence]:
         github_evidences = self._github_review_evidences(pr_number)

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -48,6 +48,7 @@ from codex_refactor_loop.wakeup_plan import (  # noqa: E402
     existing_issue_actions,
     has_dispatchable_action,
     harness_spawn_intent_line_digest,
+    highest_complete_required_review_round,
     load_github_items_with_status,
     marker_from_completed_log,
     meta_escalation_stuck_seconds,
@@ -1880,6 +1881,15 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             "\n".join(log_lines) + "\n",
             encoding="utf-8",
         )
+
+    def actions_cleanup_for_review_pr(self, pr_number: int) -> None:
+        for directory, suffix in (
+            (self.repo / ".refactor-loop" / "runs", ".md"),
+            (self.repo / ".refactor-loop" / "prompts", ".md"),
+            (self.logs, ".log"),
+        ):
+            for path in directory.glob(f"review-pr{pr_number}-*-r*{suffix}"):
+                path.unlink(missing_ok=True)
 
     def write_issue_decomposition_artifacts(self, *, issue: int = 403, round_no: int = 6) -> tuple[str, str]:
         runs = self.repo / ".refactor-loop" / "runs"
@@ -4821,6 +4831,47 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         gate = next(item for item in plan["actions"] if item.get("controller_action") == "review_gate")
         self.assertEqual(gate["head_sha"], "a" * 40)
+        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+
+    def test_review_gate_completion_uses_latest_live_head_per_role_across_independent_rounds(self) -> None:
+        live = "a" * 40
+        self.write_review_evidence(role="tests", verdict="reject", round_number=14, head_sha=live)
+        self.write_review_evidence(role="quality", verdict="comment", round_number=14, head_sha=live)
+        self.write_review_evidence(role="architect", verdict="reject", round_number=15, head_sha=live)
+        self.write_review_evidence(role="architect", verdict="approve", round_number=16, head_sha=live)
+
+        completion = highest_complete_required_review_round(self.repo, 480, live)
+        self.assertIsNotNone(completion)
+        self.assertEqual(completion.round_number, 16)
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        gate = next(item for item in plan["actions"] if item.get("controller_action") == "review_gate")
+        self.assertEqual(gate["head_sha"], live)
+        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+
+    def test_review_gate_completion_requires_each_role_to_have_live_head_valid_evidence(self) -> None:
+        live = "a" * 40
+        stale = "b" * 40
+        self.write_review_evidence(role="architect", verdict="approve", round_number=4, head_sha=live)
+        self.write_review_evidence(role="tests", verdict="approve", round_number=4, head_sha=live)
+        self.write_review_evidence(role="quality", verdict="comment", round_number=4, head_sha=stale)
+
+        self.assertIsNone(highest_complete_required_review_round(self.repo, 480, live))
+        plan = self.run_plan(fixture="open_pr_480")
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["quality"])
+
+        self.actions_cleanup_for_review_pr(480)
+        self.write_review_evidence(role="architect", verdict="approve", round_number=4, head_sha=live)
+        self.write_review_evidence(role="tests", verdict="approve", round_number=4, head_sha=live)
+        (self.logs / "review-pr480-quality-r5.log").write_text(
+            f"head_sha: {live}\nREVIEW_DONE:480:quality:comment\n",
+            encoding="utf-8",
+        )
+
+        self.assertIsNone(highest_complete_required_review_round(self.repo, 480, live))
+        plan = self.run_plan(fixture="open_pr_480")
         self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
 
     def test_review_redispatch_targets_only_missing_role_for_candidate_round(self) -> None:

--- a/skills/consensus-loop/scripts/test_wakeup_runner_review_gate.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner_review_gate.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.cross_instance_stand_down import CrossInstanceAdmission
 from codex_refactor_loop.github_actor import GitHubActorAdmission
-from codex_refactor_loop.wakeup_runner import WakeupRunner
+from codex_refactor_loop.wakeup_runner import ReviewEvidence, WakeupRunner
 
 
 class FakeActions:
@@ -250,6 +250,32 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
         self.assertEqual(result.reason, f"WAIT_OR_REDISPATCH:invalid_reviewer_evidence:{reason}")
         self.assertEqual(self.actions.merged, [])
 
+    def runner_for_gate(self, *, live_head: str = "a" * 40) -> WakeupRunner:
+        def command_runner(command):
+            if command[:3] == ["gh", "pr", "view"] and ".headRefOid" in command:
+                return subprocess.CompletedProcess(command, 0, live_head + "\n", "")
+            if command[:3] == ["gh", "pr", "view"] and "mergeable,isDraft,changedFiles" in command:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    json.dumps({"mergeable": "MERGEABLE", "isDraft": False, "changedFiles": 1}),
+                    "",
+                )
+            if command[:2] == ["gh", "api"] and command[2] == "repos/owner/repo/branches/main/protection/required_status_checks":
+                return subprocess.CompletedProcess(command, 0, json.dumps({"contexts": []}), "")
+            if command[:2] == ["gh", "api"] and command[2] == "repos/owner/repo/rules/branches/main":
+                return subprocess.CompletedProcess(command, 1, "", "404 Not Found")
+            if command[:2] == ["gh", "api"] and command[2] == "repos/owner/repo/issues/12/comments?per_page=100":
+                return subprocess.CompletedProcess(command, 0, json.dumps([self.github_comments]), "")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        return WakeupRunner(
+            self.ctx,
+            actions=self.actions,
+            supervisor=self.supervisor,
+            command_runner=command_runner,
+        )
+
     def test_review_gate_merge_only_when_reject_zero_approve_one_and_all_present(self) -> None:
         self.write_review("architect", "approve")
         self.write_review("tests", "comment")
@@ -300,6 +326,114 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
         self.assertEqual(Path(launch.call_args.kwargs["log"]).resolve(), (self.repo / ".refactor-loop/logs/fix.log").resolve())
         self.assertEqual(Path(launch.call_args.kwargs["cd"]).resolve(), self.pr_worktree.resolve())
         self.assertEqual(self.supervisor.calls, 0)
+
+    def test_review_gate_assembles_latest_live_head_per_role_across_rounds_and_routes_reject_to_fix(self) -> None:
+        live = "c" * 40
+        self.write_review("tests", "approve", head_sha="d" * 40, round_number=13)
+        self.write_review("tests", "reject", head_sha=live, round_number=14)
+        self.write_review("quality", "comment", head_sha=live, round_number=14)
+        self.write_review("architect", "reject", head_sha=live, round_number=15)
+        self.write_review("architect", "approve", head_sha=live, round_number=16)
+
+        gate = self.runner_for_gate(live_head=live)._review_gate(12)
+        self.assertTrue(gate["all_present"])
+        self.assertEqual(gate["reviewed_head_sha"], live)
+        self.assertEqual(gate["reject"], 1)
+        self.assertEqual(gate["approve"], 1)
+        self.assertEqual(gate["comment"], 1)
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
+            result = self.run_action(self.action(head_sha=live), live_head=live, required_checks=())
+
+        self.assertEqual(result.status, "applied")
+        self.assertEqual(self.actions.merged, [])
+        self.assertEqual(self.actions.rendered, [(12, 1)])
+        launch.assert_called_once()
+
+    def test_review_gate_latest_same_role_verdict_supersedes_older_same_head_verdict(self) -> None:
+        live = "e" * 40
+        self.write_review("architect", "reject", head_sha=live, round_number=15)
+        self.write_review("architect", "approve", head_sha=live, round_number=16)
+        self.write_review("tests", "approve", head_sha=live, round_number=14)
+        self.write_review("quality", "comment", head_sha=live, round_number=14)
+
+        gate = self.runner_for_gate(live_head=live)._review_gate(12)
+        self.assertEqual(gate["verdicts"]["architect"], "approve")
+        self.assertEqual(gate["reject"], 0)
+        self.assertEqual(gate["approve"], 2)
+
+        result = self.run_action(self.action(head_sha=live), live_head=live, required_checks=())
+
+        self.assertEqual(result.status, "applied")
+        self.assertEqual(self.actions.merged, ["12"])
+        self.assertEqual(self.actions.rendered, [])
+
+    def test_review_gate_newer_pending_wave_does_not_block_completion_when_role_has_valid_verdict(self) -> None:
+        live = "f" * 40
+        evidences = [
+            ReviewEvidence("architect", 4, "approve", live, "test"),
+            ReviewEvidence("architect", 5, "approve", live, "test", pending=True, reason="pending:architect"),
+            ReviewEvidence("architect", 5, "approve", live, "test", pending=True, reason="pending:architect"),
+            ReviewEvidence("tests", 4, "approve", live, "test"),
+            ReviewEvidence("quality", 4, "comment", live, "test"),
+        ]
+        runner = self.runner_for_gate(live_head=live)
+        with (
+            mock.patch.object(runner, "_review_evidences", return_value=evidences),
+            mock.patch.object(runner, "_review_gate_ci_error", return_value=None),
+        ):
+            decision = runner._review_gate_decision(self.action(head_sha=live))
+
+        self.assertEqual(decision["decision"], "MERGE_WITH_COMMENTS")
+        self.assertTrue(decision["gate"]["all_present"])
+        self.assertEqual(decision["gate"]["verdicts"]["architect"], "approve")
+        self.assertEqual(decision["gate"]["reviewed_head_sha"], live)
+        self.assertEqual(decision["gate"]["invalid"], [])
+        self.assertEqual(decision["gate"]["pending"], [])
+
+    def test_review_gate_duplicate_same_role_same_round_fails_closed(self) -> None:
+        live = "a" * 40
+        self.github_comments = [
+            self.github_review_comment("architect", "approve", head_sha=live, round_number=2),
+            self.github_review_comment("architect", "reject", head_sha=live, round_number=2),
+            self.github_review_comment("tests", "approve", head_sha=live, round_number=2),
+            self.github_review_comment("quality", "comment", head_sha=live, round_number=2),
+        ]
+
+        result = self.run_action()
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:invalid_reviewer_evidence:duplicate_reviewer_evidence:architect")
+        self.assertEqual(self.actions.merged, [])
+        self.assertEqual(self.actions.rendered, [])
+
+    def test_review_gate_role_with_only_stale_head_remains_incomplete(self) -> None:
+        self.write_review("architect", "approve")
+        self.write_review("tests", "approve")
+        self.write_review("quality", "comment", head_sha="b" * 40)
+
+        result = self.run_action()
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:invalid_reviewer_evidence:stale_reviewed_head_sha:quality")
+        self.assertEqual(self.actions.merged, [])
+        self.assertEqual(self.actions.rendered, [])
+
+    def test_review_gate_role_with_only_pending_live_head_blocks(self) -> None:
+        live = "a" * 40
+        evidences = [
+            ReviewEvidence("architect", 4, "approve", live, "test"),
+            ReviewEvidence("tests", 4, "approve", live, "test"),
+            ReviewEvidence("quality", 5, "comment", live, "test", pending=True, reason="pending:quality"),
+        ]
+        runner = self.runner_for_gate(live_head=live)
+        with mock.patch.object(runner, "_review_evidences", return_value=evidences):
+            decision = runner._review_gate_decision(self.action(head_sha=live))
+
+        self.assertEqual(decision["decision"], "WAIT_OR_REDISPATCH")
+        self.assertEqual(decision["reason"], "pending_reviewer_evidence:pending:quality")
+        self.assertEqual(self.actions.merged, [])
+        self.assertEqual(self.actions.rendered, [])
 
     def test_missing_reviewer_fails_closed(self) -> None:
         self.write_review("architect", "approve")
@@ -454,20 +588,19 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
         self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:invalid_reviewer_evidence:stale_reviewed_head_sha:architect")
         self.assertEqual(self.actions.merged, [])
 
-    def test_review_gate_uses_complete_lower_round_despite_higher_inflight_same_head(self) -> None:
+    def test_review_gate_higher_valid_same_head_supersedes_lower_complete_round(self) -> None:
         self.write_review("architect", "approve", head_sha="a" * 40, round_number=4)
         self.write_review("tests", "approve", head_sha="a" * 40, round_number=4)
         self.write_review("quality", "comment", head_sha="a" * 40, round_number=4)
-        (self.repo / ".refactor-loop/logs/review-pr12-architect-r5.log").write_text(
-            f"head_sha: {'a' * 40}\nREVIEW_DONE:12:architect:approve\n",
-            encoding="utf-8",
-        )
+        self.write_review("architect", "reject", head_sha="a" * 40, round_number=5)
 
-        result = self.run_action()
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
+            result = self.run_action()
 
         self.assertEqual(result.status, "applied")
-        self.assertEqual(self.actions.merged, ["12"])
-        self.assertEqual(self.actions.rendered, [])
+        self.assertEqual(self.actions.merged, [])
+        self.assertEqual(self.actions.rendered, [(12, 1)])
+        launch.assert_called_once()
 
     def test_review_gate_lower_complete_reject_is_not_masked_by_higher_pending(self) -> None:
         self.write_review("architect", "reject", head_sha="a" * 40, round_number=4)


### PR DESCRIPTION
### Release rollup

- Target: `auto-refact-dev` -> `dev`
- Integration branch ahead of review-base: `1` commits
- Range: `e4f38b5f462a..72144f79050b`

### Commit summary

- Fix review-gate round-coherence churn via per-role latest-live-head assembly

### Merge policy

- After required checks are green, controller auto squash-merges; when `ROLLUP_AUTO_MERGE=manual`, wait for human review/merge.
- This PR is the release rollup singleton; when an open rollup already exists, controller only updates its head and body instead of opening another PR.

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
