### PR TITLE
修复 marker-reader 终态卡死:按 filename 预期角色过滤 solver log 同列 SOLVER_DONE (Closes #1005)

### DIFF
--- a/skills/consensus-loop/prompts/solver-delete.md
+++ b/skills/consensus-loop/prompts/solver-delete.md
@@ -120,6 +120,8 @@ End with EXACTLY ONE marker line:
 - `SOLVER_DONE:delete:escalate:no-plan:<reason>` — no deletion/collapse/abstain classification can be produced
 - `SOLVER_DONE:delete:false-positive:<reason>`
 
+Emit the final `SOLVER_DONE:delete:...` marker exactly once, as the last line, at the very end; never print a draft or column-zero `SOLVER_DONE` marker mid-reasoning.
+
 ## Marker emission allowlist(强制)
 
 <!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->

--- a/skills/consensus-loop/prompts/solver-minimal.md
+++ b/skills/consensus-loop/prompts/solver-minimal.md
@@ -94,6 +94,8 @@ End with EXACTLY ONE marker line:
 - `SOLVER_DONE:minimal:escalate:no-plan:<reason>` — no concrete minimal plan can be produced
 - `SOLVER_DONE:minimal:false-positive:<reason>` — violation already fixed / misreported
 
+Emit the final `SOLVER_DONE:minimal:...` marker exactly once, as the last line, at the very end; never print a draft or column-zero `SOLVER_DONE` marker mid-reasoning.
+
 ## Marker emission allowlist(强制)
 
 <!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->

--- a/skills/consensus-loop/prompts/solver-structural.md
+++ b/skills/consensus-loop/prompts/solver-structural.md
@@ -102,6 +102,8 @@ End with EXACTLY ONE marker line:
 - `SOLVER_DONE:structural:escalate:no-plan:<reason>`
 - `SOLVER_DONE:structural:false-positive:<reason>`
 
+Emit the final `SOLVER_DONE:structural:...` marker exactly once, as the last line, at the very end; never print a draft or column-zero `SOLVER_DONE` marker mid-reasoning.
+
 ## Marker emission allowlist(强制)
 
 <!-- MarkerEmissionContract: single-valid-invalid-role-marker-source -->

--- a/skills/consensus-loop/scripts/codex_refactor_loop/worker_markers.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/worker_markers.py
@@ -53,6 +53,10 @@ def read_worker_terminal_marker(log_path: Path) -> WorkerMarkerRead:
         return WorkerMarkerRead(reason="missing_exit_zero")
     log_marker = _marker_from_clean_log_lines(lines, log_path.name)
     if log_marker.found or log_marker.reason:
+        if log_marker.reason == "duplicate_or_conflicting_log_marker":
+            artifact_marker = _solver_conflict_disambiguated_by_companion_artifact(lines, log_path)
+            if artifact_marker.found:
+                return artifact_marker
         return log_marker
     artifact_marker = _marker_from_companion_artifact(log_path)
     if artifact_marker.found or artifact_marker.reason:
@@ -177,23 +181,43 @@ def _solver_tail_marker(lines: list[str], log_name: str) -> WorkerMarkerRead:
     role = _solver_log_role(log_name)
     if role is None:
         return WorkerMarkerRead()
-    if any(_malformed_raw_solver_marker(line) for line in lines):
+    if any(_malformed_expected_role_solver_marker(line, role) for line in lines):
         return WorkerMarkerRead(reason="malformed_log_marker")
     markers = [marker for marker in (_extract_raw_solver_marker(line) for line in lines) if marker]
-    solver_markers = [marker for marker in markers if marker.startswith("SOLVER_DONE:")]
-    if not solver_markers:
-        if markers:
-            return WorkerMarkerRead(reason="duplicate_or_conflicting_log_marker")
-        return WorkerMarkerRead()
     expected_prefix = f"SOLVER_DONE:{role}:"
-    if any(not marker.startswith(expected_prefix) for marker in solver_markers):
-        return WorkerMarkerRead(reason="duplicate_or_conflicting_log_marker")
+    solver_markers = [marker for marker in markers if marker.startswith(expected_prefix)]
+    if not solver_markers:
+        return WorkerMarkerRead()
     if any(not marker.startswith("SOLVER_DONE:") for marker in markers):
         return WorkerMarkerRead(reason="duplicate_or_conflicting_log_marker")
     unique = set(solver_markers)
     if len(unique) != 1:
         return WorkerMarkerRead(reason="duplicate_or_conflicting_log_marker")
     return WorkerMarkerRead(marker=solver_markers[-1], source="log")
+
+
+def _solver_conflict_disambiguated_by_companion_artifact(lines: list[str], log_path: Path) -> WorkerMarkerRead:
+    role = _solver_log_role(log_path.name)
+    if role is None:
+        return WorkerMarkerRead()
+    try:
+        exit_index = max(index for index, line in enumerate(lines) if line.strip() == "EXIT=0")
+    except ValueError:
+        return WorkerMarkerRead()
+    before_exit = lines[:exit_index]
+    if any(_malformed_expected_role_solver_marker(line, role) for line in before_exit):
+        return WorkerMarkerRead()
+    raw_markers = [marker for marker in (_extract_raw_solver_marker(line) for line in before_exit) if marker]
+    expected_prefix = f"SOLVER_DONE:{role}:"
+    same_role_markers = [marker for marker in raw_markers if marker.startswith(expected_prefix)]
+    if len(set(same_role_markers)) < 2:
+        return WorkerMarkerRead()
+    artifact_marker = _marker_from_companion_artifact(log_path)
+    if not artifact_marker.found:
+        return WorkerMarkerRead()
+    if artifact_marker.marker != same_role_markers[-1]:
+        return WorkerMarkerRead()
+    return artifact_marker
 
 
 def _solver_log_role(log_name: str) -> str | None:
@@ -212,6 +236,12 @@ def _extract_raw_solver_marker(text: str) -> str:
 
 def _malformed_raw_solver_marker(text: str) -> bool:
     if not text.startswith("SOLVER_DONE:"):
+        return False
+    return extract_standalone_marker(text) == ""
+
+
+def _malformed_expected_role_solver_marker(text: str, role: str) -> bool:
+    if not text.startswith(f"SOLVER_DONE:{role}:"):
         return False
     return extract_standalone_marker(text) == ""
 

--- a/skills/consensus-loop/scripts/test_worker_markers.py
+++ b/skills/consensus-loop/scripts/test_worker_markers.py
@@ -114,12 +114,12 @@ class WorkerMarkerReaderTests(unittest.TestCase):
             self.assertEqual(marker.marker, marker_text)
             self.assertEqual(marker.reason, "")
 
-    def test_solver_marker_tail_requires_unique_role_matching_standalone_marker(self) -> None:
+    def test_solver_marker_tail_requires_unique_expected_role_marker(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             logs, _runs = self.repo(tmp)
-            wrong_role = logs / "phase9-issue659-r2-minimal.log"
-            wrong_role.write_text(
-                "SOLVER_DONE:structural:propose:wrong-role\n"
+            other_role_only = logs / "phase9-issue659-r2-minimal.log"
+            other_role_only.write_text(
+                "SOLVER_DONE:structural:propose:other-role-noise\n"
                 "EXIT=0\n",
                 encoding="utf-8",
             )
@@ -132,13 +132,34 @@ class WorkerMarkerReaderTests(unittest.TestCase):
             )
 
             self.assertEqual(
-                read_worker_terminal_marker(wrong_role).reason,
-                "duplicate_or_conflicting_log_marker",
+                read_worker_terminal_marker(other_role_only).reason,
+                "marker_missing",
             )
             self.assertEqual(
                 read_worker_terminal_marker(conflict).reason,
                 "duplicate_or_conflicting_log_marker",
             )
+
+    def test_solver_log_ignores_stray_other_role_and_returns_expected_log_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, _runs = self.repo(tmp)
+            log = logs / "phase9-issue1004-r2-minimal.log"
+            expected_marker = "SOLVER_DONE:minimal:propose:sync-claude-skill-mirror"
+            log.write_text(
+                "worker quotes peer output\n"
+                "SOLVER_DONE:structural:propose:example-peer-marker\n"
+                "worker own verdict\n"
+                f"{expected_marker}\n"
+                "EXIT=0\n",
+                encoding="utf-8",
+            )
+
+            marker = read_worker_terminal_marker(log)
+
+            self.assertTrue(marker.found)
+            self.assertEqual(marker.marker, expected_marker)
+            self.assertEqual(marker.source, "log")
+            self.assertEqual(marker.reason, "")
 
     def test_solver_log_ignores_diff_added_replay_and_uses_same_stem_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -163,31 +184,34 @@ class WorkerMarkerReaderTests(unittest.TestCase):
             self.assertEqual(marker.source, "artifact")
             self.assertEqual(marker.reason, "")
 
-    def test_solver_log_raw_wrong_role_marker_blocks_artifact_fallback(self) -> None:
+    def test_solver_log_other_role_only_uses_expected_role_artifact_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             logs, runs = self.repo(tmp)
             log = logs / "phase9-issue952-r2-minimal.log"
+            expected_marker = "SOLVER_DONE:minimal:propose:artifact"
             log.write_text(
-                "SOLVER_DONE:structural:propose:wrong-role\n"
+                "SOLVER_DONE:structural:propose:other-role-noise\n"
                 "EXIT=0\n",
                 encoding="utf-8",
             )
             (runs / "phase9-issue952-r2-minimal.md").write_text(
-                "SOLVER_DONE:minimal:propose:artifact\n",
+                f"{expected_marker}\n",
                 encoding="utf-8",
             )
 
             marker = read_worker_terminal_marker(log)
 
-            self.assertFalse(marker.found)
-            self.assertEqual(marker.reason, "duplicate_or_conflicting_log_marker")
+            self.assertTrue(marker.found)
+            self.assertEqual(marker.marker, expected_marker)
+            self.assertEqual(marker.source, "artifact")
+            self.assertEqual(marker.reason, "")
 
     def test_solver_log_raw_malformed_marker_blocks_artifact_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             logs, runs = self.repo(tmp)
             log = logs / "phase9-issue952-r2-minimal.log"
             log.write_text(
-                "SOLVER_DONE:<role>:<verdict>:<summary>\n"
+                "SOLVER_DONE:minimal:<verdict>:<summary>\n"
                 "EXIT=0\n",
                 encoding="utf-8",
             )
@@ -200,6 +224,209 @@ class WorkerMarkerReaderTests(unittest.TestCase):
 
             self.assertFalse(marker.found)
             self.assertEqual(marker.reason, "malformed_log_marker")
+
+    def test_verbose_solver_conflict_uses_companion_when_it_matches_last_same_role_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, runs = self.repo(tmp)
+            log = logs / "phase9-issue1005-r1-delete.log"
+            early_marker = "SOLVER_DONE:delete:propose:delete-draft"
+            final_marker = "SOLVER_DONE:delete:abstain:no-deletion-strict-marker-guard-needs-narrow-companion-disambiguation"
+            log.write_text(
+                "\n".join(
+                    [
+                        "worker reasoning",
+                        early_marker,
+                        "more reasoning",
+                        f"+{final_marker}",
+                        "artifact diff replay is not a raw solver marker",
+                        final_marker,
+                        "tokens used",
+                        "EXIT=0",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (runs / "phase9-issue1005-r1-delete.md").write_text(
+                "---\nverdict: abstain\n---\n"
+                "⟦AI:AUTO-LOOP⟧\n"
+                f"{final_marker}\n",
+                encoding="utf-8",
+            )
+
+            marker = read_worker_terminal_marker(log)
+
+            self.assertTrue(marker.found)
+            self.assertEqual(marker.marker, final_marker)
+            self.assertEqual(marker.source, "artifact")
+            self.assertEqual(marker.reason, "")
+
+    def test_verbose_solver_conflict_accepts_identical_duplicate_expected_role_companion_markers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, runs = self.repo(tmp)
+            log = logs / "phase9-issue1004-r2-minimal.log"
+            early_marker = "SOLVER_DONE:minimal:propose:early-release-proof"
+            final_marker = "SOLVER_DONE:minimal:propose:sync-claude-skill-mirror"
+            log.write_text(
+                "worker quotes peer output\n"
+                "SOLVER_DONE:structural:propose:quoted-peer-marker\n"
+                f"{early_marker}\n"
+                "more reasoning\n"
+                f"{final_marker}\n"
+                "EXIT=0\n",
+                encoding="utf-8",
+            )
+            (runs / "phase9-issue1004-r2-minimal.md").write_text(
+                "---\nverdict: propose\n---\n"
+                f"{final_marker}\n"
+                "⟦AI:AUTO-LOOP⟧\n"
+                f"{final_marker}\n",
+                encoding="utf-8",
+            )
+
+            marker = read_worker_terminal_marker(log)
+
+            self.assertTrue(marker.found)
+            self.assertEqual(marker.marker, final_marker)
+            self.assertEqual(marker.source, "artifact")
+            self.assertEqual(marker.reason, "")
+
+    def test_verbose_solver_conflict_ignores_other_role_and_uses_expected_role_companion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, runs = self.repo(tmp)
+            log = logs / "phase9-issue1004-r2-minimal.log"
+            early_marker = "SOLVER_DONE:minimal:propose:early-release-proof"
+            final_marker = "SOLVER_DONE:minimal:propose:sync-claude-skill-mirror"
+            log.write_text(
+                "worker quotes peer output\n"
+                "SOLVER_DONE:structural:propose:quoted-peer-marker\n"
+                f"{early_marker}\n"
+                "more reasoning\n"
+                f"{final_marker}\n"
+                "EXIT=0\n",
+                encoding="utf-8",
+            )
+            (runs / "phase9-issue1004-r2-minimal.md").write_text(
+                "---\nverdict: propose\n---\n"
+                f"{final_marker}\n",
+                encoding="utf-8",
+            )
+
+            marker = read_worker_terminal_marker(log)
+
+            self.assertTrue(marker.found)
+            self.assertEqual(marker.marker, final_marker)
+            self.assertEqual(marker.source, "artifact")
+            self.assertEqual(marker.reason, "")
+
+    def test_verbose_solver_conflict_fails_closed_when_companion_has_earlier_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, runs = self.repo(tmp)
+            log = logs / "phase9-issue1004-r2-minimal.log"
+            early_marker = "SOLVER_DONE:minimal:propose:early-release-proof"
+            final_marker = "SOLVER_DONE:minimal:propose:sync-claude-skill-mirror"
+            log.write_text(
+                f"{early_marker}\n"
+                "reasoning\n"
+                f"{final_marker}\n"
+                "EXIT=0\n",
+                encoding="utf-8",
+            )
+            (runs / "phase9-issue1004-r2-minimal.md").write_text(
+                f"{early_marker}\n",
+                encoding="utf-8",
+            )
+
+            marker = read_worker_terminal_marker(log)
+
+            self.assertFalse(marker.found)
+            self.assertEqual(marker.reason, "duplicate_or_conflicting_log_marker")
+
+    def test_verbose_solver_conflict_fails_closed_when_companion_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, _runs = self.repo(tmp)
+            log = logs / "phase9-issue1005-r1-delete.log"
+            log.write_text(
+                "SOLVER_DONE:delete:propose:draft\n"
+                "SOLVER_DONE:delete:abstain:final\n"
+                "EXIT=0\n",
+                encoding="utf-8",
+            )
+
+            marker = read_worker_terminal_marker(log)
+
+            self.assertFalse(marker.found)
+            self.assertEqual(marker.reason, "duplicate_or_conflicting_log_marker")
+
+    def test_verbose_solver_conflict_fails_closed_when_companion_has_distinct_markers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, runs = self.repo(tmp)
+            log = logs / "phase9-issue1005-r1-delete.log"
+            final_marker = "SOLVER_DONE:delete:abstain:final"
+            log.write_text(
+                "SOLVER_DONE:delete:propose:draft\n"
+                f"{final_marker}\n"
+                "EXIT=0\n",
+                encoding="utf-8",
+            )
+            (runs / "phase9-issue1005-r1-delete.md").write_text(
+                f"{final_marker}\n"
+                "SOLVER_DONE:delete:false-positive:other\n",
+                encoding="utf-8",
+            )
+
+            marker = read_worker_terminal_marker(log)
+
+            self.assertFalse(marker.found)
+            self.assertEqual(marker.reason, "duplicate_or_conflicting_log_marker")
+            self.assertNotEqual(marker.source, "artifact")
+
+    def test_solver_expected_role_malformed_or_conflicting_without_companion_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, _runs = self.repo(tmp)
+            conflict = logs / "phase9-issue1005-r1-delete.log"
+            conflict.write_text(
+                "SOLVER_DONE:minimal:propose:other-role-noise\n"
+                "SOLVER_DONE:delete:propose:draft\n"
+                "SOLVER_DONE:delete:abstain:final\n"
+                "EXIT=0\n",
+                encoding="utf-8",
+            )
+            malformed = logs / "phase9-issue1004-r2-minimal.log"
+            malformed.write_text(
+                "SOLVER_DONE:minimal:propose:draft\n"
+                "SOLVER_DONE:minimal:<verdict>:<summary>\n"
+                "EXIT=0\n",
+                encoding="utf-8",
+            )
+
+            conflict_marker = read_worker_terminal_marker(conflict)
+            malformed_marker = read_worker_terminal_marker(malformed)
+
+            self.assertFalse(conflict_marker.found)
+            self.assertEqual(conflict_marker.reason, "duplicate_or_conflicting_log_marker")
+            self.assertFalse(malformed_marker.found)
+            self.assertEqual(malformed_marker.reason, "malformed_log_marker")
+
+    def test_non_solver_log_conflict_does_not_use_companion_disambiguation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs, runs = self.repo(tmp)
+            log = logs / "implement-issue-1005.log"
+            log.write_text(
+                "IMPLEMENT_DONE:issue-1005:partial\n"
+                "IMPLEMENT_DONE:issue-1005:ok\n"
+                "EXIT=0\n",
+                encoding="utf-8",
+            )
+            (runs / "implement-issue-1005.md").write_text(
+                "IMPLEMENT_DONE:issue-1005:ok\n",
+                encoding="utf-8",
+            )
+
+            marker = read_worker_terminal_marker(log)
+
+            self.assertFalse(marker.found)
+            self.assertEqual(marker.reason, "duplicate_or_conflicting_log_marker")
 
     def test_reads_same_stem_artifact_when_log_markerless(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 摘要

修复 phase9 marker-reader 终态卡死:solver log 含其它角色的 column-zero `SOLVER_DONE` 行(solver 分析 marker/release 议题时引用/示例所致)被判 `duplicate_or_conflicting_log_marker`,router 随即发终态 `phase9-solver-markerless-exhausted`(restart 重新 seed),永久压制 triplet→judge。dogfood 实测卡死 #1004(release-publisher 修复,r2-minimal)与 #1005(本修复,r1-delete),并传递性卡死 beta.21 发布管线。

- **Old**:solver-log column-zero `SOLVER_DONE` 扫描不区分角色,任何多角色/冲突即 fail-closed,且 companion fallback 仅在 log marker 为空时触发。
- **New**:按 `_solver_log_role(filename)` 预期角色过滤同列 `SOLVER_DONE`,其它角色行视为推理噪声(不计冲突、不采信);预期角色单条干净→`source=log`,多条同角色冲突由 companion artifact 消歧(单一干净 marker == log 末条→`source=artifact`);malformed/无匹配 companion/companion 冲突/非 solver log 仍 fail-closed。并在 3 个 solver prompt 加“SOLVER_DONE 只在末尾输出一次”的卫生约束。

## anti-spoofing

filename 角色由 router dispatch 固定,router 仅按 `SOLVER_DONE:<filename-role>:` 计入裁决,故忽略其它角色行不削弱 anti-spoofing —— 任何 worker 无法伪造其它角色裁决。malformed / 预期角色冲突无 companion / companion mismatch / 非 solver 全部保持 fail-closed。

## 范围 / 验证

5 files changed (+282/-19):`worker_markers.py`、`test_worker_markers.py`、`solver-{minimal,structural,delete}.md`。
- 全量 `python3 -m unittest discover -s skills/consensus-loop/scripts -p 'test_*.py'`:**2510 tests OK**(skipped=1)。
- live 复现(修复后):`#1004-r2-minimal` → minimal final marker(source=artifact);`#1005-r1-delete` → delete marker(source=log)。

经 sshx 多角度共识(thinking triplet minimal/structural/delete + meta-judge + review triplet + fix + re-review,均经 nyxid codex 在隔离 worktree)。

Closes #1005

解除对 #1004 的传递性阻塞(合入并 restart-daemons 后,清除 #1004-r2 的 stale markerless-exhausted 事件即可让其 r2 judge 派发 → 共识 → 实现 → beta.21 发布)。

⟦AI:AUTO-LOOP⟧
