### PR TITLE
修复 #969:default issue intake 自指死锁——从 admission upstream-progress gate 移除 wakeup_runner_daemon

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/default_issue_intake_admission.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/default_issue_intake_admission.py
@@ -19,9 +19,10 @@ from .harness_spawn_intent_target import _harness_spawn_intent_target
 DEFAULT_ACTIVE_DESIGN_CAP = 3
 DEFAULT_CLAIM_COOLDOWN_SECONDS = 3600
 CLAIM_STATE_PATH = ".refactor-loop/state/default-issue-intake-claims.json"
+# wakeup_runner_daemon evaluates this admission inside its own begin->callback->complete tick,
+# so gating on its own progress self-deadlocks (#969); only upstream/parallel producers belong here.
 UPSTREAM_PROGRESS_DAEMONS = (
     "phase9_router_daemon",
-    "wakeup_runner_daemon",
     "concurrency_monitor",
 )
 ADMISSION_PRECONDITIONS = (

--- a/skills/consensus-loop/scripts/test_default_issue_intake_admission.py
+++ b/skills/consensus-loop/scripts/test_default_issue_intake_admission.py
@@ -19,6 +19,7 @@ from codex_refactor_loop.daemon_progress import begin_tick  # noqa: E402
 from codex_refactor_loop.default_issue_intake_admission import (  # noqa: E402
     DefaultIssueIntakeAdmission,
     DefaultIssueIntakeCandidate,
+    UPSTREAM_PROGRESS_DAEMONS,
     issue_title_is_concrete_work_unit,
 )
 
@@ -180,6 +181,36 @@ class DefaultIssueIntakeAdmissionTests(unittest.TestCase):
         self.assertFalse(decision.accepted)
         self.assertEqual("upstream_not_idle", decision.reason)
         self.assertEqual("daemon_progress_incomplete:phase9_router_daemon", decision.proof["upstream_state"])
+
+    def test_accepts_when_wakeup_runner_progress_is_in_progress(self) -> None:
+        begin_tick(self.repo, "wakeup_runner_daemon", now=1000, pid=42)
+        admission = DefaultIssueIntakeAdmission(
+            self.ctx,
+            managed_items=[],
+            pending_spawn_intents=[],
+        )
+
+        decision = admission.evaluate(self.candidate())
+
+        self.assertTrue(decision.accepted)
+        self.assertEqual("upstream_idle", decision.proof["upstream_state"])
+
+    def test_rejects_when_concurrency_monitor_progress_is_in_progress(self) -> None:
+        begin_tick(self.repo, "concurrency_monitor", now=1000, pid=42)
+        admission = DefaultIssueIntakeAdmission(
+            self.ctx,
+            managed_items=[],
+            pending_spawn_intents=[],
+        )
+
+        decision = admission.evaluate(self.candidate())
+
+        self.assertFalse(decision.accepted)
+        self.assertEqual("upstream_not_idle", decision.reason)
+        self.assertEqual("daemon_progress_incomplete:concurrency_monitor", decision.proof["upstream_state"])
+
+    def test_upstream_progress_daemons_exclude_wakeup_runner_executor(self) -> None:
+        self.assertEqual(("phase9_router_daemon", "concurrency_monitor"), UPSTREAM_PROGRESS_DAEMONS)
 
     def test_rejects_epic_tracking_and_container_titles_as_not_concrete_work_units(self) -> None:
         admission = DefaultIssueIntakeAdmission(self.ctx, managed_items=[], pending_spawn_intents=[])


### PR DESCRIPTION
## 修复 #969:default issue intake 自指死锁

### 根因
`wakeup_runner_daemon` 在自己的 `run_tick` 内评估 `DefaultIssueIntakeAdmission`,而 `heartbeat.run_tick` 在调用 callback 前先 `begin_tick()` 把自身 progress 置为 `begin`。`_upstream_state()` 把 `wakeup_runner_daemon` 列在 `UPSTREAM_PROGRESS_DAEMONS` 里并要求 `status=="complete"`,于是 daemon 读到**自己**的 progress 恒为 `begin != complete` → intake 永久 `upstream_not_idle` reject。`DefaultIssueIntakeClaim` 从 daemon 路径结构性不可达。这是 #965 修复揭开的第二个结构性死锁(此前被 152 条 stale `HARNESS_SPAWN_INTENT` 掩盖)。

out-of-band `wakeup-plan` / `wakeup-runner --once` 不经过 `run_tick`,读到上一 tick 的 `complete`,误显示 5 个 intake action —— 掩盖了 daemon 端死锁。

### 修复
`UPSTREAM_PROGRESS_DAEMONS` 收敛为 `("phase9_router_daemon", "concurrency_monitor")`,移除自指的 `wakeup_runner_daemon`(executor 不能 gate 自己的在途 critical section)。两个真实上游/并行 producer gate 保留(它们只会 transient 短暂阻塞,不会永久死锁)。无新 env 旋钮、无新 authority、无 escape hatch;cross-instance stuck 检测仍归 singleton / #191 / restart-daemons。

### 验证
- 新增 behavior 测试(真实 `begin_tick` 路径,非 mock `_upstream_state`):runner-begin→accept(复现 #969 并断言已修)、concurrency-begin→reject、常量 source-regression;复用既有 phase9_router-begin→reject。
- focused `test_default_issue_intake_admission.py` 13 passed;`test_wakeup_plan`+`test_wakeup_runner`+`test_authorization_source_regression` 551 passed。
- sshx 共识:minimal/structural/delete 三 solver 一致 propose;architecture/quality/tests 三 reviewer 一致 approve。

Closes #969

⟦AI:AUTO-LOOP⟧
