### PR TITLE
锁定 publish verification quarantine 不写 repo-root marker

### DIFF
--- a/skills/consensus-loop/scripts/test_publish_verification.py
+++ b/skills/consensus-loop/scripts/test_publish_verification.py
@@ -385,9 +385,11 @@ class PublishVerificationTests(unittest.TestCase):
     def test_failed_receipts_use_per_job_retry_schedule_then_quarantine(self) -> None:
         result = self._prepared_job_without_child()
         retry_path = result.job_dir / "retry.json"
+        root_quarantine_marker = self.tmp / "QUARANTINED"
 
         statuses: list[tuple[str, str]] = []
         now = 1_000_000.0
+        self.assertFalse(root_quarantine_marker.exists())
         for index, wait_seconds in enumerate((1800, 7200, 28800, None), start=1):
             self._write_failed_result(result.job_dir, f"failure-{index}")
             status = publish_verification.record_failed_receipt_retry(result.job_dir, now=now)
@@ -407,6 +409,7 @@ class PublishVerificationTests(unittest.TestCase):
             ],
             statuses,
         )
+        self.assertFalse(root_quarantine_marker.exists())
 
     def test_failed_receipt_wait_does_not_compound_and_elapsed_wait_relaunches_child(self) -> None:
         result = self._prepared_job_without_child()


### PR DESCRIPTION
## Changed files
- `skills/consensus-loop/scripts/test_publish_verification.py`: 在既有 failed receipt retry/quarantine 测试中加入 repo-root `QUARANTINED` 不存在断言,锁定 quarantine 只通过 per-job `retry.json` 表达。
- `QUARANTINED`: 实施前后均 absent,没有 untracked evidence file 需要删除。

## Test results
- `python3 -m unittest skills/consensus-loop/scripts/test_publish_verification.py`: PASS, 17 tests.
- `PATH="/opt/homebrew/bin:$PATH" /opt/homebrew/bin/python3 skills/consensus-loop/scripts/consensus-rnd-cli check-degradation --static`: PASS.
- `PATH="/opt/homebrew/bin:$PATH" /opt/homebrew/bin/python3 -m unittest discover -s skills/consensus-loop/scripts -p "test_*.py"`: PASS, 2562 tests, skipped=1.

## Deviations
- 未扩展 scope,未改 production code、`.gitignore` 或 root guard。
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none).
- Closes #1031

⟦AI:AUTO-LOOP⟧
