### PR TITLE
为 monitor-bridge-filter 增加有界去重

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/monitor_bridge.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/monitor_bridge.py
@@ -5,15 +5,24 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from collections import deque
 from collections.abc import Iterable, Sequence
 from typing import TextIO
 
 
+RECENT_KEY_LIMIT = 128
 TAIL_HEADER_RE = re.compile(r"^==> .+ <==$")
 RUNNER_BLOCKER_RE = re.compile(
     r"\bWAKEUP_RUNNER_BLOCKED:[^\s]*:(?:target_log_exists|target_not_open)(?::|\s|$)"
 )
 ZERO_STREAK_RE = re.compile(r'(?:"zero_streak"\s*:\s*|\bzero_streak=)(-?\d+)')
+LEADING_TIMESTAMP_RE = re.compile(
+    r"^(?:"
+    r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\]\s*"
+    r"|"
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\s+"
+    r")"
+)
 
 
 def raw_p0_zero_streak(line: str) -> int | None:
@@ -24,6 +33,10 @@ def raw_p0_zero_streak(line: str) -> int | None:
 
 
 def should_forward_line(line: str) -> bool:
+    return _should_forward_line_stateless(line)
+
+
+def _should_forward_line_stateless(line: str) -> bool:
     stripped = line.strip()
     if not stripped:
         return False
@@ -43,13 +56,53 @@ def should_forward_line(line: str) -> bool:
     return True
 
 
+def _recent_key_for_line(line: str) -> str | None:
+    output_line = line.rstrip("\n")
+    stripped = output_line.strip()
+    if stripped.startswith("DEV_SYNC_PENDING:"):
+        return f"pending:{output_line}"
+    if "P0 no-gap-violation" in stripped:
+        stable_body = LEADING_TIMESTAMP_RE.sub("", stripped, count=1)
+        return f"raw-p0:{stable_body}"
+    return None
+
+
+class MonitorBridgeFilter:
+    def __init__(self, recent_key_limit: int = RECENT_KEY_LIMIT) -> None:
+        self._recent_key_limit = recent_key_limit
+        self._recent_keys: deque[str] = deque()
+        self._recent_key_set: set[str] = set()
+
+    def should_forward(self, line: str) -> bool:
+        if not _should_forward_line_stateless(line):
+            return False
+
+        recent_key = _recent_key_for_line(line)
+        if recent_key is None:
+            return True
+        return self._remember_recent_key(recent_key)
+
+    def _remember_recent_key(self, key: str) -> bool:
+        if key in self._recent_key_set:
+            return False
+
+        self._recent_keys.append(key)
+        self._recent_key_set.add(key)
+        while len(self._recent_keys) > self._recent_key_limit:
+            old_key = self._recent_keys.popleft()
+            self._recent_key_set.discard(old_key)
+        return True
+
+
 def filtered_lines(lines: Iterable[str]) -> list[str]:
-    return [line.rstrip("\n") for line in lines if should_forward_line(line)]
+    monitor_filter = MonitorBridgeFilter()
+    return [line.rstrip("\n") for line in lines if monitor_filter.should_forward(line)]
 
 
 def filter_stream(source: TextIO, destination: TextIO) -> None:
+    monitor_filter = MonitorBridgeFilter()
     for line in source:
-        if should_forward_line(line):
+        if monitor_filter.should_forward(line):
             destination.write(line.rstrip("\n") + "\n")
             destination.flush()
 

