### PR TITLE
发布 rollup: integration ahead 1 commits (ff9ff2528260)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "consensus-rnd",
       "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-      "version": "1.0.0-beta.23",
+      "version": "1.0.0-beta.24",
       "source": "./",
       "author": {
         "name": "auric",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎，可注入 host 仓库做 repo-owned managed GitHub issue/PR 自治解决循环；audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "author": {
     "name": "auric",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "consensus-rnd",
   "displayName": "Consensus R&D",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "license": "MIT",
   "author": "auric <loning.ma@aelf.io>",

--- a/skills/consensus-loop/VERSION.json
+++ b/skills/consensus-loop/VERSION.json
@@ -1,6 +1,6 @@
 {
   "schema": "consensus-loop-version",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "repository": "ChronoAIProject/consensus-rnd",
   "release_source": "github-release-then-tag",
   "install_hint": "host-owned"


### PR DESCRIPTION
### 发布 rollup

- 目标: `auto-refact-dev` -> `dev`
- 集成分支领先 review-base: `1` commits
- 范围: `e1fa53ca6b7b..ff9ff2528260`

### commit 摘要

- Release v1.0.0-beta.24

### 合并策略

- required checks 全绿后由 controller 自动 squash merge; `ROLLUP_AUTO_MERGE=manual` 时等待人工 review/merge。
- 该 PR 是 release rollup singleton;已有 open rollup 时 controller 只更新 head 和 body,不开新 PR。

⟦AI:RELEASE-ROLLUP⟧
⟦AI:AUTO-LOOP⟧
