### PR TITLE
feat(sshx): raise default bounded-pass cap from one to five

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "consensus-rnd",
       "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-      "version": "1.0.0-beta.26",
+      "version": "1.0.0-beta.27",
       "source": "./",
       "author": {
         "name": "auric",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎，可注入 host 仓库做 repo-owned managed GitHub issue/PR 自治解决循环；audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.26",
+  "version": "1.0.0-beta.27",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.26",
+  "version": "1.0.0-beta.27",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "author": {
     "name": "auric",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "consensus-rnd",
   "displayName": "Consensus R&D",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.26",
+  "version": "1.0.0-beta.27",
   "author": {
     "name": "auric",
     "email": "loning.ma@aelf.io"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
-  "version": "1.0.0-beta.26",
+  "version": "1.0.0-beta.27",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-rnd",
-  "version": "1.0.0-beta.26",
+  "version": "1.0.0-beta.27",
   "description": "通用共识式研发 skills 库：偏置独立的多角度共识构建引擎；repo-owned managed GitHub issue/PR 自治解决引擎，audit/refactor 仅 fallback producer",
   "license": "MIT",
   "author": "auric <loning.ma@aelf.io>",

--- a/skills/consensus-loop/VERSION.json
+++ b/skills/consensus-loop/VERSION.json
@@ -1,6 +1,6 @@
 {
   "schema": "consensus-loop-version",
-  "version": "1.0.0-beta.26",
+  "version": "1.0.0-beta.27",
   "repository": "ChronoAIProject/consensus-rnd",
   "release_source": "github-release-then-tag",
   "install_hint": "host-owned"

--- a/skills/sshx/SKILL.md
+++ b/skills/sshx/SKILL.md
@@ -253,7 +253,7 @@ If review exits `done with advisory surfaced`, report the final outcome by aggre
 
 If review exits `explicit user decision or another bounded review pass`, either run one more bounded pass with a concrete next iteration question tied to `GoalArtifact`, or ask the user to decide. Do not loop indefinitely.
 
-Every bounded pass in this skill - `meta-layer convergence`, a repeated review pass, and fix passes - defaults to at most one pass unless the user explicitly authorizes more, and the chosen bound is recorded before the first such pass.
+Every bounded pass in this skill - `meta-layer convergence`, a repeated review pass, and fix passes - defaults to at most five passes unless the user explicitly authorizes more, and the chosen bound is recorded before the first such pass.
 
 ## Boundaries
 

--- a/skills/sshx/tests/test_sshx_contract.py
+++ b/skills/sshx/tests/test_sshx_contract.py
@@ -923,7 +923,7 @@ class SshxContractTests(unittest.TestCase):
 
     def test_sshx_bounded_passes_have_default_bound(self) -> None:
         text = read(SKILL)
-        self.assertIn("defaults to at most one pass unless the user explicitly authorizes more", text)
+        self.assertIn("defaults to at most five passes unless the user explicitly authorizes more", text)
 
     def test_sshx_no_runtime_control_plane_leakage(self) -> None:
         text = read(SKILL)


### PR DESCRIPTION
## Motivation
The sshx `## Fix Or Done` contract capped every bounded pass (`meta-layer convergence`, a
repeated review pass, and fix passes) at **one** by default. In practice, iterating a
fix→review loop to convergence on a high-stakes decision needs more than one pass; the
one-pass default forced re-asking the user every round. Raise the default to **at most five
passes** — still bounded, still overridable by explicit user authorization, and "do not loop
indefinitely" still holds.

## Change
- `skills/sshx/SKILL.md`: default bound "at most one pass" → "at most five passes".
- `skills/sshx/tests/test_sshx_contract.py`: update the asserted phrase to match.
- Version bump `1.0.0-beta.26` → `1.0.0-beta.27` across all plugin manifests: `package.json`,
  `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`,
  `.claude-plugin/marketplace.json`, `gemini-extension.json`, `skills/consensus-loop/VERSION.json`.

## Test
`python3 -m pytest skills/sshx/tests/test_sshx_contract.py -q` → **35 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJTXbfYjxCQs8AdRdPD3bJ
