### PR TITLE
发布 rollup: integration ahead 1 commits (60205d04c430)

### DIFF
--- a/skills/consensus-loop/prompts/_github-post-rules.md
+++ b/skills/consensus-loop/prompts/_github-post-rules.md
@@ -47,6 +47,17 @@ Escalation / consensus picks **must** include a clear option table with one-line
 - **zsh-safe exit-code variables**: if shell code captures a `gh` exit code, use variable names such as `post_exit_code` or `gh_exit_code`; **do not** use `status`. `status` is a zsh read-only special variable and assignment will fail the worker.
 - **Decomposition tracking grammar is helper-owned**: workers may discuss `IssueDecompositionPlan` artifacts, but must not write `<!-- crnd:issue-decomposition-tracking -->`, `IssueDecompositionChild fingerprint:`, or parent tracking blocks in GitHub-facing prose; the checked-in #403 helper is the only writer for that idempotency grammar.
 
+## Reviewer GitHub-visible evidence tail
+
+Reviewer roles must end the GitHub PR comment with this ordered tail after the body/evidence:
+
+1. `review_round: <round>`
+2. `head_sha: <sha>`
+3. Role-matching `REVIEW_DONE:<PR>:<role>:<verdict>`
+4. Final standalone AI sentinel
+
+No marker or body may appear after the sentinel. The wakeup runner treats only GitHub-visible, final-sentinel, same-head reviewer comments as merge/fix authority; local reviewer output files and logs are diagnostics and prompt inputs.
+
 ## Allowed `gh` Commands
 
 - `gh issue view` / `gh issue comment`
@@ -104,3 +115,4 @@ If no original authors are provided, skip this section.
 - ❌ Empty promises such as "complete overhaul" or "comprehensive review"
 - ❌ Code identifiers appear without a one-sentence explanation
 - ❌ TL;DR omits the next step or what the maintainer should do
+- ❌ For reviewer comments, any text or marker after the final standalone AI sentinel

--- a/skills/consensus-loop/prompts/reviewer-architect.md
+++ b/skills/consensus-loop/prompts/reviewer-architect.md
@@ -68,7 +68,7 @@ Verdict semantics:
 - Out-of-scope, non-flippable, or advisory findings must be `comment`.
 
 End with marker line: `REVIEW_DONE:${PR_NUMBER}:architect:<verdict>`
-Your GitHub PR comment must include `review_round: ${REVIEW_ROUND}`, `head_sha: ${HEAD_SHA}`, the same `REVIEW_DONE:${PR_NUMBER}:architect:<verdict>` marker, and the final standalone AI sentinel. The wakeup runner treats only that GitHub-visible, sentinel-bearing, same-head comment as merge/fix authority; `${REVIEW_OUTPUT_PATH}` and logs are diagnostics and prompt inputs.
+Your GitHub PR comment must follow the rendered shared Reviewer GitHub-visible evidence tail using the role-matching marker `REVIEW_DONE:${PR_NUMBER}:architect:<verdict>`.
 
 ## Marker emission allowlist(强制)
 

--- a/skills/consensus-loop/prompts/reviewer-quality.md
+++ b/skills/consensus-loop/prompts/reviewer-quality.md
@@ -71,7 +71,7 @@ Verdict semantics:
 - Out-of-scope, non-flippable, or advisory findings must be `comment`.
 
 End with marker: `REVIEW_DONE:${PR_NUMBER}:quality:<verdict>`
-Your GitHub PR comment must include `review_round: ${REVIEW_ROUND}`, `head_sha: ${HEAD_SHA}`, the same `REVIEW_DONE:${PR_NUMBER}:quality:<verdict>` marker, and the final standalone AI sentinel. The wakeup runner treats only that GitHub-visible, sentinel-bearing, same-head comment as merge/fix authority; `${REVIEW_OUTPUT_PATH}` and logs are diagnostics and prompt inputs.
+Your GitHub PR comment must follow the rendered shared Reviewer GitHub-visible evidence tail using the role-matching marker `REVIEW_DONE:${PR_NUMBER}:quality:<verdict>`.
 
 ## Marker emission allowlist(强制)
 

