### PR TITLE
添加只读版本查询命令

### DIFF
--- a/skills/consensus-loop/scripts/codex_refactor_loop/cli.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/cli.py
@@ -28,6 +28,7 @@ from .runtime_retention import main as runtime_retention_main
 from .sync.dev import main as dev_sync_main
 from .phase9.router import main as phase9_router_main
 from .update_check import main as update_check_main
+from .version import main as version_main
 from .wakeup_plan import main as wakeup_plan_main
 from .wakeup_plan import revive_implements_main
 from .wakeup_runner import main as wakeup_runner_main
@@ -162,6 +163,11 @@ COMMANDS: dict[str, CommandSpec] = {
         update_check_main,
         "run the notify-only version update check probe",
         ("read-source", "read-gh", "write-state"),
+    ),
+    "version": CommandSpec(
+        version_main,
+        "print the installed consensus-loop version",
+        ("read-source",),
     ),
     "monitor-bridge-filter": CommandSpec(
         monitor_bridge.main,

--- a/skills/consensus-loop/scripts/codex_refactor_loop/update_check.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/update_check.py
@@ -63,6 +63,27 @@ class GitHubReleaseVersion:
     release_url: str | None = None
 
 
+def load_version_manifest(path: Path) -> dict[str, str]:
+    raw = read_json(path, None)
+    if not isinstance(raw, dict):
+        raise RuntimeError("VERSION.json is missing or invalid")
+    expected = {
+        "schema": "consensus-loop-version",
+        "release_source": "github-release-then-tag",
+        "install_hint": "host-owned",
+    }
+    for key, value in expected.items():
+        if raw.get(key) != value:
+            raise RuntimeError(f"VERSION.json {key} mismatch")
+    version = raw.get("version")
+    repository = raw.get("repository")
+    if not isinstance(version, str) or not version:
+        raise RuntimeError("VERSION.json version missing")
+    if not isinstance(repository, str) or "/" not in repository:
+        raise RuntimeError("VERSION.json repository missing")
+    return {"version": version, "repository": repository}
+
+
 class UpdateCheckProbe:
     """Read local version and GitHub release/tag state, then write local notice state.
 
@@ -132,24 +153,7 @@ class UpdateCheckProbe:
             )
 
     def _load_manifest(self) -> dict[str, str]:
-        raw = read_json(self.manifest_path, None)
-        if not isinstance(raw, dict):
-            raise RuntimeError("VERSION.json is missing or invalid")
-        expected = {
-            "schema": "consensus-loop-version",
-            "release_source": "github-release-then-tag",
-            "install_hint": "host-owned",
-        }
-        for key, value in expected.items():
-            if raw.get(key) != value:
-                raise RuntimeError(f"VERSION.json {key} mismatch")
-        version = raw.get("version")
-        repository = raw.get("repository")
-        if not isinstance(version, str) or not version:
-            raise RuntimeError("VERSION.json version missing")
-        if not isinstance(repository, str) or "/" not in repository:
-            raise RuntimeError("VERSION.json repository missing")
-        return {"version": version, "repository": repository}
+        return load_version_manifest(self.manifest_path)
 
     def _latest_release_version(self, repository: str, *, timeout: int) -> GitHubReleaseVersion:
         try:

--- a/skills/consensus-loop/scripts/codex_refactor_loop/version.py
+++ b/skills/consensus-loop/scripts/codex_refactor_loop/version.py
@@ -1,0 +1,29 @@
+"""Print the installed consensus-loop version."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .update_check import load_version_manifest
+
+
+def manifest_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "VERSION.json"
+
+
+def installed_version() -> str:
+    return load_version_manifest(manifest_path())["version"]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args(argv)
+    sys.stdout.write(installed_version() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/consensus-loop/scripts/test_cli_command_router.py
+++ b/skills/consensus-loop/scripts/test_cli_command_router.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest import mock
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.cli import COMMANDS, RuntimeCommandRouter
@@ -149,6 +150,7 @@ class RuntimeCommandRouterTests(unittest.TestCase):
                 "render-github-body",
                 "revive-implements",
                 "update-check",
+                "version",
             },
             set(COMMANDS),
         )
@@ -440,6 +442,74 @@ class RuntimeCommandRouterTests(unittest.TestCase):
     def test_update_check_declares_exact_notify_only_authority(self) -> None:
         self.assertEqual(("read-source", "read-gh", "write-state"), COMMANDS["update-check"].authority)
         self.assertFalse(set(COMMANDS["update-check"].authority) & LIFECYCLE_TOKENS)
