### PR TITLE
修复 #973:default issue intake 解除 upstream-idle 串行化闸

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/default_issue_intake_admission.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/default_issue_intake_admission.py
@@ -13,7 +13,6 @@ from . import labels
 from .context import LoopContext
 from .daemon_progress import read_progress
 from .default_issue_intake import default_issue_intake_enabled
-from .harness_spawn_intent_target import _harness_spawn_intent_target
 
 
 DEFAULT_ACTIVE_DESIGN_CAP = 3
@@ -148,8 +147,6 @@ class DefaultIssueIntakeAdmission:
         return max(0, cooldown - max(0, elapsed))
 
     def _upstream_state(self) -> str:
-        if self._live_pending_spawn_intents():
-            return "pending_spawn_intent"
         repo_root = _ctx_repo_root(self.ctx)
         if repo_root is None:
             return "upstream_idle"
@@ -160,15 +157,6 @@ class DefaultIssueIntakeAdmission:
             if progress.status != "complete":
                 return f"daemon_progress_incomplete:{daemon_name}"
         return "upstream_idle"
-
-    def _live_pending_spawn_intents(self) -> tuple[Mapping[str, Any], ...]:
-        open_targets = _open_managed_targets(self.managed_items)
-        live_intents: list[Mapping[str, Any]] = []
-        for intent in self.pending_spawn_intents:
-            target = _harness_spawn_intent_target(intent)
-            if target is None or target in open_targets:
-                live_intents.append(intent)
-        return tuple(live_intents)
 
     def _reject(self, reason: str, proof: dict[str, Any]) -> DefaultIssueIntakeAdmissionDecision:
         return DefaultIssueIntakeAdmissionDecision(False, reason, (), proof)
@@ -205,31 +193,6 @@ def _item_labels(item: Mapping[str, Any] | Any) -> tuple[str, ...]:
     if isinstance(raw, (list, tuple, set)):
         return tuple(str(label) for label in raw if str(label))
     return ()
-
-
-def _item_number(item: Mapping[str, Any] | Any) -> int | None:
-    raw = item.get("number") if isinstance(item, Mapping) else getattr(item, "number", None)
-    try:
-        number = int(raw)
-    except (TypeError, ValueError):
-        return None
-    if number <= 0:
-        return None
-    return number
-
-
-def _open_managed_targets(items: Sequence[Mapping[str, Any] | Any]) -> set[tuple[str, int]]:
-    targets: set[tuple[str, int]] = set()
-    for item in items:
-        kind = str(item.get("kind") if isinstance(item, Mapping) else getattr(item, "kind", "") or "").strip()
-        number = _item_number(item)
-        if number is None:
-            continue
-        if kind == "PR" or kind.lower() == "pr":
-            targets.add(("PR", number))
-        elif kind.lower() == "issue":
-            targets.add(("issue", number))
-    return targets
 
 
 def _positive_host_int(value: object, default: int) -> int:

--- a/skills/consensus-loop/scripts/test_default_issue_intake_admission.py
+++ b/skills/consensus-loop/scripts/test_default_issue_intake_admission.py
@@ -110,7 +110,7 @@ class DefaultIssueIntakeAdmissionTests(unittest.TestCase):
         self.assertEqual("claim_cooldown_active", decision.reason)
         self.assertEqual(1800, decision.proof["claim_cooldown_remaining_seconds"])
 
