### PR TITLE
Upgrade sshx consensus rigor and release v1.0.0-beta.18

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "consensus-rnd",
       "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "source": "./",
       "author": {
         "name": "auric",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎，可注入 host 仓库做 repo-owned managed GitHub issue/PR 自治解决循环；audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "author": {
     "name": "auric",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "consensus-rnd",
   "displayName": "Consensus R&D",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "license": "MIT",
   "author": "auric <loning.ma@aelf.io>",

--- a/skills/consensus-loop/VERSION.json
+++ b/skills/consensus-loop/VERSION.json
@@ -1,6 +1,6 @@
 {
   "schema": "consensus-loop-version",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "repository": "ChronoAIProject/consensus-rnd",
   "release_source": "github-release-then-tag",
   "install_hint": "host-owned"

--- a/skills/sshx/SKILL.md
+++ b/skills/sshx/SKILL.md
@@ -88,6 +88,8 @@ Each `visible_inputs` value must include the same `GoalArtifact.normalized_goal`
 
 `abstain` is required when neither `codex-cli` nor `isolated-token-subagent` is available. Do not self-apply the triplet inside the caller context and present it as worker consensus.
 
+When `WorkerMode` resolves to `abstain`, the protocol terminates at `choose_worker_mode`: the caller emits a final `SshxResultEnvelope` whose `conclusion` records the `abstain` verdict, the reason, and any options, creates no thinking, implementation, or review flight, and runs no later stage. When a thinking, implementation, or review flight instead exhausts its bounded retries and fallback without terminal completion, that stage returns `abstain` rather than a synthesized worker conclusion or an incomplete triplet, the caller skips the remaining dependent stages, and the blocker is reported honestly. A thinking-stage exhaustion in particular skips `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done`.
+
 Every worker dispatch must create a prompt-level `SshxWorkerFlightRecord` before the worker is launched. The caller-carried transcript must keep these records under `worker_flights`, and each worker result record must reference the matching `flight_id` through `worker_flight_ref`.
 
 `SshxWorkerFlightRecord` has exactly these fields:
@@ -108,16 +110,20 @@ Every worker dispatch must create a prompt-level `SshxWorkerFlightRecord` before
 
 While any `SshxWorkerFlightRecord` for the same `work_target` is `in-flight` or `retrying`, the caller is read-only for that target. The caller must not mutate files, Git state, GitHub state, labels, releases, host configuration, lifecycle state, or the same external resource. The caller must not take over the same `work_target` because a process snapshot, log text, or workspace state appears quiet.
 
+For each `codex-cli` attempt, before launch the caller must choose unique caller-assigned `result_ref` and `completion_sentinel` paths for that flight or attempt and pass those exact paths in the worker brief; parallel workers must receive disjoint paths. The launch is a direct non-interactive worker-carrier invocation, not a helper script, daemon, or `consensus-rnd-cli`, and the exact command and sandbox flags are not part of this contract. The caller must not poll those paths while the worker is running. After the process exits, the caller performs one collection read of the assigned `result_ref` and `completion_sentinel`, and records `result_envelope_ref` and `completion_sentinel_ref` on the matching flight only if the envelope validates and the sentinel exists; completion and verdict recognition stay governed by the `## Worker Completion Contract`.
+
 `codex-cli` completion is recognized only when the caller has both a terminal `SshxResultEnvelope` and the worker-owned `completion_sentinel_ref` recorded on the matching flight. `pgrep`, process-table snapshots, log marker strings, and empty `git status` output are never completion evidence.
 
-If `codex-cli` exits abnormally without both the terminal envelope and the completion sentinel, the caller must stay read-only for that `work_target`, consume the finite same-carrier retry budget, and record the next attempt on the same `SshxWorkerFlightRecord`. If the bounded `codex-cli` retry path still lacks terminal completion, the caller may fall back to `isolated-token-subagent` when available. If no fallback carrier is available or the fallback cannot produce terminal completion, the result is `abstain`; the caller must not implement, repair, or otherwise mutate the same `work_target` itself.
+If `codex-cli` exits abnormally without both the terminal envelope and the completion sentinel, the caller must stay read-only for that `work_target`, consume the finite same-carrier retry budget, and record the next attempt on the same `SshxWorkerFlightRecord`. If the bounded `codex-cli` retry path still lacks terminal completion, the caller marks the exhausted `codex-cli` flight `abstained` with empty `result_envelope_ref` and `completion_sentinel_ref`, then may fall back to `isolated-token-subagent` when available by opening a new `SshxWorkerFlightRecord` for the same `stage`, `role`, and `work_target`; the caller stays read-only for that `work_target` until the fallback flight reaches `terminal` or `abstained`. If no fallback carrier is available or the fallback cannot produce terminal completion, the result is `abstain`; the caller must not implement, repair, or otherwise mutate the same `work_target` itself.
 
 ## Result Envelope
 
-`SshxResultEnvelope` is a prompt-level record, not a runtime API. Every caller-carried result from `thinking_triplet_workers`, `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done` must use exactly these top-level fields:
+`SshxResultEnvelope` is a prompt-level record, not a runtime API. Every `SshxResultEnvelope` returned by `thinking_triplet_workers`, `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done` uses exactly these top-level fields:
 
 - `conclusion`: compact structured result consumed by the caller. It may include verdicts, decisions, blocking goal gaps, final decision points, changed-file evidence, and test evidence when applicable. It must not include process logs, step-by-step reasoning, raw transcripts, debug output, or same-round peer output.
-- `log_ref`: artifact reference for the non-inline worker, meta-judge, implementation, review, or fix log. The caller may open the referenced artifact on demand, but caller-carried transcripts and final reports must keep only the reference and must not inline the log body.
+- `log_ref`: artifact reference for the non-inline worker, meta-judge, implementation, review, or fix log, treated as an opaque diagnostic pointer. Caller-side routing, meta-judging, worker briefs, and final reports must not open, inline, summarize, or otherwise consume its content; they keep only the reference. Opening the artifact is allowed only for out-of-band debugging outside the consensus decision context.
+
+A caller-carried stage record wraps this envelope: it references the envelope's `conclusion` and `log_ref` and may add only the stage metadata named by `InlineConsensusProtocol` and the `## Transcript Template` (such as `role`, `bias`, `visible_inputs`, `worker_mode`, `worker_carrier`, `worker_flight_ref`, `verdict`, and the `meta_judge` and `fix_or_done` `exit`, `concrete_plan`, `goal_gap`, and `next_iteration_question`). The envelope payload itself stays exactly `conclusion` and `log_ref`. A stage record's `verdict` field, when present, is a read-only mirror of its envelope's `conclusion.verdict`; `conclusion.verdict` is the sole verdict source for routing, the two must be equal, and any mismatch fails closed.
 
 Logs are not inline in caller context. Final reports aggregate `conclusion` values only and retain `log_ref` references for optional inspection.
 
@@ -128,11 +134,14 @@ For `codex-cli` workers, caller-side completion and verdict routing must be deci
 - the worker carrier process has exited with status `0`;
 - the caller-assigned `result_ref` artifact exists;
 - the `result_ref` artifact parses as a valid `SshxResultEnvelope`;
+- the caller-assigned `completion_sentinel` artifact exists and is recorded as `completion_sentinel_ref` on the matching `SshxWorkerFlightRecord`;
 - `conclusion.verdict`, when the stage requires a verdict, is present and is one of that stage's allowed verdict values.
 
 A worker is not done while its carrier process is still running, even if a partial `result_ref` artifact already exists. A worker is not done when completion markers or verdict-looking text appear only in stdout, stderr, raw transcripts, final text, prompt echoes, `log_ref` content, or log tails. Those surfaces are diagnostic only and must not participate in done detection or verdict routing.
 
 `log_ref` remains required as a diagnostic artifact reference, but it is never a verdict source. Missing `conclusion`, missing `log_ref`, placeholder verdicts, and verdicts outside the stage's allowed set fail closed.
+
+For `isolated-token-subagent` workers, terminal completion is recognized only when the isolated subagent returns a valid `SshxResultEnvelope` to the caller, with any required `conclusion.verdict` in the stage's allowed set; this carrier runs in-context rather than as a separate process, so it has no completion sentinel and its `completion_sentinel_ref` is recorded as `n/a`. The same isolation, fail-closed, and no-stdout-evidence rules apply. Missing or invalid fallback output is not terminal completion: the flight becomes `abstained`, the result is `abstain`, and the caller must not mutate the `work_target`.
 
 ## No Context Pollution
 
@@ -150,13 +159,13 @@ Same-round thinking workers must not see one another's outputs before their own 
 
 Run three biased perspectives before choosing a plan:
 
-- `minimal`: smallest coherent change that satisfies the user goal.
+- `minimal`: smallest coherent change on the root-cause-resolving path that satisfies the user goal, not a surface patch that leaves the root cause in place.
 - `structural`: architecture and contract integrity under future growth.
 - `delete`: whether the feature, abstraction, or work should be removed, collapsed, or avoided.
 
-Before proposing, revising, rejecting, or abstaining, each thinking perspective must run a lightweight Reference-frame harness pass: identify the applicable mature theory, engineering principle, industry best practice, or constraint framework governing this class of problem, then compare its conclusion against that known-good shape. `no applicable mature theory found` is an acceptable explicit harness. The perspective must surface one short free-form note naming the reference frame in `SshxResultEnvelope.conclusion`. Harness discovery does not override `GoalArtifact`, the assigned bias, the thinking truth table, or the allowed verdict set, and it is not mandatory citation work, not a literature search, not a parsed schema field, not marker data, not lifecycle authority, and not a blocker for valid `abstain` or `reject` outcomes.
+Before proposing, revising, rejecting, or abstaining, each thinking perspective must run a lightweight Reference-frame harness pass: identify the applicable mature theory, engineering principle, industry best practice, mature industry case, mature pattern, or constraint framework governing this class of problem, then surface that known-good shape and continue thinking by re-checking the candidate conclusion against it before settling the verdict. The perspective must surface one short free-form note naming the reference frame in `SshxResultEnvelope.conclusion`, stating the known-good shape and whether the candidate aligns with it, deviates for a reasoned goal-bound reason, or was revised because of the re-check. `no applicable mature theory found` is an acceptable explicit harness; in that case the note says so and still records the root-cause and minimal-path re-check against `GoalArtifact`. Harness discovery does not override `GoalArtifact`, the assigned bias, the thinking truth table, or the allowed verdict set, and it is not mandatory citation work, not a literature search, not a parsed schema field, not marker data, not lifecycle authority, and not a blocker for valid `abstain` or `reject` outcomes.
 
-Every perspective must frame `propose`, `revise`, `reject`, or `abstain` as an answer to the current `GoalArtifact`: what satisfies it, what still differs from it, or why it cannot be satisfied. `revise` must name the goal gap and a next iteration question; it must not open an unrelated design search.
+Every perspective must first identify the problem essence or root cause implied by `GoalArtifact`, then frame `propose`, `revise`, `reject`, or `abstain` as an answer to it: what satisfies it, what still differs from it, or why it cannot be satisfied. A plan that only patches a surface symptom while leaving that root cause in place does not satisfy `minimal` or the thinking gate. `revise` must name the goal gap and a next iteration question; it must not open an unrelated design search.
 
 Each perspective returns one of:
 
@@ -180,6 +189,8 @@ The meta-judge applies this fixed thinking truth table:
 
 The convergence question must be "what still differs from `GoalArtifact`?" expressed against the fixed normalized goal, constraints, and success criteria. Do not generalize the convergence pass beyond that goal gap.
 
+Before any `implement` exit, the meta-judge must include in its `meta_judge.conclusion` a compact free-form ASCII relationship diagram built only from `GoalArtifact` and the returned `SshxResultEnvelope.conclusion` values: nodes are the goal subquestions or goal-gap items, the `minimal`, `structural`, and `delete` stances, and the concrete plan; edges are labeled `agree`, `conflict`, `depends-on`, `resolved-by`, or `converges-to`. The diagram rigidly constrains convergence: every surfaced subquestion or goal-gap node must appear, the concrete plan must resolve every `conflict` edge, and any unresolved `conflict` edge is an unclosed `GoalArtifact` goal gap, so the exit stays `meta-layer convergence` or `abstain/escalate with options`, never `implement`. The diagram is free-form prompt-level content synthesized from conclusions only; it must not inline worker full reasoning or same-round peer output, and it is not a parsed schema field, marker data, lifecycle authority, or a blocker for valid `abstain` or `reject fake consensus` exits.
+
 ## Implementation Worker
 
 Implement only the concrete plan approved by the thinking gate. Keep the implementation boundary narrow and state any deviation before making it.
@@ -196,7 +207,7 @@ After implementation, run three review perspectives:
 - `quality`: behavior, edge cases, failure modes, and user impact.
 - `tests`: coverage, determinism, and verification strength.
 
-Before approving, commenting, or rejecting, each reviewer must run a lightweight Reference-frame harness pass: identify the applicable mature theory, engineering principle, industry best practice, or constraint framework governing this class of implementation, then compare the implementation evidence against that known-good shape. `no applicable mature theory found` is an acceptable explicit harness. The reviewer must surface one short free-form note naming the reference frame in `SshxResultEnvelope.conclusion`. Harness discovery does not override `GoalArtifact`, the review focus, the review truth table, or the allowed verdict set, and it is not mandatory citation work, not a literature search, not a parsed schema field, not marker data, not lifecycle authority, and not a blocker for valid `comment` or `reject` outcomes.
+Before approving, commenting, or rejecting, each reviewer must run a lightweight Reference-frame harness pass: identify the applicable mature theory, engineering principle, industry best practice, mature industry case, mature pattern, or constraint framework governing this class of implementation, then surface that known-good shape and continue thinking by re-checking the implementation evidence against it before settling the verdict. The reviewer must surface one short free-form note naming the reference frame in `SshxResultEnvelope.conclusion`, stating the known-good shape and whether the implementation aligns with it, deviates for a reasoned goal-bound reason, or needs correction because of the re-check. `no applicable mature theory found` is an acceptable explicit harness; in that case the note says so and still records the root-cause and minimal-path re-check against `GoalArtifact`. Harness discovery does not override `GoalArtifact`, the review focus, the review truth table, or the allowed verdict set, and it is not mandatory citation work, not a literature search, not a parsed schema field, not marker data, not lifecycle authority, and not a blocker for valid `comment` or `reject` outcomes.
 
 Each reviewer returns one of:
 
@@ -218,11 +229,13 @@ Advisory comments do not count as approval. A reject blocks done until the issue
 
 ## Fix Or Done
 
-If review exits `fix`, ask what still differs from `GoalArtifact`, apply the smallest change that addresses that blocking goal gap, and rerun the review triplet. Stop after a bounded number of fix passes and report remaining blockers honestly.
+If review exits `fix`, ask what still differs from `GoalArtifact`, apply the smallest change that addresses that blocking goal gap by delegating it to a worker using the selected `WorkerMode` exactly as `## Implementation Worker` requires — open a new `SshxWorkerFlightRecord` for the same `work_target` and stay orchestration-only for the repair — then rerun the review triplet on the worker's returned `conclusion`. Stop after a bounded number of fix passes and report remaining blockers honestly.
 
 If review exits `done with advisory surfaced`, report the final outcome by aggregating `conclusion` values and include any non-blocking advisory feedback without inlining logs.
 
 If review exits `explicit user decision or another bounded review pass`, either run one more bounded pass with a concrete next iteration question tied to `GoalArtifact`, or ask the user to decide. Do not loop indefinitely.
+
+Every bounded pass in this skill — `meta-layer convergence`, a repeated review pass, and fix passes — defaults to at most one pass unless the user explicitly authorizes more, and the chosen bound is recorded before the first such pass.
 
 ## Boundaries
 
@@ -320,7 +333,7 @@ meta_judge:
   concrete_plan:
   goal_gap:
   next_iteration_question:
-  conclusion:
+  conclusion: # for an implement exit, includes the free-form ASCII relationship diagram (no separate diagram field)
   log_ref:
 implementation_worker:
   worker_mode:
@@ -329,19 +342,28 @@ implementation_worker:
   log_ref:
 review_triplet_workers:
   - role: architecture
+    bias:
+    visible_inputs:
     worker_mode:
+    worker_carrier:
     worker_flight_ref:
     verdict:
     conclusion:
     log_ref:
   - role: quality
+    bias:
+    visible_inputs:
     worker_mode:
+    worker_carrier:
     worker_flight_ref:
     verdict:
     conclusion:
     log_ref:
   - role: tests
+    bias:
+    visible_inputs:
     worker_mode:
+    worker_carrier:
     worker_flight_ref:
     verdict:
     conclusion:

--- a/skills/sshx/tests/test_sshx_contract.py
+++ b/skills/sshx/tests/test_sshx_contract.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -41,6 +42,7 @@ def completed_worker_verdict(
     process_exited: bool,
     exit_code: int | None,
     result_artifact: dict[str, object] | None,
+    completion_sentinel_present: bool,
     allowed_verdicts: set[str],
 ) -> str:
     if not process_exited:
@@ -53,6 +55,8 @@ def completed_worker_verdict(
         raise ContractFailure("result_ref is not an SshxResultEnvelope")
     if not result_artifact["log_ref"]:
         raise ContractFailure("missing log_ref")
+    if not completion_sentinel_present:
+        raise ContractFailure("missing completion sentinel")
     conclusion = result_artifact["conclusion"]
     if not isinstance(conclusion, dict):
         raise ContractFailure("missing conclusion")
@@ -157,6 +161,11 @@ class SshxContractTests(unittest.TestCase):
             "ask what still differs from `GoalArtifact`, apply the smallest change that addresses that blocking goal gap",
             text,
         )
+        self.assertIn(
+            "by delegating it to a worker using the selected `WorkerMode` exactly as `## Implementation Worker` requires",
+            text,
+        )
+        self.assertIn("stay orchestration-only for the repair", text)
         self.assertIn("next_iteration_question:", text)
 
     def test_sshx_triplets_require_harness_discovery_in_conclusion(self) -> None:
@@ -191,6 +200,16 @@ class SshxContractTests(unittest.TestCase):
             "not a blocker for valid `abstain` or `reject` outcomes",
         ]:
             self.assertIn(boundary, thinking_section)
+        self.assertIn("mature industry case, mature pattern", thinking_section)
+        self.assertIn(
+            "then surface that known-good shape and continue thinking by re-checking the candidate conclusion against it before settling the verdict",
+            thinking_section,
+        )
+        self.assertIn(
+            "whether the candidate aligns with it, deviates for a reasoned goal-bound reason, or was revised because of the re-check",
+            thinking_section,
+        )
+        self.assertIn("still records the root-cause and minimal-path re-check against `GoalArtifact`", thinking_section)
         self.assertLess(
             thinking_section.index("Reference-frame harness"),
             thinking_section.index("Each perspective returns one of:"),
@@ -219,9 +238,37 @@ class SshxContractTests(unittest.TestCase):
             "not a blocker for valid `comment` or `reject` outcomes",
         ]:
             self.assertIn(boundary, review_section)
+        self.assertIn("mature industry case, mature pattern", review_section)
+        self.assertIn(
+            "then surface that known-good shape and continue thinking by re-checking the implementation evidence against it before settling the verdict",
+            review_section,
+        )
+        self.assertIn(
+            "whether the implementation aligns with it, deviates for a reasoned goal-bound reason, or needs correction because of the re-check",
+            review_section,
+        )
+        self.assertIn("still records the root-cause and minimal-path re-check against `GoalArtifact`", review_section)
         self.assertLess(
             review_section.index("Reference-frame harness"),
             review_section.index("Each reviewer returns one of:"),
+        )
+
+    def test_sshx_thinking_anchors_root_cause_and_minimal_path(self) -> None:
+        text = read(SKILL)
+        thinking_start = text.index("## Thinking Triplet")
+        design_truth_start = text.index("## Design Truth Table")
+        thinking_section = text[thinking_start:design_truth_start]
+        self.assertIn(
+            "smallest coherent change on the root-cause-resolving path that satisfies the user goal, not a surface patch that leaves the root cause in place",
+            thinking_section,
+        )
+        self.assertIn(
+            "Every perspective must first identify the problem essence or root cause implied by `GoalArtifact`",
+            thinking_section,
+        )
+        self.assertIn(
+            "A plan that only patches a surface symptom while leaving that root cause in place does not satisfy `minimal` or the thinking gate",
+            thinking_section,
         )
 
     def test_sshx_worker_modes(self) -> None:
@@ -275,6 +322,25 @@ class SshxContractTests(unittest.TestCase):
         self.assertIn("codex_cli_capability_check:", text)
         self.assertIn("fallback_reason:", text)
 
+    def test_sshx_isolated_subagent_completion_rule(self) -> None:
+        text = read(SKILL)
+        self.assertIn("For `isolated-token-subagent` workers, terminal completion is recognized only when", text)
+        self.assertIn("its `completion_sentinel_ref` is recorded as `n/a`", text)
+        self.assertIn("the flight becomes `abstained`, the result is `abstain`", text)
+
+    def test_sshx_abstain_is_terminal_transition(self) -> None:
+        text = read(SKILL)
+        self.assertIn("When `WorkerMode` resolves to `abstain`, the protocol terminates at `choose_worker_mode`", text)
+        self.assertIn("creates no thinking, implementation, or review flight", text)
+        self.assertIn(
+            "When a thinking, implementation, or review flight instead exhausts its bounded retries and fallback without terminal completion",
+            text,
+        )
+        self.assertIn(
+            "A thinking-stage exhaustion in particular skips `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done`",
+            text,
+        )
+
     def test_sshx_worker_flight_record_contract(self) -> None:
         text = read(SKILL)
         self.assertIn("`SshxWorkerFlightRecord`", text)
@@ -296,6 +362,27 @@ class SshxContractTests(unittest.TestCase):
             self.assertIn(field, text)
         self.assertIn("`status` is one of `in-flight`, `retrying`, `terminal`, or `abstained`", text)
         self.assertIn("`retry_budget` is a finite integer decided before the first launch", text)
+
+    def test_sshx_worker_invocation_collection_contract(self) -> None:
+        text = read(SKILL)
+        wd_start = text.index("## Worker Delegation")
+        wd_end = text.index("## Result Envelope")
+        worker_delegation = text[wd_start:wd_end]
+        for contract_string in [
+            "before launch the caller must choose unique caller-assigned `result_ref` and `completion_sentinel` paths",
+            "pass those exact paths in the worker brief",
+            "parallel workers must receive disjoint paths",
+            "a direct non-interactive worker-carrier invocation, not a helper script, daemon, or `consensus-rnd-cli`",
+            "the exact command and sandbox flags are not part of this contract",
+            "The caller must not poll those paths while the worker is running",
+            "the caller performs one collection read of the assigned `result_ref` and `completion_sentinel`",
+            "completion and verdict recognition stay governed by the `## Worker Completion Contract`",
+        ]:
+            self.assertIn(contract_string, worker_delegation)
+        self.assertLess(
+            worker_delegation.index("one collection read of the assigned"),
+            worker_delegation.index("`codex-cli` completion is recognized only when"),
+        )
 
     def test_sshx_in_flight_worker_blocks_caller_mutation(self) -> None:
         text = read(SKILL)
@@ -360,6 +447,15 @@ class SshxContractTests(unittest.TestCase):
         self.assertIn("If `codex-cli` exits abnormally without both the terminal envelope and the completion sentinel", text)
         self.assertIn("consume the finite same-carrier retry budget", text)
         self.assertIn("fall back to `isolated-token-subagent` when available", text)
+        self.assertIn(
+            "marks the exhausted `codex-cli` flight `abstained` with empty `result_envelope_ref` and `completion_sentinel_ref`",
+            text,
+        )
+        self.assertIn(
+            "opening a new `SshxWorkerFlightRecord` for the same `stage`, `role`, and `work_target`",
+            text,
+        )
+        self.assertIn("until the fallback flight reaches `terminal` or `abstained`", text)
         self.assertIn("the result is `abstain`", text)
         self.assertIn("must not implement, repair, or otherwise mutate the same `work_target` itself", text)
 
@@ -437,11 +533,22 @@ class SshxContractTests(unittest.TestCase):
         self.assertIn("## Result Envelope", text)
         self.assertIn("`SshxResultEnvelope` is a prompt-level record, not a runtime API", text)
         self.assertIn(
-            "Every caller-carried result from `thinking_triplet_workers`, `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done` must use exactly these top-level fields",
+            "Every `SshxResultEnvelope` returned by `thinking_triplet_workers`, `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done` uses exactly these top-level fields",
+            text,
+        )
+        self.assertIn("A caller-carried stage record wraps this envelope", text)
+        self.assertIn("The envelope payload itself stays exactly `conclusion` and `log_ref`", text)
+        self.assertIn("is a read-only mirror of its envelope's `conclusion.verdict`", text)
+        self.assertIn(
+            "`conclusion.verdict` is the sole verdict source for routing, the two must be equal, and any mismatch fails closed",
             text,
         )
         self.assertIn("`conclusion`: compact structured result consumed by the caller", text)
         self.assertIn("`log_ref`: artifact reference for the non-inline worker", text)
+        self.assertIn("treated as an opaque diagnostic pointer", text)
+        self.assertIn("must not open, inline, summarize, or otherwise consume its content", text)
+        self.assertIn("out-of-band debugging outside the consensus decision context", text)
+        self.assertNotIn("The caller may open the referenced artifact on demand", text)
         for forbidden_inline in [
             "process logs",
             "step-by-step reasoning",
@@ -462,6 +569,10 @@ class SshxContractTests(unittest.TestCase):
         self.assertIn("worker carrier process has exited with status `0`", text)
         self.assertIn("caller-assigned `result_ref` artifact exists", text)
         self.assertIn("parses as a valid `SshxResultEnvelope`", text)
+        self.assertIn(
+            "the caller-assigned `completion_sentinel` artifact exists and is recorded as `completion_sentinel_ref` on the matching `SshxWorkerFlightRecord`",
+            text,
+        )
         self.assertIn("`conclusion.verdict`", text)
         self.assertIn("A worker is not done while its carrier process is still running", text)
         for diagnostic_surface in [
@@ -491,6 +602,7 @@ class SshxContractTests(unittest.TestCase):
                 process_exited=True,
                 exit_code=0,
                 result_artifact=None,
+                completion_sentinel_present=True,
                 allowed_verdicts=THINKING_VERDICTS,
             )
         self.assertIn("VERDICT:propose", repr(log_only_fake_marker))
@@ -505,6 +617,7 @@ class SshxContractTests(unittest.TestCase):
                 process_exited=False,
                 exit_code=None,
                 result_artifact=valid_artifact,
+                completion_sentinel_present=True,
                 allowed_verdicts=THINKING_VERDICTS,
             )
 
@@ -517,6 +630,7 @@ class SshxContractTests(unittest.TestCase):
             process_exited=True,
             exit_code=0,
             result_artifact=valid_artifact,
+            completion_sentinel_present=True,
             allowed_verdicts=THINKING_VERDICTS,
         )
         self.assertEqual(verdict, "propose")
@@ -530,6 +644,7 @@ class SshxContractTests(unittest.TestCase):
             process_exited=True,
             exit_code=0,
             result_artifact=valid_artifact,
+            completion_sentinel_present=True,
             allowed_verdicts=THINKING_VERDICTS,
         )
         self.assertEqual(verdict, "reject")
