### PR TITLE
发布 rollup: integration ahead 1 commits (82c8623db24a)

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/default_issue_intake_admission.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/default_issue_intake_admission.py
@@ -19,9 +19,10 @@ from .harness_spawn_intent_target import _harness_spawn_intent_target
 DEFAULT_ACTIVE_DESIGN_CAP = 3
 DEFAULT_CLAIM_COOLDOWN_SECONDS = 3600
 CLAIM_STATE_PATH = ".refactor-loop/state/default-issue-intake-claims.json"
+# wakeup_runner_daemon evaluates this admission inside its own begin->callback->complete tick,
+# so gating on its own progress self-deadlocks (#969); only upstream/parallel producers belong here.
 UPSTREAM_PROGRESS_DAEMONS = (
     "phase9_router_daemon",
-    "wakeup_runner_daemon",
     "concurrency_monitor",
 )
 ADMISSION_PRECONDITIONS = (

--- a/skills/consensus-loop/scripts/test_default_issue_intake_admission.py
+++ b/skills/consensus-loop/scripts/test_default_issue_intake_admission.py
@@ -19,6 +19,7 @@ from codex_refactor_loop.daemon_progress import begin_tick  # noqa: E402
 from codex_refactor_loop.default_issue_intake_admission import (  # noqa: E402
     DefaultIssueIntakeAdmission,
     DefaultIssueIntakeCandidate,
+    UPSTREAM_PROGRESS_DAEMONS,
     issue_title_is_concrete_work_unit,
 )
 
@@ -180,6 +181,36 @@ class DefaultIssueIntakeAdmissionTests(unittest.TestCase):
         self.assertFalse(decision.accepted)
         self.assertEqual("upstream_not_idle", decision.reason)
         self.assertEqual("daemon_progress_incomplete:phase9_router_daemon", decision.proof["upstream_state"])
+
+    def test_accepts_when_wakeup_runner_progress_is_in_progress(self) -> None:
+        begin_tick(self.repo, "wakeup_runner_daemon", now=1000, pid=42)
+        admission = DefaultIssueIntakeAdmission(
+            self.ctx,
+            managed_items=[],
+            pending_spawn_intents=[],
+        )
+
+        decision = admission.evaluate(self.candidate())
+
+        self.assertTrue(decision.accepted)
+        self.assertEqual("upstream_idle", decision.proof["upstream_state"])
+
+    def test_rejects_when_concurrency_monitor_progress_is_in_progress(self) -> None:
+        begin_tick(self.repo, "concurrency_monitor", now=1000, pid=42)
+        admission = DefaultIssueIntakeAdmission(
+            self.ctx,
+            managed_items=[],
+            pending_spawn_intents=[],
+        )
+
+        decision = admission.evaluate(self.candidate())
+
+        self.assertFalse(decision.accepted)
+        self.assertEqual("upstream_not_idle", decision.reason)
+        self.assertEqual("daemon_progress_incomplete:concurrency_monitor", decision.proof["upstream_state"])
+
+    def test_upstream_progress_daemons_exclude_wakeup_runner_executor(self) -> None:
+        self.assertEqual(("phase9_router_daemon", "concurrency_monitor"), UPSTREAM_PROGRESS_DAEMONS)
 
     def test_rejects_epic_tracking_and_container_titles_as_not_concrete_work_units(self) -> None:
         admission = DefaultIssueIntakeAdmission(self.ctx, managed_items=[], pending_spawn_intents=[])


### PR DESCRIPTION
### 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `1ef983c91766..82c8623db24a`
- 涉及 issue: #969, #970

### commit 摘要

- 修复 #969:default issue intake 自指死锁——从 admission upstream-progress gate 移除 wakeup_runner_daemon (#970)

### 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