--- a/skills/consensus-loop/scripts/test_monitor_bridge.py
+++ b/skills/consensus-loop/scripts/test_monitor_bridge.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import unittest
@@ -96,6 +97,73 @@ class MonitorBridgeFilterTests(unittest.TestCase):
                 [
                     "[2026-06-13T00:00:00Z] P0 no-gap-violation | detail={\"zero_streak\": 1}",
                     "2026-06-13T00:02:00Z SOLVER_DONE:issue-890:structural:propose",
+                    "",
+                ]
+            ),
+            result.stdout,
+        )
+
+    def test_cli_suppresses_duplicate_dev_sync_pending_events(self) -> None:
+        event = "DEV_SYNC_PENDING:rollup-adoption-rebase-ambiguous:stale-adoption-operation"
+        payload = "\n".join(
+            [
+                event,
+                event,
+                "DEV_SYNC_PENDING:rollup-adoption-rebase-ambiguous:missing-head-or-remote",
+                "2026-06-13T00:03:00Z new-team-comment 42 maintainer 99",
+                "",
+            ]
+        )
+
+        result = subprocess.run(
+            [sys.executable, str(CLI), "monitor-bridge-filter"],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            "\n".join(
+                [
+                    event,
+                    "DEV_SYNC_PENDING:rollup-adoption-rebase-ambiguous:missing-head-or-remote",
+                    "2026-06-13T00:03:00Z new-team-comment 42 maintainer 99",
+                    "",
+                ]
+            ),
+            result.stdout,
+        )
+
+    def test_cli_suppresses_raw_p0_duplicate_after_timestamp_normalization(self) -> None:
+        base_detail = {"zero_streak": 1, "issue_breakdown": {"996": 1}, "severity": "P0"}
+        changed_detail = {"zero_streak": 1, "issue_breakdown": {"997": 1}, "severity": "P0"}
+        payload = "\n".join(
+            [
+                f"[2026-06-13T00:00:00Z] P0 no-gap-violation | detail={json.dumps(base_detail, sort_keys=True)}",
+                f"[2026-06-13T00:01:00Z] P0 no-gap-violation | detail={json.dumps(base_detail, sort_keys=True)}",
+                f"[2026-06-13T00:02:00Z] P0 no-gap-violation | detail={json.dumps(changed_detail, sort_keys=True)}",
+                f"[2026-06-13T00:03:00Z] P0 no-gap-violation | detail={json.dumps({**base_detail, 'zero_streak': 5}, sort_keys=True)}",
+                "",
+            ]
+        )
+
+        result = subprocess.run(
+            [sys.executable, str(CLI), "monitor-bridge-filter"],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            "\n".join(
+                [
+                    f"[2026-06-13T00:00:00Z] P0 no-gap-violation | detail={json.dumps(base_detail, sort_keys=True)}",
+                    f"[2026-06-13T00:02:00Z] P0 no-gap-violation | detail={json.dumps(changed_detail, sort_keys=True)}",
+                    f"[2026-06-13T00:03:00Z] P0 no-gap-violation | detail={json.dumps({**base_detail, 'zero_streak': 5}, sort_keys=True)}",
                     "",
                 ]
             ),

--- a/skills/consensus-loop/scripts/test_monitor_bridge.py
+++ b/skills/consensus-loop/scripts/test_monitor_bridge.py
@@ -13,7 +13,11 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from codex_refactor_loop.monitor_bridge import filtered_lines, should_forward_line
+from codex_refactor_loop.monitor_bridge import (
+    MonitorBridgeFilter,
+    filtered_lines,
+    should_forward_line,
+)
 
 
 CLI = SCRIPT_DIR / "consensus-rnd-cli"
@@ -134,6 +138,23 @@ class MonitorBridgeFilterTests(unittest.TestCase):
                 ]
             ),
             result.stdout,
+        )
+
+    def test_recent_key_dedup_re_forwards_after_bounded_window_eviction(self) -> None:
+        first_event = "DEV_SYNC_PENDING:rollup-adoption-rebase-ambiguous:stale-adoption-operation"
+        second_event = "DEV_SYNC_PENDING:rollup-adoption-rebase-ambiguous:missing-head-or-remote"
+        third_event = "DEV_SYNC_PENDING:rollup-adoption-rebase-ambiguous:pending-review"
+        monitor_filter = MonitorBridgeFilter(recent_key_limit=2)
+
+        forwarded = [
+            line
+            for line in [first_event, first_event, second_event, third_event, first_event]
+            if monitor_filter.should_forward(line)
+        ]
+
+        self.assertEqual(
+            [first_event, second_event, third_event, first_event],
+            forwarded,
         )
 
     def test_cli_suppresses_raw_p0_duplicate_after_timestamp_normalization(self) -> None:


### PR DESCRIPTION
## Changed files

- `skills/consensus-loop/scripts/codex_refactor_loop/monitor_bridge.py`: 增加进程内有界 recent-key 去重。`DEV_SYNC_PENDING:*` 重复行只转发首次;raw `P0 no-gap-violation` 只剥离受控行首 timestamp 后比较稳定 body,仍保留 changed breakdown 和 zero-streak escalation。
- `skills/consensus-loop/scripts/test_monitor_bridge.py`: 增加 CLI stdin 行为测试,覆盖 duplicate pending event、timestamp-only raw P0 duplicate、changed P0 breakdown、zero_streak escalation 和 `new-team-comment` 继续转发。

## Test results

- `python3 -m unittest skills/consensus-loop/scripts/test_monitor_bridge.py`: 先红后绿,最终 7 tests OK。
- `PATH="/opt/homebrew/bin:$PATH" /opt/homebrew/bin/python3 skills/consensus-loop/scripts/consensus-rnd-cli check-degradation --static`: `skill-degradation: ok`。
- `PATH="/opt/homebrew/bin:$PATH" /opt/homebrew/bin/python3 -m unittest discover -s skills/consensus-loop/scripts -p "test_*.py"`: 2495 tests OK, skipped=1。

## Deviations

- `HOST_REFACTOR_COMMENT_POLICY=none`,未添加 refactor self-documentation source comments。
- 未扩展 scope;未运行 git/GitHub lifecycle 操作。
- Closes #996

⟦AI:AUTO-LOOP⟧