@@ -550,8 +665,23 @@ class SshxContractTests(unittest.TestCase):
                         process_exited=True,
                         exit_code=0,
                         result_artifact=artifact,
+                        completion_sentinel_present=True,
                         allowed_verdicts=THINKING_VERDICTS,
                     )
+
+    def test_sshx_missing_completion_sentinel_fails_closed(self) -> None:
+        valid_artifact = {
+            "conclusion": {"verdict": "propose", "decision": "use artifact authority"},
+            "log_ref": "artifacts/sshx/minimal.log",
+        }
+        with self.assertRaisesRegex(ContractFailure, "missing completion sentinel"):
+            completed_worker_verdict(
+                process_exited=True,
+                exit_code=0,
+                result_artifact=valid_artifact,
+                completion_sentinel_present=False,
+                allowed_verdicts=THINKING_VERDICTS,
+            )
 
     def test_sshx_result_envelope_caller_context_excludes_inline_logs(self) -> None:
         caller_carried_transcript = {
@@ -684,6 +814,15 @@ class SshxContractTests(unittest.TestCase):
             transcript["worker_flights"][0]["flight_id"],
         )
 
+    def test_sshx_review_transcript_entries_have_full_fields(self) -> None:
+        text = read(SKILL)
+        review_start = text.index("review_triplet_workers:")
+        fix_start = text.index("fix_or_done:", review_start)
+        review_block = text[review_start:fix_start]
+        self.assertGreaterEqual(review_block.count("    bias:"), 3)
+        self.assertGreaterEqual(review_block.count("    visible_inputs:"), 3)
+        self.assertGreaterEqual(review_block.count("    worker_carrier:"), 3)
+
     def test_sshx_design_truth_table(self) -> None:
         text = read(SKILL)
         for row in [
@@ -695,6 +834,20 @@ class SshxContractTests(unittest.TestCase):
             self.assertIn(row, text)
         self.assertIn("stop with options instead of inventing agreement", text)
 
+    def test_sshx_meta_judge_requires_relationship_diagram(self) -> None:
+        text = read(SKILL)
+        design_truth_section = text[text.index("## Design Truth Table") : text.index("## Implementation Worker")]
+        for required in [
+            "compact free-form ASCII relationship diagram",
+            "edges are labeled `agree`, `conflict`, `depends-on`, `resolved-by`, or `converges-to`",
+            "any unresolved `conflict` edge is an unclosed `GoalArtifact` goal gap",
+            "never `implement`",
+            "not a parsed schema field, marker data, lifecycle authority, or a blocker for valid `abstain` or `reject fake consensus` exits",
+        ]:
+            self.assertIn(required, design_truth_section)
+        self.assertIn("includes the free-form ASCII relationship diagram (no separate diagram field)", text)
+        self.assertNotIn("relationship_diagram:", text)
+
     def test_sshx_review_truth_table(self) -> None:
         text = read(SKILL)
         for row in [
@@ -705,6 +858,10 @@ class SshxContractTests(unittest.TestCase):
             self.assertIn(row, text)
         self.assertIn("Advisory comments do not count as approval", text)
         self.assertIn("A reject blocks done", text)
+
+    def test_sshx_bounded_passes_have_default_bound(self) -> None:
+        text = read(SKILL)
+        self.assertIn("defaults to at most one pass unless the user explicitly authorizes more", text)
 
     def test_sshx_no_runtime_control_plane_leakage(self) -> None:
         text = read(SKILL)
@@ -740,7 +897,14 @@ class SshxContractTests(unittest.TestCase):
             self.assertIn(failure_mode, text)
         self.assertIn("source-owned contract or test evidence", text)
         self.assertIn("Do not track `.refactor-loop/` runtime artifacts", text)
-        self.assertFalse(BASELINE_ARTIFACT.exists())
+        tracked = subprocess.run(
+            ["git", "ls-files", "--", ".refactor-loop/runs/baseline-issue342-sshx.md"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        self.assertEqual(tracked, "")
 
     def test_sshx_docs_and_ci_discovery(self) -> None:
         self.assertRegex(read(README), r"\| `sshx` \|")


### PR DESCRIPTION
## 动机
通过 sshx 自身的 InlineConsensusProtocol(codex-cli 隔离 worker + 真值表 + artifact-authority 完成判定 + No Context Pollution)对 `sshx` skill 做共识驱动升级,并对其契约做对抗式审计(loop-until-dry)收敛。

## 影响范围
仅 `skills/sshx/`(prompt 契约 + 测试),无运行时/脚本/daemon/lifecycle 改动;`## Boundaries` 不变。

### 能力升级
- **harness 强制最佳实践→继续思考**:思考/审查视角必须 surface known-good shape 并在定 verdict 前回灌再检验(对齐/有理由偏离/修正)。
- **根因/最小路径**:思考闸先识别本质/根因;`minimal` = 解决根因的最小路径,而非表面修补。
- **codex 调用契约**:确定化的预分配 + 单次收集(result_ref/completion_sentinel 预分配、并行 worker 路径互斥、退出后单次读、不轮询),保留 artifact-authority 与 no-scripts 边界。
- **meta_judge 强制 ASCII 关系图**:`implement` 前必须画 free-form ASCII 关系图,未解 conflict 边 = 未闭合 goal gap,刚性阻断收敛。

### 契约一致性修复(对抗审计 + 复审)
完成证据 SSOT 收口(sentinel 入 Worker Completion Contract);envelope/stage-record 分层 + verdict 镜像 fail-closed;`isolated-token-subagent` 完成规则;`abstain` 终结化(含 thinking-flight 耗尽);codex→fallback flight 转移;`fix` 走 worker 委派;bounded passes 默认上限;`log_ref` opaque(删逃逸口);baseline-evidence 测试由文件系统存在性改为 git-tracked 判定。

### 不变量(守住)
6 个 harness carve-out 全保留;无 parsed schema 字段/marker;No Context Pollution、artifact-authority、no-scripts/daemon/CLI、无 version 后缀 —— 均未破。

## 验证
`python3 -m unittest discover -s skills/sshx/tests -p 'test_*.py'` → **35 tests OK**(27 → 35)。每项契约改动均先 RED(旧文本)再 GREEN。

## 发布
含 `Release v1.0.0-beta.18`:`.version-bump.json` 全部 manifest 同步至 1.0.0-beta.18(上一坐标 beta.17 机械递推)。合并后在绿提交上打 `v1.0.0-beta.18` tag 并发 release。

🤖 Generated with [Claude Code](https://claude.com/claude-code)