### PR TITLE
修复 GitHub secondary rate limit:孤儿 reap + ghwrap 舰队级限流闸

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/gh_accounting.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/gh_accounting.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import shutil
 import subprocess
 import sys
+import time
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -17,8 +19,10 @@ from typing import Any, Iterable, Mapping, Sequence
 
 SCHEMA_VERSION = 1
 DEFAULT_ARTIFACT_RELATIVE = Path(".refactor-loop") / "state" / "gh-usage.jsonl"
+SECONDARY_STATE_RELATIVE = Path(".refactor-loop") / "state"
 DEFAULT_RETENTION_LINES = 20_000
 DEFAULT_WINDOW_MINUTES = 60
+DEFAULT_SECONDARY_BACKOFF_JITTER_MAX_SECONDS = 5.0
 GRAPHQL_COMMANDS = {
     "issue",
     "pr",
@@ -92,6 +96,13 @@ def default_usage_path(env: Mapping[str, str] | None = None, cwd: Path | None = 
         if bounded is not None:
             return bounded
     return usage_path_for_repo(repo_root)
+
+
+def secondary_state_dir_for_repo(env: Mapping[str, str] | None = None, cwd: Path | None = None) -> Path:
+    source_env = os.environ if env is None else env
+    repo_root = _repo_root(source_env, cwd=cwd)
+    bounded = _repo_contained_path(str(repo_root / SECONDARY_STATE_RELATIVE), repo_root=repo_root)
+    return bounded or (repo_root / SECONDARY_STATE_RELATIVE)
 
 
 def accounting_env(
@@ -174,11 +185,67 @@ def run_real_gh(argv: Sequence[str], *, argv0: str) -> int:
     if real_gh is None:
         sys.stderr.write("ghwrap: real gh not found after removing shim directory from PATH\n")
         return 127
+    _maybe_apply_secondary_backoff()
     try:
-        return subprocess.call([real_gh, *argv])
+        proc = subprocess.Popen([real_gh, *argv], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
     except OSError as exc:
         sys.stderr.write(f"ghwrap: failed to exec real gh: {exc}\n")
         return 127
+    sys.stdout.buffer.write(stdout)
+    sys.stdout.buffer.flush()
+    sys.stderr.buffer.write(stderr)
+    sys.stderr.buffer.flush()
+    _maybe_record_secondary_backoff(stdout, stderr)
+    return int(proc.returncode or 0)
+
+
+def _maybe_apply_secondary_backoff() -> None:
+    try:
+        from .secondary_mutation_backoff import currently_backing_off
+
+        state_dir = secondary_state_dir_for_repo()
+        backoff = currently_backing_off(state_dir)
+        if not backoff.active:
+            return
+        now = time.time()
+        jitter = random.uniform(0.0, _secondary_backoff_jitter_max(os.environ))
+        sleep_seconds = max(0.0, float(backoff.until_epoch) - now) + jitter
+        sys.stderr.write(f"ghwrap: secondary-backoff sleep={sleep_seconds:.3f}s until={int(backoff.until_epoch)}\n")
+        if sleep_seconds > 0:
+            time.sleep(sleep_seconds)
+    except Exception:
+        return
+
+
+def _maybe_record_secondary_backoff(stdout: bytes, stderr: bytes) -> None:
+    try:
+        from .secondary_mutation_backoff import (
+            record_backoff_from_gh_output,
+            record_generic_secondary_backoff_from_gh_output,
+        )
+
+        stdout_text = stdout.decode("utf-8", errors="replace")
+        stderr_text = stderr.decode("utf-8", errors="replace")
+        state_dir = secondary_state_dir_for_repo()
+        recorded = record_backoff_from_gh_output(state_dir, stdout_text, stderr_text, env=os.environ)
+        if recorded is None:
+            record_generic_secondary_backoff_from_gh_output(state_dir, stdout_text, stderr_text, env=os.environ)
+    except Exception:
+        return
+
+
+def _secondary_backoff_jitter_max(env: Mapping[str, str]) -> float:
+    raw = str(env.get("CRND_GH_SECONDARY_BACKOFF_JITTER_MAX_SECONDS") or "").strip()
+    if not raw:
+        return DEFAULT_SECONDARY_BACKOFF_JITTER_MAX_SECONDS
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return DEFAULT_SECONDARY_BACKOFF_JITTER_MAX_SECONDS
+    if parsed < 0:
+        return 0.0
+    return min(parsed, 60.0)
 
 
 def classify_subcommand(argv: Sequence[str]) -> str:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/monitors/concurrency.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/monitors/concurrency.py
@@ -28,6 +28,7 @@ from ..safe_progress_scheduler import (
     MEDIUM_DISPATCH_LIMIT_PER_TICK,
     classify_dispatch_payload,
 )
+from ..secondary_mutation_backoff import currently_backing_off
 from ..state import read_json, write_json
 from ..task_spawn_claim import TaskSpawnClaimError, safe_task_id_from_task
 from ..update_check import parse_time
@@ -1223,6 +1224,15 @@ class ConcurrencyMonitor:
         if not graphql_headroom_ok(cwd=self.ctx.repo_root, env=self.ctx.env_for_subprocess()):
             self.write_pending_event("DISPATCH_BACKOFF:graphql-headroom-low")
             log_tick_status("skip:graphql-backoff remaining=unknown")
+            return actual
+        try:
+            secondary_backoff = currently_backing_off(self.ctx.paths.state)
+        except Exception:
+            secondary_backoff = None
+        if secondary_backoff is not None and secondary_backoff.active:
+            until = int(secondary_backoff.until_epoch)
+            self.write_pending_event(f"DISPATCH_BACKOFF:secondary until={until}")
+            log_tick_status(f"skip:secondary-backoff until={until}")
             return actual
         max_dispatches = floor - actual
         dispatched = 0

--- a/skills/consensus-loop/scripts/codex_refactor_loop/processes.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/processes.py
@@ -13,6 +13,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping, Sequence
 
+from .secondary_mutation_backoff import currently_backing_off
+
 
 STALL_EXIT_CODE = 137
 TIMEOUT_EXIT_CODE = STALL_EXIT_CODE
@@ -105,6 +107,16 @@ def launch_spawn_codex_supervisor(
     if stall <= 0:
         raise ValueError(f"total wall-clock timeout must be positive: {stall}")
     repo_root = repo_root.resolve()
+    try:
+        backoff = currently_backing_off(repo_root / ".refactor-loop" / "state")
+    except Exception:
+        backoff = None
+    if backoff is not None and backoff.active:
+        diagnostic = f"SPAWN_SUPERVISOR_BACKOFF:secondary until={int(backoff.until_epoch)}\n"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        _append(log, diagnostic)
+        sys.stderr.write(diagnostic)
+        return 3
     skill_root = skill_root.resolve()
     cli = skill_root / "scripts" / "consensus-rnd-cli"
     if not cli.is_file():

--- a/skills/consensus-loop/scripts/codex_refactor_loop/restart.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/restart.py
@@ -380,7 +380,7 @@ class DaemonProcessInventory:
                 continue
             if process.pid in canonical or process.ppid != 1:
                 continue
-            if not _restart_daemon_command_matches(process.command, command):
+            if not _restart_daemon_command_matches_strict_path(process.command, command):
                 continue
             pids.append(process.pid)
         return tuple(sorted(set(pids)))
@@ -862,8 +862,16 @@ class RestartDaemons:
         )
 
     def _stop_existing_daemon(self, target: DaemonTarget, *, instance: DaemonInstanceProjection) -> None:
+        singleton_holder_pids = set(instance.singleton_holder_pids)
+        repair_pids = set(instance.repair_pids)
         self._terminate_pids(instance.singleton_holder_pids)
-        self._terminate_pids(pid for pid in instance.repair_pids if pid not in set(instance.singleton_holder_pids))
+        self._terminate_pids(pid for pid in instance.repair_pids if pid not in singleton_holder_pids)
+        orphan_reap_pids = tuple(
+            pid for pid in instance.orphan_child_pids if pid not in singleton_holder_pids and pid not in repair_pids
+        )
+        if orphan_reap_pids:
+            self._log(f"ORPHAN_REAP daemon={target.name} pids={','.join(str(pid) for pid in orphan_reap_pids)}")
+            self._terminate_pids(orphan_reap_pids)
         target.pid_file.unlink(missing_ok=True)
 
     @staticmethod
@@ -1156,6 +1164,20 @@ def _restart_daemon_command_matches(actual_tail: str, expected: Sequence[str]) -
         if index == 0 and _is_python_launcher(actual_part) and _is_python_launcher(expected_part):
             continue
         if index == 1 and _is_consensus_cli_path(actual_part) and _is_consensus_cli_path(expected_part):
+            continue
+        if actual_part != expected_part:
+            return False
+    return True
+
+
+def _restart_daemon_command_matches_strict_path(actual_tail: str, expected: Sequence[str]) -> bool:
+    actual_parts = _normalize_process_command(actual_tail).split()
+    expected_parts = [_normalize_process_command(part) for part in expected]
+    if len(actual_parts) != len(expected_parts):
+        return False
+    for index, expected_part in enumerate(expected_parts):
+        actual_part = actual_parts[index]
+        if index == 0 and _is_python_launcher(actual_part) and _is_python_launcher(expected_part):
             continue
         if actual_part != expected_part:
             return False

--- a/skills/consensus-loop/scripts/codex_refactor_loop/secondary_mutation_backoff.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/secondary_mutation_backoff.py
@@ -18,6 +18,7 @@ STATE_FILE_NAME = "secondary-mutation-backoff.json"
 STATE_RELATIVE_PATH = Path(".refactor-loop/state") / STATE_FILE_NAME
 CONTENT_CREATION_KEY = "contentCreation"
 MUTATION_KEY = "mutationThrottle"
+GENERIC_SECONDARY_KEY = "genericSecondary"
 DEFAULT_COOLDOWN_SECONDS = 600
 DEFAULT_BACKOFF_SECONDS = 900
 SECONDARY_MUTATION_RE = re.compile(r"GraphQL:\s*was submitted too quickly\s*\(([A-Za-z][A-Za-z0-9_]*)\)")
@@ -82,6 +83,17 @@ def currently_backing_off(state_dir: Path, *, now: float | None = None) -> Secon
                     str(content_payload.get("reason") or ""),
                 )
             )
+    generic_payload = payload.get(GENERIC_SECONDARY_KEY)
+    if isinstance(generic_payload, dict):
+        generic_until = _float(generic_payload.get("until_epoch"))
+        if generic_until is not None:
+            entries.append(
+                (
+                    str(generic_payload.get("operation") or GENERIC_SECONDARY_KEY),
+                    generic_until,
+                    str(generic_payload.get("reason") or ""),
+                )
+            )
     active_entries = [(mutation, until, reason) for mutation, until, reason in entries if until > now_value]
     if not active_entries:
         return SecondaryMutationBackoff(active=False, mutation="", until_epoch=0.0, reason="")
@@ -136,6 +148,47 @@ def record_backoff_from_gh_output(
     if not mutation:
         return None
     return record_secondary_mutation_backoff(state_dir, mutation, output=output, now=now, env=env)
+
+
+def record_generic_secondary_backoff_from_gh_output(
+    state_dir: Path,
+    stdout: str,
+    stderr: str,
+    *,
+    now: float | None = None,
+    env: Mapping[str, str] | None = None,
+) -> SecondaryMutationBackoff | None:
+    """Detect non-mutation secondary-limit gh output and persist a shared cooldown."""
+
+    output = f"{stdout}\n{stderr}"
+    lowered = output.lower()
+    if not any(needle in lowered for needle in SECONDARY_LIMIT_NEEDLES):
+        return None
+    now_value = time.time() if now is None else now
+    cooldown = _cooldown_seconds(os.environ if env is None else env)
+    until = now_value + cooldown
+    path = _state_path(state_dir)
+    state = _read_state(path)
+    state[GENERIC_SECONDARY_KEY] = {
+        "operation": GENERIC_SECONDARY_KEY,
+        "until_epoch": until,
+        "recorded_at_epoch": now_value,
+        "cooldown_seconds": cooldown,
+        "reason": _one_line(output) or "secondary-rate-limit",
+        "not_live_state_fact_source": True,
+        "not_host_production_ssot": True,
+        "no_lifecycle_authority": True,
+    }
+    state.setdefault("mutation", GENERIC_SECONDARY_KEY)
+    state.setdefault("until_epoch", until)
+    state.setdefault("reason", _one_line(output) or "secondary-rate-limit")
+    _write_state(path, state)
+    return SecondaryMutationBackoff(
+        active=True,
+        mutation=GENERIC_SECONDARY_KEY,
+        until_epoch=until,
+        reason=str(state[GENERIC_SECONDARY_KEY]["reason"]),
+    )
 
 
 def record_content_creation_backoff(

--- a/skills/consensus-loop/scripts/codex_refactor_loop/spawn.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/spawn.py
@@ -12,6 +12,7 @@ from typing import Any, Sequence
 
 from .gh_accounting import accounting_env
 from .processes import ProcessSupervisor, prompt_file_from_text
+from .secondary_mutation_backoff import currently_backing_off
 from .task_spawn_claim import TaskSpawnClaimError, TaskSpawnClaimStore, safe_task_id_from_task
 
 
@@ -63,6 +64,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 2
     usage_repo = Path(os.environ.get("REPO_ROOT") or args.cd)
     repo_root = usage_repo.resolve()
+    try:
+        backoff = currently_backing_off(repo_root / ".refactor-loop" / "state")
+    except Exception:
+        backoff = None
+    if backoff is not None and backoff.active:
+        sys.stderr.write(f"SPAWN_CODEX_BACKOFF:secondary until={int(backoff.until_epoch)}\n")
+        return 3
     try:
         claim = TaskSpawnClaimStore(repo_root).acquire(task_id, log_path=log_path)
     except TaskSpawnClaimError as exc:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -55,6 +55,7 @@ from .release.candidate_liveness import classify_release_candidate_liveness
 from .release.publish_preflight import ReleasePublishPreflight
 from .release.publisher import ReleasePublisher
 from .safe_progress_scheduler import MEDIUM_NON_SPAWN_LIMIT_PER_TICK, validate_runner_action
+from .secondary_mutation_backoff import SecondaryMutationBackoff, currently_backing_off
 from .state import read_json
 from .work_items import extract_closing_issue_numbers
 from .wakeup_plan import (
@@ -440,12 +441,19 @@ class WakeupRunner:
         stand_down_reason = self._cross_instance_stand_down_reason(action)
         if stand_down_reason:
             return self._record(RunnerResult(action_id, "skipped", stand_down_reason), action)
+        controller_action = str(action.get("controller_action") or "")
+        if controller_action == "spawn_codex_harness_background":
+            secondary_backoff = self._secondary_backoff()
+            if secondary_backoff is not None and secondary_backoff.active:
+                until = int(secondary_backoff.until_epoch)
+                self._append_pending_event(f"WAKEUP_RUNNER_SPAWN_BACKOFF:{action_id}:secondary until={until}")
+                _log_tick_status("wakeup-runner", f"skip:secondary-backoff until={until}")
+                return self._record(RunnerResult(action_id, "skipped", "backoff:secondary"), action)
         if action.get("capability") == "release-rollup-body":
             self._prepare_release_rollup_body_prompt(action)
         if action.get("capability") == "implementation-pr-artifact-repair":
             self._prepare_implementation_pr_artifact_repair_prompt(action)
 
-        controller_action = str(action.get("controller_action") or "")
         try:
             exit_code = self._dispatch(controller_action, action)
         except Exception as exc:
@@ -1555,6 +1563,12 @@ class WakeupRunner:
         if exit_code != 0:
             self._append_pending_event(f"WAKEUP_RUNNER_SPAWN_LAUNCH_EXIT:{action.get('action_id', '')}:{exit_code}")
         return exit_code
+
+    def _secondary_backoff(self) -> SecondaryMutationBackoff | None:
+        try:
+            return currently_backing_off(self.ctx.paths.state)
+        except Exception:
+            return None
 
     def _spawn_log_suppresses_retry(self, log: Path) -> bool:
         if is_implement_log(log):

--- a/skills/consensus-loop/scripts/ghwrap/gh
+++ b/skills/consensus-loop/scripts/ghwrap/gh
@@ -39,10 +39,16 @@ def _fallback_exec() -> int:
         sys.stderr.write("ghwrap: real gh not found after removing shim directory from PATH\n")
         return 127
     try:
-        return subprocess.call([real, *sys.argv[1:]])
+        proc = subprocess.Popen([real, *sys.argv[1:]], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
     except OSError as exc:
         sys.stderr.write(f"ghwrap: failed to exec real gh: {exc}\n")
         return 127
+    sys.stdout.buffer.write(stdout)
+    sys.stdout.buffer.flush()
+    sys.stderr.buffer.write(stderr)
+    sys.stderr.buffer.flush()
+    return int(proc.returncode or 0)
 
 
 if __name__ == "__main__":

--- a/skills/consensus-loop/scripts/test_concurrency_monitor.py
+++ b/skills/consensus-loop/scripts/test_concurrency_monitor.py
@@ -258,6 +258,27 @@ class ConcurrencyMonitorDispatchQueueTests(unittest.TestCase):
         archived = sorted((self.refactor_loop / "dispatch-dispatched").glob("*.json"))
         self.assertEqual([p.name for p in archived], ["audit-iter-5.json", "fix-pr44-round-3.json"])
 
+    def test_top_up_from_dispatch_queue_defers_during_secondary_backoff_and_preserves_queue(self) -> None:
+        dispatch = self.write_dispatch("p1", "fix-pr44-round-3")
+        (self.refactor_loop / "state").mkdir(parents=True, exist_ok=True)
+        (self.refactor_loop / "state" / "secondary-mutation-backoff.json").write_text(
+            '{"until_epoch": 9999999999, "mutation": "readThrottle", "reason": "unit"}\n',
+            encoding="utf-8",
+        )
+        calls: list[list[str]] = []
+
+        with mock.patch.object(self.module.subprocess, "Popen", side_effect=self.fake_popen(calls)):
+            with mock.patch.object(self.monitor, "count_in_flight_codex", return_value=0):
+                actual = self.monitor.top_up_from_dispatch_queue(actual=0, floor=2)
+
+        self.assertEqual(0, actual)
+        self.assertEqual(calls, [])
+        self.assertTrue(dispatch.exists())
+        self.assertFalse((self.refactor_loop / "dispatch-dispatched").exists())
+        self.assertEqual([], self.harness_spawn_intents())
+        events = (self.refactor_loop / ".controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertIn("DISPATCH_BACKOFF:secondary until=9999999999", events)
+
     def test_dispatch_queue_rejects_high_risk_payload_and_continues_to_low(self) -> None:
         unsafe = self.write_dispatch("p0", "unsafe-task")
         payload = json.loads(unsafe.read_text(encoding="utf-8"))

--- a/skills/consensus-loop/scripts/test_gh_accounting.py
+++ b/skills/consensus-loop/scripts/test_gh_accounting.py
@@ -30,12 +30,34 @@ from codex_refactor_loop.gh_accounting import (
     classify_subcommand,
     default_usage_path,
     load_records,
+    run_real_gh,
 )
 from codex_refactor_loop import spawn
 from codex_refactor_loop.cli import COMMANDS, CommandSpec, RuntimeCommandRouter
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.processes import ProcessSupervisor
 from codex_refactor_loop.restart import DAEMON_COMMANDS, DaemonProcessInventory, RestartConfig, RestartDaemons
+
+
+class StringBuffer:
+    def __init__(self) -> None:
+        self._raw = bytearray()
+
+    @property
+    def buffer(self) -> "StringBuffer":
+        return self
+
+    @property
+    def text(self) -> str:
+        return self._raw.decode("utf-8", errors="replace")
+
+    def write(self, value) -> int:
+        raw = value if isinstance(value, bytes) else str(value).encode("utf-8", errors="replace")
+        self._raw.extend(raw)
+        return len(raw)
+
+    def flush(self) -> None:
+        return None
 
 
 class GhAccountingBehaviorTests(unittest.TestCase):
@@ -133,6 +155,99 @@ class GhAccountingBehaviorTests(unittest.TestCase):
         self.assertEqual("daemon:comment-monitor", record["source"])
         self.assertEqual(23, record["exit_code"])
         self.assertEqual("unknown", record["pool"])
+
+    def test_shim_sleeps_for_active_secondary_backoff_before_real_gh(self) -> None:
+        state = self.repo / ".refactor-loop" / "state" / "secondary-mutation-backoff.json"
+        state.write_text(json.dumps({"until_epoch": 110, "mutation": "readThrottle", "reason": "unit"}) + "\n", encoding="utf-8")
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{SHIM.parent}{os.pathsep}{self.realbin}{os.pathsep}{env.get('PATH', '')}",
+                "REPO_ROOT": str(self.repo),
+                "CRND_GH_SECONDARY_BACKOFF_JITTER_MAX_SECONDS": "0",
+            }
+        )
+        call_order: list[str] = []
+
+        class FakeProcess:
+            returncode = 0
+
+            def communicate(self) -> tuple[bytes, bytes]:
+                return (b"real stdout\n", b"real stderr\n")
+
+        def fake_sleep(seconds: float) -> None:
+            call_order.append(f"sleep:{seconds}")
+
+        def fake_popen(command: list[str], **_kwargs) -> FakeProcess:
+            call_order.append("popen:" + " ".join(command[1:]))
+            return FakeProcess()
+
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch("codex_refactor_loop.gh_accounting.time.time", return_value=100):
+                with mock.patch("codex_refactor_loop.gh_accounting.time.sleep", side_effect=fake_sleep) as sleep:
+                    with mock.patch("codex_refactor_loop.gh_accounting.subprocess.Popen", side_effect=fake_popen):
+                        with mock.patch("codex_refactor_loop.gh_accounting.sys.stdout", new_callable=StringBuffer) as stdout:
+                            with mock.patch("codex_refactor_loop.gh_accounting.sys.stderr", new_callable=StringBuffer) as stderr:
+                                exit_code = run_real_gh(["issue", "view", "1"], argv0=str(SHIM))
+
+        self.assertEqual(0, exit_code)
+        sleep.assert_called_once_with(10.0)
+        self.assertEqual(["sleep:10.0", "popen:issue view 1"], call_order)
+        self.assertIn("real stdout", stdout.text)
+        self.assertIn("real stderr", stderr.text)
+        self.assertIn("ghwrap: secondary-backoff sleep=10.000s until=110", stderr.text)
+
+    def test_shim_records_secondary_rate_limit_from_read_command_output(self) -> None:
+        self.fake_gh.write_text(
+            "#!/usr/bin/env bash\nprintf 'You have exceeded a secondary rate limit\\n' >&2\nexit 1\n",
+            encoding="utf-8",
+        )
+        self.fake_gh.chmod(0o755)
+
+        result = self.run_shim(
+            ["issue", "view", "455"],
+            extra_env={"SECONDARY_MUTATION_BACKOFF_SECONDS": "30", "CRND_GH_SECONDARY_BACKOFF_JITTER_MAX_SECONDS": "0"},
+        )
+
+        self.assertEqual(1, result.returncode)
+        self.assertIn("You have exceeded a secondary rate limit", result.stderr)
+        state = json.loads((self.repo / ".refactor-loop/state/secondary-mutation-backoff.json").read_text(encoding="utf-8"))
+        self.assertEqual("genericSecondary", state["genericSecondary"]["operation"])
+        self.assertEqual(30, state["genericSecondary"]["cooldown_seconds"])
+
+    def test_shim_records_named_secondary_mutation_from_write_command_output(self) -> None:
+        self.fake_gh.write_text(
+            "#!/usr/bin/env bash\nprintf 'GraphQL: was submitted too quickly (createPullRequest)\\n' >&2\nexit 1\n",
+            encoding="utf-8",
+        )
+        self.fake_gh.chmod(0o755)
+
+        result = self.run_shim(
+            ["pr", "create", "--title", "x"],
+            extra_env={"SECONDARY_MUTATION_BACKOFF_SECONDS": "30", "CRND_GH_SECONDARY_BACKOFF_JITTER_MAX_SECONDS": "0"},
+        )
+
+        self.assertEqual(1, result.returncode)
+        self.assertIn("createPullRequest", result.stderr)
+        state = json.loads((self.repo / ".refactor-loop/state/secondary-mutation-backoff.json").read_text(encoding="utf-8"))
+        self.assertEqual("createPullRequest", state["mutationThrottle"]["mutation"])
+        self.assertEqual(30, state["mutationThrottle"]["cooldown_seconds"])
+
+    def test_shim_secondary_backoff_import_failure_fails_open_to_real_gh(self) -> None:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{SHIM.parent}{os.pathsep}{self.realbin}{os.pathsep}{env.get('PATH', '')}",
+                "REPO_ROOT": str(self.repo),
+            }
+        )
+
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch("codex_refactor_loop.gh_accounting.secondary_state_dir_for_repo", side_effect=RuntimeError("boom")):
+                with mock.patch("codex_refactor_loop.gh_accounting.time.sleep", side_effect=AssertionError("must not sleep")):
+                    exit_code = run_real_gh(["issue", "view", "1"], argv0=str(SHIM))
+
+        self.assertEqual(0, exit_code)
 
     def test_accounting_failure_fails_open_after_real_gh(self) -> None:
         bad_parent = self.repo / "not-a-dir"
@@ -469,6 +584,40 @@ class GhAccountingBehaviorTests(unittest.TestCase):
         self.assertEqual(str(SKILL_ROOT / "scripts" / "ghwrap"), payload["path_head"])
         self.assertEqual(["exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "-C", str(self.repo), "-"], payload["argv"])
 
+    def test_spawn_codex_main_defers_during_secondary_backoff_without_worker_launch(self) -> None:
+        prompt = self.tmp / "prompt.md"
+        log = self.tmp / "review-pr458-fix.log"
+        prompt.write_text("prompt\n", encoding="utf-8")
+        state = self.repo / ".refactor-loop" / "state" / "secondary-mutation-backoff.json"
+        state.write_text(json.dumps({"until_epoch": 110, "mutation": "readThrottle", "reason": "unit"}) + "\n", encoding="utf-8")
+        env = {
+            "PATH": f"{self.realbin}{os.pathsep}/usr/bin{os.pathsep}/bin",
+            "REPO_ROOT": str(self.repo),
+            "CRND_GH_USAGE_PATH": str(self.usage),
+        }
+
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch("codex_refactor_loop.secondary_mutation_backoff.time.time", return_value=100):
+                with mock.patch("codex_refactor_loop.spawn.ProcessSupervisor") as supervisor:
+                    with mock.patch("codex_refactor_loop.spawn.sys.stderr", new_callable=StringBuffer) as stderr:
+                        exit_code = spawn.main(
+                            [
+                                "--cd",
+                                str(self.repo),
+                                "--prompt",
+                                str(prompt),
+                                "--log",
+                                str(log),
+                                "--stall",
+                                "5",
+                            ]
+                        )
+
+        self.assertEqual(3, exit_code)
+        supervisor.assert_not_called()
+        self.assertIn("SPAWN_CODEX_BACKOFF:secondary until=110", stderr.text)
+        self.assertFalse(log.exists())
+
 
 class GhAccountingSourceRegressionTests(unittest.TestCase):
     def test_shim_transparent_forwarding_and_fail_open_contract_is_literal(self) -> None:
@@ -479,15 +628,18 @@ class GhAccountingSourceRegressionTests(unittest.TestCase):
             "run_real_gh(argv, argv0=sys.argv[0])",
             "record_gh_call(argv, exit_code)",
             "except Exception:\n        pass",
-            "subprocess.call([real, *sys.argv[1:]])",
+            "subprocess.Popen([real, *sys.argv[1:]], stdout=subprocess.PIPE, stderr=subprocess.PIPE)",
         ):
             with self.subTest(token=token):
                 self.assertIn(token, source)
         for token in (
             "DEFAULT_ARTIFACT_RELATIVE = Path(\".refactor-loop\") / \"state\" / \"gh-usage.jsonl\"",
+            "SECONDARY_STATE_RELATIVE = Path(\".refactor-loop\") / \"state\"",
             "CRND_GH_USAGE_PATH",
             "_repo_contained_path",
             "resolved.relative_to(root)",
+            "currently_backing_off",
+            "record_generic_secondary_backoff_from_gh_output",
             "CRND_GH_USAGE_MAX_LINES",
             "1 <= value <= DEFAULT_RETENTION_LINES",
             "schema",

--- a/skills/consensus-loop/scripts/test_restart_daemons.py
+++ b/skills/consensus-loop/scripts/test_restart_daemons.py
@@ -971,6 +971,34 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         self.assertNotEqual(old_wrapper_pid, new_pid)
         self.assert_start_count("phase9_router_daemon", 2)
 
+    def test_lockless_orphan_managed_children_are_reaped_on_restart(self) -> None:
+        self.run_helper()
+        old_wrapper_pid = self.read_pid("phase9_router_daemon")
+        old_child_pid = self.runtime.child_pids_by_wrapper[old_wrapper_pid]
+        orphan_child_pid = 515152
+        target = restart.daemon_target(self.ctx, "phase9_router_daemon", FAKE_COMMAND)
+        self.stale_heartbeat("phase9_router_daemon")
+        self.runtime.live_pids.update({old_wrapper_pid, old_child_pid, orphan_child_pid})
+        self.runtime.inventory_override = DaemonProcessInventory(
+            (
+                DaemonProcess(old_wrapper_pid, self.runtime.canonical_command(self.ctx, "phase9_router_daemon", FAKE_COMMAND), 1),
+                DaemonProcess(old_child_pid, " ".join(target.command), old_wrapper_pid),
+                DaemonProcess(orphan_child_pid, " ".join(target.command), 1),
+            )
+        )
+
+        helper = RestartDaemons(self.ctx, self.config, runtime=self.runtime)
+        with mock.patch("builtins.print") as print_mock:
+            helper.start_daemon("phase9_router_daemon", FAKE_COMMAND)
+
+        self.assertIn((old_child_pid, self.config.stop_grace_seconds), self.runtime.terminated)
+        self.assertIn((old_wrapper_pid, self.config.stop_grace_seconds), self.runtime.terminated)
+        self.assertIn((orphan_child_pid, self.config.stop_grace_seconds), self.runtime.terminated)
+        self.assertTrue(
+            any("ORPHAN_REAP daemon=phase9_router_daemon pids=515152" in str(call.args[0]) for call in print_mock.mock_calls)
+        )
+        self.assert_start_count("phase9_router_daemon", 2)
+
     def test_duplicate_canonical_matching_ignores_other_repo_and_non_allowlist_commands(self) -> None:
         command = self.runtime.canonical_command(self.ctx, "concurrency_monitor", FAKE_COMMAND)
         other_repo = command.replace(str(self.ctx.repo_root), "/tmp/other-repo")
@@ -1029,6 +1057,32 @@ class RestartDaemonsBehaviorTests(unittest.TestCase):
         self.assertEqual((222,), projection.bounded_lock_holder_pids)
         self.assertEqual((111, 222), projection.repair_pids)
         self.assertEqual((), projection.singleton_holder_pids)
+
+    def test_orphan_child_matching_requires_current_absolute_skill_command_path(self) -> None:
+        template = ("python3", "{skill_root}/scripts/consensus-rnd-cli", "phase9-router", "--daemon")
+        target = restart.daemon_target(self.ctx, "phase9_router_daemon", template)
+        other_skill_command = " ".join(target.command).replace(
+            str(self.ctx.skill_root / "scripts" / "consensus-rnd-cli"),
+            "/tmp/other-skill/scripts/consensus-rnd-cli",
+        )
+        inventory = DaemonProcessInventory(
+            (
+                DaemonProcess(111, " ".join(target.command), 1),
+                DaemonProcess(222, other_skill_command, 1),
+            )
+        )
+        self.runtime.live_pids.update({111, 222})
+
+        projection = inventory.daemon_instance(
+            name="phase9_router_daemon",
+            repo_root=self.ctx.repo_root,
+            pid_file=target.pid_file,
+            died_file=target.died_file,
+            command=target.command,
+            is_alive=self.runtime.pid_alive,
+        )
+
+        self.assertEqual((111,), projection.orphan_child_pids)
 
     def test_daemon_instance_projects_lockless_orphans_excluding_pid_file_and_locks(self) -> None:
         target = restart.daemon_target(self.ctx, "phase9_router_daemon", FAKE_COMMAND)

--- a/skills/consensus-loop/scripts/test_secondary_mutation_backoff.py
+++ b/skills/consensus-loop/scripts/test_secondary_mutation_backoff.py
@@ -17,9 +17,13 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.secondary_mutation_backoff import (
+    STATE_FILE_NAME,
     STATE_RELATIVE_PATH,
     is_secondary_content_creation_failure,
+    record_backoff_from_gh_output,
     record_content_creation_backoff,
+    record_generic_secondary_backoff_from_gh_output,
+    currently_backing_off,
 )
 
 
@@ -78,6 +82,39 @@ class SecondaryMutationBackoffTests(unittest.TestCase):
         self.assertTrue(entry["not_live_state_fact_source"])
         self.assertTrue(entry["not_host_production_ssot"])
         self.assertTrue(entry["no_lifecycle_authority"])
+
+    def test_generic_secondary_needle_writes_shared_backoff_without_loop_context(self) -> None:
+        recorded = record_generic_secondary_backoff_from_gh_output(
+            self.ctx.paths.state,
+            "",
+            "You have exceeded a secondary rate limit",
+            now=100,
+            env={"SECONDARY_MUTATION_BACKOFF_SECONDS": "30"},
+        )
+
+        self.assertIsNotNone(recorded)
+        state = json.loads((self.ctx.paths.state / STATE_FILE_NAME).read_text(encoding="utf-8"))
+        entry = state["genericSecondary"]
+        self.assertEqual("genericSecondary", entry["operation"])
+        self.assertEqual(130, entry["until_epoch"])
+        self.assertEqual("You have exceeded a secondary rate limit", entry["reason"])
+        active = currently_backing_off(self.ctx.paths.state, now=101)
+        self.assertTrue(active.active)
+        self.assertEqual("genericSecondary", active.mutation)
+
+    def test_named_mutation_detector_still_uses_existing_mutation_state(self) -> None:
+        recorded = record_backoff_from_gh_output(
+            self.ctx.paths.state,
+            "",
+            "GraphQL: was submitted too quickly (createPullRequest)",
+            now=100,
+            env={"SECONDARY_MUTATION_BACKOFF_SECONDS": "30"},
+        )
+
+        self.assertIsNotNone(recorded)
+        state = json.loads((self.ctx.paths.state / STATE_FILE_NAME).read_text(encoding="utf-8"))
+        self.assertEqual("createPullRequest", state["mutationThrottle"]["mutation"])
+        self.assertEqual(130, state["mutationThrottle"]["until_epoch"])
 
 
 if __name__ == "__main__":

--- a/skills/consensus-loop/scripts/test_spawn_supervisor.py
+++ b/skills/consensus-loop/scripts/test_spawn_supervisor.py
@@ -297,6 +297,34 @@ class SpawnSupervisorTests(unittest.TestCase):
         self.assertIn("SPAWN_SUPERVISOR_CLI_MISSING:", text)
         self.assertIn(str((skill_root / "scripts" / "consensus-rnd-cli").resolve()), text)
 
+    def test_launch_spawn_codex_supervisor_defers_during_secondary_backoff_without_popen(self) -> None:
+        repo = self.tmp_root / "host-repo"
+        repo.mkdir()
+        skill_root = self.tmp_root / "installed-skill"
+        cli = skill_root / "scripts" / "consensus-rnd-cli"
+        cli.parent.mkdir(parents=True, exist_ok=True)
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        state_dir = repo / ".refactor-loop" / "state"
+        state_dir.mkdir(parents=True)
+        state_dir.joinpath("secondary-mutation-backoff.json").write_text(
+            '{"until_epoch": 9999999999, "mutation": "readThrottle", "reason": "unit"}\n',
+            encoding="utf-8",
+        )
+
+        with mock.patch("codex_refactor_loop.processes.subprocess.Popen") as popen:
+            exit_code = launch_spawn_codex_supervisor(
+                repo_root=repo,
+                skill_root=skill_root,
+                cd=repo,
+                prompt=self.prompt,
+                log=self.log,
+                stall=30,
+            )
+
+        self.assertEqual(3, exit_code)
+        popen.assert_not_called()
+        self.assertIn("SPAWN_SUPERVISOR_BACKOFF:secondary until=9999999999", self.log.read_text(encoding="utf-8"))
+
     def test_spawn_supervisor_source_preserves_claim_before_process_supervision(self) -> None:
         source = (SCRIPT_DIR / "codex_refactor_loop" / "spawn.py").read_text(encoding="utf-8")
         self.assertIn("TaskSpawnClaimStore(repo_root).acquire(task_id, log_path=log_path)", source)

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -4086,6 +4086,26 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual(results[0].status, "applied")
         launch.assert_called_once()
 
+    def test_spawn_codex_defers_during_secondary_backoff_without_log_or_claim_creation(self) -> None:
+        action = self.design_consensus_spawn_action(action_id="harness-spawn-intent:phase9-router:104:2:secondary-backoff")
+        log_path = Path(action["log"])
+        (self.repo / ".refactor-loop/state/secondary-mutation-backoff.json").write_text(
+            '{"until_epoch": 9999999999, "mutation": "readThrottle", "reason": "unit"}\n',
+            encoding="utf-8",
+        )
+
+        with mock.patch("codex_refactor_loop.wakeup_runner.launch_spawn_codex_supervisor") as launch:
+            results = self.run_result(self.base_plan(action), gh_state="OPEN", actions=FakeActions())
+
+        self.assertEqual(results[0].status, "skipped")
+        self.assertEqual(results[0].reason, "backoff:secondary")
+        launch.assert_not_called()
+        self.assertFalse(log_path.exists())
+        self.assertFalse((self.repo / ".refactor-loop/locks/spawn-tasks").exists())
+        pending = (self.repo / ".refactor-loop/.controller-pending-events.log").read_text(encoding="utf-8")
+        self.assertIn("WAKEUP_RUNNER_SPAWN_BACKOFF:harness-spawn-intent:phase9-router:104:2:secondary-backoff:secondary until=9999999999", pending)
+        self.assertNotIn("WAKEUP_RUNNER_SPAWN_LAUNCH_EXIT", pending)
+
     def test_terminal_closed_target_block_suppresses_next_tick_retry(self) -> None:
         actions = FakeActions()
         action = self.reviewer_dispatch_action(action_id="stale-review:423:dedupe")


### PR DESCRIPTION
## 根因(经 sshx 共识根因分析)
loop 缺少对 GitHub **总请求并发**的舰队级治理,且产生大量本不该有的 gh 流量:孤儿重复 daemon + worker 各自重查 controller 已有状态 + 碎片化轮询。多进程并发突发触发 **secondary rate limit**(并发/突发限流,**非配额耗尽**——budget 充足、HTTP 403=0)。换号只 reset 症状,不修必复发。

## 修复(sshx thinking→meta-judge→implement→review triplet 共识)
- **#1 孤儿 reap**:`restart._stop_existing_daemon` 彻底 reap `orphan_child_pids`(ppid=1 泄漏旧实例,之前只 reap singleton-holder+wrapper 漏了它们 → 4 个孤儿跑 1.6 天)。严格命令匹配 scoped `$REPO_ROOT`,不误杀别仓库 daemon。
- **#3 ghwrap 统一 secondary admission**:`ghwrap/gh` capture-and-replay;每次 gh 前读共享 cooldown→bounded sleep+jitter(cap 60s),每次 gh 后检测 secondary 信号(read+write)→记共享 `secondary-mutation-backoff.json`。**ghwrap 是 daemon+worker 所有 gh 的统一 choke point**(`accounting_env` prepend PATH),一处覆盖全舰队。fail-open 不 wedge daemon。
- **worker spawn defer**:`spawn.py::main`(spawn-codex 入口,含 dev-sync 直接 Popen)+ `launch_spawn_codex_supervisor` + concurrency top-up + wakeup spawn 在 backoff 期 defer(不 drop)。

## 影响范围
14 文件(+510/-6)。daemon 无新 lifecycle authority;复用现有 backoff state 不建平行系统;shim fail-open、spawn fail-safe-defer。

## 验证
- 全套 `unittest discover -s skills/consensus-loop/scripts` → **Ran 2381 tests OK (skipped=1)**;sshx → **27 OK**
- review triplet:architecture/quality/tests 全 approve(r1 抓出 spawn gate bypass + test 顺序漏洞,r2 修复后通过)。

⟦AI:AUTO-LOOP⟧