### PR TITLE
仅用 GitHub 评论证明必需 reviewer 完成

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -2387,8 +2387,13 @@ def _github_comment_id(comment: Mapping[str, Any]) -> int | None:
     return None
 
 
-def _github_review_completion_evidences(repo_root: Path, pr_number: int) -> list[ReviewCompletionEvidence]:
-    slug = github_repo_slug()
+def _github_review_completion_evidences(
+    repo_root: Path,
+    pr_number: int,
+    *,
+    gh_repo_slug: str | None = None,
+) -> list[ReviewCompletionEvidence]:
+    slug = gh_repo_slug if gh_repo_slug is not None else github_repo_slug()
     if not slug:
         return []
     try:
@@ -2571,37 +2576,7 @@ def latest_valid_reviewer_rounds(repo_root: Path, pr_number: int) -> dict[str, t
 def highest_complete_required_review_round(repo_root: Path, pr_number: int, head_sha: str) -> ReviewRoundCompletion | None:
     if not head_sha:
         return None
-    evidences: list[ReviewCompletionEvidence] = []
-    evidences.extend(_github_review_completion_evidences(repo_root, pr_number))
-    artifact_keys: set[tuple[str, int]] = set()
-    runs_dir = repo_root / ".refactor-loop" / "runs"
-    logs_dir = repo_root / ".refactor-loop" / "logs"
-    prompts_dir = repo_root / ".refactor-loop" / "prompts"
-    for path in sorted(runs_dir.glob(f"review-pr{pr_number}-*-r*.md")):
-        match = REVIEW_ARTIFACT_RE.match(path.name)
-        if not match or int(match.group(1)) != pr_number:
-            continue
-        role = match.group(2)
-        round_number = int(match.group(3))
-        artifact_keys.add((role, round_number))
-        log_path = logs_dir / f"review-pr{pr_number}-{role}-r{round_number}.log"
-        if not _reviewer_log_has_exit_zero(log_path) or not _reviewer_log_has_valid_marker(log_path, pr_number, role):
-            continue
-        reviewed_head = _reviewed_head_sha_from_file(path) or _reviewed_head_sha_from_file(prompts_dir / path.name) or _reviewed_head_sha_from_file(log_path)
-        evidences.append(ReviewCompletionEvidence(role=role, round_number=round_number, head_sha=reviewed_head, valid=bool(reviewed_head)))
-    for path in sorted(logs_dir.glob(f"review-pr{pr_number}-*-r*.log")):
-        match = REVIEW_LOG_RE.match(path.name)
-        if not match or int(match.group(1)) != pr_number:
-            continue
-        role = match.group(2)
-        round_number = int(match.group(3))
-        if (role, round_number) in artifact_keys:
-            continue
-        if not _reviewer_log_has_exit_zero(path) or not _reviewer_log_has_valid_marker(path, pr_number, role):
-            continue
-        prompt_path = prompts_dir / path.with_suffix(".md").name
-        reviewed_head = _reviewed_head_sha_from_file(path) or _reviewed_head_sha_from_file(prompt_path)
-        evidences.append(ReviewCompletionEvidence(role=role, round_number=round_number, head_sha=reviewed_head, valid=bool(reviewed_head)))
+    evidences = _github_review_completion_evidences(repo_root, pr_number)
     selection = select_latest_live_head_review_evidence(
         evidences,
         live_head_sha=head_sha,
@@ -2673,6 +2648,24 @@ def valid_required_review_round_complete(repo_root: Path, pr_number: int, head_s
     return highest_complete_required_review_round(repo_root, pr_number, head_sha) is not None
 
 
+def github_review_completion_roles(
+    repo_root: Path,
+    pr_number: int,
+    head_sha: str,
+    *,
+    gh_repo_slug: str | None = None,
+) -> tuple[set[str], set[str], bool]:
+    evidences = _github_review_completion_evidences(repo_root, pr_number, gh_repo_slug=gh_repo_slug)
+    selection = select_latest_live_head_review_evidence(
+        evidences,
+        live_head_sha=head_sha,
+        required_roles=REQUIRED_REVIEW_ROLES,
+    )
+    complete_roles = set(selection.by_role)
+    github_roles = {evidence.role for evidence in evidences if evidence.role in REQUIRED_REVIEW_ROLES}
+    return complete_roles, github_roles, selection.complete_round is not None
+
+
 def pending_review_spawn_exists(
     repo_root: Path,
     pr_number: int,
@@ -2741,19 +2734,42 @@ def review_evidence_redispatch_actions(repo_root: Path, gh_items: list[GhItem], 
             continue
         if not item.head_sha:
             continue
-        if highest_complete_required_review_round(repo_root, item.number, item.head_sha) is not None:
+        context_slug_value = getattr(ctx, "gh_repo_slug", None) if ctx is not None else None
+        context_slug = context_slug_value if isinstance(context_slug_value, str) and context_slug_value else None
+        if ctx is not None and not context_slug:
+            github_complete_roles: set[str] = set()
+            github_evidence_roles: set[str] = set()
+            github_round_complete = False
+        elif ctx is None:
+            github_complete_roles = set()
+            github_evidence_roles = set()
+            github_round_complete = False
+        else:
+            github_complete_roles, github_evidence_roles, github_round_complete = github_review_completion_roles(
+                repo_root,
+                item.number,
+                item.head_sha,
+                gh_repo_slug=context_slug,
+            )
+        if github_round_complete:
             continue
         heads = latest_reviewer_heads(repo_root, item.number)
         dead_roles = dead_reviewer_roles(repo_root, item.number)
         evidence_roles = reviewer_roles_with_evidence(repo_root, item.number)
         pending_roles = pending_or_fresh_review_evidence_roles(repo_root, item.number)
-        live_head_roles = {role for role, head in heads.items() if head == item.head_sha}
+        redispatch_candidate_roles = (evidence_roles | dead_roles | github_evidence_roles) - pending_roles
+        local_roles = evidence_roles | dead_roles
+        if github_evidence_roles:
+            redispatch_candidate_roles |= {
+                role
+                for role in local_roles
+                if heads.get(role, "") != item.head_sha or role in dead_roles
+            }
         stale_roles = [
             role
             for role in REQUIRED_REVIEW_ROLES
-            if heads.get(role, "") != item.head_sha
-            and role not in pending_roles
-            and (heads.get(role, "") or role in dead_roles or role in evidence_roles or live_head_roles)
+            if role not in github_complete_roles
+            and role in redispatch_candidate_roles
             and not pending_review_spawn_exists(repo_root, item.number, ctx, role=role, head_sha=item.head_sha)
         ]
         if not stale_roles:

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -5222,7 +5222,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
         self.assertEqual(action["target_number"], 480)
         self.assertEqual(action["head_sha"], "a" * 40)
-        self.assertEqual(action["stale_review_roles"], ["architect"])
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
         self.assertNotIn("status_only", action)
 
     def test_reviewing_pr_with_fresh_pending_reviewer_log_does_not_redispatch(self) -> None:
@@ -5235,7 +5235,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         plan = self.run_plan(fixture="open_pr_480")
 
-        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests"])
 
     def test_reviewing_pr_with_terminal_failed_reviewer_log_redispatches_only_that_role(self) -> None:
         for role, verdict in (("architect", "approve"), ("tests", "approve")):
@@ -5248,7 +5249,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         plan = self.run_plan(fixture="open_pr_480")
 
         action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
-        self.assertEqual(action["stale_review_roles"], ["quality"])
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
         self.assertNotIn("status_only", action)
 
     def test_reviewing_pr_with_stale_pending_reviewer_log_redispatches_only_that_role(self) -> None:
@@ -5265,7 +5266,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         plan = self.run_plan(fixture="open_pr_480")
 
         action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
-        self.assertEqual(action["stale_review_roles"], ["quality"])
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
         self.assertNotIn("status_only", action)
 
     def test_reviewing_pr_with_complete_same_head_round_suppresses_duplicate_redispatch(self) -> None:
@@ -5274,24 +5275,47 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         plan = self.run_plan(fixture="open_pr_480")
 
-        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
 
-    def test_complete_lower_review_round_suppresses_higher_inflight_redispatch_for_same_head(self) -> None:
+    def test_github_complete_lower_review_round_suppresses_higher_inflight_redispatch_for_same_head(self) -> None:
+        live = "a" * 40
         for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):
             self.write_review_evidence(role=role, verdict=verdict, round_number=4)
         for role in ("architect", "tests"):
             (self.logs / f"review-pr480-{role}-r5.log").write_text(
-                f"head_sha: {'a' * 40}\nREVIEW_DONE:480:{role}:approve\n",
+                f"head_sha: {live}\nREVIEW_DONE:480:{role}:approve\n",
                 encoding="utf-8",
             )
+        comments = [
+            [
+                {
+                    "id": 200 + index,
+                    "created_at": f"2026-06-12T00:0{index}:00Z",
+                    "body": (
+                        f"review_round: 4\nhead_sha: {live}\n"
+                        f"REVIEW_DONE:480:{role}:{verdict}\n\n"
+                        "⟦AI:AUTO-LOOP⟧"
+                    ),
+                }
+                for index, (role, verdict) in enumerate(
+                    (("architect", "approve"), ("tests", "approve"), ("quality", "comment")),
+                    start=1,
+                )
+            ]
+        ]
+        (self.repo / "gh-api-repos-owner-repo-issues-480-comments?per_page=100-comments.json").write_text(
+            json.dumps(comments),
+            encoding="utf-8",
+        )
 
         plan = self.run_plan(fixture="open_pr_480")
 
         gate = next(item for item in plan["actions"] if item.get("controller_action") == "review_gate")
-        self.assertEqual(gate["head_sha"], "a" * 40)
+        self.assertEqual(gate["head_sha"], live)
         self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
 
-    def test_review_gate_completion_uses_latest_live_head_per_role_across_independent_rounds(self) -> None:
+    def test_review_gate_completion_ignores_local_artifacts_across_independent_rounds(self) -> None:
         live = "a" * 40
         self.write_review_evidence(role="tests", verdict="reject", round_number=14, head_sha=live)
         self.write_review_evidence(role="quality", verdict="comment", round_number=14, head_sha=live)
@@ -5299,14 +5323,12 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.write_review_evidence(role="architect", verdict="approve", round_number=16, head_sha=live)
 
         completion = highest_complete_required_review_round(self.repo, 480, live)
-        self.assertIsNotNone(completion)
-        self.assertEqual(completion.round_number, 16)
+        self.assertIsNone(completion)
 
         plan = self.run_plan(fixture="open_pr_480")
 
-        gate = next(item for item in plan["actions"] if item.get("controller_action") == "review_gate")
-        self.assertEqual(gate["head_sha"], live)
-        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
 
     def test_review_gate_completion_uses_recency_resolved_github_comments_with_empty_rounds(self) -> None:
         live = "a" * 40
@@ -5410,7 +5432,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertIsNone(highest_complete_required_review_round(self.repo, 480, live))
         plan = self.run_plan(fixture="open_pr_480")
         action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
-        self.assertEqual(action["stale_review_roles"], ["quality"])
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
 
         self.actions_cleanup_for_review_pr(480)
         self.write_review_evidence(role="architect", verdict="approve", round_number=4, head_sha=live)
@@ -5422,7 +5444,58 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         self.assertIsNone(highest_complete_required_review_round(self.repo, 480, live))
         plan = self.run_plan(fixture="open_pr_480")
-        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests"])
+
+    def test_review_gate_completion_requires_github_comments_even_when_local_artifacts_are_complete(self) -> None:
+        live = "a" * 40
+        for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):
+            self.write_review_evidence(role=role, verdict=verdict, round_number=7, head_sha=live)
+
+        self.assertIsNone(highest_complete_required_review_round(self.repo, 480, live))
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
+
+    def test_partial_github_review_evidence_redispatches_only_missing_roles_despite_local_artifacts(self) -> None:
+        live = "a" * 40
+        for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):
+            self.write_review_evidence(role=role, verdict=verdict, round_number=7, head_sha=live)
+        comments = [
+            [
+                {
+                    "id": 301,
+                    "created_at": "2026-06-12T00:01:00Z",
+                    "body": (
+                        f"review_round: 7\nhead_sha: {live}\n"
+                        "REVIEW_DONE:480:architect:approve\n\n"
+                        "⟦AI:AUTO-LOOP⟧"
+                    ),
+                },
+                {
+                    "id": 302,
+                    "created_at": "2026-06-12T00:02:00Z",
+                    "body": (
+                        f"review_round: 7\nhead_sha: {live}\n"
+                        "REVIEW_DONE:480:tests:approve\n\n"
+                        "⟦AI:AUTO-LOOP⟧"
+                    ),
+                },
+            ]
+        ]
+        (self.repo / "gh-api-repos-owner-repo-issues-480-comments?per_page=100-comments.json").write_text(
+            json.dumps(comments),
+            encoding="utf-8",
+        )
+
+        self.assertIsNone(highest_complete_required_review_round(self.repo, 480, live))
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["quality"])
 
     def test_review_redispatch_targets_only_missing_role_for_candidate_round(self) -> None:
         self.write_review_evidence(role="architect", verdict="approve", round_number=3)
@@ -5436,7 +5509,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
         self.assertEqual(action["head_sha"], "a" * 40)
-        self.assertEqual(action["stale_review_roles"], ["quality"])
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
 
     def test_review_redispatch_next_round_intent_projects_despite_stale_exit_zero_r1_log(self) -> None:
         stale = "b" * 40
@@ -5479,7 +5552,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(spawn["log"], str((self.logs / "review-pr480-architect-r2.log").resolve()))
         self.assertNotEqual(spawn["log"], str((self.logs / "review-pr480-architect-r1.log").resolve()))
 
-    def test_reviewing_pr_with_prompt_bound_valid_heads_does_not_redispatch_reviewers(self) -> None:
+    def test_reviewing_pr_with_prompt_bound_valid_heads_redispatches_until_github_completion_visible(self) -> None:
         for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):
             (self.repo / ".refactor-loop" / "runs").mkdir(parents=True, exist_ok=True)
             (self.repo / ".refactor-loop" / "prompts").mkdir(parents=True, exist_ok=True)