-    def test_rejects_when_upstream_has_pending_spawn_intent(self) -> None:
+    def test_admits_with_pending_spawn_intent_when_design_cap_has_room(self) -> None:
         admission = DefaultIssueIntakeAdmission(
             self.ctx,
             managed_items=[],
@@ -119,9 +119,11 @@ class DefaultIssueIntakeAdmissionTests(unittest.TestCase):
 
         decision = admission.evaluate(self.candidate())
 
-        self.assertFalse(decision.accepted)
-        self.assertEqual("upstream_not_idle", decision.reason)
-        self.assertEqual("pending_spawn_intent", decision.proof["upstream_state"])
+        # Before #973 this binary pending-intent gate rejected here and serialized intake.
+        self.assertTrue(decision.accepted)
+        self.assertEqual("", decision.reason)
+        self.assertEqual("upstream_idle", decision.proof["upstream_state"])
+        self.assertEqual(1, decision.proof["pending_spawn_intents"])
 
     def test_ignores_stale_pending_spawn_intents_targeting_closed_managed_work(self) -> None:
         admission = DefaultIssueIntakeAdmission(
@@ -140,7 +142,7 @@ class DefaultIssueIntakeAdmissionTests(unittest.TestCase):
         self.assertEqual("", decision.reason)
         self.assertEqual("upstream_idle", decision.proof["upstream_state"])
 
-    def test_rejects_when_pending_spawn_intent_targets_open_managed_work(self) -> None:
+    def test_admits_with_live_pending_spawn_intent_targeting_open_managed_work(self) -> None:
         admission = DefaultIssueIntakeAdmission(
             self.ctx,
             managed_items=[{"kind": "PR", "number": 123, "labels": [labels.MANAGED]}],
@@ -149,12 +151,12 @@ class DefaultIssueIntakeAdmissionTests(unittest.TestCase):
 
         decision = admission.evaluate(self.candidate())
 
-        self.assertEqual("pending_spawn_intent", admission._upstream_state())
-        self.assertFalse(decision.accepted)
-        self.assertEqual("upstream_not_idle", decision.reason)
-        self.assertEqual("pending_spawn_intent", decision.proof["upstream_state"])
+        self.assertEqual("upstream_idle", admission._upstream_state())
+        self.assertTrue(decision.accepted)
+        self.assertEqual("", decision.reason)
+        self.assertEqual("upstream_idle", decision.proof["upstream_state"])
 
-    def test_rejects_unresolvable_pending_spawn_intent_as_live(self) -> None:
+    def test_admits_with_unresolvable_pending_spawn_intent(self) -> None:
         admission = DefaultIssueIntakeAdmission(
             self.ctx,
             managed_items=[],
@@ -163,10 +165,27 @@ class DefaultIssueIntakeAdmissionTests(unittest.TestCase):
 
         decision = admission.evaluate(self.candidate())
 
-        self.assertEqual("pending_spawn_intent", admission._upstream_state())
+        self.assertEqual("upstream_idle", admission._upstream_state())
+        self.assertTrue(decision.accepted)
+        self.assertEqual("", decision.reason)
+        self.assertEqual("upstream_idle", decision.proof["upstream_state"])
+
+    def test_pending_spawn_intent_still_rejects_when_active_design_cap_reached(self) -> None:
+        admission = DefaultIssueIntakeAdmission(
+            self.ctx,
+            managed_items=[
+                self.managed_issue(11, labels.PHASE_DESIGN_SOLVING),
+                self.managed_issue(12, labels.PHASE_DESIGN_SOLVING),
+            ],
+            pending_spawn_intents=[{"controller_action": "dispatch_consensus_implementation"}],
+        )
+
+        decision = admission.evaluate(self.candidate())
+
         self.assertFalse(decision.accepted)
-        self.assertEqual("upstream_not_idle", decision.reason)
-        self.assertEqual("pending_spawn_intent", decision.proof["upstream_state"])
+        self.assertEqual("active_design_cap_reached", decision.reason)
+        self.assertEqual(2, decision.proof["active_design_solving"])
+        self.assertEqual(1, decision.proof["pending_spawn_intents"])
 
     def test_rejects_when_daemon_progress_is_in_progress(self) -> None:
         begin_tick(self.repo, "phase9_router_daemon", now=1000, pid=42)

--- a/skills/consensus-loop/scripts/test_default_issue_intake_admission.py
+++ b/skills/consensus-loop/scripts/test_default_issue_intake_admission.py
@@ -119,7 +119,6 @@ class DefaultIssueIntakeAdmissionTests(unittest.TestCase):
 
         decision = admission.evaluate(self.candidate())
 
-        # Before #973 this binary pending-intent gate rejected here and serialized intake.
         self.assertTrue(decision.accepted)
         self.assertEqual("", decision.reason)
         self.assertEqual("upstream_idle", decision.proof["upstream_state"])

--- a/skills/consensus-loop/scripts/test_wakeup_plan.py
+++ b/skills/consensus-loop/scripts/test_wakeup_plan.py
@@ -261,7 +261,7 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
         self.assertEqual("accepted", actions[0]["default_issue_intake_admission"]["status"])
         self.assertEqual("upstream_idle", actions[0]["default_issue_intake_admission"]["proof"]["upstream_state"])
 
-    def test_default_issue_intake_projection_rejects_live_pending_spawn_intent(self) -> None:
+    def test_default_issue_intake_projection_admits_with_live_pending_spawn_intent(self) -> None:
         ctx = mock.Mock(host_env={"DEFAULT_ISSUE_INTAKE_ENABLE": "true"})
         actions = default_issue_intake_actions(
             [
@@ -279,7 +279,10 @@ class WakeupPlanBehaviorTests(unittest.TestCase):
             now_iso="2026-06-07T02:00:00Z",
         )
 
-        self.assertEqual([], actions)
+        self.assertEqual([88], [action["target_number"] for action in actions])
+        self.assertEqual("apply_default_issue_intake_claim", actions[0]["controller_action"])
+        self.assertEqual("accepted", actions[0]["default_issue_intake_admission"]["status"])
+        self.assertEqual("upstream_idle", actions[0]["default_issue_intake_admission"]["proof"]["upstream_state"])
 
     def test_default_issue_intake_projection_suppresses_when_active_design_cap_reached(self) -> None:
         ctx = mock.Mock(

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.context import LoopContext
 from codex_refactor_loop.consensus_gate import consensus_gate_digest, consensus_gate_file_digest
+from codex_refactor_loop.daemon_progress import begin_tick
 from codex_refactor_loop.issue_decomposition import (
     IssueDecompositionBackoff,
     issue_decomposition_child_fingerprint,
@@ -552,20 +553,9 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual("default_issue_intake_admission:claim_cooldown_active", result[0].reason)
         self.assertEqual([], actions.calls)
 
-    def test_apply_default_issue_intake_claim_revalidates_pending_spawn_intent_before_helper_dispatch(self) -> None:
+    def test_apply_default_issue_intake_claim_revalidates_admission_before_helper_dispatch(self) -> None:
         action = self.default_issue_intake_claim_action()
-        pending_intent = {
-            "intent_id": "dispatch-consensus-implementation:77",
-            "task_id": "implement-issue-77",
-            "source": "wakeup-plan",
-            "route": "dispatch-consensus-implementation",
-            "queued_at": "2026-06-01T00:00:00Z",
-            "log": ".refactor-loop/logs/implement-issue-77.log",
-        }
-        self.ctx.paths.pending_events.write_text(
-            f"2026-06-01T00:00:00Z HARNESS_SPAWN_INTENT {json.dumps(pending_intent, sort_keys=True)}\n",
-            encoding="utf-8",
-        )
+        begin_tick(self.repo, "phase9_router_daemon", now=1000, pid=42)
         actions = FakeActions()
 
         result = self.run_result(self.base_plan(action), gh_labels=[], actions=actions)

--- a/skills/consensus-loop/scripts/test_wakeup_runner.py
+++ b/skills/consensus-loop/scripts/test_wakeup_runner.py
@@ -450,7 +450,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual("applied", result[0].status)
         self.assertEqual([("apply_default_issue_intake_claim", 77)], actions.calls)
 
-    def test_apply_default_issue_intake_claim_revalidates_admission_before_helper_dispatch(self) -> None:
+    def test_apply_default_issue_intake_claim_revalidates_active_design_cap_before_helper_dispatch(self) -> None:
         action = {
             "kind": "default-issue-intake-claim",
             "action_id": "default-issue-intake-claim:issue:77",
@@ -553,7 +553,7 @@ class WakeupRunnerBehaviorTests(unittest.TestCase):
         self.assertEqual("default_issue_intake_admission:claim_cooldown_active", result[0].reason)
         self.assertEqual([], actions.calls)
 
-    def test_apply_default_issue_intake_claim_revalidates_admission_before_helper_dispatch(self) -> None:
+    def test_apply_default_issue_intake_claim_revalidates_daemon_progress_before_helper_dispatch(self) -> None:
         action = self.default_issue_intake_claim_action()
         begin_tick(self.repo, "phase9_router_daemon", now=1000, pid=42)
         actions = FakeActions()


### PR DESCRIPTION
## 动机
`#973`:`default_issue_intake_admission.py::_upstream_state()` 以 `_live_pending_spawn_intents()` 二元闸开头——只要有任一在途 live spawn intent,整个 admission 即以 `upstream_not_idle` 拒绝所有新 default issue intake。结果 intake 退化为「1 issue / 完整生命周期」串行消化,`DEFAULT_ISSUE_INTAKE_ACTIVE_DESIGN_CAP=3` 形同虚设,backlog 永远到不了 >1 并发。

## 改动
移除该二元分支,使 `_upstream_state()` 只读 `UPSTREAM_PROGRESS_DAEMONS`(`phase9_router_daemon`、`concurrency_monitor`)的 mid-tick 进度闸,其余返回 `upstream_idle`。并发上限单一归口 `active_design_cap`,时间节流归 cooldown(3600s),worker 进程背压归 `concurrency_monitor`/`CODEX_FLOOR`,上游 producer 进度归 `UPSTREAM_PROGRESS_DAEMONS`——消除对同一并发量的第二授权,并解除把非 design(PR review/fix)负载误耦合进 design intake 的错误背压。

随之失效的本地 helper(`_live_pending_spawn_intents`、`_open_managed_targets`、`_item_number`)及未用 import(`_harness_spawn_intent_target`)一并删除;`pending_spawn_intents` 构造参数与 `proof["pending_spawn_intents"]` 计数保留为只读诊断。`evaluate()` 顺序、reason 字符串、`ADMISSION_PRECONDITIONS`、#969 自闸排除不变。

## 范围
4 文件(1 source + 3 test),纯收窄,无新 host knob / 无新授权 / 无 escape-hatch,保持 fail-closed 与英文源码。

## 验证
- 行为测试复现旧串行死锁(在途 live intent + cap 有余 → 旧码 `upstream_not_idle` 拒绝)并断言修复(现 admit 至 `active_design_cap`);新增 cap 测试证明 `active_design_cap_reached` 仍优先;`wakeup_runner` 预派发复验改由真实 daemon-progress-incomplete 触发;daemon-progress 与 #969 排除测试保持不变。
- focused 套件 `test_default_issue_intake_admission.py` + `test_wakeup_plan.py` + `test_wakeup_runner.py`:**567 passed**。
- 经 sshx inline 共识产出:thinking 三元组(minimal/structural/delete)一致 propose、单一收敛 plan;review 三元组(architecture/quality/tests)一致 approve(tests reviewer 复跑 567 passed 并确认回归测试非同义反复)。

Closes #973

⟦AI:AUTO-LOOP⟧
