### PR TITLE
feat(sshx): make the thinking stage a five-seat philosopher panel with the locus dyad

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "consensus-rnd",
       "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-      "version": "1.0.0-beta.25",
+      "version": "1.0.0-beta.26",
       "source": "./",
       "author": {
         "name": "auric",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎，可注入 host 仓库做 repo-owned managed GitHub issue/PR 自治解决循环；audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.25",
+  "version": "1.0.0-beta.26",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.25",
+  "version": "1.0.0-beta.26",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "author": {
     "name": "auric",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "consensus-rnd",
   "displayName": "Consensus R&D",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.25",
+  "version": "1.0.0-beta.26",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.25",
+  "version": "1.0.0-beta.26",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.25",
+  "version": "1.0.0-beta.26",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "license": "MIT",
   "author": "auric <loning.ma@aelf.io>",

--- a/skills/consensus-loop/VERSION.json
+++ b/skills/consensus-loop/VERSION.json
@@ -1,6 +1,6 @@
 {
   "schema": "consensus-loop-version",
-  "version": "1.0.0-beta.25",
+  "version": "1.0.0-beta.26",
   "repository": "ChronoAIProject/consensus-rnd",
   "release_source": "github-release-then-tag",
   "install_hint": "host-owned"

--- a/skills/sshx/SKILL.md
+++ b/skills/sshx/SKILL.md
@@ -48,7 +48,7 @@ Run the stages in this exact order:
 
 1. `intake` (write `GoalArtifact` and normalize the goal)
 2. `choose_worker_mode`
-3. `thinking_triplet_workers`
+3. `thinking_panel_workers`
 4. `meta_judge`
 5. `implementation_worker`
 6. `review_triplet_workers`
@@ -118,7 +118,7 @@ If `codex-cli` exits abnormally without both the terminal envelope and the compl
 
 ## Result Envelope
 
-`SshxResultEnvelope` is a prompt-level record, not a runtime API. Every `SshxResultEnvelope` returned by `thinking_triplet_workers`, `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done` uses exactly these top-level fields:
+`SshxResultEnvelope` is a prompt-level record, not a runtime API. Every `SshxResultEnvelope` returned by `thinking_panel_workers`, `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done` uses exactly these top-level fields:
 
 - `conclusion`: compact structured result consumed by the caller. It may include verdicts, decisions, blocking goal gaps, final decision points, changed-file evidence, and test evidence when applicable. It must not include process logs, step-by-step reasoning, raw transcripts, debug output, or same-round peer output.
 - `log_ref`: artifact reference for the non-inline worker, meta-judge, implementation, review, or fix log, treated as an opaque diagnostic pointer. Caller-side routing, meta-judging, worker briefs, and final reports must not open, inline, summarize, or otherwise consume its content; they keep only the reference. Opening the artifact is allowed only for out-of-band debugging outside the consensus decision context.
@@ -157,7 +157,7 @@ Same-round thinking workers must not see one another's outputs before their own 
 
 ## Reasoning Discipline
 
-`## Reasoning Discipline` is the single source of truth for the reasoning pass used by both `## Thinking Triplet` and `## Review Triplet`. It is prompt-level guidance only: not a runtime API, not a daemon, not a CLI, not a parsed schema field, not marker data, not lifecycle authority, and not a second transcript channel. The stages reference this section; they do not restate it.
+`## Reasoning Discipline` is the single source of truth for the reasoning pass used by both `## Thinking Panel` and `## Review Triplet`. It is prompt-level guidance only: not a runtime API, not a daemon, not a CLI, not a parsed schema field, not marker data, not lifecycle authority, and not a second transcript channel. The stages reference this section; they do not restate it.
 
 sshx's essence is independent context-isolated perspectives that oppose ugliness to converge on a beautiful answer.
 
@@ -169,19 +169,23 @@ seek truth from facts: verify every factual premise against actual evidence befo
 
 Each thinking or review worker must surface one compact free-form reasoning-discipline note in `SshxResultEnvelope.conclusion` naming the reference frame, stating the known-good shape and alignment, deviation, or revision status; stating the ugly defect and beautiful form for each candidate weighed; and stating the verified-premise or `ASSUMED-UNVERIFIED` status needed for the verdict. This does not override `GoalArtifact`, assigned bias or review focus, truth tables, or allowed verdict sets, and it is not mandatory citation work, not a literature search, not a parsed schema field, not marker data, not lifecycle authority, and not a blocker for valid `abstain`, `reject`, or `comment` outcomes.
 
-## Thinking Triplet
+## Thinking Panel
 
-Run three biased perspectives before choosing a plan:
+Run five whole-picture philosopher seats before choosing a plan — the same universal judgment lenses the consensus engine debates with. Each seat is one independent, context-isolated perspective that opposes ugliness from its own lens:
 
-- `minimal`: smallest coherent change on the root-cause-resolving path that satisfies the user goal, not a surface patch that leaves the root cause in place.
-- `structural`: architecture and contract integrity under future growth.
-- `delete`: whether the feature, abstraction, or work should be removed, collapsed, or avoided.
+- `teleology`: purpose and inevitability. What is this for, and is the form forced by that purpose? Attacks skipped-purpose and missing-inevitability.
+- `parsimony`: economy. Delete until nothing is left to delete; every element must prove its right to exist. Attacks magic numbers, symptom branches, and machinery that has not earned its place.
+- `fidelity`: truth over proxy. Does it measure the real thing, and is every premise verified at its source? Attacks proxy-over-truth and narrative-over-verification.
+- `natural-ownership`: locus dyad, ownership pole. Which layer naturally owns this invariant, duty, or constraint — the layer with semantic responsibility and causal control? Attacks symptom patches, duplicated enforcement, and invariants forced onto consumers of what a producer should own.
+- `proportional-containment`: locus dyad, containment pole. How far may this intervention rightfully bind, across scope, authority, and duration, given the evidence? Attacks over-hoisting, speculative abstraction, and turning a local fact into universal law.
 
-Before proposing, revising, rejecting, or abstaining, each thinking perspective must apply `## Reasoning Discipline` to every candidate conclusion it weighs and surface the compact reasoning-discipline note in `SshxResultEnvelope.conclusion` before returning a verdict.
+`natural-ownership` and `proportional-containment` are a coupled **must-clash locus dyad**: they run together, each must answer the other pole's claim, and they converge on the natural owner layer — not the highest layer imaginable. Ownership pulls the fix toward the layer that owns the invariant; containment resists over-reaching past it. This is the "go upstream to the root, but not past the natural owner" balance expressed as two adversarial seats the meta-judge converges, rather than a single balanced checklist.
 
-Every perspective must first identify the problem essence or root cause implied by `GoalArtifact`, then frame `propose`, `revise`, `reject`, or `abstain` as an answer to it: what satisfies it, what still differs from it, or why it cannot be satisfied. A plan that only patches a surface symptom while leaving that root cause in place does not satisfy `minimal` or the thinking gate. `revise` must name the goal gap and a next iteration question; it must not open an unrelated design search.
+Before proposing, revising, rejecting, or abstaining, each seat must apply `## Reasoning Discipline` to every candidate conclusion it weighs and surface the compact reasoning-discipline note in `SshxResultEnvelope.conclusion` before returning a verdict.
 
-Each perspective returns one of:
+Every seat must first identify the problem essence or root cause implied by `GoalArtifact`, then frame `propose`, `revise`, `reject`, or `abstain` as an answer to it: what satisfies it, what still differs from it, or why it cannot be satisfied. A plan that only patches a surface symptom while leaving that root cause in place does not satisfy the thinking gate. `revise` must name the goal gap and a next iteration question; it must not open an unrelated design search.
+
+Each seat returns one of:
 
 - `propose`
 - `revise`
@@ -203,7 +207,7 @@ The meta-judge applies this fixed thinking truth table:
 
 The convergence question must be "what still differs from `GoalArtifact`?" expressed against the fixed normalized goal, constraints, and success criteria. Do not generalize the convergence pass beyond that goal gap.
 
-Before any `implement` exit, the meta-judge must include in its `meta_judge.conclusion` a compact free-form ASCII relationship diagram built only from `GoalArtifact` and the returned `SshxResultEnvelope.conclusion` values: nodes are the goal subquestions or goal-gap items, the `minimal`, `structural`, and `delete` stances, and the concrete plan; edges are labeled `agree`, `conflict`, `depends-on`, `resolved-by`, or `converges-to`. The diagram rigidly constrains convergence: every surfaced subquestion or goal-gap node must appear, the concrete plan must resolve every `conflict` edge, and any unresolved `conflict` edge is an unclosed `GoalArtifact` goal gap, so the exit stays `meta-layer convergence` or `abstain/escalate with options`, never `implement`. The diagram is free-form prompt-level content synthesized from conclusions only; it must not inline worker full reasoning or same-round peer output, and it is not a parsed schema field, marker data, lifecycle authority, or a blocker for valid `abstain` or `reject fake consensus` exits.
+Before any `implement` exit, the meta-judge must include in its `meta_judge.conclusion` a compact free-form ASCII relationship diagram built only from `GoalArtifact` and the returned `SshxResultEnvelope.conclusion` values: nodes are the goal subquestions or goal-gap items, the five philosopher-seat stances (`teleology`, `parsimony`, `fidelity`, `natural-ownership`, `proportional-containment`), and the concrete plan; edges are labeled `agree`, `conflict`, `depends-on`, `resolved-by`, or `converges-to`. The diagram rigidly constrains convergence: every surfaced subquestion or goal-gap node must appear, the concrete plan must resolve every `conflict` edge — including the `natural-ownership` vs `proportional-containment` locus clash — and any unresolved `conflict` edge is an unclosed `GoalArtifact` goal gap, so the exit stays `meta-layer convergence` or `abstain/escalate with options`, never `implement`. The diagram is free-form prompt-level content synthesized from conclusions only; it must not inline worker full reasoning or same-round peer output, and it is not a parsed schema field, marker data, lifecycle authority, or a blocker for valid `abstain` or `reject fake consensus` exits.
 
 ## Implementation Worker
 
@@ -316,8 +320,8 @@ worker_flights:
     attempt:
     result_envelope_ref:
     completion_sentinel_ref:
-thinking_triplet_workers:
-  - role: minimal
+thinking_panel_workers:
+  - role: teleology
     bias:
     visible_inputs:
     worker_mode:
@@ -326,7 +330,7 @@ thinking_triplet_workers:
     verdict:
     conclusion:
     log_ref:
-  - role: structural
+  - role: parsimony
     bias:
     visible_inputs:
     worker_mode:
@@ -335,7 +339,25 @@ thinking_triplet_workers:
     verdict:
     conclusion:
     log_ref:
-  - role: delete
+  - role: fidelity
+    bias:
+    visible_inputs:
+    worker_mode:
+    worker_carrier:
+    worker_flight_ref:
+    verdict:
+    conclusion:
+    log_ref:
+  - role: natural-ownership
+    bias:
+    visible_inputs:
+    worker_mode:
+    worker_carrier:
+    worker_flight_ref:
+    verdict:
+    conclusion:
+    log_ref:
+  - role: proportional-containment
     bias:
     visible_inputs:
     worker_mode:

--- a/skills/sshx/tests/test_sshx_contract.py
+++ b/skills/sshx/tests/test_sshx_contract.py
@@ -116,7 +116,7 @@ class SshxContractTests(unittest.TestCase):
             "## Worker Completion Contract",
             "## No Context Pollution",
             "## Reasoning Discipline",
-            "## Thinking Triplet",
+            "## Thinking Panel",
             "## Design Truth Table",
             "## Implementation Worker",
             "## Review Triplet",
@@ -129,13 +129,13 @@ class SshxContractTests(unittest.TestCase):
         ]:
             self.assertIn(anchor, text)
         self.assertLess(heading_index(text, "## No Context Pollution"), heading_index(text, "## Reasoning Discipline"))
-        self.assertLess(heading_index(text, "## Reasoning Discipline"), heading_index(text, "## Thinking Triplet"))
-        self.assertLess(heading_index(text, "## Thinking Triplet"), heading_index(text, "## Design Truth Table"))
+        self.assertLess(heading_index(text, "## Reasoning Discipline"), heading_index(text, "## Thinking Panel"))
+        self.assertLess(heading_index(text, "## Thinking Panel"), heading_index(text, "## Design Truth Table"))
         self.assertLess(heading_index(text, "## Design Truth Table"), heading_index(text, "## Implementation Worker"))
         self.assertLess(heading_index(text, "## Implementation Worker"), heading_index(text, "## Review Triplet"))
         self.assertLess(heading_index(text, "## Review Triplet"), heading_index(text, "## Review Truth Table"))
         self.assertIn(
-            "`intake` (write `GoalArtifact` and normalize the goal)\n2. `choose_worker_mode`\n3. `thinking_triplet_workers`\n4. `meta_judge`\n5. `implementation_worker`\n6. `review_triplet_workers`\n7. `fix_or_done`",
+            "`intake` (write `GoalArtifact` and normalize the goal)\n2. `choose_worker_mode`\n3. `thinking_panel_workers`\n4. `meta_judge`\n5. `implementation_worker`\n6. `review_triplet_workers`\n7. `fix_or_done`",
             text,
         )
 
@@ -187,8 +187,8 @@ class SshxContractTests(unittest.TestCase):
 
     def test_sshx_triplets_require_reasoning_discipline_in_conclusion(self) -> None:
         text = read(SKILL)
-        reasoning_section = text[heading_index(text, "## Reasoning Discipline") : heading_index(text, "## Thinking Triplet")]
-        thinking_section = text[heading_index(text, "## Thinking Triplet") : heading_index(text, "## Design Truth Table")]
+        reasoning_section = text[heading_index(text, "## Reasoning Discipline") : heading_index(text, "## Thinking Panel")]
+        thinking_section = text[heading_index(text, "## Thinking Panel") : heading_index(text, "## Design Truth Table")]
         review_section = text[heading_index(text, "## Review Triplet") : heading_index(text, "## Review Truth Table")]
 
         for required in [
@@ -273,7 +273,7 @@ class SshxContractTests(unittest.TestCase):
             self.assertNotIn(forbidden, text)
 
         self.assertIn(
-            "Before proposing, revising, rejecting, or abstaining, each thinking perspective must apply `## Reasoning Discipline`",
+            "Before proposing, revising, rejecting, or abstaining, each seat must apply `## Reasoning Discipline`",
             thinking_section,
         )
         self.assertIn(
@@ -282,7 +282,7 @@ class SshxContractTests(unittest.TestCase):
         )
         self.assertLess(
             thinking_section.index("Before proposing, revising, rejecting, or abstaining"),
-            thinking_section.index("Each perspective returns one of:"),
+            thinking_section.index("Each seat returns one of:"),
         )
         self.assertIn(
             "Before approving, commenting, or rejecting, each reviewer must apply `## Reasoning Discipline`",
@@ -303,21 +303,33 @@ class SshxContractTests(unittest.TestCase):
         self.assertNotIn("applicable mature theory, engineering principle, industry best practice", thinking_section)
         self.assertNotIn("applicable mature theory, engineering principle, industry best practice", review_section)
 
-    def test_sshx_thinking_anchors_root_cause_and_minimal_path(self) -> None:
+    def test_sshx_thinking_panel_seats_and_anchors_root_cause(self) -> None:
         text = read(SKILL)
-        thinking_start = text.index("## Thinking Triplet")
+        thinking_start = text.index("## Thinking Panel")
         design_truth_start = text.index("## Design Truth Table")
         thinking_section = text[thinking_start:design_truth_start]
         self.assertIn(
-            "smallest coherent change on the root-cause-resolving path that satisfies the user goal, not a surface patch that leaves the root cause in place",
+            "Run five whole-picture philosopher seats before choosing a plan",
+            thinking_section,
+        )
+        for seat in [
+            "`teleology`",
+            "`parsimony`",
+            "`fidelity`",
+            "`natural-ownership`",
+            "`proportional-containment`",
+        ]:
+            self.assertIn(seat, thinking_section)
+        self.assertIn(
+            "coupled **must-clash locus dyad**",
             thinking_section,
         )
         self.assertIn(
-            "Every perspective must first identify the problem essence or root cause implied by `GoalArtifact`",
+            "Every seat must first identify the problem essence or root cause implied by `GoalArtifact`",
             thinking_section,
         )
         self.assertIn(
-            "A plan that only patches a surface symptom while leaving that root cause in place does not satisfy `minimal` or the thinking gate",
+            "A plan that only patches a surface symptom while leaving that root cause in place does not satisfy the thinking gate",
             thinking_section,
         )
 
@@ -583,7 +595,7 @@ class SshxContractTests(unittest.TestCase):
         self.assertIn("## Result Envelope", text)
         self.assertIn("`SshxResultEnvelope` is a prompt-level record, not a runtime API", text)
         self.assertIn(
-            "Every `SshxResultEnvelope` returned by `thinking_triplet_workers`, `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done` uses exactly these top-level fields",
+            "Every `SshxResultEnvelope` returned by `thinking_panel_workers`, `meta_judge`, `implementation_worker`, `review_triplet_workers`, and `fix_or_done` uses exactly these top-level fields",
             text,
         )
         self.assertIn("A caller-carried stage record wraps this envelope", text)
@@ -735,16 +747,16 @@ class SshxContractTests(unittest.TestCase):
 
     def test_sshx_result_envelope_caller_context_excludes_inline_logs(self) -> None:
         caller_carried_transcript = {
-            "thinking_triplet_workers": [
+            "thinking_panel_workers": [
                 {
-                    "role": "minimal",
-                    "worker_flight_ref": "flight-thinking-minimal",
+                    "role": "teleology",
+                    "worker_flight_ref": "flight-thinking-teleology",
                     "verdict": "propose",
                     "conclusion": {
-                        "decision": "use the smallest contract edit",
+                        "decision": "the form is forced by the stated purpose",
                         "goal_gap": "none",
                     },
-                    "log_ref": "artifacts/sshx/minimal.log",
+                    "log_ref": "artifacts/sshx/teleology.log",
                 }
             ],
             "meta_judge": {
@@ -784,7 +796,7 @@ class SshxContractTests(unittest.TestCase):
             self.assertNotIn("report", node)
             self.assertNotIn("synthesis", node)
 
-        for worker in caller_carried_transcript["thinking_triplet_workers"]:
+        for worker in caller_carried_transcript["thinking_panel_workers"]:
             assert_envelope(worker)
         assert_envelope(caller_carried_transcript["meta_judge"])
         assert_envelope(caller_carried_transcript["implementation_worker"])


### PR DESCRIPTION
## What
Change the `/sshx` skill's **thinking stage** from the `minimal / structural / delete` triplet to the **five whole-picture philosopher seats** the consensus engine debates with — the philosophical-debate form:

- **teleology** — purpose / inevitability (what is this for; is the form forced by that purpose?)
- **parsimony** — delete-until-nothing; magic numbers; symptom branches
- **fidelity** — measure the real thing, not a proxy; verify every premise at its source
- **natural-ownership** ⟷ **proportional-containment** — a coupled **must-clash locus dyad**: ownership pulls the fix toward the layer that naturally owns the invariant; containment resists over-reaching past it; they converge on *the natural owner layer, not the highest layer imaginable*. The "go upstream to the root, but not past the natural owner" balance, as two adversarial seats the meta-judge converges — not a single balanced checklist.

## Why
sshx *is* the consensus-engine philosophy applied inline, so its thinking seats should **be** the philosopher seats. `minimal/structural/delete` judged "how much to change"; the philosopher panel judges the proposal from universal lenses (purpose, economy, truth, and the ownership⟷containment altitude tension), which is the debate form this repo's consensus core uses.

## Changes
- `## Thinking Triplet` → `## Thinking Panel` (honest name: five seats, not three); `thinking_triplet_workers` → `thinking_panel_workers`.
- Thinking seats rewritten to the five philosopher lenses + the coupled must-clash locus dyad.
- Design Truth Table ASCII diagram now references the five seat stances and requires resolving the `natural-ownership` vs `proportional-containment` locus clash.
- Transcript Template lists the five thinking roles.
- **Review stage unchanged** (`architecture / quality / tests`) — implementation verification is a distinct concern; both stages keep applying the shared, already-philosophical Reasoning Discipline (BEAUTY GATE + seek-truth-from-facts).
- Worker delegation, isolation, truth tables, and the envelope contract are unchanged.
- Contract test updated to the panel form.

**Not touched:** the `consensus-loop` skill keeps its own `minimal/structural/delete` design-consensus solver triplet — this PR is scoped to `/sshx` only.

## Cost note
The thinking stage now dispatches **five** isolated workers instead of three.

## Tests
`python3 -m unittest discover -s skills/sshx/tests -p 'test_*.py'` → **35 tests pass**. This is the exact command in `.github/workflows/consensus-rnd-ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⟦AI:FKST⟧