@@ -5498,7 +5571,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         plan = self.run_plan(fixture="open_pr_480")
 
-        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
 
     def test_review_done_completed_marker_projects_prompt_bound_reviewed_head(self) -> None:
         for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):
@@ -5523,7 +5597,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual(action["target_kind"], "PR")
         self.assertEqual(action["target_number"], 480)
         self.assertEqual(action["head_sha"], "a" * 40)
-        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+        redispatch = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(redispatch["stale_review_roles"], ["architect", "tests", "quality"])
 
     def test_fix_done_without_review_thread_artifact_ignores_unrelated_unresolved_threads(self) -> None:
         self.write_completed_log("fix-pr77-r3.log", "FIX_DONE")
@@ -6990,7 +7065,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertIn("review-evidence-redispatch", projection.set_members["EXECUTABLE_ACTION_KINDS"])
         self.assertIn('"action_id": f"review-evidence-redispatch:{item.number}:{item.head_sha}"', redispatch_source)
         self.assertIn('"head_sha": item.head_sha', redispatch_source)
-        self.assertIn("highest_complete_required_review_round", redispatch_source)
+        self.assertIn("github_review_completion_roles", redispatch_source)
 
     def test_wakeup_plan_source_locks_stale_unexecutable_status_only_suppression(self) -> None:
         projection = wakeup_plan_projection()


### PR DESCRIPTION
## Changed files

- `skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py`: required-review completion 改为只读取 GitHub-visible、same-head、final-sentinel reviewer comments；本地 reviewer runs/logs/prompts 不再证明完成或 suppress redispatch，只保留为诊断、pending/dead/stale 与 bounded role redispatch 输入。
- `skills/consensus-loop/scripts/test_wakeup_plan.py`: 增加 local-only 完成证据必须 redispatch、partial GitHub evidence 只 redispatch 缺失角色、完整 GitHub comment round 才 suppress redispatch 的行为覆盖。

## Test results

- Static guard: `skill-degradation: ok`
- Full unittest discovery: `Ran 2404 tests in 406.964s`, `OK (skipped=1)`
- Focused wakeup-plan regression: `9 passed, 339 deselected in 6.44s`

## Deviations

- Closes #948
- SCOPE_EXTEND records: none.
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

⟦AI:AUTO-LOOP⟧