--- a/skills/consensus-loop/prompts/reviewer-tests.md
+++ b/skills/consensus-loop/prompts/reviewer-tests.md
@@ -70,7 +70,7 @@ Verdict semantics:
 - Out-of-scope, non-flippable, or advisory findings must be `comment`.
 
 End with marker: `REVIEW_DONE:${PR_NUMBER}:tests:<verdict>`
-Your GitHub PR comment must include `review_round: ${REVIEW_ROUND}`, `head_sha: ${HEAD_SHA}`, the same `REVIEW_DONE:${PR_NUMBER}:tests:<verdict>` marker, and the final standalone AI sentinel. The wakeup runner treats only that GitHub-visible, sentinel-bearing, same-head comment as merge/fix authority; `${REVIEW_OUTPUT_PATH}` and logs are diagnostics and prompt inputs.
+Your GitHub PR comment must follow the rendered shared Reviewer GitHub-visible evidence tail using the role-matching marker `REVIEW_DONE:${PR_NUMBER}:tests:<verdict>`.
 
 ## Marker emission allowlist(强制)
 

--- a/skills/consensus-loop/scripts/test_prompt_contracts.py
+++ b/skills/consensus-loop/scripts/test_prompt_contracts.py
@@ -61,6 +61,29 @@ class PromptContractsTests(unittest.TestCase):
                 self.assertIn("post_exit_code=$?", rendered)
                 self.assertNotIn("status=$?", rendered)
 
+    def test_reviewer_prompts_share_one_github_visible_evidence_tail_contract(self) -> None:
+        shared = (PROMPTS_DIR / "_github-post-rules.md").read_text(encoding="utf-8")
+        for needle in (
+            "Reviewer GitHub-visible evidence tail",
+            "body/evidence",
+            "`review_round: <round>`",
+            "`head_sha: <sha>`",
+            "`REVIEW_DONE:<PR>:<role>:<verdict>`",
+            "final standalone AI sentinel",
+            "No marker or body may appear after the sentinel",
+        ):
+            with self.subTest(shared_needles=needle):
+                self.assertIn(needle, shared)
+
+        for name in ("reviewer-architect.md", "reviewer-tests.md", "reviewer-quality.md"):
+            body = (PROMPTS_DIR / name).read_text(encoding="utf-8")
+            rendered = inline_prompt_contracts(body, skill_root=SKILL_ROOT)
+            role = name.removeprefix("reviewer-").removesuffix(".md")
+            with self.subTest(prompt=name):
+                self.assertIn("Reviewer GitHub-visible evidence tail", rendered)
+                self.assertIn(f"`REVIEW_DONE:${{PR_NUMBER}}:{role}:<verdict>`", body)
+                self.assertNotIn("Your GitHub PR comment must include `review_round", body)
+
     def test_prompts_do_not_keep_hidden_legacy_contract_anchor_blocks(self) -> None:
         for path in PROMPTS_DIR.glob("*.md"):
             body = path.read_text(encoding="utf-8")

--- a/skills/consensus-loop/scripts/test_wakeup_runner_review_gate.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner_review_gate.py
@@ -652,6 +652,17 @@ class WakeupRunnerReviewGateTests(unittest.TestCase):
                 {"body": f"review_round: 1\nhead_sha: {'a' * 40}\nREVIEW_DONE:12:tests:approve"},
             ),
             (
+                "missing_final_ai_sentinel:tests",
+                {
+                    "body": (
+                        f"review_round: 1\nhead_sha: {'a' * 40}\n"
+                        "REVIEW_DONE:12:tests:approve\n\n"
+                        "⟦AI:AUTO-LOOP⟧\n"
+                        "REVIEW_DONE:12:tests:approve"
+                    )
+                },
+            ),
+            (
                 "missing_reviewed_head_sha:tests",
                 {"body": "review_round: 1\nREVIEW_DONE:12:tests:approve\n\n⟦AI:AUTO-LOOP⟧"},
             ),


### PR DESCRIPTION
### 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `a18ce3faf4bd..60205d04c430`
- 涉及 issue: #963, #979

### commit 摘要

- 实现 issue #963 (#979)

### 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
