### PR TITLE
发布 rollup: integration ahead 1 commits (b4e04961c77c)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/controller_actions.py
@@ -1608,7 +1608,7 @@ class ControllerActions:
         if str(action.get("design_decision_path")) != str(action.get("consensus_artifact")):
             sys.stderr.write("dispatch_consensus_implementation: design_decision_path must match consensus_artifact\n")
             return 2
-        readiness_reason = consensus_implementation_suppressed_reason(dict(action), self.ctx.repo_root)
+        readiness_reason = consensus_implementation_suppressed_reason(dict(action), self.ctx.repo_root, ctx=self.ctx)
         if readiness_reason:
             sys.stderr.write(f"dispatch_consensus_implementation: target not ready: {readiness_reason}\n")
             return 2

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -395,6 +395,7 @@ def harness_spawn_intent_actions(
         suppressed = _suppressed_consensus_implementation_spawn_intent(
             intent,
             repo_root,
+            ctx,
             gh_items if gh_items_loaded else None,
             monitor,
         )
@@ -843,6 +844,7 @@ def _suppress_harness_spawn_intent(
 def _suppressed_consensus_implementation_spawn_intent(
     intent: dict[str, Any],
     repo_root: Path,
+    ctx: LoopContext,
     gh_items: list[GhItem] | None,
     monitor: Any | None,
 ) -> str | None:
@@ -857,6 +859,7 @@ def _suppressed_consensus_implementation_spawn_intent(
         repo_root,
         gh_items,
         monitor,
+        ctx=ctx,
         ignore_pending_implement_intent=True,
     )
     if reason in {"pending_implement_intent", None}:
@@ -1450,7 +1453,7 @@ def completed_marker_actions(
                     "durable_consensus_artifact",
                     "consensus_implementation_ready",
                 ]
-                _apply_consensus_implementation_readiness(action, repo_root, gh_items, monitor)
+                _apply_consensus_implementation_readiness(action, repo_root, gh_items, monitor, ctx)
             else:
                 action["status_only"] = True
                 action["no_lifecycle_authority"] = True
@@ -3730,7 +3733,7 @@ def _worktrees_by_branch(repo_root: Path) -> dict[str, Path]:
     return parse_worktree_branches(listed.stdout)
 
 
-def existing_issue_actions(items: list[GhItem], repo_root: Path | None = None) -> list[dict[str, Any]]:
+def existing_issue_actions(items: list[GhItem], repo_root: Path | None = None, ctx: LoopContext | None = None) -> list[dict[str, Any]]:
     actions: list[dict[str, Any]] = []
     raw_by_key = {(item.kind.lower(), item.number): item for item in items}
     actionable = open_actionable_managed_items(_projection_items(items))
@@ -3780,7 +3783,7 @@ def existing_issue_actions(items: list[GhItem], repo_root: Path | None = None) -
                         **consensus_fields,
                     }
                 )
-                _apply_consensus_implementation_readiness(action, repo_root, items, None)
+                _apply_consensus_implementation_readiness(action, repo_root, items, None, ctx)
                 if action.get("consensus_implementation_ready") is True:
                     action.pop("status_only", None)
         actions.append(action)
@@ -3960,8 +3963,9 @@ def _apply_consensus_implementation_readiness(
     repo_root: Path,
     gh_items: list[GhItem] | None,
     monitor: Any | None,
+    ctx: LoopContext | None,
 ) -> None:
-    reason = consensus_implementation_suppressed_reason(action, repo_root, gh_items, monitor)
+    reason = consensus_implementation_suppressed_reason(action, repo_root, gh_items, monitor, ctx=ctx)
     if not reason:
         action["consensus_implementation_ready"] = True
         return
@@ -4137,6 +4141,7 @@ def consensus_implementation_suppressed_reason(
     gh_items: list[GhItem] | None = None,
     monitor: Any | None = None,
     *,
+    ctx: LoopContext | None = None,
     ignore_pending_implement_intent: bool = False,
 ) -> str | None:
     target_kind = action.get("target_kind")
