### PR TITLE
发布 rollup: integration ahead 1 commits (359941b1f4c7)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_plan.py
@@ -2601,7 +2601,7 @@ def pending_or_fresh_review_evidence_exists(repo_root: Path, pr_number: int) -> 
     return False
 
 
-def pending_or_fresh_review_evidence_roles(repo_root: Path, pr_number: int) -> set[str]:
+def pending_or_fresh_review_evidence_roles(repo_root: Path, pr_number: int, head_sha: str | None = None) -> set[str]:
     roles: set[str] = set()
     now = time.time()
     for path in sorted((repo_root / ".refactor-loop" / "logs").glob(f"review-pr{pr_number}-*-r*.log")):
@@ -2609,6 +2609,8 @@ def pending_or_fresh_review_evidence_roles(repo_root: Path, pr_number: int) -> s
         if not match or int(match.group(1)) != pr_number:
             continue
         if _reviewer_log_has_exit_zero(path) or _reviewer_log_terminal_failed(path):
+            continue
+        if head_sha is not None and _reviewed_head_sha_from_file(path) != head_sha:
             continue
         if now - path.stat().st_mtime < REVIEW_PENDING_SECONDS:
             roles.add(match.group(2))
@@ -2756,8 +2758,15 @@ def review_evidence_redispatch_actions(repo_root: Path, gh_items: list[GhItem], 
         heads = latest_reviewer_heads(repo_root, item.number)
         dead_roles = dead_reviewer_roles(repo_root, item.number)
         evidence_roles = reviewer_roles_with_evidence(repo_root, item.number)
-        pending_roles = pending_or_fresh_review_evidence_roles(repo_root, item.number)
-        redispatch_candidate_roles = (evidence_roles | dead_roles | github_evidence_roles) - pending_roles
+        pending_roles = pending_or_fresh_review_evidence_roles(repo_root, item.number, item.head_sha)
+        missing_same_head_roles = {
+            role
+            for role in REQUIRED_REVIEW_ROLES
+            if role not in github_complete_roles and heads.get(role, "") != item.head_sha
+        }
+        redispatch_candidate_roles = (
+            missing_same_head_roles | evidence_roles | dead_roles | github_evidence_roles
+        ) - pending_roles
         local_roles = evidence_roles | dead_roles
         if github_evidence_roles:
             redispatch_candidate_roles |= {
@@ -2789,6 +2798,8 @@ def review_evidence_redispatch_actions(repo_root: Path, gh_items: list[GhItem], 
                 "target": {"kind": "PR", "number": item.number},
                 "stale_review_roles": stale_roles,
                 "head_sha": item.head_sha,
+                "source_artifact": "wakeup-plan",
+                "source_marker": "review-evidence-redispatch",
                 "preconditions": ["active_controller_owner", "live_open_target_if_present", "missing_or_stale_reviewer_head_evidence"],
                 "runner_authority": RUNNER_AUTHORITY,
                 "no_generic_command": True,

--- a/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/wakeup_runner.py
@@ -428,6 +428,9 @@ class WakeupRunner:
             return self._record(RunnerResult(action_id, "skipped", "duplicate"), action)
         if action.get("kind") == "harness-spawn-intent-invalid":
             return self._apply_invalid_harness_spawn_intent(action, action_id)
+        same_tick_terminal_reason = self._same_tick_terminal_target_reason(action)
+        if same_tick_terminal_reason:
+            return self._record(RunnerResult(action_id, "skipped", same_tick_terminal_reason), action)
         error = self._validate_action(action)
         if error:
             if error == "issue_decomposition_duplicate_sentinel" or error in NON_BLOCKING_VALIDATION_REASONS:
@@ -438,9 +441,6 @@ class WakeupRunner:
             ):
                 return self._record(RunnerResult(action_id, "skipped", error), action)
             return self._blocked(action, error)
-        same_tick_terminal_reason = self._same_tick_terminal_target_reason(action)
-        if same_tick_terminal_reason:
-            return self._record(RunnerResult(action_id, "skipped", same_tick_terminal_reason), action)
         if self.dry_run:
             return self._record(RunnerResult(action_id, "dry-run"), action)
         stand_down_reason = self._cross_instance_stand_down_reason(action)
@@ -1251,7 +1251,52 @@ class WakeupRunner:
     def _validate_dispatch_reviewers(self, action: Mapping[str, Any]) -> str | None:
         if action.get("target_kind") != "PR" or not isinstance(action.get("target_number"), int):
             return "dispatch_reviewers_target_missing"
+        if action.get("kind") == "review-evidence-redispatch":
+            return self._validate_review_evidence_redispatch(action)
         return None
+
+    def _validate_review_evidence_redispatch(self, action: Mapping[str, Any]) -> str | None:
+        target = action.get("target_number")
+        if not isinstance(target, int) or target <= 0:
+            return "dispatch_reviewers_target_missing"
+        preconditions = action.get("preconditions")
+        if not isinstance(preconditions, list) or "missing_or_stale_reviewer_head_evidence" not in preconditions:
+            return "dispatch_reviewers_missing_precondition:missing_or_stale_reviewer_head_evidence"
+        projected_head = str(action.get("head_sha") or "").strip()
+        if not projected_head:
+            return "dispatch_reviewers_head_sha_missing"
+        live_head = self._pr_head_sha(target)
+        if not live_head:
+            return "dispatch_reviewers_live_head_missing"
+        if live_head != projected_head:
+            return "dispatch_reviewers_live_head_mismatch"
+        roles = self._projected_stale_review_roles(action)
+        if not roles:
+            return "dispatch_reviewers_stale_roles_missing"
+        gate = self._review_gate(target)
+        heads = gate.get("heads_by_role")
+        if not isinstance(heads, Mapping):
+            return "dispatch_reviewers_review_evidence_unavailable"
+        missing_roles = [
+            role
+            for role in roles
+            if str(heads.get(role) or "") != projected_head
+            and not self._pending_review_spawn_intent_exists(target, role, projected_head)
+        ]
+        if not missing_roles:
+            return "dispatch_reviewers_reviewer_evidence_current"
+        return None
+
+    def _projected_stale_review_roles(self, action: Mapping[str, Any]) -> list[str]:
+        stale_roles = action.get("stale_review_roles")
+        if not isinstance(stale_roles, list):
+            return []
+        roles: list[str] = []
+        for role in stale_roles:
+            role_text = str(role)
+            if role_text in REQUIRED_REVIEW_ROLES and role_text not in roles:
+                roles.append(role_text)
+        return roles
 
     def _validate_publish_review_fix_output(self, action: Mapping[str, Any]) -> str | None:
         if action.get("target_kind") != "PR" or not isinstance(action.get("target_number"), int):

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -5204,6 +5204,44 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertTrue(action["no_generic_command"])
         self.assertNotIn("status_only", action)
 
+    def test_reviewing_pr_with_zero_reviewer_evidence_projects_initial_reviewers(self) -> None:
+        plan = self.run_plan(fixture="open_pr_480")
+
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["controller_action"], "dispatch_reviewers")
+        self.assertEqual(action["target_kind"], "PR")
+        self.assertEqual(action["target_number"], 480)
+        self.assertEqual(action["head_sha"], "a" * 40)
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
+        self.assertEqual(action["source_artifact"], "wakeup-plan")
+        self.assertEqual(action["source_marker"], "review-evidence-redispatch")
+        self.assertIn("missing_or_stale_reviewer_head_evidence", action["preconditions"])
+        self.assertEqual(action["runner_authority"], "wakeup-runner-396")
+        self.assertTrue(action["no_generic_command"])
+        self.assertNotIn("status_only", action)
+
+    def test_reviewing_pr_with_zero_evidence_and_same_head_pending_intents_does_not_redispatch(self) -> None:
+        for role in ("architect", "tests", "quality"):
+            self.append_harness_spawn_intent(
+                intent_id=f"dispatch-reviewers:480:{role}:r1",
+                source="dispatch-reviewers",
+                route="dispatch-reviewers",
+                task_id=f"review-pr480-{role}-r1",
+                cd=str(self.repo.resolve()),
+                prompt=f".refactor-loop/prompts/review-pr480-{role}-r1.md",
+                log=f".refactor-loop/logs/review-pr480-{role}-r1.log",
+                reason=f"review PR #480 as {role}",
+            )
+            (self.repo / ".refactor-loop" / "prompts").mkdir(parents=True, exist_ok=True)
+            (self.repo / ".refactor-loop" / "prompts" / f"review-pr480-{role}-r1.md").write_text(
+                f"head_sha: {'a' * 40}\n",
+                encoding="utf-8",
+            )
+
+        plan = self.run_plan(fixture="open_pr_480", ps_count=0)
+
+        self.assertNotIn("review-evidence-redispatch", json.dumps(plan, sort_keys=True))
+
     def test_reviewing_pr_with_stale_reviewer_head_projects_dispatch_reviewers(self) -> None:
         stale = "b" * 40
         for role, verdict in (("architect", "approve"), ("tests", "approve"), ("quality", "comment")):
@@ -5237,6 +5275,19 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
         self.assertEqual(action["stale_review_roles"], ["architect", "tests"])
+
+    def test_reviewing_pr_with_different_head_fresh_pending_reviewer_log_still_redispatches_role(self) -> None:
+        for role, verdict in (("architect", "approve"), ("tests", "approve")):
+            self.write_review_evidence(role=role, verdict=verdict)
+        (self.logs / "review-pr480-quality-r1.log").write_text(
+            f"head_sha: {'b' * 40}\nREVIEW_DONE:480:quality:comment\n",
+            encoding="utf-8",
+        )
+
+        plan = self.run_plan(fixture="open_pr_480")
+
+        action = next(item for item in plan["actions"] if item["kind"] == "review-evidence-redispatch")
+        self.assertEqual(action["stale_review_roles"], ["architect", "tests", "quality"])
 
     def test_reviewing_pr_with_terminal_failed_reviewer_log_redispatches_only_that_role(self) -> None:
         for role, verdict in (("architect", "approve"), ("tests", "approve")):
@@ -6190,7 +6241,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         self.assertEqual(1, len(actions))
         self.assertEqual("dispatch_reviewers", actions[0]["controller_action"])
-        self.assertEqual(["architect"], actions[0]["stale_review_roles"])
+        self.assertEqual(["architect", "tests", "quality"], actions[0]["stale_review_roles"])
 
     def test_legacy_malformed_review_intent_for_merged_pr_projects_invalid_quarantine_once(self) -> None:
         malformed_intent = self.valid_review_harness_spawn_intent(774, "quality", 6)
@@ -6265,7 +6316,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         actions = review_evidence_redispatch_actions(self.repo, [item], ctx)
 
-        self.assertEqual([], actions)
+        self.assertEqual(1, len(actions))
+        self.assertEqual(["tests", "quality"], actions[0]["stale_review_roles"])
 
     def test_live_valid_review_spawn_intent_suppresses_review_redispatch(self) -> None:
         item = GhItem(
@@ -6289,7 +6341,8 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
 
         actions = review_evidence_redispatch_actions(self.repo, [item], ctx)
 
-        self.assertEqual([], actions)
+        self.assertEqual(1, len(actions))
+        self.assertEqual(["tests", "quality"], actions[0]["stale_review_roles"])
 
     def test_rollup_pr_projects_ci_only_auto_merge_action(self) -> None:
         item = GhItem(

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -2841,12 +2841,12 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         )
         other_pr_dispatch = self.reviewer_dispatch_action(
             kind="review-evidence-redispatch",
-            action_id="review-evidence-redispatch:78:" + "b" * 40,
+            action_id="review-evidence-redispatch:78:" + "a" * 40,
             source_artifact="wakeup-plan",
             source_marker="review-evidence-redispatch",
             target_number=78,
             target={"kind": "PR", "number": 78},
-            head_sha="b" * 40,
+            head_sha="a" * 40,
             stale_review_roles=["tests"],
             preconditions=[
                 "active_controller_owner",
@@ -2867,7 +2867,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             [
                 ("review-gate:77:merge-before-reviewer-top-up", "applied", ""),
                 ("review-evidence-redispatch:77:" + "a" * 40, "skipped", "same_tick_terminal_target:MERGED"),
-                ("review-evidence-redispatch:78:" + "b" * 40, "applied", ""),
+                ("review-evidence-redispatch:78:" + "a" * 40, "applied", ""),
             ],
         )
         self.assertEqual([call[0] for call in actions.calls], ["merge_pr", "dispatch_reviewers"])
@@ -5396,7 +5396,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
             action_id="review-evidence-redispatch:77:" + "a" * 40,
             source_artifact="wakeup-plan",
             source_marker="review-evidence-redispatch",
-            head_sha="b" * 40,
+            head_sha="a" * 40,
             stale_review_roles=["architect", "tests"],
             preconditions=[
                 "active_controller_owner",
@@ -5410,6 +5410,100 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual(results[0].status, "applied")
         self.assertEqual(actions.calls[0][0], "dispatch_reviewers")
         self.assertEqual(actions.calls[0][1]["stale_review_roles"], ["architect", "tests"])
+
+    def test_review_evidence_redispatch_revalidates_live_head_before_helper(self) -> None:
+        actions = FakeActions()
+        action = self.reviewer_dispatch_action(
+            kind="review-evidence-redispatch",
+            action_id="review-evidence-redispatch:77:" + "b" * 40,
+            source_artifact="wakeup-plan",
+            source_marker="review-evidence-redispatch",
+            head_sha="b" * 40,
+            stale_review_roles=["architect", "tests", "quality"],
+            preconditions=[
+                "active_controller_owner",
+                "live_open_target_if_present",
+                "missing_or_stale_reviewer_head_evidence",
+            ],
+        )
+
+        results = self.run_result(self.base_plan(action), actions=actions, gh_head_ref="refactor/iter77-worker")
+
+        self.assertEqual(results[0].status, "blocked")
+        self.assertEqual(results[0].reason, "dispatch_reviewers_live_head_mismatch")
+        self.assertEqual(actions.calls, [])
+
+    def test_review_evidence_redispatch_revalidates_same_head_evidence_before_helper(self) -> None:
+        self.add_review_comments({"architect": "approve", "tests": "approve", "quality": "comment"})
+        actions = FakeActions()
+        action = self.reviewer_dispatch_action(
+            kind="review-evidence-redispatch",
+            action_id="review-evidence-redispatch:77:" + "a" * 40,
+            source_artifact="wakeup-plan",
+            source_marker="review-evidence-redispatch",
+            head_sha="a" * 40,
+            stale_review_roles=["architect", "tests", "quality"],
+            preconditions=[
+                "active_controller_owner",
+                "live_open_target_if_present",
+                "missing_or_stale_reviewer_head_evidence",
+            ],
+        )
+
+        results = self.run_result(self.base_plan(action), actions=actions)
+
+        self.assertEqual(results[0].status, "blocked")
+        self.assertEqual(results[0].reason, "dispatch_reviewers_reviewer_evidence_current")
+        self.assertEqual(actions.calls, [])
+
+    def test_review_evidence_redispatch_revalidates_pending_same_head_intent_before_helper(self) -> None:
+        actions = FakeActions()
+        action = self.reviewer_dispatch_action(
+            kind="review-evidence-redispatch",
+            action_id="review-evidence-redispatch:77:" + "a" * 40,
+            source_artifact="wakeup-plan",
+            source_marker="review-evidence-redispatch",
+            head_sha="a" * 40,
+            stale_review_roles=["architect"],
+            preconditions=[
+                "active_controller_owner",
+                "live_open_target_if_present",
+                "missing_or_stale_reviewer_head_evidence",
+            ],
+        )
+        intent = {
+            "intent_id": "dispatch-reviewers:77:architect:r1",
+            "source": "dispatch-reviewers",
+            "route": "dispatch-reviewers",
+            "task_id": "review-pr77-architect-r1",
+            "priority": "p1",
+            "command": "spawn-codex",
+            "controller_action": "spawn_codex_harness_background",
+            "cd": ".",
+            "prompt": ".refactor-loop/prompts/review-pr77-architect-r1.md",
+            "log": ".refactor-loop/logs/review-pr77-architect-r1.log",
+            "stall": 5400,
+            "reason": "review PR #77 as architect",
+            "queued_at": "2026-05-31T00:00:00Z",
+            "run_in_background_required": True,
+            "no_lifecycle_authority": True,
+        }
+        self.ctx.paths.pending_events.write_text(
+            "2026-05-31T00:00:00Z HARNESS_SPAWN_INTENT "
+            + json.dumps(intent, sort_keys=True)
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.repo / ".refactor-loop/prompts/review-pr77-architect-r1.md").write_text(
+            f"head_sha: {'a' * 40}\n",
+            encoding="utf-8",
+        )
+
+        results = self.run_result(self.base_plan(action), actions=actions)
+
+        self.assertEqual(results[0].status, "blocked")
+        self.assertEqual(results[0].reason, "dispatch_reviewers_reviewer_evidence_current")
+        self.assertEqual(actions.calls, [])
 
     def test_stale_review_dispatch_applied_row_retries_when_evidence_still_stale(self) -> None:
         for role in ("architect", "tests"):


### PR DESCRIPTION
### 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `51f9a8b1cc10..359941b1f4c7`
- 涉及 issue: #959

### commit 摘要

- 唤醒计划为 reviewing PR 自动补发 reviewer (#959)

### 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
