### PR TITLE
Release rollup: integration ahead 1 commits (61c3bbf0604d)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/review_gate_selection.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/review_gate_selection.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 from typing import Protocol, Sequence
+
+
+REVIEW_DONE_RE = re.compile(r"^REVIEW_DONE:([1-9][0-9]*):([A-Za-z][A-Za-z0-9_-]*):(approve|comment|reject)$")
+REVIEW_HEAD_RE = re.compile(r"(?im)^(?:reviewed[-_ ]?head[-_ ]?sha|head[-_ ]?sha|headRefOid|REVIEW_HEAD_SHA)\s*[:=]\s*([0-9a-f]{7,64})\s*$")
+REVIEW_ROUND_RE = re.compile(r"(?im)^(?:review[-_ ]?round|round)\s*[:=]\s*([1-9][0-9]*)\s*$")
+AI_SENTINEL = "⟦AI:AUTO-LOOP⟧"
 
 
 class ReviewEvidenceLike(Protocol):
@@ -14,6 +21,9 @@ class ReviewEvidenceLike(Protocol):
     pending: bool
     terminal_failed: bool
     reason: str
+    created_at: str
+    source_index: int
+    comment_id: int | None
 
 
 @dataclass(frozen=True)
@@ -23,6 +33,156 @@ class SelectedReviewEvidence:
     pending: list[str]
     terminal_failed_roles: list[str]
     complete_round: int | None