@@ -4164,11 +4169,14 @@ def consensus_implementation_suppressed_reason(
         return "implementation_ready_to_publish"
     if (
         not ignore_pending_implement_intent
-        and _pending_implement_intent_exists(repo_root, target_number, action)
         # Stale queued intents can point at deleted worktrees; allow fresh dispatch to recreate them.
         and _canonical_consensus_worktree_exists(repo_root, action)
     ):
-        return "pending_implement_intent"
+        pending_intent_exists = _pending_implement_intent_exists(repo_root, target_number, action, ctx=ctx)
+        if pending_intent_exists is None:
+            return "readiness_context_unavailable"
+        if pending_intent_exists:
+            return "pending_implement_intent"
     if _in_flight_implement_exists(repo_root, action, monitor):
         return "in_flight_implement"
     if gh_items is not None and _open_pr_exists_for_branch(gh_items, branch):
@@ -4263,7 +4271,7 @@ def _open_pr_exists_for_branch(items: list[GhItem], head_ref: str) -> bool:
     return False
 
 
-def _pending_implement_intent_exists(repo_root: Path, issue: int, action: dict[str, Any], ctx: LoopContext | None = None) -> bool:
+def _pending_implement_intent_exists(repo_root: Path, issue: int, action: dict[str, Any], ctx: LoopContext | None = None) -> bool | None:
     pending_path = repo_root / ".refactor-loop" / ".controller-pending-events.log"
     if not pending_path.exists():
         return False
@@ -4271,8 +4279,6 @@ def _pending_implement_intent_exists(repo_root: Path, issue: int, action: dict[s
         lines = pending_path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
         return False
-    if ctx is None:
-        ctx = LoopContext.load(repo_root=repo_root, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}, cwd=repo_root, read_only=True)
     archived_invalid_markers = archived_invalid_harness_spawn_intent_markers(lines)
     cluster_id = str(action.get("cluster_id") or "").strip()
     expected_ids = {f"{IMPLEMENT_PENDING_INTENT_PREFIX}{issue}"}
@@ -4287,11 +4293,14 @@ def _pending_implement_intent_exists(repo_root: Path, issue: int, action: dict[s
             continue
         if not isinstance(intent, dict):
             continue
+        intent_values = {str(intent.get("intent_id") or ""), str(intent.get("task_id") or "")}
+        if not expected_ids.intersection(intent_values):
+            continue
+        if ctx is None:
+            return None
         if not live_valid_harness_spawn_intent(ctx, line, intent, archived_invalid_markers):
             continue
-        intent_values = {str(intent.get("intent_id") or ""), str(intent.get("task_id") or "")}
-        if expected_ids.intersection(intent_values):
-            return True
+        return True
     return False
 
 
@@ -5265,7 +5274,7 @@ def build_plan(repo_root: Path) -> dict[str, Any]:
     else:
         actions.extend(host_actions)
     actions.extend(release_countdown_actions(repo_root, gh_items))
-    actions.extend(existing_issue_actions(gh_items, repo_root))
+    actions.extend(existing_issue_actions(gh_items, repo_root, ctx))
     suppress_stale_unexecutable_actions(actions, repo_root=repo_root, gh_items=gh_items, gh_items_loaded=gh_items_loaded)
     actions.extend(implementation_pr_artifact_repair_actions(actions, repo_root))
     suppress_publish_superseded_implementation_spawn_intents(actions)

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -1080,7 +1080,7 @@ class WakeupRunner:
                 return f"consensus_implementation_missing_field:{field}"
         if str(action.get("design_decision_path") or "") != str(action.get("consensus_artifact") or ""):
             return "consensus_implementation_design_path_mismatch"
-        readiness_reason = consensus_implementation_suppressed_reason(dict(action), self.ctx.repo_root)
+        readiness_reason = consensus_implementation_suppressed_reason(dict(action), self.ctx.repo_root, ctx=self.ctx)
         if readiness_reason:
             return f"consensus_implementation_not_ready:{readiness_reason}"
         return None
@@ -2142,7 +2142,7 @@ class WakeupRunner:
         return False
 
     def _consensus_implementation_current_effect_suppresses_retry(self, action: Mapping[str, Any]) -> bool:
-        if consensus_implementation_suppressed_reason(dict(action), self.ctx.repo_root):
+        if consensus_implementation_suppressed_reason(dict(action), self.ctx.repo_root, ctx=self.ctx):
             return True
         receipt = self._consensus_implementation_dispatch_receipt(action)
         try:

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import subprocess
@@ -4907,6 +4908,23 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertNotIn("Path.cwd().resolve()", wakeup_source)
         self.assertIn("LoopContext.load(repo_root=arg_root", wakeup_source)
 
+    def test_pending_implement_intent_helper_has_no_hard_coded_context_load(self) -> None:
+        wakeup_source = (SKILL_ROOT / "scripts" / "codex_refactor_loop" / "wakeup_plan.py").read_text(encoding="utf-8")
+        tree = ast.parse(wakeup_source)
+        helper = next(
+            node for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_pending_implement_intent_exists"
+        )
+        helper_literals = {
+            node.value
+            for node in ast.walk(helper)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+
+        self.assertNotIn(".config/consensus-rnd/host.env", helper_literals)
+        self.assertNotIn("CONSENSUS_RND_HOST_ENV", helper_literals)
+        self.assertIn("LoopContext.load(repo_root=arg_root", wakeup_source)
+
     def test_wakeup_plan_bootstrap_uses_explicit_host_env_locator_not_legacy_path(self) -> None:
         (self.repo / ".refactor-loop" / "host.env").unlink(missing_ok=True)
         host_env = self.repo / ".config" / "consensus-rnd" / "host.env"
@@ -6417,10 +6435,90 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             route="dispatch-consensus-implementation",
             log=".refactor-loop/logs/implement-issue-20.log",
         )
+        ctx = LoopContext.load(repo_root=self.repo, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}, cwd=self.repo, read_only=True)
+
+        reason = consensus_implementation_suppressed_reason(action, self.repo, monitor=None, ctx=ctx)
+
+        self.assertEqual("pending_implement_intent", reason)
+
+    def test_consensus_implementation_readiness_fails_closed_without_context_for_pending_intent(self) -> None:
+        action = {
+            "target_kind": "issue",
+            "target_number": 20,
+            "iteration": "20",
+            "cluster_id": "issue-20",
+        }
+        (self.repo / ".worktrees" / "iter20-issue-20").mkdir(parents=True)
+        self.append_harness_spawn_intent(
+            intent_id="dispatch-consensus-implementation:20",
+            task_id="implement-issue-20",
+            route="dispatch-consensus-implementation",
+            log=".refactor-loop/logs/implement-issue-20.log",
+        )
 
         reason = consensus_implementation_suppressed_reason(action, self.repo, monitor=None)
 
-        self.assertEqual("pending_implement_intent", reason)
+        self.assertEqual("readiness_context_unavailable", reason)
+
+    def test_consensus_implementation_readiness_uses_tick_context_under_poisoned_process_env(self) -> None:
+        self.write_consensus_artifact()
+        self.write_completed_log("phase9-issue20-r5-judge.log", "META_JUDGE_DONE:consensus:structural")
+        self.write_completed_log("review-pr331-architect-r1.log", "REVIEW_DONE:331:architect:approve")
+        (self.repo / ".worktrees" / "iter20-issue-20").mkdir(parents=True)
+        (self.repo / ".refactor-loop" / "prompts" / "implement-issue-20.md").parent.mkdir(parents=True, exist_ok=True)
+        (self.repo / ".refactor-loop" / "prompts" / "implement-issue-20.md").write_text("implement\n", encoding="utf-8")
+        tick_host_env = self.repo / ".config" / "consensus-rnd" / "tick-host.env"
+        tick_host_env.write_text(
+            f"REPO_ROOT={self.repo}\nGH_REPO_SLUG=owner/repo\nCODEX_FLOOR=5\nINTEGRATION_BRANCH=auto-refact-dev\n",
+            encoding="utf-8",
+        )
+        ctx = LoopContext.load(
+            repo_root=self.repo,
+            env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/tick-host.env"},
+            cwd=self.repo,
+            read_only=True,
+        )
+        self.append_harness_spawn_intent(
+            intent_id="dispatch-consensus-implementation:20",
+            task_id="implement-issue-20",
+            source="wakeup-plan",
+            route="dispatch-consensus-implementation",
+            prompt=".refactor-loop/prompts/implement-issue-20.md",
+            log=".refactor-loop/logs/implement-issue-20.log",
+        )
+        (self.repo / ".config" / "consensus-rnd" / "host.env").unlink()
+        gh_items = [
+            GhItem(kind="issue", number=20, title="open target", labels=(label_catalog.MANAGED, label_catalog.PHASE_IMPLEMENTING, label_catalog.HUMAN_AUTO)),
+            GhItem(kind="PR", number=331, title="unrelated review", labels=(label_catalog.MANAGED, label_catalog.PHASE_REVIEWING, label_catalog.HUMAN_AUTO)),
+        ]
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "REPO_ROOT": str(self.repo),
+                "CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env",
+            },
+        ):
+            actions = completed_marker_actions(
+                self.repo,
+                ctx=ctx,
+                open_targets={("issue", 20), ("PR", 331)},
+                gh_items=gh_items,
+                monitor=None,
+            )
+
+        implementation = next(
+            action for action in actions
+            if action.get("controller_action") == "dispatch_consensus_implementation"
+        )
+        self.assertTrue(implementation["status_only"])
+        self.assertEqual("pending_implement_intent", implementation["suppressed_reason"])
+        self.assertFalse(implementation["consensus_implementation_ready"])
+        unrelated = [
+            action for action in actions
+            if action.get("controller_action") == "review_gate" and action.get("target_number") == 331
+        ]
+        self.assertTrue(unrelated)
 
     def test_consensus_implementation_readiness_non_ok_marker_waits_on_pending_intent(self) -> None:
         action = {
@@ -6439,8 +6537,9 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         (self.logs / "implement-issue-537.log").write_text(
             "IMPLEMENT_DONE:issue-537:blocked\nEXIT=0\n", encoding="utf-8"
         )
+        ctx = LoopContext.load(repo_root=self.repo, env={"CONSENSUS_RND_HOST_ENV": ".config/consensus-rnd/host.env"}, cwd=self.repo, read_only=True)
 
-        reason = consensus_implementation_suppressed_reason(action, self.repo, monitor=None)
+        reason = consensus_implementation_suppressed_reason(action, self.repo, monitor=None, ctx=ctx)
 
         self.assertEqual("pending_implement_intent", reason)
 


### PR DESCRIPTION
### 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `f999e9cc7bff..b4e04961c77c`
- 涉及 issue: #939

### commit 摘要

- 让实现就绪检查复用 tick 级上下文 (#939)

### 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