+
+    def test_version_command_declares_read_source_only_authority(self) -> None:
+        self.assertEqual(("read-source",), COMMANDS["version"].authority)
+        forbidden = {
+            "read-gh",
+            "read-git",
+            "read-state",
+            "write-state",
+            "spawn",
+            "git-fetch",
+            "git-push",
+            "gh-open",
+            "gh-merge",
+            "gh-close",
+            "gh-label",
+            "controller-lifecycle-runner",
+        }
+        self.assertFalse(set(COMMANDS["version"].authority) & forbidden)
+
+    def test_version_cli_prints_only_manifest_version_without_update_check_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="version-cli-") as raw_tmp:
+            tmp = Path(raw_tmp)
+            repo = tmp / "repo"
+            repo.mkdir()
+            state_path = repo / ".refactor-loop" / "state" / "update-check.json"
+            state_path.parent.mkdir(parents=True)
+            state_path.write_text('{"status":"old"}\n', encoding="utf-8")
+            before_stat = state_path.stat()
+            fake_bin = tmp / "bin"
+            fake_bin.mkdir()
+            gh_marker = tmp / "gh-called"
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                f"#!/bin/sh\nprintf called > {gh_marker}\nexit 71\n",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+
+            result = subprocess.run(
+                [sys.executable, str(CLI), "version"],
+                cwd=repo,
+                env={
+                    "PATH": str(fake_bin),
+                    "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            expected_version = json.loads((REPO_ROOT / "skills/consensus-loop/VERSION.json").read_text(encoding="utf-8"))["version"]
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual(f"{expected_version}\n", result.stdout)
+            self.assertEqual("", result.stderr)
+            self.assertFalse(gh_marker.exists())
+            after_stat = state_path.stat()
+            self.assertEqual(before_stat.st_mtime_ns, after_stat.st_mtime_ns)
+            self.assertEqual('{"status":"old"}\n', state_path.read_text(encoding="utf-8"))
+
+    def test_version_is_positional_command_not_top_level_option(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(CLI), "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(2, result.returncode)
+        self.assertIn("unrecognized arguments: --version", result.stderr)
 
     def test_monitor_bridge_filter_declares_read_stdin_only_authority(self) -> None:
         self.assertEqual(("read-stdin",), COMMANDS["monitor-bridge-filter"].authority)

--- a/skills/consensus-loop/scripts/test_update_check.py
+++ b/skills/consensus-loop/scripts/test_update_check.py
@@ -19,7 +19,7 @@ REPO_ROOT = SCRIPT_DIR.parents[2]
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from codex_refactor_loop.context import LoopContext
-from codex_refactor_loop.update_check import UpdateCheckProbe
+from codex_refactor_loop.update_check import UpdateCheckProbe, load_version_manifest
 
 
 NOW = datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
@@ -114,6 +114,40 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertEqual("unknown", result["status"])
         self.assertIn("network down", result["reason"])
         self.assertEqual("unknown", self.read_state()["status"])
+
+    def test_valid_manifest_helper_returns_version_and_repository(self) -> None:
+        manifest = load_version_manifest(self.skill / "VERSION.json")
+
+        self.assertEqual("ChronoAIProject/consensus-rnd", manifest["repository"])
+        self.assertRegex(manifest["version"], r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+        self.assertEqual({"version", "repository"}, set(manifest))
+
+    def test_invalid_manifest_fails_before_update_check_runner(self) -> None:
+        self.write_host_env('export UPDATE_CHECK_ENABLE="true"\n')
+        (self.skill / "VERSION.json").write_text(
+            json.dumps(
+                {
+                    "schema": "wrong",
+                    "version": "1.0.0",
+                    "repository": "ChronoAIProject/consensus-rnd",
+                    "release_source": "github-release-then-tag",
+                    "install_hint": "host-owned",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        calls: list[list[str]] = []
+
+        result = UpdateCheckProbe(
+            self.ctx(),
+            now=lambda: NOW,
+            runner=lambda cmd: calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 0, "{}", ""),
+        ).maybe_run(startup=True)
+
+        self.assertEqual("unknown", result["status"])
+        self.assertIn("VERSION.json schema mismatch", result["reason"])
+        self.assertEqual([], calls)
 
     def test_manual_probe_reuses_fresh_state_before_interval(self) -> None:
         self.write_host_env('export UPDATE_CHECK_ENABLE="true"\nexport UPDATE_CHECK_INTERVAL_SECONDS="21600"\n')


### PR DESCRIPTION
## Changed files
- `update_check.py`: 抽出 `load_version_manifest(path)`，让 update-check 和新命令共享 `VERSION.json` 校验。
- `version.py` / `cli.py`: 新增 positional `consensus-rnd-cli version`，只声明 `("read-source",)` authority，只输出版本号加换行。
- `test_cli_command_router.py` / `test_update_check.py`: 覆盖 stdout 精确性、authority 收窄、无 gh/网络调用、无 update-check state 写入、manifest helper 复用和 invalid manifest fail-before-runner。

## Test results
- `check-degradation --static`: PASS。
- `test_cli_command_router.py`: 38 tests OK。
- `test_update_check.py`: 8 tests OK。
- Full unittest discover: 2548 tests OK, skipped=1。

## Deviations
- `HOST_REFACTOR_COMMENT_POLICY=none`，未添加 refactor-history source comments。
- `CI_GUARDS` 未配置，architecture guards 跳过。
- Closes #1020

⟦AI:AUTO-LOOP⟧