+
+
+@dataclass(frozen=True)
+class ParsedGithubReviewEvidence:
+    role: str
+    round_number: int
+    verdict: str
+    head_sha: str
+    source: str
+    valid: bool = True
+    reason: str = ""
+    terminal_failed: bool = False
+    pending: bool = False
+    created_at: str = ""
+    source_index: int = 0
+    comment_id: int | None = None
+
+
+def _evidence_created_at(evidence: ReviewEvidenceLike) -> str:
+    return str(getattr(evidence, "created_at", "") or "")
+
+
+def _evidence_source_index(evidence: ReviewEvidenceLike) -> int:
+    value = getattr(evidence, "source_index", 0)
+    return value if isinstance(value, int) else 0
+
+
+def _evidence_comment_id(evidence: ReviewEvidenceLike) -> int:
+    value = getattr(evidence, "comment_id", None)
+    return value if isinstance(value, int) else 0
+
+
+def _has_ordering_metadata(evidence: ReviewEvidenceLike) -> bool:
+    return bool(_evidence_created_at(evidence)) or _evidence_comment_id(evidence) > 0 or _evidence_source_index(evidence) > 0
+
+
+def _recency_key(evidence: ReviewEvidenceLike) -> tuple[str, int, int]:
+    return (_evidence_created_at(evidence), _evidence_comment_id(evidence), _evidence_source_index(evidence))
+
+
+def extract_review_head_sha(text: str) -> str:
+    match = REVIEW_HEAD_RE.search(text)
+    return match.group(1) if match else ""
+
+
+def extract_review_round(text: str) -> int | None:
+    match = REVIEW_ROUND_RE.search(text)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def _has_final_ai_sentinel(text: str) -> bool:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return bool(lines) and lines[-1] == AI_SENTINEL
+
+
+def _loose_review_marker_role(body: str) -> str:
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("REVIEW_DONE:"):
+            continue
+        parts = stripped.split(":")
+        if len(parts) >= 3:
+            return parts[2]
+    return ""
+
+
+def _parsed_github_review_evidence(
+    role: str,
+    round_number: int,
+    verdict: str,
+    head_sha: str,
+    source: str,
+    valid: bool = True,
+    reason: str = "",
+    *,
+    created_at: str = "",
+    source_index: int = 0,
+    comment_id: int | None = None,
+) -> ParsedGithubReviewEvidence:
+    return ParsedGithubReviewEvidence(
+        role,
+        round_number,
+        verdict,
+        head_sha,
+        source,
+        valid,
+        reason,
+        created_at=created_at,
+        source_index=source_index,
+        comment_id=comment_id,
+    )
+
+
+def parse_github_review_evidence(
+    body: str,
+    pr_number: int,
+    *,
+    source: str,
+    created_at: str = "",
+    source_index: int = 0,
+    comment_id: int | None = None,
+) -> ParsedGithubReviewEvidence | None:
+    if "REVIEW_DONE:" not in body:
+        return None
+    parsed_head_sha = extract_review_head_sha(body)
+    parsed_round_number = extract_review_round(body) or 1
+    marker_matches = [REVIEW_DONE_RE.fullmatch(line.strip()) for line in body.splitlines()]
+    marker_matches = [match for match in marker_matches if match is not None]
+    if not marker_matches:
+        role = _loose_review_marker_role(body) or "github"
+        return _parsed_github_review_evidence(role, parsed_round_number, "", parsed_head_sha, source, False, f"invalid_review_marker:{role}", created_at=created_at, source_index=source_index, comment_id=comment_id)
+    marker_keys = {(match.group(1), match.group(2), match.group(3)) for match in marker_matches}
+    marker = marker_matches[0]
+    role = marker.group(2)
+    verdict = marker.group(3)
+    if len(marker_keys) != 1:
+        return _parsed_github_review_evidence(role, parsed_round_number, "", parsed_head_sha, source, False, f"invalid_review_marker:{role}", created_at=created_at, source_index=source_index, comment_id=comment_id)
+    if marker.group(1) != str(pr_number):
+        return _parsed_github_review_evidence(role, parsed_round_number, "", parsed_head_sha, source, False, f"invalid_review_marker:{role}", created_at=created_at, source_index=source_index, comment_id=comment_id)
+    if not _has_final_ai_sentinel(body):
+        return _parsed_github_review_evidence(role, parsed_round_number, verdict, parsed_head_sha, source, False, f"missing_final_ai_sentinel:{role}", created_at=created_at, source_index=source_index, comment_id=comment_id)
+    round_number = parsed_round_number
+    head_sha = parsed_head_sha
+    if not head_sha:
+        return _parsed_github_review_evidence(role, round_number, verdict, "", source, False, f"missing_reviewed_head_sha:{role}", created_at=created_at, source_index=source_index, comment_id=comment_id)
+    return _parsed_github_review_evidence(role, round_number, verdict, head_sha, source, created_at=created_at, source_index=source_index, comment_id=comment_id)
+
+
+def _append_block_for_evidence(
+    evidence: ReviewEvidenceLike,
+    *,
+    role: str,
+    live_head_sha: str,
+    invalid: list[str],
+    pending: list[str],
+    terminal_failed_roles: list[str],
+) -> None:
+    if evidence.pending:
+        pending.append(evidence.reason or f"pending:{role}")
+    elif evidence.terminal_failed:
+        terminal_failed_roles.append(role)
+        invalid.append(evidence.reason or f"terminal_failed:{role}")
+    elif not evidence.valid:
+        invalid.append(evidence.reason or f"invalid:{role}")
+    elif not evidence.head_sha:
+        invalid.append(f"missing_reviewed_head_sha:{role}")
+    elif evidence.head_sha != live_head_sha:
+        invalid.append(f"stale_reviewed_head_sha:{role}")
 
 
 def select_latest_live_head_review_evidence(
@@ -39,6 +199,31 @@ def select_latest_live_head_review_evidence(
 
     for role in required_roles:
         role_items = [evidence for evidence in evidences if evidence.role == role]
+        ordered_items = [evidence for evidence in role_items if _has_ordering_metadata(evidence)]
+        unordered_items = [evidence for evidence in role_items if not _has_ordering_metadata(evidence)]
+        max_ordered_round = max((evidence.round_number for evidence in ordered_items), default=0)
+        max_unordered_round = max((evidence.round_number for evidence in unordered_items), default=0)
+        if ordered_items and max_ordered_round >= max_unordered_round:
+            highest_key = max(_recency_key(evidence) for evidence in ordered_items)
+            latest_ordered = [evidence for evidence in ordered_items if _recency_key(evidence) == highest_key]
+            if len(latest_ordered) > 1:
+                invalid.append(f"duplicate_reviewer_evidence:{role}")
+                continue
+            evidence = latest_ordered[0]
+            if evidence.valid and not evidence.pending and not evidence.terminal_failed and evidence.head_sha == live_head_sha:
+                selected[role] = evidence
+                max_round = evidence.round_number if max_round is None else max(max_round, evidence.round_number)
+            else:
+                _append_block_for_evidence(
+                    evidence,
+                    role=role,
+                    live_head_sha=live_head_sha,
+                    invalid=invalid,
+                    pending=pending,
+                    terminal_failed_roles=terminal_failed_roles,
+                )
+            continue
+
         live_items = [evidence for evidence in role_items if evidence.head_sha and evidence.head_sha == live_head_sha]
         selectable = [
             evidence
@@ -60,13 +245,14 @@ def select_latest_live_head_review_evidence(
             highest_live_round = max(evidence.round_number for evidence in live_items)
             latest_live = [evidence for evidence in live_items if evidence.round_number == highest_live_round]
             evidence = latest_live[0]
-            if evidence.pending:
-                pending.append(evidence.reason or f"pending:{role}")
-            elif evidence.terminal_failed:
-                terminal_failed_roles.append(role)
-                invalid.append(evidence.reason or f"terminal_failed:{role}")
-            elif not evidence.valid:
-                invalid.append(evidence.reason or f"invalid:{role}")
+            _append_block_for_evidence(
+                evidence,
+                role=role,
+                live_head_sha=live_head_sha,
+                invalid=invalid,
+                pending=pending,
+                terminal_failed_roles=terminal_failed_roles,
+            )
             continue
 
         missing_head_valid = [

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -46,7 +46,7 @@ from codex_refactor_loop.issue_decomposition import (
 from codex_refactor_loop.managed_work_snapshot import load_open_managed_work_snapshot
 from codex_refactor_loop.phase9.progress import issue_has_terminal_consensus_judge
 from codex_refactor_loop.pr_checks import PrMergeReadinessProjection
-from codex_refactor_loop.review_gate_selection import select_latest_live_head_review_evidence
+from codex_refactor_loop.review_gate_selection import parse_github_review_evidence, select_latest_live_head_review_evidence
 from codex_refactor_loop.release.candidate_liveness import classify_release_candidate_liveness
 from codex_refactor_loop.release.required_checks import ReleaseRequiredChecksProjection, required_release_checks
 from codex_refactor_loop.release.gate import decide_release_artifact
@@ -273,6 +273,9 @@ class ReviewCompletionEvidence:
     pending: bool = False
     terminal_failed: bool = False
     reason: str = ""
+    created_at: str = ""
+    source_index: int = 0
+    comment_id: int | None = None
 
 
 RELEASE_ROLLUP_LIVE_PR_LIST_TIMEOUT_SECONDS = 15
@@ -2323,6 +2326,74 @@ def _reviewed_head_sha_from_file(path: Path) -> str:
     return match.group(1) if match else ""
 
 
+def _github_comment_items(payload: object) -> list[object] | None:
+    if isinstance(payload, list):
+        if all(isinstance(page, list) for page in payload):
+            return [item for page in payload for item in page]
+        return payload
+    if isinstance(payload, Mapping):
+        comments = payload.get("comments")
+        if isinstance(comments, list):
+            return comments
+    return None
+
+
+def _github_comment_id(comment: Mapping[str, Any]) -> int | None:
+    raw_comment_id = comment.get("id")
+    if isinstance(raw_comment_id, int) and raw_comment_id > 0:
+        return raw_comment_id
+    if isinstance(raw_comment_id, str) and raw_comment_id.isdigit():
+        comment_id = int(raw_comment_id)
+        return comment_id if comment_id > 0 else None
+    return None
+
+
+def _github_review_completion_evidences(repo_root: Path, pr_number: int) -> list[ReviewCompletionEvidence]:
+    slug = github_repo_slug()
+    if not slug:
+        return []
+    try:
+        payload = run_json(
+            ["gh", "api", f"repos/{slug}/issues/{pr_number}/comments?per_page=100", "--paginate", "--slurp"],
+            cwd=repo_root,
+        )
+    except Exception:
+        return []
+    comments = _github_comment_items(payload)
+    if comments is None:
+        return []
+    evidences: list[ReviewCompletionEvidence] = []
+    for index, comment in enumerate(comments):
+        if not isinstance(comment, Mapping):
+            continue
+        body = str(comment.get("body") or "")
+        evidence = parse_github_review_evidence(
+            body,
+            pr_number,
+            source=f"github:issues/comments[{index}]",
+            created_at=str(comment.get("created_at") or comment.get("createdAt") or ""),
+            source_index=index + 1,
+            comment_id=_github_comment_id(comment),
+        )
+        if evidence is None:
+            continue
+        evidences.append(
+            ReviewCompletionEvidence(
+                role=evidence.role,
+                round_number=evidence.round_number,
+                head_sha=evidence.head_sha,
+                valid=evidence.valid,
+                pending=evidence.pending,
+                terminal_failed=evidence.terminal_failed,
+                reason=evidence.reason,
+                created_at=evidence.created_at,
+                source_index=evidence.source_index,
+                comment_id=evidence.comment_id,
+            )
+        )
+    return evidences
+
+
 def _review_done_action_head_sha(repo_root: Path, log_path: Path, marker: str, gh_items: list[GhItem] | None) -> str:
     match = re.match(r"^REVIEW_DONE:([1-9][0-9]*):([A-Za-z][A-Za-z0-9_-]*):(approve|comment|reject)(?::real)?$", marker)
     if match is None:
@@ -2462,6 +2533,7 @@ def highest_complete_required_review_round(repo_root: Path, pr_number: int, head
     if not head_sha:
         return None
     evidences: list[ReviewCompletionEvidence] = []
+    evidences.extend(_github_review_completion_evidences(repo_root, pr_number))
     artifact_keys: set[tuple[str, int]] = set()
     runs_dir = repo_root / ".refactor-loop" / "runs"
     logs_dir = repo_root / ".refactor-loop" / "logs"

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -48,7 +48,7 @@ from .issue_decomposition import (
 )
 from .pr_checks import PrMergeReadinessProjection
 from .processes import ProcessSupervisor, launch_spawn_codex_supervisor
-from .review_gate_selection import select_latest_live_head_review_evidence
+from .review_gate_selection import extract_review_head_sha, parse_github_review_evidence, select_latest_live_head_review_evidence
 from .release.gate import AutoReleaseGate
 from .release.commits import write_release_commits
 from .release.candidate_liveness import classify_release_candidate_liveness
@@ -90,9 +90,6 @@ FORBIDDEN_ACTION_FIELDS = {
 }
 REQUIRED_REVIEW_ROLES = ("architect", "tests", "quality")
 REVIEW_DONE_RE = re.compile(r"^REVIEW_DONE:([1-9][0-9]*):([A-Za-z][A-Za-z0-9_-]*):(approve|comment|reject)$")
-REVIEW_HEAD_RE = re.compile(r"(?im)^(?:reviewed[-_ ]?head[-_ ]?sha|head[-_ ]?sha|headRefOid|REVIEW_HEAD_SHA)\s*[:=]\s*([0-9a-f]{7,64})\s*$")
-REVIEW_ROUND_RE = re.compile(r"(?im)^(?:review[-_ ]?round|round)\s*[:=]\s*([1-9][0-9]*)\s*$")
-AI_SENTINEL = "⟦AI:AUTO-LOOP⟧"
 CONSENSUS_JUDGE_ARTIFACT_RE = re.compile(r"^phase9-issue([1-9][0-9]*)-r([1-9][0-9]*)-judge\.md$")
 TARGET_TEXT_PATTERNS = (
     (re.compile(r"(?i)\bPR\s*#([1-9][0-9]*)\b"), "PR"),
@@ -201,6 +198,9 @@ class ReviewEvidence:
     reason: str = ""
     terminal_failed: bool = False
     pending: bool = False
+    created_at: str = ""
+    source_index: int = 0
+    comment_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -1803,7 +1803,16 @@ class WakeupRunner:
             if not isinstance(comment, Mapping):
                 continue
             body = str(comment.get("body") or "")
-            evidence = _review_evidence_from_github_comment(body, pr_number, source=f"github:issues/comments[{index}]")
+            created_at = str(comment.get("created_at") or comment.get("createdAt") or "")
+            comment_id = _github_comment_id(comment)
+            evidence = _review_evidence_from_github_comment(
+                body,
+                pr_number,
+                source=f"github:issues/comments[{index}]",
+                created_at=created_at,
+                source_index=index + 1,
+                comment_id=comment_id,
+            )
             if evidence is not None:
                 evidences.append(evidence)
         return evidences
@@ -2239,15 +2248,13 @@ def _is_relative_to(path: Path, parent: Path) -> bool:
 
 
 def _extract_review_head_sha(text: str) -> str:
-    match = REVIEW_HEAD_RE.search(text)
-    return match.group(1) if match else ""
+    return extract_review_head_sha(text)
 
 
 def _extract_review_round(text: str) -> int | None:
-    match = REVIEW_ROUND_RE.search(text)
-    if match is None:
-        return None
-    return int(match.group(1))
+    from .review_gate_selection import extract_review_round
+
+    return extract_review_round(text)
 
 
 def _github_comment_items(payload: object) -> list[object] | None:
@@ -2259,6 +2266,16 @@ def _github_comment_items(payload: object) -> list[object] | None:
         comments = payload.get("comments")
         if isinstance(comments, list):
             return comments
+    return None
+
+
+def _github_comment_id(comment: Mapping[str, Any]) -> int | None:
+    raw_comment_id = comment.get("id")
+    if isinstance(raw_comment_id, int) and raw_comment_id > 0:
+        return raw_comment_id
+    if isinstance(raw_comment_id, str) and raw_comment_id.isdigit():
+        comment_id = int(raw_comment_id)
+        return comment_id if comment_id > 0 else None
     return None
 
 
@@ -2277,46 +2294,39 @@ def _invalid_github_review_evidences(reason: str) -> list[ReviewEvidence]:
     ]
 
 
-def _has_final_ai_sentinel(text: str) -> bool:
-    lines = [line.strip() for line in text.splitlines() if line.strip()]
-    return bool(lines) and lines[-1] == AI_SENTINEL
-
-
-def _review_evidence_from_github_comment(body: str, pr_number: int, *, source: str) -> ReviewEvidence | None:
-    if "REVIEW_DONE:" not in body:
+def _review_evidence_from_github_comment(
+    body: str,
+    pr_number: int,
+    *,
+    source: str,
+    created_at: str = "",
+    source_index: int = 0,
+    comment_id: int | None = None,
+) -> ReviewEvidence | None:
+    parsed = parse_github_review_evidence(
+        body,
+        pr_number,
+        source=source,
+        created_at=created_at,
+        source_index=source_index,
+        comment_id=comment_id,
+    )
+    if parsed is None:
         return None
-    marker_matches = [REVIEW_DONE_RE.fullmatch(line.strip()) for line in body.splitlines()]
-    marker_matches = [match for match in marker_matches if match is not None]
-    if not marker_matches:
-        role = _loose_review_marker_role(body) or "github"
-        return ReviewEvidence(role, 1, "", "", source, False, f"invalid_review_marker:{role}")
-    marker = marker_matches[0]
-    role = marker.group(2)
-    verdict = marker.group(3)
-    if len(marker_matches) != 1:
-        return ReviewEvidence(role, 1, "", "", source, False, f"invalid_review_marker:{role}")
-    if marker.group(1) != str(pr_number):
-        return ReviewEvidence(role, 1, "", "", source, False, f"invalid_review_marker:{role}")
-    if not _has_final_ai_sentinel(body):
-        return ReviewEvidence(role, 1, verdict, "", source, False, f"missing_final_ai_sentinel:{role}")
-    round_number = _extract_review_round(body)
-    if round_number is None:
-        return ReviewEvidence(role, 1, verdict, "", source, False, f"missing_review_round:{role}")
-    head_sha = _extract_review_head_sha(body)
-    if not head_sha:
-        return ReviewEvidence(role, round_number, verdict, "", source, False, f"missing_reviewed_head_sha:{role}")
-    return ReviewEvidence(role, round_number, verdict, head_sha, source)
-
-
-def _loose_review_marker_role(body: str) -> str:
-    for line in body.splitlines():
-        stripped = line.strip()
-        if not stripped.startswith("REVIEW_DONE:"):
-            continue
-        parts = stripped.split(":")
-        if len(parts) >= 3:
-            return parts[2]
-    return ""
+    return ReviewEvidence(
+        parsed.role,
+        parsed.round_number,
+        parsed.verdict,
+        parsed.head_sha,
+        parsed.source,
+        parsed.valid,
+        parsed.reason,
+        parsed.terminal_failed,
+        parsed.pending,
+        parsed.created_at,
+        parsed.source_index,
+        parsed.comment_id,
+    )
 
 
 def _single_linked_issue_from_body(body: str) -> int | None:

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -1153,7 +1153,10 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
                     exit 0
                   fi
                   if [[ "$api_flag1" == "--paginate" && "$api_flag2" == "--slurp" ]]; then
-                    if [[ "$fixture" == "ci_red" && "$api_path" == "repos/owner/repo/commits/ci-red-sha/check-runs" ]]; then
+                    api_comments_file="${WAKEUP_PLAN_REPO_ROOT:-.}/gh-api-${api_path//\\//-}-comments.json"
+                    if [[ -f "$api_comments_file" ]]; then
+                      cat "$api_comments_file"
+                    elif [[ "$fixture" == "ci_red" && "$api_path" == "repos/owner/repo/commits/ci-red-sha/check-runs" ]]; then
                       printf '[{"check_runs":[{"name":"unit","status":"completed","conclusion":"failure","html_url":"https://checks/unit"},{"name":"lint","status":"completed","conclusion":"success","html_url":"https://checks/lint"}]}]\n'
                     elif [[ ( "$fixture" == "draft_rollup_missing_snapshot_draft" || "$fixture" == "draft_rollup_only_missing_snapshot_draft" ) && ( "$api_path" == "repos/owner/repo/commits/integration-sha/check-runs" || "$api_path" == "repos/owner/repo/commits/integration-sha-2/check-runs" ) ]]; then
                       printf '[{"check_runs":[{"name":"contract-tests","status":"completed","conclusion":"success","html_url":"https://checks/contract-tests"}]}]\n'
@@ -4849,6 +4852,98 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         gate = next(item for item in plan["actions"] if item.get("controller_action") == "review_gate")
         self.assertEqual(gate["head_sha"], live)
         self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+
+    def test_review_gate_completion_uses_recency_resolved_github_comments_with_empty_rounds(self) -> None:
+        live = "a" * 40
+
+        def comment(role: str, verdict: str, created_at: str, comment_id: int) -> dict[str, object]:
+            return {
+                "id": comment_id,
+                "created_at": created_at,
+                "body": (
+                    f"review_round: \nhead_sha: {live}\n"
+                    f"REVIEW_DONE:480:{role}:{verdict}\n\n"
+                    "⟦AI:AUTO-LOOP⟧"
+                ),
+            }
+
+        comments = [
+            [
+                comment("architect", "reject", "2026-06-12T00:00:00Z", 101),
+                comment("architect", "approve", "2026-06-12T00:05:00Z", 102),
+                comment("tests", "approve", "2026-06-12T00:01:00Z", 103),
+                comment("quality", "comment", "2026-06-12T00:02:00Z", 104),
+                comment("quality", "comment", "2026-06-12T00:06:00Z", 105),
+            ]
+        ]
+
+        with (
+            mock.patch("codex_refactor_loop.wakeup_plan.github_repo_slug", return_value="owner/repo"),
+            mock.patch("codex_refactor_loop.wakeup_plan.run_json", return_value=comments),
+        ):
+            completion = highest_complete_required_review_round(self.repo, 480, live)
+        self.assertIsNotNone(completion)
+        self.assertEqual(completion.round_number, 1)
+
+        (self.repo / "gh-api-repos-owner-repo-issues-480-comments?per_page=100-comments.json").write_text(
+            json.dumps(comments),
+            encoding="utf-8",
+        )
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+        gates = [item for item in plan["actions"] if item.get("controller_action") == "review_gate"]
+        if gates:
+            self.assertEqual(gates[0]["head_sha"], live)
+
+    def test_review_gate_completion_latest_conflicting_github_comment_blocks_older_valid_role(self) -> None:
+        live = "a" * 40
+
+        def comment(role: str, verdict: str, created_at: str, comment_id: int) -> dict[str, object]:
+            return {
+                "id": comment_id,
+                "created_at": created_at,
+                "body": (
+                    f"review_round: \nhead_sha: {live}\n"
+                    f"REVIEW_DONE:480:{role}:{verdict}\n\n"
+                    "⟦AI:AUTO-LOOP⟧"
+                ),
+            }
+
+        comments = [
+            [
+                comment("architect", "approve", "2026-06-12T00:00:00Z", 101),
+                comment("tests", "approve", "2026-06-12T00:01:00Z", 102),
+                comment("quality", "comment", "2026-06-12T00:02:00Z", 103),
+                {
+                    "id": 104,
+                    "created_at": "2026-06-12T00:05:00Z",
+                    "body": (
+                        f"review_round: \nhead_sha: {live}\n"
+                        "REVIEW_DONE:480:tests:approve\n"
+                        "REVIEW_DONE:480:tests:reject\n\n"
+                        "⟦AI:AUTO-LOOP⟧"
+                    ),
+                },
+            ]
+        ]
+
+        with (
+            mock.patch("codex_refactor_loop.wakeup_plan.github_repo_slug", return_value="owner/repo"),
+            mock.patch("codex_refactor_loop.wakeup_plan.run_json", return_value=comments),
+        ):
+            completion = highest_complete_required_review_round(self.repo, 480, live)
+        self.assertIsNone(completion)
+
+        (self.repo / "gh-api-repos-owner-repo-issues-480-comments?per_page=100-comments.json").write_text(
+            json.dumps(comments),
+            encoding="utf-8",
+        )
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        self.assertFalse(any(item.get("controller_action") == "review_gate" for item in plan["actions"]))
 
     def test_review_gate_completion_requires_each_role_to_have_live_head_valid_evidence(self) -> None:
         live = "a" * 40

--- a/skills/consensus-loop/scripts/test_wakeup_runner_review_gate.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner_review_gate.py
@@ -69,15 +69,30 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.tmp.cleanup()
 
-    def github_review_comment(self, role: str, verdict: str, *, head_sha: str = "a" * 40, round_number: int = 1) -> dict[str, object]:
-        return {
+    def github_review_comment(
+        self,
+        role: str,
+        verdict: str,
+        *,
+        head_sha: str = "a" * 40,
+        round_number: int | None = 1,
+        created_at: str = "",
+        comment_id: int | None = None,
+    ) -> dict[str, object]:
+        round_line = f"review_round: {round_number}\n" if round_number is not None else "review_round: \n"
+        comment: dict[str, object] = {
             "body": (
-                f"review_round: {round_number}\n"
-                f"head_sha: {head_sha}\n"
-                f"REVIEW_DONE:12:{role}:{verdict}\n\n"
-                "⟦AI:AUTO-LOOP⟧"
+                round_line
+                + f"head_sha: {head_sha}\n"
+                + f"REVIEW_DONE:12:{role}:{verdict}\n\n"
+                + "⟦AI:AUTO-LOOP⟧"
             )
         }
+        if created_at:
+            comment["created_at"] = created_at
+        if comment_id is not None:
+            comment["id"] = comment_id
+        return comment
 
     def write_review(
         self,
@@ -368,6 +383,54 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
         self.assertEqual(self.actions.merged, ["12"])
         self.assertEqual(self.actions.rendered, [])
 
+    def test_github_comment_empty_review_round_is_valid_and_gate_completes(self) -> None:
+        live = "a" * 40
+        self.github_comments = [
+            self.github_review_comment("architect", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:00:00Z", comment_id=101),
+            self.github_review_comment("tests", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:01:00Z", comment_id=102),
+            self.github_review_comment("quality", "comment", head_sha=live, round_number=None, created_at="2026-06-12T00:02:00Z", comment_id=103),
+        ]
+
+        result = self.run_action(required_checks=())
+
+        self.assertEqual(result.status, "applied")
+        self.assertEqual(self.actions.merged, ["12"])
+        self.assertEqual(self.actions.rendered, [])
+
+    def test_github_comment_ordered_same_role_latest_verdict_wins_without_duplicate(self) -> None:
+        live = "a" * 40
+        self.github_comments = [
+            self.github_review_comment("architect", "reject", head_sha=live, round_number=None, created_at="2026-06-12T00:00:00Z", comment_id=101),
+            self.github_review_comment("architect", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:05:00Z", comment_id=102),
+            self.github_review_comment("tests", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:01:00Z", comment_id=103),
+            self.github_review_comment("quality", "comment", head_sha=live, round_number=None, created_at="2026-06-12T00:02:00Z", comment_id=104),
+        ]
+
+        result = self.run_action(required_checks=())
+        gate = self.runner_for_gate(live_head=live)._review_gate(12)
+
+        self.assertEqual(result.status, "applied")
+        self.assertEqual(gate["invalid"], [])
+        self.assertEqual(gate["verdicts"]["architect"], "approve")
+        self.assertEqual(self.actions.merged, ["12"])
+
+    def test_github_comment_later_reject_flip_flop_routes_to_fix(self) -> None:
+        live = "a" * 40
+        self.github_comments = [
+            self.github_review_comment("architect", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:00:00Z", comment_id=101),
+            self.github_review_comment("architect", "reject", head_sha=live, round_number=None, created_at="2026-06-12T00:05:00Z", comment_id=102),
+            self.github_review_comment("tests", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:01:00Z", comment_id=103),
+            self.github_review_comment("quality", "comment", head_sha=live, round_number=None, created_at="2026-06-12T00:02:00Z", comment_id=104),
+        ]
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor", return_value=0) as launch:
+            result = self.run_action(required_checks=())
+
+        self.assertEqual(result.status, "applied")
+        self.assertEqual(self.actions.merged, [])
+        self.assertEqual(self.actions.rendered, [(12, 1)])
+        launch.assert_called_once()
+
     def test_review_gate_newer_pending_wave_does_not_block_completion_when_role_has_valid_verdict(self) -> None:
         live = "f" * 40
         evidences = [
@@ -391,21 +454,111 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
         self.assertEqual(decision["gate"]["invalid"], [])
         self.assertEqual(decision["gate"]["pending"], [])
 
-    def test_review_gate_duplicate_same_role_same_round_fails_closed(self) -> None:
+    def test_local_artifact_duplicate_same_role_same_round_still_fails_closed(self) -> None:
+        live = "a" * 40
+        evidences = [
+            ReviewEvidence("architect", 2, "approve", live, "test"),
+            ReviewEvidence("architect", 2, "reject", live, "test"),
+            ReviewEvidence("tests", 2, "approve", live, "test"),
+            ReviewEvidence("quality", 2, "comment", live, "test"),
+        ]
+        runner = self.runner_for_gate(live_head=live)
+        with mock.patch.object(runner, "_review_evidences", return_value=evidences):
+            decision = runner._review_gate_decision(self.action(head_sha=live))
+
+        self.assertEqual(decision["decision"], "WAIT_OR_REDISPATCH")
+        self.assertEqual(decision["reason"], "invalid_reviewer_evidence:duplicate_reviewer_evidence:architect")
+
+    def test_github_comment_identical_duplicate_marker_in_one_body_is_single_valid_evidence(self) -> None:
         live = "a" * 40
         self.github_comments = [
-            self.github_review_comment("architect", "approve", head_sha=live, round_number=2),
-            self.github_review_comment("architect", "reject", head_sha=live, round_number=2),
-            self.github_review_comment("tests", "approve", head_sha=live, round_number=2),
-            self.github_review_comment("quality", "comment", head_sha=live, round_number=2),
+            {
+                "id": 101,
+                "created_at": "2026-06-12T00:00:00Z",
+                "body": (
+                    f"review_round: \nhead_sha: {live}\n"
+                    "REVIEW_DONE:12:architect:approve\n"
+                    f"head_sha: {live}\n"
+                    "REVIEW_DONE:12:architect:approve\n\n"
+                    "⟦AI:AUTO-LOOP⟧"
+                ),
+            },
+            self.github_review_comment("tests", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:01:00Z", comment_id=102),
+            self.github_review_comment("quality", "comment", head_sha=live, round_number=None, created_at="2026-06-12T00:02:00Z", comment_id=103),
         ]
 
-        result = self.run_action()
+        gate = self.runner_for_gate(live_head=live)._review_gate(12)
+        result = self.run_action(required_checks=())
+
+        self.assertEqual(gate["invalid"], [])
+        self.assertEqual(gate["verdicts"]["architect"], "approve")
+        self.assertEqual(result.status, "applied")
+        self.assertEqual(self.actions.merged, ["12"])
+
+    def test_github_comment_conflicting_markers_in_one_body_fails_closed(self) -> None:
+        live = "a" * 40
+        self.github_comments = [
+            self.github_review_comment("architect", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:00:00Z", comment_id=101),
+            self.github_review_comment("quality", "comment", head_sha=live, round_number=None, created_at="2026-06-12T00:01:00Z", comment_id=102),
+            {
+                "id": 103,
+                "created_at": "2026-06-12T00:02:00Z",
+                "body": (
+                    f"review_round: \nhead_sha: {live}\n"
+                    "REVIEW_DONE:12:tests:approve\n"
+                    "REVIEW_DONE:12:tests:reject\n\n"
+                    "⟦AI:AUTO-LOOP⟧"
+                ),
+            },
+        ]
+
+        result = self.run_action(required_checks=())
 
         self.assertEqual(result.status, "blocked")
-        self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:invalid_reviewer_evidence:duplicate_reviewer_evidence:architect")
+        self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:invalid_reviewer_evidence:invalid_review_marker:tests")
         self.assertEqual(self.actions.merged, [])
-        self.assertEqual(self.actions.rendered, [])
+
+    def test_github_comment_newer_conflicting_same_role_blocks_older_valid_live_head(self) -> None:
+        live = "a" * 40
+        self.github_comments = [
+            self.github_review_comment("architect", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:00:00Z", comment_id=100),
+            self.github_review_comment("tests", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:01:00Z", comment_id=101),
+            self.github_review_comment("quality", "comment", head_sha=live, round_number=None, created_at="2026-06-12T00:02:00Z", comment_id=102),
+            {
+                "id": 103,
+                "created_at": "2026-06-12T00:05:00Z",
+                "body": (
+                    f"review_round: \nhead_sha: {live}\n"
+                    "REVIEW_DONE:12:tests:approve\n"
+                    "REVIEW_DONE:12:tests:reject\n\n"
+                    "⟦AI:AUTO-LOOP⟧"
+                ),
+            },
+        ]
+
+        result = self.run_action(required_checks=())
+        gate = self.runner_for_gate(live_head=live)._review_gate(12)
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:invalid_reviewer_evidence:invalid_review_marker:tests")
+        self.assertEqual(gate["invalid"], ["invalid_review_marker:tests"])
+        self.assertNotIn("tests", gate["verdicts"])
+        self.assertEqual(self.actions.merged, [])
+
+    def test_github_comment_missing_live_head_role_remains_incomplete(self) -> None:
+        live = "a" * 40
+        stale = "b" * 40
+        self.github_comments = [
+            self.github_review_comment("architect", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:00:00Z", comment_id=101),
+            self.github_review_comment("tests", "approve", head_sha=live, round_number=None, created_at="2026-06-12T00:01:00Z", comment_id=102),
+            self.github_review_comment("quality", "comment", head_sha=stale, round_number=None, created_at="2026-06-12T00:02:00Z", comment_id=103),
+        ]
+
+        result = self.run_action(required_checks=())
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason, "WAIT_OR_REDISPATCH:invalid_reviewer_evidence:stale_reviewed_head_sha:quality")
+        self.assertEqual(self.actions.merged, [])
 
     def test_review_gate_role_with_only_stale_head_remains_incomplete(self) -> None:
         self.write_review("architect", "approve")
@@ -497,10 +650,6 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
             (
                 "missing_final_ai_sentinel:tests",
                 {"body": f"review_round: 1\nhead_sha: {'a' * 40}\nREVIEW_DONE:12:tests:approve"},
-            ),
-            (
-                "missing_review_round:tests",
-                {"body": f"head_sha: {'a' * 40}\nREVIEW_DONE:12:tests:approve\n\n⟦AI:AUTO-LOOP⟧"},
             ),
             (
                 "missing_reviewed_head_sha:tests",


### PR DESCRIPTION
### Release rollup

- Target: `auto-refact-dev` -> `dev`
- Integration branch ahead of review-base: `1` commits
- Range: `c75667dabb99..61c3bbf0604d`

### Commit summary

- Resolve review gate via GitHub comment recency, not body-parsed round

### Merge policy

- After required checks are green, controller auto squash-merges; when `ROLLUP_AUTO_MERGE=manual`, wait for human review/merge.
- This PR is the release rollup singleton; when an open rollup already exists, controller only updates its head and body instead of opening another PR.

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
