### PR TITLE
修复 verbose solver marker 误判

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/worker_markers.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/worker_markers.py
@@ -24,6 +24,7 @@ DONE_PREFIXES = (
 DONE_PREFIX_RE = re.compile(r"^(?:" + "|".join(re.escape(prefix) for prefix in DONE_PREFIXES) + r")(?::[^\s`]+)*$")
 GENERIC_DONE_PREFIX_RE = re.compile(r"^[A-Z][A-Z0-9_]*(?:_DONE|_RESOLVED|_BLOCKED)$")
 REVIEW_DONE_STRICT_RE = re.compile(r"^REVIEW_DONE:[1-9][0-9]*:[A-Za-z][A-Za-z0-9_-]*:(?:approve|comment|reject)(?::real)?$")
+ANGLE_PLACEHOLDER_FIELD_RE = re.compile(r"^<[^<>\n]+>$")
 IMPLEMENT_DONE_STATUSES = {"ok", "partial", "blocked"}
 IMPLEMENT_LOG_RE = re.compile(r"^implement-(?:issue-)?[A-Za-z0-9._-]+\.log$")
 SOLVER_LOG_RE = re.compile(r"^(?:" + "phase9-" + r"|solver-)issue[1-9][0-9]*-r[1-9][0-9]*-(?:minimal|structural|delete)\.log$")
@@ -83,7 +84,7 @@ def extract_standalone_marker(text: str) -> str:
     stripped = _normalized_marker_candidate(text)
     if not stripped:
         return ""
-    if "<" in stripped and ">" in stripped:
+    if _has_unreplaced_marker_template_field(stripped):
         return ""
     if stripped.startswith("REVIEW_DONE:"):
         return stripped if REVIEW_DONE_STRICT_RE.fullmatch(stripped) else ""
@@ -100,7 +101,7 @@ def _extract_generic_standalone_marker(text: str) -> str:
     stripped = _normalized_marker_candidate(text)
     if not stripped:
         return ""
-    if "<" in stripped and ">" in stripped:
+    if _has_unreplaced_marker_template_field(stripped):
         return ""
     parts = stripped.split(":")
     if len(parts) >= 2 and GENERIC_DONE_PREFIX_RE.fullmatch(parts[0]):
@@ -110,13 +111,25 @@ def _extract_generic_standalone_marker(text: str) -> str:
 
 def _malformed_standalone_marker(text: str) -> bool:
     stripped = _normalized_marker_candidate(text)
-    if not stripped or ("<" in stripped and ">" in stripped):
+    if not stripped:
         return False
+    if _has_unreplaced_marker_template_field(stripped):
+        return True
     if stripped.startswith("REVIEW_DONE:"):
         return REVIEW_DONE_STRICT_RE.fullmatch(stripped) is None
     if stripped.startswith("IMPLEMENT_DONE:"):
         return _reject_malformed_implement_marker(stripped)
     return False
+
+
+def _has_unreplaced_marker_template_field(marker: str) -> bool:
+    parts = marker.split(":")
+    if len(parts) < 2:
+        return False
+    prefix = parts[0]
+    if prefix not in DONE_PREFIXES and GENERIC_DONE_PREFIX_RE.fullmatch(prefix) is None:
+        return False
+    return any(ANGLE_PLACEHOLDER_FIELD_RE.fullmatch(part.strip()) is not None for part in parts[1:])
 
 
 def _normalized_marker_candidate(text: str) -> str:
@@ -143,6 +156,8 @@ def _marker_from_clean_log_lines(lines: list[str], log_name: str) -> WorkerMarke
     except ValueError:
         return WorkerMarkerRead()
     before_exit = lines[:exit_index]
+    if _solver_log_role(log_name) is not None:
+        return _solver_tail_marker(before_exit, log_name)
     return _marker_from_log_tail_lines(before_exit[-MARKER_TAIL_LINES:], log_name)
 
 

--- a/skills/consensus-loop/scripts/test_phase9_router_package.py
+++ b/skills/consensus-loop/scripts/test_phase9_router_package.py
@@ -162,6 +162,28 @@ class Phase9RouterPackageTests(unittest.TestCase):
         self.assertEqual(self.commands[0]["command"], "spawn-codex")
         self.assertEqual([entry["key"] for entry in self.ledger_entries()], ["160-3-judge"])
 
+    def test_package_router_dispatches_judge_for_verbose_solver_marker_triplet(self) -> None:
+        marker_text = "SOLVER_DONE:minimal:propose:accept rollup/<current integration sha> only"
+        self.write_log(
+            "phase9-issue997-r1-minimal.log",
+            "worker summary begins",
+            marker_text,
+            *[f"verbose diagnostic line {index}" for index in range(40)],
+            f"+{marker_text}",
+            f"prose repeats `{marker_text}` as context",
+            "worker output footer",
+        )
+        self.write_log("phase9-issue997-r1-structural.log", "SOLVER_DONE:structural:propose:structural-summary")
+        self.write_log("phase9-issue997-r1-delete.log", "SOLVER_DONE:delete:abstain:no-delete")
+
+        self.router.tick()
+
+        self.assertEqual(len(self.commands), 1)
+        joined = self.intent_text(self.commands[0])
+        self.assertIn("phase9-issue997-r1-judge.log", joined)
+        self.assertEqual(self.commands[0]["command"], "spawn-codex")
+        self.assertEqual([entry["key"] for entry in self.ledger_entries()], ["997-1-judge"])
+
     def test_package_router_design_issue_intake_dispatches_r1_triplet(self) -> None:
         rows = [
             {

--- a/skills/consensus-loop/scripts/test_worker_markers.py
+++ b/skills/consensus-loop/scripts/test_worker_markers.py
@@ -60,6 +60,60 @@ class WorkerMarkerReaderTests(unittest.TestCase):
             self.assertEqual(marker.marker, "SOLVER_DONE:minimal:propose:shared-reader")
             self.assertEqual(marker.source, "log")
 
+    def test_reads_verbose_solver_marker_from_full_clean_log_before_exit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, runs = self.repo(tmp)
+            log = logs / "phase9-issue997-r1-minimal.log"
+            marker_text = "SOLVER_DONE:minimal:propose:accept rollup/<current integration sha> only"
+            verbose_lines = [f"verbose diagnostic line {index}" for index in range(40)]
+            log.write_text(
+                "\n".join(
+                    [
+                        "worker summary begins",
+                        marker_text,
+                        *verbose_lines,
+                        f"+{marker_text}",
+                        f"prose repeats `{marker_text}` as context",
+                        "worker output footer",
+                        "EXIT=0",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (runs / "phase9-issue997-r1-minimal.md").write_text(
+                "\n".join(
+                    [
+                        "## result",
+                        marker_text,
+                        "⟦AI:AUTO-LOOP⟧",
+                        marker_text,
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            marker = read_worker_terminal_marker(log)
+
+            self.assertTrue(marker.found)
+            self.assertEqual(marker.marker, marker_text)
+            self.assertEqual(marker.source, "log")
+            self.assertEqual(marker.reason, "")
+
+    def test_solver_marker_allows_angle_brackets_in_summary_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, _runs = self.repo(tmp)
+            log = logs / "phase9-issue997-r1-minimal.log"
+            marker_text = "SOLVER_DONE:minimal:propose:accept rollup/<current integration sha> only"
+            log.write_text(f"{marker_text}\nEXIT=0\n", encoding="utf-8")
+
+            marker = read_worker_terminal_marker(log)
+
+            self.assertTrue(marker.found)
+            self.assertEqual(marker.marker, marker_text)
+            self.assertEqual(marker.reason, "")
+
     def test_solver_marker_tail_requires_unique_role_matching_standalone_marker(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             logs, _runs = self.repo(tmp)


### PR DESCRIPTION
## Changed files
- `worker_markers.py`: solver clean log 改为扫描 `EXIT=0` 前的 role-matching column-zero raw `SOLVER_DONE:<role>:`，并保留 wrong-role、模板占位符、多个不同 marker 的 fail-closed。
- `test_worker_markers.py`: 增加 verbose-but-valid solver marker 与 summary angle-bracket payload 回归测试。
- `test_phase9_router_package.py`: 增加三 solver 中一个 verbose marker 仍 dispatch judge 的回归。

## Test results
- `check-degradation --static`: passed.
- `pytest test_worker_markers.py`: 23 passed.
- `pytest test_phase9_router_package.py`: 30 passed.
- `pytest test_phase9_router_daemon.py`: 113 passed.
- `unittest discover`: 2499 passed, 1 skipped.

## Deviations
- 无 scope expansion。
- `HOST_REFACTOR_COMMENT_POLICY=none`，未新增 refactor-history source comments。
- Closes #997

⟦AI:AUTO-LOOP⟧
